### PR TITLE
fix(mobile): finish multi-board offline downloads

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -88,7 +88,17 @@ For every `(board_type, layout_id)` pair with at least one climb (`discoverLayou
    than risking a watermark that covers it before it's actually visible.
 4. Computes each table's watermark — the max `(updated_at, sync_seq)` over the exported rows — from the
    **same transaction snapshot** as the row stream, and writes it into `snapshot_meta` alongside
-   `row_count`, `schema_version` (`LATEST_SCHEMA_VERSION`), and `format_version`.
+   `row_count`, `schema_version` (`LATEST_SCHEMA_VERSION`), and `format_version`. The transaction also
+   captures a conservative tombstone boundary into a metadata-only `sync_deletions` row: the oldest of
+   run `builtAt`, export-transaction start minus `SYNC_STABILITY_WINDOW_SECONDS`, and the oldest active
+   same-role transaction start. A second primary-pool connection samples `pg_stat_activity` while the
+   export transaction is open but before its first artifact SELECT fixes the `REPEATABLE READ` snapshot.
+   That ordering covers a delete transaction that began before the snapshot but committed after it.
+   The row is omitted (clients use the legacy scoped-watermark fallback) if the pool has fewer than two
+   connections, the activity probe fails, another-role client or prepared transaction exists in the
+   database, activity tracking/visibility is incomplete, or any timestamp is invalid. Every per-layout
+   build/upload log carries `deletionsReplayFrom` and `deletionsReplayFallbackReason`: success is a
+   timestamp plus a null reason; fallback is a null timestamp plus one stable, low-cardinality reason.
 5. Uploads the SQLite file to `<keyPrefix>/<boardType>/<layoutId>/<builtAt-colon-free>.db` — identity by
    default, or `gzip` (with `Content-Encoding: gzip`) under `--gzip`. The manifest's `contentEncoding`
    field records which, so the client stays agnostic.
@@ -174,12 +184,12 @@ logged and swallowed, never fails the run.
 
 ## Artifact format
 
-The whole-layout `.db` file carries exactly two data tables — `board_climbs` and `board_climb_stats` —
-plus `snapshot_meta`. That has not changed since the first release and must not: every shipped binary
-verifies the file against its own two-table list and throws `snapshot_meta missing row for <table>` on a
-mismatch, which is a **counted** import failure. Two of those settle the scope onto the paged crawl, so
-widening this file's meta would break the fleet for the whole 14-day prune-grace window. Boardsesh grades
-ride in a separate file for exactly that reason (see "Grades artifact" below).
+The whole-layout `.db` file carries exactly two **data tables** — `board_climbs` and `board_climb_stats` —
+plus `snapshot_meta`. That data-table list has not changed since the first release and must not: every
+shipped binary verifies its required metadata rows by table name and throws
+`snapshot_meta missing row for <table>` when one is absent. The additive `sync_deletions` metadata row is
+safe because old clients ignore rows they do not query; it does not add a data table. Boardsesh grades ride
+in a separate file for exactly that reason (see "Grades artifact" below).
 
 ```sql
 CREATE TABLE snapshot_meta (
@@ -193,7 +203,9 @@ CREATE TABLE snapshot_meta (
 );
 ```
 
-One row per data table (`board_climbs`, `board_climb_stats`).
+There is one required row per data table (`board_climbs`, `board_climb_stats`) plus a metadata-only
+`sync_deletions` row in newly-built whole-layout artifacts. The latter has `row_count = 0`,
+`watermark_sync_seq = '0'`, and uses `watermark_updated_at` for the conservative deletion replay boundary.
 
 These rows are artifact-level metadata for the whole `(boardType, layoutId)` artifact. A client importing
 one narrower size scope uses them to validate the file, then computes its checkpoint watermarks from the
@@ -461,15 +473,26 @@ inside the artifact, then in **one exclusive transaction**:
 - Imports `board_climb_stats` via a correlated `EXISTS` against the just-scoped `board_climbs`, mirroring
   the resolver's semi-join.
 - Stamps both table checkpoints at the scoped imported-row watermarks.
-- **Rewinds the deletions checkpoint** to the older scoped table watermark timestamp with deletion cursor
-  `syncSeq = '0'`, in the _same_ transaction as the import. Deletion cursors page over deletion-row ids, not
-  board table `sync_seq` values. A committed import stamps `bootstrap-done:`, which disqualifies the scope
-  from ever bootstrapping again, so a crash between the import commit and a separate rewind step would
-  permanently strand any board-row deletions that fell in `(watermark, deletions-head]` — they'd never
-  replay against the freshly-imported rows. Doing it in the same transaction closes that gap. Note the
-  rewind target is `min(scoped watermarks)`, the max `updated_at` of the artifact's rows FOR THIS SCOPE:
-  on a quiet layout that timestamp can be weeks old, so the replay window is bounded by the 80-day
-  tombstone retention, not by one nightly export window.
+- **Rewinds the deletions checkpoint** to the artifact's `sync_deletions` replay boundary with deletion
+  cursor `syncSeq = '0'`, in the _same_ transaction as the import. Deletion cursors page over deletion-row
+  ids, not board table `sync_seq` values. A 30-second stability boundary alone is not safe: a delete
+  transaction can run longer, remain invisible to the snapshot, then commit afterwards with an older
+  `deleted_at`. The exporter therefore includes the oldest visible same-role `xact_start`; it samples from
+  a second connection before the RR snapshot is acquired, so a commit cannot disappear from activity while
+  remaining invisible to an already-fixed artifact snapshot. `pg_stat_activity` exposes full details to
+  ordinary users only for same-role sessions, so production writers and the exporter deliberately share
+  one DB role. Any other-role client fails the optimization closed. Prepared transactions are absent from
+  `pg_stat_activity`, so their presence does too. Old artifacts and malformed/missing/future optional
+  metadata fall back to the older scoped row watermark. Rewind and imported rows commit together so a
+  crash cannot permanently strand tombstones against the freshly-imported scope.
+
+The following deletions pull applies each fetched tombstone page **and that page's checkpoint** in one
+SQLite exclusive transaction. Playlist-child cleanup, resurrection guards, and composite-key validation
+run inside that same transaction. A failed tombstone rolls back the whole page; a successful page pays one
+lock/commit instead of one autocommit per row. Expo opens the wrapper with deferred `BEGIN`, so the page
+first rewrites its current deletion cursor to acquire SQLite's writer lock, then rechecks the global purge
+epoch. It checks again before publishing the fetched cursor; a purge that wins the lock makes the page roll
+back, while a purge that starts after the page owns the lock necessarily clears the cursor after commit.
 
 **Wipe-epoch guard**: a sign-out wipe can start (or fully complete) across any of the `await`s above. The
 bootstrap captures the monotonic wipe epoch before its first `await` and re-checks it (and the
@@ -634,7 +657,7 @@ pre-import empty result set.
   Swift, reachable only via a bun patch or an upstream PR.
 
 - **Download fallback status**: My Boards keeps the normal per-row download state (`pending`,
-  `downloading`, or `downloaded`) and separately derives a `BoardDownloadNotice` from the persisted
+  `downloading`, `finalizing`, or `downloaded`) and separately derives a `BoardDownloadNotice` from the persisted
   attempt, done, and explicit paged-fallback markers plus board checkpoints. The explicit outcome closes
   the ambiguous failure-then-permanent-miss path; checkpoints keep a restored or flag-toggled mid-crawl
   scope from being labelled as a retry after restart. Active bootstrap always outranks persisted history,
@@ -644,6 +667,9 @@ pre-import empty result set.
   waiting for a multi-scope cycle to finish. The full transition message wraps instead of truncating.
   Android exposes it as the only polite live region; iOS announces semantic notice changes through
   VoiceOver explicitly. The changing climb count remains readable but is never auto-announced per page.
+  Once a snapshot's durable import marker lands, that row stays `finalizing` throughout work on sibling
+  snapshots and shared deletion/user-data phases instead of falling back to “Waiting to download.” A
+  scope on the paged fallback has no import marker and therefore never gets that label prematurely.
 
 - **Per-connection ATTACH invariant (BOARDSESH-AA)**: expo-sqlite's
   `withExclusiveTransactionAsync` runs its task on a **new native connection**
@@ -672,6 +698,11 @@ pre-import empty result set.
   stale-negative read gets two bounded re-probes; if the link remains unreachable, the scheduler's next
   reachability edge reads the durable setting. This closes the ordering window that otherwise left a
   reachable device on “Waiting to download” with no future edge to wake it.
+- **Bounded offline GraphQL requests**: only the client used by the mutation drainer and pull engine has a
+  30-second hard deadline. It forwards caller cancellation and aborts the underlying native request, but
+  releases the scheduler even if the platform fetch never settles. Interactive GraphQL calls keep their
+  existing transport behaviour. A deadline failure reaches the ordinary 30-second cycle retry rather than
+  holding the global single-flight latch forever.
 - **Gzip magic-byte sniff** (`packages/mobile/src/offline/snapshot-source.ts`): identity artifacts skip
   gzip verification. For manifest entries with `contentEncoding: 'gzip'`, the expectation is that the
   native HTTP stack (`NSURLSession` / OkHttp via `expo-file-system`'s `DownloadTask`)
@@ -704,10 +735,15 @@ pre-import empty result set.
     only: at the manifest stage it also skips the attempt counter, but a transport-shaped download failure
     still burns an attempt (see the matrix above). The real exception is attached as the wrapper's `cause`,
     which is what lets the shared classifier recognise them at all (issue #4238).
+  - `Offline Sync Cycle Failed` records a bounded `phase`, `currentTable`, document count, HTTP status,
+    and stable error kind when a whole drain/pull cycle throws. It never sends raw exception text. An
+    unchanged signature is emitted at most once per five minutes; unexpected failures also reach Sentry
+    under the same throttle. Reporter failures are swallowed by the scheduler so telemetry cannot suppress
+    the failed-idle frame or retry alarm.
 
 ## Download funnel events
 
-Five PostHog events (`@boardsesh/analytics`'s `SHARED_EVENTS`) make board downloads measurable
+Six PostHog events (`@boardsesh/analytics`'s `SHARED_EVENTS`) make board downloads measurable
 end-to-end (issue #4316). Before them the feature had exactly one — `Offline Board Download
 Completed` — so abandonment was structurally unmeasurable and failures went only to Sentry.
 
@@ -853,6 +889,98 @@ node --import tsx src/scripts/export-board-snapshots.ts \
 - `DATABASE_URL` must point at the **primary**, never a read replica (see the rationale above) — this is
   read-only-sufficient (the export only `SELECT`s) but the write-time/commit-order mismatch on a replica is
   a correctness bug, not a permissions one.
+
+### Verify deletion replay metadata after a live full refresh
+
+After an unfiltered full gzip refresh, inspect the `Export board snapshots (gzip →
+board-snapshots/v1-gzip)` job logs before treating the refresh as complete. Every rebuilt layout — including
+Kilter, Tension, and So iLL — must have a non-null `deletionsReplayFrom` and
+`deletionsReplayFallbackReason: null` in its `[export-snapshots] uploaded` record. The live gzip pass refuses
+to replace a layout's previous manifest entry when the boundary is unavailable and fails the run after the
+remaining layouts finish; the next queued refresh retries it. Identity exports and dry-runs remain log-only
+so operators can diagnose the environment without blocking the live pass. The bounded reasons are
+`observer-pool-capacity`,
+`activity-probe-failed`, `exporter-transaction-not-observed`, `activity-visibility-incomplete`, and
+`invalid-probe-timestamp`; none include database session details.
+
+Then verify the objects actually published behind the live manifest, not just the local build result. This
+uses a no-cache request plus a unique query tag so the manifest's five-minute CDN TTL cannot return the
+pre-refresh object. It checks every current layout artifact against the same metadata gates as the client:
+
+```sh
+set -euo pipefail
+snapshot_check_dir="$(mktemp -d)"
+snapshot_manifest="$snapshot_check_dir/manifest.json"
+manifest_url='https://boardsesh-board-snapshots.t3.tigrisfiles.io/board-snapshots/v1-gzip/manifest.json'
+manifest_cache_tag="$(date +%s)"
+latest_schema_version="$(vp node --import tsx -e \
+  "import('./packages/shared/offline-sync/src/db/migrations.ts').then(({ LATEST_SCHEMA_VERSION }) => console.log(LATEST_SCHEMA_VERSION))")"
+curl -fsSL -H 'Cache-Control: no-cache' -H 'Pragma: no-cache' \
+  "$manifest_url?verify=$manifest_cache_tag" \
+  -o "$snapshot_manifest"
+
+jq -e --argjson current_schema "$latest_schema_version" '
+  .formatVersion == 1
+  and (.entries | length) > 0
+  and all(.entries[];
+    (.schemaVersion | type) == "number"
+    and .schemaVersion >= $current_schema
+    and (.builtAt | type) == "string"
+    and (.url | type) == "string")
+' "$snapshot_manifest" >/dev/null
+
+selected_artifacts="$(jq -r '.entries[]
+  | [.boardType, (.layoutId | tostring), .builtAt, (.schemaVersion | tostring), .url]
+  | @tsv' "$snapshot_manifest")"
+if [ -z "$selected_artifacts" ]; then
+  echo 'FAIL live manifest contains no layout artifacts' >&2
+  exit 1
+fi
+
+while IFS="$(printf '\t')" read -r board_type layout_id manifest_built_at manifest_schema_version artifact_url; do
+  artifact_path="$snapshot_check_dir/$board_type-$layout_id.db"
+  curl -fsSL --compressed "$artifact_url" -o "$artifact_path"
+  replay_meta="$(sqlite3 "$artifact_path" \
+    "SELECT deletions.watermark_updated_at || char(9) || deletions.built_at
+     FROM snapshot_meta AS deletions
+     JOIN snapshot_meta AS climbs ON climbs.table_name = 'board_climbs'
+     JOIN snapshot_meta AS stats ON stats.table_name = 'board_climb_stats'
+     WHERE deletions.table_name = 'sync_deletions'
+       AND deletions.row_count = 0
+       AND deletions.watermark_sync_seq = '0'
+       AND deletions.format_version = 1
+       AND climbs.format_version = 1
+       AND stats.format_version = 1
+       AND deletions.schema_version = $manifest_schema_version
+       AND climbs.schema_version = $manifest_schema_version
+       AND stats.schema_version = $manifest_schema_version
+       AND deletions.schema_version >= $latest_schema_version
+       AND deletions.built_at = climbs.built_at
+       AND deletions.built_at = stats.built_at
+       AND julianday(deletions.built_at) IS NOT NULL
+       AND julianday(deletions.watermark_updated_at) IS NOT NULL
+       AND julianday(deletions.watermark_updated_at) <= julianday(deletions.built_at)
+       AND climbs.row_count = (SELECT COUNT(*) FROM board_climbs)
+       AND stats.row_count = (SELECT COUNT(*) FROM board_climb_stats)")"
+  IFS="$(printf '\t')" read -r replay_from artifact_built_at <<< "$replay_meta"
+  if [ -z "$replay_from" ] || [ "$artifact_built_at" != "$manifest_built_at" ]; then
+    echo "FAIL $board_type:$layout_id artifact/manifest deletion metadata mismatch" >&2
+    exit 1
+  fi
+  echo "OK $board_type:$layout_id $replay_from <= $artifact_built_at"
+done <<< "$selected_artifacts"
+```
+
+The timestamp on the left may be much older than `built_at` when a long-running same-role transaction was
+open during export; that is expected and is the safety property.
+
+The optimized replay boundary exists only in newly published live gzip artifacts. Older artifacts, the
+identity rollback prefix, and a live manifest retained by the CDN for up to five minutes use the compatible
+legacy rewind to table watermarks, which can replay a much longer deletion history. Deploy the client and
+exporter first, complete this unfiltered live gzip refresh, and wait for the canonical manifest cache to
+serve the verified keys before using multi-board download speed as release evidence.
+That compatibility fallback can also miss a tombstone from a transaction that began before its scoped
+watermark; only a verified live gzip replay boundary carries the stronger long-transaction guarantee.
 
 ### Required Production secrets
 

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -332,7 +332,7 @@ total spend; the cooldown ladder and scheduler alarm bound frequency.
 
 | Kind                  | Raised by                                                                            | Budget                                | Cooldown ladder      | Re-armed by a new `builtAt`?                         |
 | --------------------- | ------------------------------------------------------------------------------------ | ------------------------------------- | -------------------- | ---------------------------------------------------- |
-| `transport`           | `isNetworkError(cause)` at the download stage (offline, DNS, TLS, timeout)           | `MAX_TRANSPORT_DOWNLOAD_FAILURES` = 3 | 2 min → 15 min → 2 h | no                                                   |
+| `transport`           | network/DNS/TLS/timeout, short body, or iOS background-session decode interruption   | `MAX_TRANSPORT_DOWNLOAD_FAILURES` = 3 | 2 min → 15 min → 2 h | no                                                   |
 | `structural-artifact` | anything raised inside the import (`quick_check`, `snapshot_meta` mismatch, throw)   | `MAX_BOOTSTRAP_ATTEMPTS` = 2          | 6 h → 24 h           | yes, `MAX_STRUCTURAL_REARMS` = 1 per scope, lifetime |
 | `structural-device`   | every other non-transport cause (disk space, cache dir, CDN non-2xx, unclassifiable) | `MAX_BOOTSTRAP_ATTEMPTS` = 2          | 6 h → 24 h           | **no**                                               |
 
@@ -572,9 +572,10 @@ pre-import empty result set.
     survived the pocket, so a later failure belongs to the network or the device. Without the closing
     rule, one screen lock during a nine-minute Android transfer would launder every subsequent wifi
     drop, HTTP 500 or disk error into a free, cooldown-free 100 MB retry loop.
-  - the cause must be **network-shaped** (`isNetworkError`), which is what a suspension kill produces
-    (`NSURLErrorNetworkConnectionLost`, a timeout, a `SocketException`) and what a disk-full or an
-    HTTP 500 is not.
+  - the cause must be **transport-shaped**: either `isNetworkError` (for example
+    `NSURLErrorNetworkConnectionLost`, a timeout, or a `SocketException`) or iOS background
+    URLSession's exact `cannot decode raw data` response-decoding interruption. A disk-full or HTTP 500
+    is not a pause.
 
   Free pauses are **bounded at three per scope** (`MAX_FREE_BACKGROUND_PAUSES`, persisted as
   `BootstrapRetryState.backgroundPauses`). The fourth is charged to the **transport** budget on its
@@ -602,8 +603,11 @@ pre-import empty result set.
 
   The strategy is fixed for the bundle lifetime. No feature-flag resolution can restart the scheduler or
   replace a transfer's transport mid-download. Continue watching `sizeMismatch`,
-  `reason: 'permanent-miss'`, and `wireKbps`; the gzip sniff and paged fallback remain the safety net if a
-  platform HTTP stack ever stops decoding `Content-Encoding: gzip` transparently.
+  `reason: 'permanent-miss'`, `reason: 'background-transfer-decode'`, and `wireKbps`; the gzip sniff and
+  paged fallback remain the safety net if a platform HTTP stack ever stops decoding
+  `Content-Encoding: gzip` transparently. The exact iOS decode interruption is a known transport failure,
+  not a structural device defect: within an open suspension window it gets the bounded free-pause path;
+  otherwise it uses the normal transport ladder instead of the six-hour structural cooldown.
 
   Both platforms are real task arms: Android ignores `sessionType` but a `DownloadTask` builds
   its **own** `OkHttpClient` (60 s connect/read/write timeouts), while iOS hands the transfer to a
@@ -667,6 +671,9 @@ pre-import empty result set.
   waiting for a multi-scope cycle to finish. The full transition message wraps instead of truncating.
   Android exposes it as the only polite live region; iOS announces semantic notice changes through
   VoiceOver explicitly. The changing climb count remains readable but is never auto-announced per page.
+  An active paged crawl always outranks a future fast-path retry notice, so the row shows the slower-path
+  explanation and its live count instead of a static “Faster download interrupted” spinner while 500-row
+  pages are landing.
   Once a snapshot's durable import marker lands, that row stays `finalizing` throughout work on sibling
   snapshots and shared deletion/user-data phases instead of falling back to “Waiting to download.” A
   scope on the paged fallback has no import marker and therefore never gets that label prematurely.
@@ -703,6 +710,11 @@ pre-import empty result set.
   releases the scheduler even if the platform fetch never settles. Interactive GraphQL calls keep their
   existing transport behaviour. A deadline failure reaches the ordinary 30-second cycle retry rather than
   holding the global single-flight latch forever.
+- **Interrupted cycles terminalize their live status**: every expected background/offline/purge/sign-out
+  exit emits `phase: 'idle', interrupted: true`. This clears the per-board spinner without stamping
+  `lastSyncedAt`. Bootstrap and grades downloads also latch a cycle teardown across their native awaits,
+  so a foreground event that arrives before a rejection is handled queues a fresh cycle instead of letting
+  the stale one continue into deletions or paged pulls.
 - **Gzip magic-byte sniff** (`packages/mobile/src/offline/snapshot-source.ts`): identity artifacts skip
   gzip verification. For manifest entries with `contentEncoding: 'gzip'`, the expectation is that the
   native HTTP stack (`NSURLSession` / OkHttp via `expo-file-system`'s `DownloadTask`)

--- a/packages/backend/src/__tests__/snapshot-export-golden.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-golden.test.ts
@@ -34,7 +34,7 @@ import { createPool } from '@boardsesh/db/client';
 import { db } from '../db/client';
 import { syncQueries } from '../graphql/resolvers/sync/queries';
 import { toIso } from '../graphql/resolvers/sync/row-normalize';
-import { exportLayoutSnapshot } from '../scripts/export-board-snapshots';
+import { exportLayoutSnapshot, selectDeletionReplayBoundary } from '../scripts/export-board-snapshots';
 
 const USER_ID = 'snapshot-export-user';
 const BOARD_TYPE = 'kilter';
@@ -229,6 +229,107 @@ afterEach(() => {
 });
 
 describe('board-snapshot export ↔ live pull parity', () => {
+  it('models a long-running delete older than the stability window and fails closed without activity visibility', () => {
+    const boundary = selectDeletionReplayBoundary({
+      artifactBuiltAt: '2026-06-01T11:59:50.000Z',
+      exportTransactionStartedAt: '2026-06-01T12:00:00.000Z',
+      // This DELETE began two minutes before the export. Its deleted_at can be
+      // older than the ordinary 30-second stability boundary even though its
+      // uncommitted row remains visible in the artifact snapshot.
+      oldestActiveTransactionStartedAt: '2026-06-01T11:58:00.000Z',
+      stabilityWindowSeconds: 30,
+      visibilityEstablished: true,
+    });
+    expect(boundary).toBe('2026-06-01T11:58:00.000Z');
+
+    expect(
+      selectDeletionReplayBoundary({
+        artifactBuiltAt: '2026-06-01T11:59:50.000Z',
+        exportTransactionStartedAt: '2026-06-01T12:00:00.000Z',
+        oldestActiveTransactionStartedAt: null,
+        stabilityWindowSeconds: 30,
+        visibilityEstablished: false,
+      }),
+    ).toBeNull();
+
+    expect(
+      selectDeletionReplayBoundary({
+        artifactBuiltAt: new Date('invalid'),
+        exportTransactionStartedAt: '2026-06-01T12:00:00.000Z',
+        oldestActiveTransactionStartedAt: null,
+        stabilityWindowSeconds: 30,
+        visibilityEstablished: true,
+      }),
+    ).toBeNull();
+  });
+
+  it('samples an open delete transaction before fixing the artifact snapshot', async () => {
+    await insertClimb({ uuid: 'open-delete', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+
+    let releaseDeleteTransaction = (): void => {};
+    const deleteTransactionRelease = new Promise<void>((resolve) => {
+      releaseDeleteTransaction = resolve;
+    });
+    let resolveDeleteStarted!: (startedAt: string) => void;
+    let rejectDeleteStarted!: (error: unknown) => void;
+    const deleteStarted = new Promise<string>((resolve, reject) => {
+      resolveDeleteStarted = resolve;
+      rejectDeleteStarted = reject;
+    });
+    const deleteTransaction = createPool()
+      .begin(async (transaction) => {
+        await transaction.unsafe('DELETE FROM board_climbs WHERE uuid = $1', ['open-delete']);
+        const startRows = await transaction.unsafe('SELECT transaction_timestamp() AS xact_start');
+        const startRow = startRows[0] as unknown as { xact_start: unknown };
+        resolveDeleteStarted(new Date(Date.parse(toIso(startRow.xact_start))).toISOString());
+        await deleteTransactionRelease;
+      })
+      .catch((error: unknown) => {
+        rejectDeleteStarted(error);
+        throw error;
+      });
+
+    const deleteStartedAt = await deleteStarted;
+    const builtAtRow = (await db.execute(sql`SELECT clock_timestamp() AS built_at`))[0] as { built_at: unknown };
+    const artifactBuiltAt = toIso(builtAtRow.built_at);
+    const filePath = join(workDir, 'open-delete-artifact.db');
+    let replayBoundary: string | null = null;
+    try {
+      const result = await exportLayoutSnapshot({
+        sqlClient: createPool(),
+        boardType: BOARD_TYPE,
+        layoutId: LAYOUT_ID,
+        filePath,
+        builtAt: artifactBuiltAt,
+        stabilityWindowSeconds: 0,
+      });
+
+      // The uncommitted DELETE is invisible to the RR snapshot, so the row is
+      // present in the artifact. Its old transaction timestamp must therefore
+      // be the replay boundary that catches the tombstone after commit.
+      expect(readArtifactRows(filePath, 'board_climbs', ['uuid'])).toEqual([{ uuid: 'open-delete' }]);
+      const rawReplayBoundary = readArtifactMeta(filePath, 'sync_deletions')?.watermark_updated_at;
+      replayBoundary = typeof rawReplayBoundary === 'string' ? rawReplayBoundary : null;
+      expect(replayBoundary).toBe(deleteStartedAt);
+      expect(result.deletionsReplayFrom).toBe(deleteStartedAt);
+      expect(result.deletionsReplayFallbackReason).toBeNull();
+    } finally {
+      releaseDeleteTransaction();
+      await deleteTransaction;
+    }
+
+    const tombstone = (
+      await db.execute(sql`
+        SELECT deleted_at
+        FROM sync_deletions
+        WHERE table_name = 'board_climbs' AND record_id = 'open-delete'
+        ORDER BY id DESC
+        LIMIT 1
+      `)
+    )[0] as { deleted_at: unknown };
+    expect(Date.parse(replayBoundary ?? '')).toBeLessThanOrEqual(Date.parse(toIso(tombstone.deleted_at)));
+  });
+
   it('produces byte-identical board_climbs / board_climb_stats rows via the export core and the real resolver pull', async () => {
     // Tricky shapes: booleans, int[] and text[] arrays, NULLs in arrays/text,
     // fractional-second timestamps, multi-angle stats, and a climb with no stats.
@@ -385,6 +486,48 @@ describe('board-snapshot export ↔ live pull parity', () => {
     expect(statsMeta.watermark_sync_seq).toBe(String(statsWatermarkRow.sync_seq));
   });
 
+  it('records a deletion replay boundary from the export transaction clock minus the stability window', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+    const stabilityWindowSeconds = 30;
+    const beforeRow = (
+      await db.execute(sql`
+        SELECT
+          clock_timestamp() AS built_at,
+          clock_timestamp() - (${stabilityWindowSeconds} * INTERVAL '1 second') AS replay_from
+      `)
+    )[0] as { built_at: unknown; replay_from: unknown };
+    const artifactBuiltAt = toIso(beforeRow.built_at);
+
+    const filePath = join(workDir, 'artifact-deletion-replay.db');
+    await exportLayoutSnapshot({
+      sqlClient: createPool(),
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath,
+      builtAt: artifactBuiltAt,
+      stabilityWindowSeconds,
+    });
+
+    const afterRow = (
+      await db.execute(sql`
+        SELECT clock_timestamp() - (${stabilityWindowSeconds} * INTERVAL '1 second') AS replay_from
+      `)
+    )[0] as { replay_from: unknown };
+    const deletionMeta = readArtifactMeta(filePath, 'sync_deletions')!;
+    const replayFromMs = Date.parse(String(deletionMeta.watermark_updated_at));
+
+    expect(replayFromMs).toBeGreaterThanOrEqual(Date.parse(toIso(beforeRow.replay_from)));
+    expect(replayFromMs).toBeLessThanOrEqual(Date.parse(toIso(afterRow.replay_from)));
+    expect(deletionMeta).toMatchObject({
+      table_name: 'sync_deletions',
+      watermark_sync_seq: '0',
+      row_count: 0,
+      built_at: artifactBuiltAt,
+      schema_version: expect.any(Number),
+      format_version: 1,
+    });
+  });
+
   it('excludes a row inside the stability window from both the artifact and its watermark', async () => {
     // Old rows are well outside any window; the recent row is inside a 30s window.
     await insertClimb({ uuid: 'old-1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
@@ -483,11 +626,11 @@ describe('board_climb_grades snapshot artifact', () => {
     expect(artifactGrades).toHaveLength(3);
   });
 
-  it('leaves the WHOLE-LAYOUT artifact untouched — same tables, same two snapshot_meta rows', async () => {
-    // Every already-shipped binary verifies the whole-layout artifact against
-    // its own two-table list and throws "snapshot_meta missing row for <table>"
-    // on a mismatch. That failure is COUNTED, and two of them settle the scope
-    // onto the paged crawl — so growing this file's meta would break the fleet.
+  it('adds deletion replay metadata without changing the whole-layout data tables', async () => {
+    // Every already-shipped binary queries its two required snapshot_meta rows
+    // by name rather than requiring an exact row count. The metadata-only
+    // sync_deletions row is therefore ignored by old clients, while the file's
+    // actual board data tables remain byte-compatible.
     await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
     await insertGrade({ climbUuid: 'c1', angle: 40, localGrade: 20, computedAt: '2026-05-01T00:00:00Z' });
 
@@ -502,8 +645,34 @@ describe('board_climb_grades snapshot artifact', () => {
       stabilityWindowSeconds: 0,
     });
 
-    expect(readArtifactMetaTableNames(filePath)).toEqual(['board_climb_stats', 'board_climbs']);
+    expect(readArtifactMetaTableNames(filePath)).toEqual(['board_climb_stats', 'board_climbs', 'sync_deletions']);
     expect(readArtifactTableNames(filePath)).not.toContain('board_climb_grades');
+    expect(readArtifactTableNames(filePath)).not.toContain('sync_deletions');
+  });
+
+  it('surfaces a bounded fallback reason when a second observer connection is unavailable', async () => {
+    await insertClimb({ uuid: 'c1', compatibleSizeIds: [5], updatedAt: '2026-05-01T00:00:00Z' });
+
+    const primaryPool = createPool();
+    const singleConnectionObserverView = new Proxy(primaryPool, {
+      get(target, property) {
+        if (property === 'options') return { ...target.options, max: 1 };
+        return Reflect.get(target, property, target);
+      },
+    });
+    const filePath = join(workDir, 'observer-fallback-artifact.db');
+    const result = await exportLayoutSnapshot({
+      sqlClient: singleConnectionObserverView,
+      boardType: BOARD_TYPE,
+      layoutId: LAYOUT_ID,
+      filePath,
+      builtAt: BUILT_AT,
+      stabilityWindowSeconds: 0,
+    });
+
+    expect(result.deletionsReplayFrom).toBeNull();
+    expect(result.deletionsReplayFallbackReason).toBe('observer-pool-capacity');
+    expect(readArtifactMetaTableNames(filePath)).toEqual(['board_climb_stats', 'board_climbs']);
   });
 
   it('carries ONLY board_climb_grades and its own one-row snapshot_meta', async () => {

--- a/packages/backend/src/__tests__/snapshot-export-run.test.ts
+++ b/packages/backend/src/__tests__/snapshot-export-run.test.ts
@@ -23,6 +23,7 @@ vi.mock('../storage/s3', () => ({
 import { Readable } from 'node:stream';
 import { sql } from 'drizzle-orm';
 import { LATEST_SCHEMA_VERSION, type SnapshotManifest, type SnapshotManifestEntry } from '@boardsesh/offline-sync';
+import { createPool } from '@boardsesh/db/client';
 import { db } from '../db/client';
 import { uploadToS3, getFromS3Strict, deleteFromS3, listS3Objects } from '../storage/s3';
 import { runExport, mergeManifestEntries } from '../scripts/export-board-snapshots';
@@ -270,6 +271,33 @@ describe('runExport — threshold refresh', () => {
     expect(manifest.entries.find((entry) => entry.layoutId === 1)?.key).not.toBe(staleLayout.key);
     expect(manifest.entries.find((entry) => entry.layoutId === 2)).toEqual(currentLayout);
     // A partial live refresh never has enough information to prune safely.
+    expect(listS3Objects).not.toHaveBeenCalled();
+  });
+
+  it('keeps the previous live entry and uploads no replacement when the replay-boundary probe falls back', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+    await seedStatsDelta('kilter', 'k1-a', 1);
+    const previousEntry = manifestEntryFixture('kilter', 1, `${GZIP_PREFIX}/kilter/1/old.db`);
+    serveExistingManifest(manifestFixture([previousEntry]));
+
+    // Temporarily advertise one connection so the observer probe fails closed:
+    // the export transaction can still run, but its LayoutSnapshotResult carries
+    // observer-pool-capacity and no boundary. Restore the shared pool immediately.
+    const poolOptions = createPool().options as { max: number };
+    const originalPoolMax = poolOptions.max;
+    poolOptions.max = 1;
+    try {
+      await expect(runExport(['--gzip', '--key-prefix', GZIP_PREFIX, '--refresh-threshold', '1'])).rejects.toThrow(
+        /Export failed for 1 layout\(s\): kilter:1/,
+      );
+    } finally {
+      poolOptions.max = originalPoolMax;
+    }
+
+    const artifactUploads = vi.mocked(uploadToS3).mock.calls.filter(([, key]) => key !== GZIP_MANIFEST_KEY);
+    expect(artifactUploads).toHaveLength(0);
+    expect(uploadToS3).toHaveBeenCalledTimes(1);
+    expect(uploadedManifest(GZIP_MANIFEST_KEY).entries).toEqual([previousEntry]);
     expect(listS3Objects).not.toHaveBeenCalled();
   });
 
@@ -603,6 +631,16 @@ describe('runExport — gzip + key-prefix (dual-publish transition)', () => {
     await seedClimb('kilter', 1, 'k1-a');
     await expect(runExport(['--key-prefix', '../evil'])).rejects.toThrow(/--key-prefix expects a safe key/);
     await expect(runExport(['--key-prefix'])).rejects.toThrow(/--key-prefix expects a safe key/);
+    expect(uploadToS3).not.toHaveBeenCalled();
+  });
+
+  it('rejects an identity export aimed at the live gzip prefix before any upload', async () => {
+    await seedClimb('kilter', 1, 'k1-a');
+
+    await expect(runExport(['--key-prefix', GZIP_PREFIX])).rejects.toThrow(
+      '--key-prefix board-snapshots/v1-gzip requires --gzip',
+    );
+
     expect(uploadToS3).not.toHaveBeenCalled();
   });
 

--- a/packages/backend/src/scripts/export-board-snapshots.ts
+++ b/packages/backend/src/scripts/export-board-snapshots.ts
@@ -27,6 +27,7 @@
 // effects.
 
 import { pathToFileURL } from 'node:url';
+import { randomUUID } from 'node:crypto';
 import { DatabaseSync } from 'node:sqlite';
 import { gzipSync } from 'node:zlib';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
@@ -61,6 +62,7 @@ import { logger } from '../utils/logger';
 // side. Each prefix is a self-contained, single-encoding manifest: the merge and
 // prune logic below scope entirely to whichever prefix the run targets.
 const DEFAULT_SNAPSHOT_KEY_PREFIX = 'board-snapshots/v1';
+const LIVE_SNAPSHOT_KEY_PREFIX = 'board-snapshots/v1-gzip';
 // A safe key prefix: lowercase alphanumerics separated by single `-`/`/`, no
 // leading/trailing separator and no `..`. It's spliced into S3 object keys and
 // the manifest path, so validate it (mirrors SAFE_IDENTIFIER's intent for keys).
@@ -106,6 +108,14 @@ const EPOCH_WATERMARK_UPDATED_AT = '1970-01-01T00:00:00.000Z';
 const EPOCH_WATERMARK_SYNC_SEQ = '0';
 
 const SNAPSHOT_TABLES: readonly SnapshotTableName[] = ['board_climbs', 'board_climb_stats'];
+
+// Metadata-only row in the whole-layout artifact. It does NOT imply that the
+// artifact carries a sync_deletions data table: its watermark is the oldest
+// deletion timestamp that may still belong to a transaction invisible to the
+// export's REPEATABLE READ snapshot. Existing clients query only their two
+// required table names, so an extra snapshot_meta row is backwards-compatible.
+const DELETIONS_SNAPSHOT_META_TABLE = 'sync_deletions';
+const SNAPSHOT_EXPORT_APPLICATION_PREFIX = 'boardsesh-snapshot-export-';
 
 // The SEPARATE per-layout grades artifact's single table (issue #4310). It is
 // not folded into SNAPSHOT_TABLES on purpose: the client verifies a whole-layout
@@ -156,6 +166,22 @@ export type SnapshotTableExportResult = {
   watermarkSyncSeq: string;
 };
 
+/**
+ * Stable, bounded reasons an otherwise-valid artifact can omit the optional
+ * deletion replay metadata. These values are emitted in production exporter
+ * logs, so keep them low-cardinality and never append connection/session data.
+ */
+export type DeletionReplayFallbackReason =
+  | 'observer-pool-capacity'
+  | 'activity-probe-failed'
+  | 'exporter-transaction-not-observed'
+  | 'activity-visibility-incomplete'
+  | 'invalid-probe-timestamp';
+
+type DeletionReplayMetadataResult =
+  | { deletionsReplayFrom: string; deletionsReplayFallbackReason: null }
+  | { deletionsReplayFrom: null; deletionsReplayFallbackReason: DeletionReplayFallbackReason };
+
 export type LayoutSnapshotResult = {
   boardType: string;
   layoutId: number;
@@ -170,7 +196,7 @@ export type LayoutSnapshotResult = {
    * for any run that did not ask for one.
    */
   grades?: LayoutGradesSnapshotResult;
-};
+} & DeletionReplayMetadataResult;
 
 export type LayoutGradesSnapshotResult = {
   filePath: string;
@@ -435,13 +461,159 @@ async function tableWatermark(
   };
 }
 
+type DeletionReplayProbeRow = {
+  export_xact_start: unknown;
+  oldest_same_role_xact_start: unknown;
+  visibility_established: boolean;
+};
+
+function normalizedProbeTimestamp(rawTimestamp: unknown): { iso: string; timestampMs: number } | null {
+  if (rawTimestamp === null || rawTimestamp === undefined) return null;
+  try {
+    const timestampMs = Date.parse(toIso(rawTimestamp));
+    if (!Number.isFinite(timestampMs)) return null;
+    return { iso: new Date(timestampMs).toISOString(), timestampMs };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pick the oldest safe replay bound. Export `builtAt` is included deliberately:
+ * it is chosen before any layout transaction, so it both supplies a client-side
+ * validation ceiling and safely widens later layouts whose transaction clock is
+ * more than one stability window after the run began.
+ */
+export function selectDeletionReplayBoundary(params: {
+  artifactBuiltAt: unknown;
+  exportTransactionStartedAt: unknown;
+  oldestActiveTransactionStartedAt: unknown;
+  stabilityWindowSeconds: number;
+  visibilityEstablished: boolean;
+}): string | null {
+  if (!params.visibilityEstablished) return null;
+  const artifactBuiltAt = normalizedProbeTimestamp(params.artifactBuiltAt);
+  const exportTransactionStartedAt = normalizedProbeTimestamp(params.exportTransactionStartedAt);
+  if (!artifactBuiltAt || !exportTransactionStartedAt) return null;
+
+  const stabilityBoundaryMs =
+    exportTransactionStartedAt.timestampMs - Math.max(0, params.stabilityWindowSeconds) * 1000;
+  const oldestActiveTransaction = normalizedProbeTimestamp(params.oldestActiveTransactionStartedAt);
+  const replayFromMs = Math.min(
+    artifactBuiltAt.timestampMs,
+    stabilityBoundaryMs,
+    oldestActiveTransaction?.timestampMs ?? Number.POSITIVE_INFINITY,
+  );
+  return new Date(replayFromMs).toISOString();
+}
+
+/**
+ * Observe the open export transaction from a SECOND primary-pool connection.
+ * The export connection has run only SET commands at this point, so its
+ * REPEATABLE READ data snapshot is not fixed yet. Sampling activity first and
+ * reading artifact rows second closes the opposite ordering's race: a long
+ * delete cannot commit after the RR snapshot is fixed but before pg_stat_activity
+ * notices it has disappeared.
+ *
+ * Fail closed. PostgreSQL exposes full activity details to ordinary users only
+ * for sessions owned by the same role. Production writers and this exporter use
+ * that one role; ANY other-role client in this database, hidden/disabled peer
+ * state, a prepared transaction (not represented in pg_stat_activity), a
+ * missing exporter row, or a query/pool failure returns a bounded fallback
+ * reason. The artifact then omits this optional row and clients use the older
+ * scoped-row watermark rewind. `runExport` logs the boundary or that stable
+ * reason for every layout without exposing peer-session details.
+ */
+async function probeDeletionReplayBoundary(params: {
+  sqlClient: Sql;
+  applicationName: string;
+  artifactBuiltAt: string;
+  stabilityWindowSeconds: number;
+}): Promise<DeletionReplayMetadataResult> {
+  const { sqlClient, applicationName, artifactBuiltAt, stabilityWindowSeconds } = params;
+  // The observer must not queue behind the export connection forever. The
+  // production primary pool has max=10; a generic/max=1 caller still gets a
+  // valid artifact, just without this optional optimization.
+  const configuredPoolMax = (sqlClient as Sql & { options?: { max?: unknown } }).options?.max;
+  if (typeof configuredPoolMax !== 'number' || configuredPoolMax < 2) {
+    return { deletionsReplayFrom: null, deletionsReplayFallbackReason: 'observer-pool-capacity' };
+  }
+  try {
+    const rows = await sqlClient.unsafe(
+      `SELECT
+         exporter.xact_start AS export_xact_start,
+         (
+           SELECT min(peer.xact_start)
+           FROM pg_stat_activity peer
+           WHERE peer.datname = exporter.datname
+             AND peer.usesysid = exporter.usesysid
+             AND peer.backend_type = 'client backend'
+             AND peer.pid NOT IN (exporter.pid, pg_backend_pid())
+             AND peer.xact_start IS NOT NULL
+         ) AS oldest_same_role_xact_start,
+         current_setting('track_activities', true) = 'on'
+           AND exporter.xact_start IS NOT NULL
+           AND NOT EXISTS (
+             SELECT 1
+             FROM pg_prepared_xacts prepared
+             WHERE prepared.database = exporter.datname
+           )
+           AND NOT EXISTS (
+             SELECT 1
+             FROM pg_stat_activity peer
+             WHERE peer.datname = exporter.datname
+               AND peer.backend_type = 'client backend'
+               AND peer.pid NOT IN (exporter.pid, pg_backend_pid())
+               AND (
+                 peer.usesysid IS DISTINCT FROM exporter.usesysid
+                 OR peer.state IS NULL
+                 OR peer.state = 'disabled'
+                 OR (peer.state <> 'idle' AND peer.xact_start IS NULL)
+               )
+           ) AS visibility_established
+       FROM pg_stat_activity exporter
+       WHERE exporter.datname = current_database()
+         AND exporter.backend_type = 'client backend'
+         AND exporter.application_name = $1`,
+      [applicationName],
+    );
+    if (rows.length !== 1) {
+      return {
+        deletionsReplayFrom: null,
+        deletionsReplayFallbackReason: 'exporter-transaction-not-observed',
+      };
+    }
+    const probe = rows[0] as unknown as DeletionReplayProbeRow;
+    if (probe.visibility_established !== true) {
+      return {
+        deletionsReplayFrom: null,
+        deletionsReplayFallbackReason: 'activity-visibility-incomplete',
+      };
+    }
+    const deletionsReplayFrom = selectDeletionReplayBoundary({
+      artifactBuiltAt,
+      exportTransactionStartedAt: probe.export_xact_start,
+      oldestActiveTransactionStartedAt: probe.oldest_same_role_xact_start,
+      stabilityWindowSeconds,
+      visibilityEstablished: true,
+    });
+    if (!deletionsReplayFrom) {
+      return { deletionsReplayFrom: null, deletionsReplayFallbackReason: 'invalid-probe-timestamp' };
+    }
+    return { deletionsReplayFrom, deletionsReplayFallbackReason: null };
+  } catch {
+    return { deletionsReplayFrom: null, deletionsReplayFallbackReason: 'activity-probe-failed' };
+  }
+}
+
 // --- Layout snapshot build ----------------------------------------------------
 
-/** Writes one `snapshot_meta` row per table into an artifact. */
+/** Writes required table metadata plus the optional deletion replay boundary. */
 function writeSnapshotMeta(
   sqliteDb: DatabaseSync,
   builtAt: string,
   tables: Record<string, SnapshotTableExportResult>,
+  deletionsReplayFrom?: string | null,
 ): void {
   const insertMeta = sqliteDb.prepare(
     `INSERT OR REPLACE INTO snapshot_meta
@@ -454,6 +626,17 @@ function writeSnapshotMeta(
       tableResult.watermarkUpdatedAt,
       tableResult.watermarkSyncSeq,
       tableResult.rowCount,
+      builtAt,
+      LATEST_SCHEMA_VERSION,
+      SNAPSHOT_MANIFEST_FORMAT_VERSION,
+    );
+  }
+  if (deletionsReplayFrom) {
+    insertMeta.run(
+      DELETIONS_SNAPSHOT_META_TABLE,
+      deletionsReplayFrom,
+      EPOCH_WATERMARK_SYNC_SEQ,
+      0,
       builtAt,
       LATEST_SCHEMA_VERSION,
       SNAPSHOT_MANIFEST_FORMAT_VERSION,
@@ -473,9 +656,10 @@ function writeSnapshotMeta(
  * `board_climbs`, so a climb committed between the two reads would otherwise
  * make the grade rows and the climbs they hang off disagree.
  *
- * The whole-layout artifact is BYTE-FOR-BYTE what it was before grades existed
- * — same DDL, same two tables, same two `snapshot_meta` rows — because every
- * shipped binary verifies it against a two-table list.
+ * The whole-layout DATA tables remain byte-for-byte what they were before
+ * grades existed. Its additive metadata-only sync_deletions row is safe for old
+ * clients because they query the two required snapshot_meta rows by name and
+ * ignore extras.
  */
 export async function exportLayoutSnapshot(params: {
   sqlClient: Sql;
@@ -509,6 +693,18 @@ export async function exportLayoutSnapshot(params: {
     gradesDb?.exec('BEGIN');
     const streamed = await sqlClient.begin(async (tx) => {
       await tx.unsafe('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ');
+      const exportApplicationName = `${SNAPSHOT_EXPORT_APPLICATION_PREFIX}${randomUUID()}`;
+      // SET does not acquire the REPEATABLE READ data snapshot. The second-
+      // connection activity probe MUST finish before the first artifact SELECT;
+      // see probeDeletionReplayBoundary for the commit-between-sample race this
+      // ordering closes. The generated value contains only a fixed prefix + UUID.
+      await tx.unsafe(`SET LOCAL application_name = '${exportApplicationName}'`);
+      const deletionReplayMetadata = await probeDeletionReplayBoundary({
+        sqlClient,
+        applicationName: exportApplicationName,
+        artifactBuiltAt: builtAt,
+        stabilityWindowSeconds,
+      });
 
       const climbColumns = TABLE_CONFIGS.board_climbs.localColumns;
       const statsColumns = TABLE_CONFIGS.board_climb_stats.localColumns;
@@ -540,7 +736,7 @@ export async function exportLayoutSnapshot(params: {
         board_climb_stats: { rowCount: statsRowCount, ...statsWatermark },
       } satisfies Record<SnapshotTableName, SnapshotTableExportResult>;
 
-      if (!gradesDb) return { tables, gradesTables: null };
+      if (!gradesDb) return { tables, gradesTables: null, ...deletionReplayMetadata };
 
       const gradesRowCount = await streamTableIntoSqlite(
         tx,
@@ -555,13 +751,14 @@ export async function exportLayoutSnapshot(params: {
 
       return {
         tables,
+        ...deletionReplayMetadata,
         gradesTables: {
           board_climb_grades: { rowCount: gradesRowCount, ...gradesWatermark },
         } satisfies Record<SnapshotGradesTableName, SnapshotTableExportResult>,
       };
     });
 
-    writeSnapshotMeta(sqliteDb, builtAt, streamed.tables);
+    writeSnapshotMeta(sqliteDb, builtAt, streamed.tables, streamed.deletionsReplayFrom);
     sqliteDb.exec('COMMIT');
 
     let grades: LayoutGradesSnapshotResult | undefined;
@@ -576,6 +773,14 @@ export async function exportLayoutSnapshot(params: {
       }
     }
 
+    const deletionReplayMetadata: DeletionReplayMetadataResult =
+      streamed.deletionsReplayFrom === null
+        ? {
+            deletionsReplayFrom: null,
+            deletionsReplayFallbackReason: streamed.deletionsReplayFallbackReason,
+          }
+        : { deletionsReplayFrom: streamed.deletionsReplayFrom, deletionsReplayFallbackReason: null };
+
     return {
       boardType,
       layoutId,
@@ -583,6 +788,7 @@ export async function exportLayoutSnapshot(params: {
       builtAt,
       schemaVersion: LATEST_SCHEMA_VERSION,
       tables: streamed.tables,
+      ...deletionReplayMetadata,
       ...(grades ? { grades } : {}),
     };
   } catch (error) {
@@ -871,6 +1077,13 @@ export async function runExport(argv: string[]): Promise<void> {
   const keyPrefix = options.keyPrefix;
   const manifestKey = manifestKeyForPrefix(keyPrefix);
 
+  // The production fleet reads this prefix as gzip. A mistyped manual command
+  // must not replace it with an identity artifact or bypass its replay-boundary
+  // publication gate; the workflow always supplies this exact pairing.
+  if (keyPrefix === LIVE_SNAPSHOT_KEY_PREFIX && !options.gzip) {
+    throw new Error(`--key-prefix ${LIVE_SNAPSHOT_KEY_PREFIX} requires --gzip`);
+  }
+
   if (options.dryRun && isThresholdRefresh) {
     throw new Error(
       '--dry-run cannot be combined with --refresh-threshold: threshold selection requires the live manifest',
@@ -993,6 +1206,18 @@ export async function runExport(argv: string[]): Promise<void> {
           ...(options.gzip ? { gradesFilePath } : {}),
         });
 
+        // The fleet reads only the gzip prefix. Publishing a newly-built live
+        // artifact without the conservative deletion replay boundary can turn
+        // the next import into a huge JS-native tombstone crawl, so fail this
+        // layout closed before any of its objects upload. The per-layout catch
+        // preserves its previous immutable manifest entry, successful siblings
+        // still publish, and the run fails at the end so the queued refresh
+        // retries. Identity (rollback) exports and dry-runs remain observable
+        // but ungated.
+        if (keyPrefix === LIVE_SNAPSHOT_KEY_PREFIX && !options.dryRun && result.deletionsReplayFrom === null) {
+          throw new Error(`live gzip deletion replay boundary unavailable: ${result.deletionsReplayFallbackReason}`);
+        }
+
         const rawBuffer = readFileSync(filePath);
         // Encoding default is IDENTITY until transparent Content-Encoding: gzip
         // decode is verified on-device for both platforms: straight-to-disk
@@ -1027,6 +1252,8 @@ export async function runExport(argv: string[]): Promise<void> {
             uploadBytes: uploadBody.length,
             gradesUploadBytes: gradesUploadBody?.length ?? 0,
             contentEncoding,
+            deletionsReplayFrom: result.deletionsReplayFrom,
+            deletionsReplayFallbackReason: result.deletionsReplayFallbackReason,
             durationMs: Date.now() - startedAt,
           });
           // publicUrlForKey may fall back to getPublicUrl, which instantiates
@@ -1077,6 +1304,8 @@ export async function runExport(argv: string[]): Promise<void> {
             contentEncoding,
             key: uploaded.key,
             gradesKey: uploadedGrades?.key ?? null,
+            deletionsReplayFrom: result.deletionsReplayFrom,
+            deletionsReplayFallbackReason: result.deletionsReplayFallbackReason,
             durationMs: Date.now() - startedAt,
           });
           newEntries.push(

--- a/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
@@ -768,6 +768,190 @@ describe('My Boards with no usable network list', () => {
     expect(row?.getAttribute('data-download-count')).toBe('73');
   });
 
+  it.each(['deletions', 'user_data'] as const)(
+    'shows incomplete scopes as finalizing during shared %s work',
+    (phase) => {
+      state.profileId = 'me';
+      state.myBoards = {
+        data: {
+          boards: [
+            board({ uuid: 'board-a', name: 'Board A' }),
+            board({ uuid: 'board-b', name: 'Board B', boardType: 'tension', layoutId: 2, sizeId: 10 }),
+            board({ uuid: 'board-c', name: 'Board C', boardType: 'tension', layoutId: 3, sizeId: 12 }),
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        isRefetching: false,
+      };
+      state.enabledBoards = ['kilter:8:17', 'tension:2:10', 'tension:3:12'];
+      state.downloadedScopeKeys = ['kilter:8:17'];
+      state.bootstrapMetadataByScope = new Map([
+        [
+          'tension:2:10',
+          {
+            attempts: 0,
+            isBootstrapDone: true,
+            isPagedFallback: false,
+            hasBoardCheckpoint: true,
+            isScopeComplete: false,
+          },
+        ],
+        [
+          'tension:3:12',
+          {
+            attempts: 1,
+            isBootstrapDone: false,
+            isPagedFallback: true,
+            hasBoardCheckpoint: false,
+            isScopeComplete: false,
+            isTerminal: true,
+          },
+        ],
+      ]);
+      state.syncStatus = {
+        isSyncing: true,
+        progress: {
+          phase,
+          currentTable: phase === 'user_data' ? 'boardsesh_ticks' : null,
+        },
+        bootstrapMetadataRevision: 0,
+        scopeCompletionRevision: 0,
+      };
+
+      render(createElement(ManageBoards));
+
+      expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-download-state')).toBe('downloaded');
+      expect(document.querySelector('[data-board="board-b"]')?.getAttribute('data-download-state')).toBe('finalizing');
+      expect(document.querySelector('[data-board="board-c"]')?.getAttribute('data-download-state')).toBe('pending');
+      expect(document.querySelector('[data-board="board-c"]')?.getAttribute('data-download-notice')).toBe(
+        'paged-fallback',
+      );
+    },
+  );
+
+  it.each([
+    ['bootstrap', 'tension:2:10', false],
+    ['board_data', 'board_climbs:tension:2:10', true],
+  ] as const)(
+    'keeps imported scope A finalizing while scope B is active in %s',
+    (phase, currentTable, isSecondBootstrapDone) => {
+      state.profileId = 'me';
+      state.myBoards = {
+        data: {
+          boards: [
+            board({ uuid: 'board-a', name: 'Board A' }),
+            board({ uuid: 'board-b', name: 'Board B', boardType: 'tension', layoutId: 2, sizeId: 10 }),
+          ],
+        },
+        isLoading: false,
+        isError: false,
+        isRefetching: false,
+      };
+      state.enabledBoards = ['kilter:8:17', 'tension:2:10'];
+      state.bootstrapMetadataByScope = new Map([
+        [
+          'kilter:8:17',
+          {
+            attempts: 0,
+            isBootstrapDone: true,
+            isPagedFallback: false,
+            hasBoardCheckpoint: true,
+            isScopeComplete: false,
+          },
+        ],
+        [
+          'tension:2:10',
+          {
+            attempts: 0,
+            isBootstrapDone: isSecondBootstrapDone,
+            isPagedFallback: false,
+            hasBoardCheckpoint: isSecondBootstrapDone,
+            isScopeComplete: false,
+          },
+        ],
+      ]);
+      state.syncStatus = {
+        isSyncing: true,
+        progress: { phase, currentTable },
+        bootstrapMetadataRevision: isSecondBootstrapDone ? 2 : 1,
+        scopeCompletionRevision: 0,
+      };
+
+      render(createElement(ManageBoards));
+
+      expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-download-state')).toBe('finalizing');
+      expect(document.querySelector('[data-board="board-b"]')?.getAttribute('data-download-state')).toBe('downloading');
+    },
+  );
+
+  it('uses the bootstrap metadata revision to finalize the last imported scope at deletion handoff', async () => {
+    state.profileId = 'me';
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'board-a', name: 'Board A' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+    state.enabledBoards = ['kilter:8:17'];
+    const beforeImport = new Map([
+      [
+        'kilter:8:17',
+        {
+          attempts: 0,
+          isBootstrapDone: false,
+          isPagedFallback: false,
+          hasBoardCheckpoint: false,
+          isScopeComplete: false,
+        },
+      ],
+    ]);
+    state.bootstrapQueryAsync = true;
+    state.bootstrapMetadataRead = Promise.resolve(beforeImport);
+    state.syncStatus = {
+      isSyncing: true,
+      progress: { phase: 'bootstrap', currentTable: 'kilter:8:17' },
+      bootstrapMetadataRevision: 0,
+      scopeCompletionRevision: 0,
+    };
+
+    const { rerender } = render(createElement(ManageBoards));
+    await waitFor(() =>
+      expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-download-state')).toBe('downloading'),
+    );
+
+    const afterImport = new Map([
+      [
+        'kilter:8:17',
+        {
+          attempts: 0,
+          isBootstrapDone: true,
+          isPagedFallback: false,
+          hasBoardCheckpoint: true,
+          isScopeComplete: false,
+        },
+      ],
+    ]);
+    const refreshedMetadata = deferred<ReadonlyMap<string, unknown>>();
+    state.bootstrapMetadataRead = refreshedMetadata.promise;
+    state.syncStatus = {
+      isSyncing: true,
+      progress: { phase: 'deletions', currentTable: null },
+      bootstrapMetadataRevision: 1,
+      scopeCompletionRevision: 0,
+    };
+    rerender(createElement(ManageBoards));
+
+    // The prior revision's unfinished marker is rejected while the new-key read
+    // is pending, so the row cannot claim finalizing until SQLite confirms it.
+    expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-download-state')).toBe('pending');
+
+    await act(async () => refreshedMetadata.resolve(afterImport));
+    await waitFor(() =>
+      expect(document.querySelector('[data-board="board-a"]')?.getAttribute('data-download-state')).toBe('finalizing'),
+    );
+  });
+
   it('clears the first scope on completion while a second scope keeps downloading', () => {
     state.profileId = 'me';
     state.myBoards = {

--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -176,6 +176,7 @@ export default function BoardSelection() {
       boardDownloadState({
         scopeKey: offlineBoardKeyForBoard(board),
         enabled: enabledScopeKeys.includes(offlineBoardKeyForBoard(board)),
+        isBootstrapDone: false,
         downloaded: (downloadedScopeKeys ?? []).includes(offlineBoardKeyForBoard(board)),
         isSyncing: false,
         currentTable: null,

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -33,7 +33,6 @@ import { useConfirmBoardDownload } from '../../src/offline/use-confirm-board-dow
 import { useDownloadedScopeKeys } from '../../src/offline/use-downloaded-scope-keys';
 import { useRememberDownloadedBoards } from '../../src/offline/use-remember-downloaded-boards';
 import { useSnapshotSource } from '../../src/offline/use-snapshot-source';
-import { useOfflineSchemaReady } from '../../src/db/use-offline-schema-ready';
 import { formatBytes } from '../../src/lib/format-bytes';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../../src/lib/analytics';
@@ -139,9 +138,6 @@ export default function ManageBoards() {
   const snapshotManifestRef = useRef(snapshotManifest);
   snapshotManifestRef.current = snapshotManifest;
   const db = useSQLiteContext();
-  // This connection is handed out as soon as the launch gate opens — after the first
-  // init attempt, whatever it did — so on a contended launch it has no tables yet.
-  const schemaReady = useOfflineSchemaReady();
   const syncStatus = useSyncStatus();
   // Mirrored for the toggle-off handler, which only reads it at tap time: keeping
   // the live status out of that callback's deps means a progress frame can't churn
@@ -473,6 +469,7 @@ export default function ManageBoards() {
       const downloadStateInput = {
         scopeKey,
         enabled: enabledSet.has(scopeKey),
+        isBootstrapDone: bootstrapMetadata?.isBootstrapDone ?? false,
         isSyncing,
         downloaded: isDownloaded,
         currentTable,

--- a/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
+++ b/packages/mobile/src/components/__tests__/offline-sync-bridge.test.tsx
@@ -100,7 +100,7 @@ vi.mock('../../notifications', () => ({
 }));
 
 vi.mock('../../lib/graphql/client', () => ({
-  getHttpClient: () => ({ request: vi.fn() }),
+  getOfflineSyncHttpClient: () => ({ request: vi.fn() }),
 }));
 
 const snapshotBaseUrlConfigured = vi.hoisted(() => ({ value: true }));

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -132,7 +132,9 @@ export function BoardDiscoveryCard({ item, onPress, onDownload, downloadLabel }:
           <View style={styles.offlineBadge}>
             <Icon name="offline.downloaded" size={15} color={brandColors.primary} />
           </View>
-        ) : item.offlineState === 'downloading' || item.offlineState === 'pending' ? (
+        ) : item.offlineState === 'downloading' ||
+          item.offlineState === 'finalizing' ||
+          item.offlineState === 'pending' ? (
           <View style={styles.offlineBadge}>
             <Icon name="offline.pending" size={15} color={systemColors.secondaryLabel} />
           </View>

--- a/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
@@ -171,9 +171,11 @@ function BoardManageRowComponent({
             : t('mobile.offline.downloadingCount', { count: downloadCount ?? 0 })
           : downloadState === 'downloaded'
             ? t('mobile.offline.available')
-            : downloadState === 'pending'
-              ? t('mobile.offline.pending')
-              : null;
+            : downloadState === 'finalizing'
+              ? t('mobile.offline.finalizing')
+              : downloadState === 'pending'
+                ? t('mobile.offline.pending')
+                : null;
 
   const offlineStatusAccessibilityLabel =
     effectiveDownloadNotice === 'snapshot-retrying'

--- a/packages/mobile/src/components/board-discovery/BoardOfflineToggle.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardOfflineToggle.tsx
@@ -19,12 +19,13 @@ const HIT_SLOP = { top: spacing[2], bottom: spacing[2], left: spacing[2], right:
  * Compact plain-RN offline control for a board row — an icon button (never an
  * @expo/ui Host, to keep the FlashList light). Dumb + memoised: it renders the
  * glyph for the primitive `state` and calls `onPress`; the parent owns the
- * toggle logic and the status text. Downloading shows a spinner (no tap target).
+ * toggle logic and the status text. Active download work shows a spinner (no
+ * tap target), including the shared finalizing phases after snapshots land.
  */
 function BoardOfflineToggleComponent({ state, onPress, accessibilityLabel, disabled }: BoardOfflineToggleProps) {
   const { systemColors, brandColors } = useTheme();
 
-  if (state === 'downloading') {
+  if (state === 'downloading' || state === 'finalizing') {
     return <ActivityIndicator size="small" style={styles.control} />;
   }
 

--- a/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-discovery-card.test.tsx
@@ -101,6 +101,7 @@ describe('BoardDiscoveryCard', () => {
   it.each([
     ['downloaded', 'offline.downloaded'],
     ['downloading', 'offline.pending'],
+    ['finalizing', 'offline.pending'],
     ['pending', 'offline.pending'],
   ] as const)('shows a status badge for a %s board', (offlineState, icon) => {
     const { container } = render(

--- a/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
@@ -172,6 +172,13 @@ describe('BoardManageRow offline toggle gating', () => {
     expect(offlineToggleProps.last?.state).toBe('downloaded');
   });
 
+  it('shows a finishing caption while shared post-download work is still running', () => {
+    const { queryByText } = render(<BoardManageRow {...rowProps} downloadState="finalizing" />);
+    expect(queryByText('mobile.offline.finalizing')).not.toBeNull();
+    expect(queryByText('mobile.offline.pending')).toBeNull();
+    expect(offlineToggleProps.last?.state).toBe('finalizing');
+  });
+
   it('shows the bootstrapping caption (not the climb count) during the snapshot warm-up', () => {
     const { queryByText } = render(
       <BoardManageRow {...rowProps} downloadState="downloading" isBootstrapping downloadCount={0} />,

--- a/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
@@ -11,6 +11,7 @@ import type { SnapshotBootstrapProgress } from '@boardsesh/offline-sync';
 const base = {
   scopeKey: 'kilter:1:5',
   enabled: true,
+  isBootstrapDone: false,
   isSyncing: false,
   downloaded: false,
   currentTable: null as string | null,
@@ -53,6 +54,7 @@ describe('boardDownloadState', () => {
       boardDownloadState({
         scopeKey: 'kilter:1:50',
         enabled: true,
+        isBootstrapDone: false,
         isSyncing: true,
         downloaded: false,
         currentTable: 'board_climbs:kilter:1:5',
@@ -65,6 +67,7 @@ describe('boardDownloadState', () => {
       boardDownloadState({
         scopeKey: 'kilter:1:50',
         enabled: true,
+        isBootstrapDone: false,
         isSyncing: true,
         downloaded: false,
         currentTable: 'board_climb_grades:kilter:1:5',
@@ -82,6 +85,58 @@ describe('boardDownloadState', () => {
         currentTable: 'board_climbs:tension:8:10',
       }),
     ).toBe('pending');
+  });
+
+  it.each([
+    ['bootstrap', 'tension:8:10'],
+    ['deletions', null],
+    ['user_data', 'boardsesh_ticks'],
+    ['board_data', 'board_climbs:tension:8:10'],
+  ] as const)(
+    'is finalizing during the active %s phase once its snapshot imported but the scope is incomplete',
+    (phase, currentTable) => {
+      expect(
+        boardDownloadState({
+          ...base,
+          isBootstrapDone: true,
+          isSyncing: true,
+          downloaded: false,
+          currentTable,
+          phase,
+        }),
+      ).toBe('finalizing');
+    },
+  );
+
+  it.each([
+    ['bootstrap', 'tension:8:10'],
+    ['deletions', null],
+    ['user_data', 'boardsesh_ticks'],
+    ['board_data', 'board_climbs:tension:8:10'],
+  ] as const)('stays pending during active %s work when snapshot bootstrap did not land', (phase, currentTable) => {
+    expect(
+      boardDownloadState({
+        ...base,
+        isBootstrapDone: false,
+        isSyncing: true,
+        currentTable,
+        phase,
+      }),
+    ).toBe('pending');
+  });
+
+  it('does not call an incomplete board finalizing when no sync cycle is active', () => {
+    expect(boardDownloadState({ ...base, isBootstrapDone: true, isSyncing: false, phase: 'deletions' })).toBe(
+      'pending',
+    );
+  });
+
+  it.each([null, 'idle'] as const)('does not call an imported board finalizing for a %s progress phase', (phase) => {
+    expect(boardDownloadState({ ...base, isBootstrapDone: true, isSyncing: true, phase })).toBe('pending');
+  });
+
+  it('keeps a completed board downloaded during shared finalizing work', () => {
+    expect(boardDownloadState({ ...base, isSyncing: true, downloaded: true, phase: 'deletions' })).toBe('downloaded');
   });
 
   it('stays downloaded when a later cycle is syncing a different board', () => {
@@ -106,6 +161,7 @@ describe('boardDownloadState', () => {
       boardDownloadState({
         scopeKey: 'kilter:1:50',
         enabled: true,
+        isBootstrapDone: false,
         isSyncing: true,
         downloaded: false,
         currentTable: 'kilter:1:5',
@@ -151,6 +207,7 @@ describe('boardIsBootstrapping', () => {
       boardIsBootstrapping({
         scopeKey: 'kilter:1:50',
         enabled: true,
+        isBootstrapDone: false,
         isSyncing: true,
         downloaded: false,
         currentTable: 'kilter:1:5',

--- a/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-offline-state.test.ts
@@ -245,6 +245,17 @@ describe('boardDownloadNotice', () => {
     );
   });
 
+  it('shows the live paged-fallback notice when a crawl is active after snapshot retry evidence', () => {
+    expect(
+      boardDownloadNotice({
+        ...noticeBase,
+        bootstrapAttempts: 1,
+        retryAfter: 1_800_000_000_000,
+        isPagedDownloadActive: true,
+      }),
+    ).toBe('paged-fallback');
+  });
+
   it('shows a paged-fallback notice once both snapshot budgets are spent', () => {
     expect(boardDownloadNotice({ ...noticeBase, bootstrapAttempts: 2, isTerminal: true })).toBe('paged-fallback');
   });

--- a/packages/mobile/src/components/board-discovery/__tests__/board-offline-toggle.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-offline-toggle.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('react-native', () => ({
+  Pressable: ({ children }: { children?: ReactNode }) => createElement('button', null, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { secondaryLabel: '#888' },
+    brandColors: { primary: '#6D28D9' },
+  }),
+}));
+vi.mock('../../../theme/tokens', () => ({ spacing: new Proxy({}, { get: () => 4 }) }));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('span', { 'data-testid': 'icon' }) }));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('span', { 'data-testid': 'spinner' }),
+}));
+
+import { BoardOfflineToggle } from '../BoardOfflineToggle';
+
+afterEach(cleanup);
+
+describe('BoardOfflineToggle', () => {
+  it('shows non-actionable activity while shared work finalizes the download', () => {
+    const { getByTestId, queryByRole } = render(
+      <BoardOfflineToggle state="finalizing" onPress={vi.fn()} accessibilityLabel="Remove board from offline" />,
+    );
+
+    expect(getByTestId('spinner')).toBeTruthy();
+    expect(queryByRole('button')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/board-discovery/board-offline-state.ts
+++ b/packages/mobile/src/components/board-discovery/board-offline-state.ts
@@ -232,9 +232,19 @@ export function boardDownloadNotice(input: BoardDownloadNoticeInput): BoardDownl
     input.isBootstrapping
   )
     return null;
-  // A settled scope is the only permanent verdict now. A scheduled retry keeps
-  // the softer "we'll try the fast download again" caption even though the crawl
-  // is running underneath it, because that is exactly what will happen.
+  // Once the ordinary crawl is visibly active, describe the work happening now
+  // and let the row show its live count. Keeping a future snapshot-retry caption
+  // here hid a real 500-row crawl behind a static spinner, making progress look
+  // wedged even though rows were landing.
+  if (
+    input.isPagedDownloadActive &&
+    (input.isTerminal || input.isPagedFallback || input.retryAfter !== null || input.bootstrapAttempts > 0)
+  ) {
+    return 'paged-fallback';
+  }
+  // A settled scope is the only permanent verdict now. Outside an active crawl,
+  // a scheduled retry keeps the softer "we'll try the fast download again"
+  // caption because that is exactly what will happen.
   if (input.isTerminal) return 'paged-fallback';
   if (input.retryAfter !== null) return 'snapshot-retrying';
   if (input.isPagedFallback) return 'paged-fallback';

--- a/packages/mobile/src/components/board-discovery/board-offline-state.ts
+++ b/packages/mobile/src/components/board-discovery/board-offline-state.ts
@@ -8,13 +8,14 @@ export type BoardDownloadState =
   | 'off' // not made available offline
   | 'pending' // enabled but not yet pulled (e.g. enabled while offline)
   | 'downloading' // the pull is fetching this exact board right now
+  | 'finalizing' // snapshot imported; shared work is running before scope completion
   | 'downloaded'; // a sync cycle has completed since it was enabled
 
 /**
  * A persisted explanation for an in-progress offline download. This is kept
  * separate from BoardDownloadState: the download still has the same pending /
- * downloading lifecycle, but a failed snapshot bootstrap changes what the user
- * should expect next.
+ * downloading / finalizing lifecycle, but a failed snapshot bootstrap changes
+ * what the user should expect next.
  */
 export type BoardDownloadNotice = 'snapshot-retrying' | 'paged-fallback' | null;
 
@@ -23,6 +24,8 @@ export type BoardDownloadStateInput = {
   scopeKey: string;
   /** Whether this scope key is in syncEnabledBoards. */
   enabled: boolean;
+  /** Durable marker set only after this scope's snapshot artifact imports successfully. */
+  isBootstrapDone: boolean;
   /** From useSyncStatus(): a cycle is mid-flight. */
   isSyncing: boolean;
   /**
@@ -34,11 +37,12 @@ export type BoardDownloadStateInput = {
   /** From useSyncStatus().progress: the table:scope label being pulled, or null. */
   currentTable: string | null;
   /**
-   * From useSyncStatus().progress?.phase: which pull phase is running. Only
-   * matters for distinguishing the snapshot-bootstrap warm-up (currentTable is
-   * the bare scope key, not a `table:scope` label) from the paged crawl.
-   * Undefined/null is treated as "not bootstrapping" — the paged-crawl match
-   * below still applies.
+   * From useSyncStatus().progress?.phase: which pull phase is running. This
+   * distinguishes the snapshot-bootstrap warm-up (currentTable is the bare
+   * scope key) and active phases that are finalizing an imported sibling scope
+   * from an idle or absent progress frame.
+   * Undefined/null is treated as neither bootstrapping nor finalizing — the
+   * paged-crawl match below still applies.
    */
   phase?: SyncProgress['phase'] | null;
 };
@@ -60,8 +64,9 @@ function isBootstrappingThisScope(
  * tables (matched exactly so a sibling scope, e.g. kilter:1:50 vs kilter:1:5,
  * can't cross-trigger) OR while it's being warmed from a snapshot artifact.
  * "downloaded" is driven by this scope's own checkpoint, so a board enabled
- * after another already synced shows "pending" (not a false "downloaded")
- * until its own data lands.
+ * after another already synced never reads as downloaded before its own scope
+ * completes. Once a snapshot has imported, work on the rest of the cycle is
+ * surfaced as "finalizing" instead of making that download look queued again.
  */
 export function boardDownloadState(input: BoardDownloadStateInput): BoardDownloadState {
   if (!input.enabled) return 'off';
@@ -74,6 +79,9 @@ export function boardDownloadState(input: BoardDownloadStateInput): BoardDownloa
   if (input.isSyncing && isCurrentBoard) return 'downloading';
 
   if (input.downloaded) return 'downloaded';
+  if (input.isSyncing && input.isBootstrapDone && input.phase != null && input.phase !== 'idle') {
+    return 'finalizing';
+  }
   return 'pending';
 }
 
@@ -112,6 +120,7 @@ export function offlineCatalogState(input: OfflineCatalogStateInput): OfflineCat
   const state = boardDownloadState({
     scopeKey: input.scopeKey,
     enabled: input.enabledScopeKeys.includes(input.scopeKey),
+    isBootstrapDone: false,
     downloaded: (input.downloadedScopeKeys ?? []).includes(input.scopeKey),
     isSyncing: false,
     currentTable: null,

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -13,7 +13,7 @@ import { startSyncScheduler, drainMutationQueue, startBackgroundTracking } from 
 import { reportOutboxBacklogOnce } from '../offline/outbox-telemetry';
 import { getSetting } from '../settings';
 import { setupNotificationHandlers } from '../notifications';
-import { getHttpClient } from '../lib/graphql/client';
+import { getOfflineSyncHttpClient } from '../lib/graphql/client';
 import { setOfflineEngineEnabled } from '../lib/offline-engine';
 import { registerOfflineEngineState } from '../lib/analytics-offline-engine-state';
 import { useAuth } from '../providers/auth-provider';
@@ -61,9 +61,13 @@ export function OfflineSyncBridge() {
   // this db has no tables yet. See src/db/schema-ready.ts.
   const schemaReady = useOfflineSchemaReady();
 
-  // getHttpClient() already carries auth + endpoint; binding .request keeps the
+  // getOfflineSyncHttpClient() carries auth, endpoint, and a hard request
+  // deadline; binding .request keeps the
   // GraphQLFetch shape the scheduler and drainer expect.
-  const graphqlFetch = useMemo<GraphQLFetch>(() => (query, variables) => getHttpClient().request(query, variables), []);
+  const graphqlFetch = useMemo<GraphQLFetch>(
+    () => (query, variables) => getOfflineSyncHttpClient().request(query, variables),
+    [],
+  );
 
   // Who the local user-data rows belong to. Written here rather than inside
   // pullSync because this is the layer that knows the signed-in climber, and

--- a/packages/mobile/src/lib/graphql/__tests__/client.test.ts
+++ b/packages/mobile/src/lib/graphql/__tests__/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import {
   GRAPHQL_EMPTY_RESPONSE_ERROR_NAME,
   getErrorStatus,
@@ -13,12 +13,20 @@ vi.mock('../../auth-interceptor', () => ({
 }));
 
 import { authenticatedFetch } from '../../auth-interceptor';
-import { graphqlFetchWithEmptyBodyGuard, GraphQLEmptyResponseError } from '../client';
+import {
+  graphqlFetchWithEmptyBodyGuard,
+  graphqlFetchWithOfflineSyncTimeout,
+  GraphQLEmptyResponseError,
+} from '../client';
 
 const mockAuthenticatedFetch = authenticatedFetch as Mock;
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('graphqlFetchWithEmptyBodyGuard', () => {
@@ -115,5 +123,56 @@ describe('graphqlFetchWithEmptyBodyGuard', () => {
     await graphqlFetchWithEmptyBodyGuard('https://api.example.com/graphql', options);
 
     expect(mockAuthenticatedFetch).toHaveBeenCalledWith('https://api.example.com/graphql', options);
+  });
+});
+
+describe('graphqlFetchWithOfflineSyncTimeout', () => {
+  it('aborts and rejects a request that never settles once the offline-sync deadline elapses', async () => {
+    vi.useFakeTimers();
+    mockAuthenticatedFetch.mockImplementation(() => new Promise<Response>(() => undefined));
+
+    const request = graphqlFetchWithOfflineSyncTimeout('https://api.example.com/graphql', {}, 1_000);
+    // Attach the rejection handler before advancing time so Vitest never sees
+    // the intentional timeout as an unhandled rejection.
+    const rejection = expect(request).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'Offline sync GraphQL request timed out after 1000ms',
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await rejection;
+
+    const requestOptions = mockAuthenticatedFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(requestOptions?.signal?.aborted).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('forwards caller cancellation and clears its deadline', async () => {
+    vi.useFakeTimers();
+    mockAuthenticatedFetch.mockImplementation(() => new Promise<Response>(() => undefined));
+    const callerController = new AbortController();
+    const callerReason = new Error('caller cancelled');
+
+    const request = graphqlFetchWithOfflineSyncTimeout(
+      'https://api.example.com/graphql',
+      { signal: callerController.signal },
+      1_000,
+    );
+    const rejection = expect(request).rejects.toBe(callerReason);
+    callerController.abort(callerReason);
+
+    await rejection;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('clears its deadline after a successful response', async () => {
+    vi.useFakeTimers();
+    const responseBody = JSON.stringify({ data: { boardClimbs: [] } });
+    mockAuthenticatedFetch.mockResolvedValue(new Response(responseBody, { status: 200 }));
+
+    const response = await graphqlFetchWithOfflineSyncTimeout('https://api.example.com/graphql', {}, 1_000);
+
+    await expect(response.text()).resolves.toBe(responseBody);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/mobile/src/lib/graphql/client.ts
+++ b/packages/mobile/src/lib/graphql/client.ts
@@ -73,7 +73,71 @@ export function createGraphQLHttpClient(): GraphQLClient {
   });
 }
 
+/**
+ * Offline pulls are retried by the sync scheduler, but it can only do that
+ * after the current request settles. A fetch that never resolves would
+ * otherwise hold the scheduler's single-flight lock forever and leave every
+ * newly enabled board waiting behind it.
+ *
+ * Keep this deadline scoped to offline sync. Interactive GraphQL requests use
+ * the ordinary client above and retain their existing transport behaviour.
+ */
+export const OFFLINE_SYNC_GRAPHQL_REQUEST_TIMEOUT_MS = 30_000;
+
+function createAbortError(message: string): Error {
+  const error = new Error(message);
+  error.name = 'AbortError';
+  return error;
+}
+
+export async function graphqlFetchWithOfflineSyncTimeout(
+  url: string | URL | Request,
+  options: RequestInit = {},
+  timeoutMs = OFFLINE_SYNC_GRAPHQL_REQUEST_TIMEOUT_MS,
+): Promise<Response> {
+  const callerSignal = options.signal;
+  if (callerSignal?.aborted) {
+    throw callerSignal.reason ?? createAbortError('GraphQL request aborted');
+  }
+
+  const requestController = new AbortController();
+  let rejectCancellation: (reason: unknown) => void = () => undefined;
+  const cancellation = new Promise<never>((_resolve, reject) => {
+    rejectCancellation = reject;
+  });
+
+  const abortFromCaller = (): void => {
+    const reason = callerSignal?.reason ?? createAbortError('GraphQL request aborted');
+    requestController.abort(reason);
+    rejectCancellation(reason);
+  };
+  callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
+
+  const timeout = setTimeout(() => {
+    const error = createAbortError(`Offline sync GraphQL request timed out after ${timeoutMs}ms`);
+    requestController.abort(error);
+    rejectCancellation(error);
+  }, timeoutMs);
+
+  try {
+    return await Promise.race([
+      graphqlFetchWithEmptyBodyGuard(url, { ...options, signal: requestController.signal }),
+      cancellation,
+    ]);
+  } finally {
+    clearTimeout(timeout);
+    callerSignal?.removeEventListener('abort', abortFromCaller);
+  }
+}
+
+export function createOfflineSyncGraphQLHttpClient(): GraphQLClient {
+  return new GraphQLClient(getGraphQLHttpUrl(), {
+    fetch: graphqlFetchWithOfflineSyncTimeout,
+  });
+}
+
 let httpClient: GraphQLClient | null = null;
+let offlineSyncHttpClient: GraphQLClient | null = null;
 
 export function getHttpClient(): GraphQLClient {
   if (!httpClient) {
@@ -82,6 +146,14 @@ export function getHttpClient(): GraphQLClient {
   return httpClient;
 }
 
+export function getOfflineSyncHttpClient(): GraphQLClient {
+  if (!offlineSyncHttpClient) {
+    offlineSyncHttpClient = createOfflineSyncGraphQLHttpClient();
+  }
+  return offlineSyncHttpClient;
+}
+
 export function resetHttpClient(): void {
   httpClient = null;
+  offlineSyncHttpClient = null;
 }

--- a/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
+++ b/packages/mobile/src/lib/offline-nudges/use-offline-nudge.ts
@@ -101,6 +101,7 @@ export function useOfflineNudge({ surface, board, storeReviewWillPrompt }: UseOf
       boardDownloadState({
         scopeKey: scopeKey ?? '',
         enabled: scopeKey !== null && enabledBoards.includes(scopeKey),
+        isBootstrapDone: false,
         downloaded: scopeKey !== null && (downloadedScopeKeys ?? []).includes(scopeKey),
         isSyncing: false,
         currentTable: null,

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -85,6 +85,7 @@ vi.mock('../../lib/analytics', () => ({ track: (...args: unknown[]) => trackMock
 
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { rememberDownloadTrigger } from '../../settings';
+import { __resetSyncStatusForTests, setSyncProgress } from '../../sync';
 import {
   drainMutationQueue,
   startSyncScheduler,
@@ -95,6 +96,7 @@ import {
   subscribeMutationDelivery,
   reportScopeDownloadAbandoned,
   __resetCoverageVerdictDedupeForTests,
+  __resetCycleErrorDedupeForTests,
   __resetMeteredStateForTests,
 } from '../offline-sync-adapter';
 import type {
@@ -135,11 +137,14 @@ const NO_PHASE_PROPS = {
 };
 
 const db = {} as OfflineDatabase;
-const queryClient = { invalidateQueries: vi.fn() } as unknown as import('@tanstack/react-query').QueryClient;
+const invalidateQueries = vi.fn();
+const queryClient = { invalidateQueries } as unknown as import('@tanstack/react-query').QueryClient;
 const graphqlFetch = vi.fn() as unknown as import('@boardsesh/offline-sync').GraphQLFetch;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetSyncStatusForTests();
+  __resetCycleErrorDedupeForTests();
   appStateListener = null;
   netInfoListener = null;
   onlineManagerIsOnline.mockReturnValue(true);
@@ -846,8 +851,8 @@ describe('snapshot-bootstrap bindings', () => {
       phases: NO_PHASES,
     });
 
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['downloadedScopeKeys'] });
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ['offlineStorage'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['downloadedScopeKeys'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['offlineStorage'] });
   });
 
   it('captures a PostHog event — not a Sentry error — when the coverage guard forces a resync', () => {
@@ -1213,6 +1218,142 @@ describe('triggerSync / pullSync bindings', () => {
     expect(options.onProgress).toBe(onProgress);
     expect(options.onSchemaDrift).toBeTypeOf('function');
     expect(options.onCycleError).toBeTypeOf('function');
+  });
+
+  it('reports the last visible phase when a cycle fails after snapshot transfers', () => {
+    setSyncProgress({ phase: 'deletions', currentTable: null, documentsProcessed: 500 });
+    triggerSync(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => ['soill:1:1'],
+      async () => {},
+    );
+
+    const options = triggerSyncCore.mock.calls[0][5] as SchedulerOptions;
+    const cycleError = new Error('database write failed at /private/device/offline.db');
+    options.onCycleError?.(cycleError);
+
+    expect(trackMock).toHaveBeenCalledWith(SHARED_EVENTS.OfflineSyncCycleFailed, {
+      phase: 'deletions',
+      currentTable: null,
+      documentsProcessed: 500,
+      expected: false,
+      status: null,
+      errorKind: 'exception',
+      offlineEngineEnabled: false,
+    });
+    expect(reportHandledError).toHaveBeenCalledWith(cycleError, {
+      tags: { source: 'offline-sync', kind: 'cycle', phase: 'deletions' },
+      extra: { currentTable: null, documentsProcessed: 500 },
+    });
+  });
+
+  it('tracks an expected request timeout without sending routine reachability failures to Sentry', () => {
+    setSyncProgress({ phase: 'board_data', currentTable: 'board_climb_stats:kilter:1:10', documentsProcessed: 42 });
+    triggerSync(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => ['kilter:1:10'],
+      async () => {},
+    );
+
+    const options = triggerSyncCore.mock.calls[0][5] as SchedulerOptions;
+    const timeoutError = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    options.onCycleError?.(timeoutError);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineSyncCycleFailed,
+      expect.objectContaining({
+        phase: 'board_data',
+        currentTable: 'board_climb_stats:kilter:1:10',
+        expected: true,
+        errorKind: 'aborted',
+      }),
+    );
+    expect(reportHandledError).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates a repeating expected cycle failure for five minutes', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-15T00:00:00.000Z'));
+    try {
+      setSyncProgress({ phase: 'deletions', currentTable: null, documentsProcessed: 0 });
+      triggerSync(
+        db,
+        queryClient,
+        graphqlFetch,
+        () => ['soill:1:1'],
+        async () => {},
+      );
+      const options = triggerSyncCore.mock.calls[0][5] as SchedulerOptions;
+      const timeoutError = Object.assign(new Error('private request text'), { name: 'AbortError' });
+
+      options.onCycleError?.(timeoutError);
+      options.onCycleError?.(timeoutError);
+      vi.advanceTimersByTime(299_999);
+      options.onCycleError?.(timeoutError);
+      expect(trackMock).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(1);
+      options.onCycleError?.(timeoutError);
+      expect(trackMock).toHaveBeenCalledTimes(2);
+      for (const [, properties] of trackMock.mock.calls as [string, Record<string, unknown>][]) {
+        expect(properties).not.toHaveProperty('error');
+        expect(properties).not.toHaveProperty('errorMessage');
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('deduplicates repeating unexpected failures but reports a changed phase immediately', () => {
+    setSyncProgress({ phase: 'deletions', currentTable: null, documentsProcessed: 0 });
+    triggerSync(
+      db,
+      queryClient,
+      graphqlFetch,
+      () => ['soill:1:1'],
+      async () => {},
+    );
+    const options = triggerSyncCore.mock.calls[0][5] as SchedulerOptions;
+    const sqliteError = new Error('database is locked');
+
+    options.onCycleError?.(sqliteError);
+    options.onCycleError?.(sqliteError);
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(reportHandledError).toHaveBeenCalledTimes(1);
+
+    setSyncProgress({ phase: 'user_data', currentTable: 'boardsesh_ticks', documentsProcessed: 0 });
+    options.onCycleError?.(sqliteError);
+    expect(trackMock).toHaveBeenCalledTimes(2);
+    expect(reportHandledError).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not suppress cycle telemetry when the wall clock moves backwards', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-15T01:00:00.000Z'));
+    try {
+      setSyncProgress({ phase: 'deletions', currentTable: null, documentsProcessed: 0 });
+      triggerSync(
+        db,
+        queryClient,
+        graphqlFetch,
+        () => ['soill:1:1'],
+        async () => {},
+      );
+      const options = triggerSyncCore.mock.calls[0][5] as SchedulerOptions;
+      const timeoutError = Object.assign(new Error('timeout'), { name: 'AbortError' });
+
+      options.onCycleError?.(timeoutError);
+      vi.setSystemTime(new Date('2026-08-15T00:00:00.000Z'));
+      options.onCycleError?.(timeoutError);
+
+      expect(trackMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('pullSync binds schema-drift telemetry but lets caller options win', async () => {

--- a/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
+++ b/packages/mobile/src/offline/__tests__/snapshot-source.test.ts
@@ -241,7 +241,8 @@ vi.mock('../../lib/env', () => ({
 // The strategy resolver reads Platform.OS. RN's real entry is Flow source that
 // Rolldown's scan cannot parse, so it is stubbed here the way
 // offline-sync-adapter.test.ts does.
-vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }));
+const platformState = vi.hoisted(() => ({ OS: 'ios' as 'ios' | 'android' }));
+vi.mock('react-native', () => ({ Platform: platformState }));
 
 const reportHandledError = vi.fn();
 vi.mock('../../lib/error-reporting', () => ({
@@ -255,13 +256,11 @@ vi.mock('../artifact-transfer-telemetry', () => ({
   reportArtifactTransfer: (...args: unknown[]) => reportArtifactTransfer(...args),
 }));
 
-// The FAKE File class the vi.mock above installs — imported so the strategy
-// tests can read the exact options object each transport was handed.
-import { File } from 'expo-file-system';
 import { mobileSnapshotSource, SNAPSHOT_MANIFEST_FETCH_TIMEOUT_MS } from '../snapshot-source';
 import {
   setBackgrounded,
   SnapshotArtifactTruncatedError,
+  SnapshotBackgroundTransferInterruptedError,
   SnapshotPermanentMissError,
   type SnapshotManifestEntry,
 } from '@boardsesh/offline-sync';
@@ -300,6 +299,8 @@ function brokenJsonResponse(status = 200): Response {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  setBackgrounded(false);
+  platformState.OS = 'ios';
   state.availableDiskSpace = 10_000_000_000;
   state.createdDirectories = [];
   state.downloadProgressFrames = [];
@@ -515,6 +516,45 @@ describe('downloadArtifact', () => {
 
     expect(rejection).toBeInstanceOf(Error);
     expect((rejection as Error).cause).toBe(downloadError);
+  });
+
+  it('turns cannot-decode-raw-data from a background task into a typed transport error without AppState evidence', async () => {
+    const downloadError = new Error("The operation couldn't be completed. cannot decode raw data");
+    state.downloadError = downloadError;
+
+    const rejection = await mobileSnapshotSource.downloadArtifact(ENTRY).catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(SnapshotBackgroundTransferInterruptedError);
+    expect((rejection as Error).cause).toBe(downloadError);
+    expect(reportArtifactTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        strategy: 'task-background',
+        outcome: 'failed',
+        backgroundedDuringTransfer: false,
+      }),
+    );
+  });
+
+  it('keeps cannot-decode-raw-data from a foreground task as an ordinary transfer failure', async () => {
+    const downloadError = new Error("The operation couldn't be completed. cannot decode raw data");
+    state.downloadError = downloadError;
+    platformState.OS = 'android';
+    vi.resetModules();
+    const { mobileSnapshotSource: foregroundSnapshotSource } = await import('../snapshot-source');
+
+    const rejection = await foregroundSnapshotSource.downloadArtifact(ENTRY).catch((error: unknown) => error);
+
+    expect(rejection).toBeInstanceOf(Error);
+    expect(rejection).not.toBeInstanceOf(SnapshotBackgroundTransferInterruptedError);
+    expect((rejection as Error).message).toMatch(/transfer failed.*cannot decode raw data/);
+    expect((rejection as Error).cause).toBe(downloadError);
+    expect(reportArtifactTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        strategy: 'task-foreground',
+        outcome: 'failed',
+        backgroundedDuringTransfer: false,
+      }),
+    );
   });
 
   it('throws a descriptive error wrapping the underlying cause when the cache directory cannot be created', async () => {

--- a/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
+++ b/packages/mobile/src/offline/__tests__/use-board-downloads.test.tsx
@@ -35,7 +35,7 @@ vi.mock('../offline-sync-adapter', () => ({
 }));
 vi.mock('../use-snapshot-source', () => ({ useSnapshotSource: () => fixtures.snapshotSource }));
 vi.mock('../../lib/graphql/client', () => ({
-  getHttpClient: () => ({ request: spies.graphqlRequest }),
+  getOfflineSyncHttpClient: () => ({ request: spies.graphqlRequest }),
 }));
 vi.mock('../../settings', () => ({
   getSetting: () => ['kilter:1:10', 'tension:2:11'],

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -4,7 +4,7 @@
 //   - connectivity probe   → React Query's onlineManager (wired to NetInfo in
 //                            query-provider)
 //   - scheduler wake-ups   → AppState 'active' transitions + NetInfo changes
-//   - schema-drift + cycle telemetry → Sentry / dev-only console.warn
+//   - schema-drift + cycle telemetry → Sentry / PostHog / dev console
 //
 // RULE: mobile code never imports drainMutationQueue / startSyncScheduler /
 // triggerSync / pullSync from '@boardsesh/offline-sync' directly — always from
@@ -48,10 +48,12 @@ import {
   type AbandonedDownloadInfo,
 } from '@boardsesh/offline-sync';
 import { SHARED_EVENTS, sanitizeErrorForAnalytics } from '@boardsesh/analytics';
+import { getErrorStatus, isNetworkError } from '@boardsesh/offline-sync/error-classification';
 import { reportHandledError } from '../lib/error-reporting';
 import { isOfflineEngineEnabled } from '../lib/offline-engine';
 import { takeDownloadTrigger } from '../settings';
 import { track } from '../lib/analytics';
+import { getSyncStatusSnapshot } from '../sync/sync-status';
 
 // Exported so non-drain reporters can record the one dimension that decides
 // whether a failed local write actually lost data: a tick that falls through to
@@ -453,14 +455,78 @@ export function __resetMeteredStateForTests(): void {
   isConnectionMetered = null;
 }
 
-// A failed cycle is routine for offline users (the reconnect trigger retries),
-// so production neither spams the console nor reports expected network errors
-// as handled exceptions.
+// A failed cycle is recoverable — the scheduler retries after 30 seconds — but
+// it still needs an operational terminal event. Artifact events alone cannot
+// reveal whether the later deletion/user-data/board-data handoff failed, which
+// made the multi-board "Waiting to download" incident look like a CDN wedge.
 const warnCycleError = (error: unknown) => {
+  const syncStatus = getSyncStatusSnapshot();
+  // A drain can throw before this cycle emits progress. Do not attribute that
+  // error to the idle frame left by the previous completed cycle.
+  const progress = syncStatus.isSyncing ? syncStatus.progress : null;
+  const expected = isNetworkError(error);
+  const status = getErrorStatus(error);
+  const errorKind =
+    error instanceof Error && error.name === 'AbortError'
+      ? 'aborted'
+      : expected
+        ? 'network'
+        : status !== null
+          ? 'server'
+          : error instanceof Error
+            ? 'exception'
+            : 'non-error';
+  const phase = progress?.phase ?? null;
+  const currentTable = progress?.currentTable ?? null;
+  const errorSignature = `${phase ?? 'unknown'}|${currentTable ?? 'none'}|${errorKind}|${status ?? 'none'}`;
+  const now = Date.now();
+  const shouldReport =
+    errorSignature !== lastCycleErrorSignature || now < lastCycleErrorAt || now - lastCycleErrorAt >= 300_000;
+  if (shouldReport) {
+    track(SHARED_EVENTS.OfflineSyncCycleFailed, {
+      phase,
+      currentTable,
+      documentsProcessed: progress?.documentsProcessed ?? 0,
+      expected,
+      status,
+      errorKind,
+      offlineEngineEnabled: isOfflineEngineEnabled(),
+    });
+    lastCycleErrorSignature = errorSignature;
+    lastCycleErrorAt = now;
+  }
+
+  // Expected reachability failures remain out of Sentry: a phone moving between
+  // networks is routine and PostHog now carries the retry/funnel signal. A
+  // non-transport throw means the engine/database itself failed and deserves a
+  // searchable handled exception as well.
+  if (!expected && shouldReport) {
+    reportHandledError(error, {
+      tags: {
+        source: 'offline-sync',
+        kind: 'cycle',
+        phase: progress?.phase ?? 'unknown',
+      },
+      extra: {
+        currentTable: progress?.currentTable ?? null,
+        documentsProcessed: progress?.documentsProcessed ?? 0,
+      },
+    });
+  }
+
   if (__DEV__) {
     console.warn('[Sync] Sync cycle failed:', error instanceof Error ? error.message : 'unknown');
   }
 };
+
+let lastCycleErrorSignature: string | null = null;
+let lastCycleErrorAt = 0;
+
+/** Test-only reset for the cycle-error telemetry throttle. */
+export function __resetCycleErrorDedupeForTests(): void {
+  lastCycleErrorSignature = null;
+  lastCycleErrorAt = 0;
+}
 
 // Feeds setBackgrounded() (Sentry BOARDSESH-AN) and the metered-link flag above;
 // call once for the app's lifetime — see OfflineSyncBridge.

--- a/packages/mobile/src/offline/snapshot-source.ts
+++ b/packages/mobile/src/offline/snapshot-source.ts
@@ -32,6 +32,7 @@ import {
   isBackgrounded,
   onTeardown,
   SnapshotArtifactTruncatedError,
+  SnapshotBackgroundTransferInterruptedError,
   SnapshotPermanentMissError,
   type SnapshotArtifactHandle,
   type SnapshotDownloadOptions,
@@ -375,6 +376,20 @@ function formatError(error: unknown): string {
 }
 
 /**
+ * NSURLErrorCannotDecodeRawData as surfaced by Expo's iOS DownloadTask. The
+ * native exception currently exposes no stable numeric code to JavaScript, so
+ * walk the bounded cause chain for its exact Foundation description.
+ */
+function isCannotDecodeRawDataError(error: unknown, depth = 0): boolean {
+  if (error === null || typeof error !== 'object') return false;
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === 'string' && /cannot decode raw data/i.test(message)) return true;
+  if (depth >= 3) return false;
+  const cause = (error as { cause?: unknown }).cause;
+  return cause !== undefined && cause !== error && isCannotDecodeRawDataError(cause, depth + 1);
+}
+
+/**
  * The disk-space, directory-creation, and actual-download failure branches
  * below used to `return null` on a real error, which is a legal SnapshotSource
  * contract (see the doc comment on downloadArtifact in snapshot-bootstrap.ts —
@@ -539,6 +554,16 @@ async function downloadSnapshotFile(
       });
     } catch (error) {
       emitTransfer(options?.signal?.aborted === true ? 'aborted' : 'failed');
+      // iOS's background URLSession can surface this response-decoding failure
+      // before AppState delivers a background transition as well as while the
+      // app is suspended. The native session type + exact Foundation message is
+      // the stable signal; lifecycle timing is telemetry, not classification.
+      if (strategy === 'task-background' && isCannotDecodeRawDataError(error)) {
+        throw new SnapshotBackgroundTransferInterruptedError(
+          `snapshot download: background transfer interrupted for ${artifact.label}: ${formatError(error)}`,
+          { cause: error },
+        );
+      }
       throw new Error(`snapshot download: transfer failed for ${artifact.label}: ${formatError(error)}`, {
         cause: error,
       });

--- a/packages/mobile/src/offline/use-board-downloads.ts
+++ b/packages/mobile/src/offline/use-board-downloads.ts
@@ -15,7 +15,7 @@ import {
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { track } from '../lib/analytics';
 import { isOfflineEngineEnabled } from '../lib/offline-engine';
-import { getHttpClient } from '../lib/graphql/client';
+import { getOfflineSyncHttpClient } from '../lib/graphql/client';
 import { notifyBootstrapMetadataChanged, notifyScopeDownloadComplete, setSyncProgress } from '../sync';
 import { triggerSync, drainMutationQueue, hasUsableInternetConnection } from './offline-sync-adapter';
 import { useSnapshotSource } from './use-snapshot-source';
@@ -49,7 +49,10 @@ export function useBoardDownloads() {
   // it has no tables yet and a snapshot import would land in a half-set-up file.
   const schemaReady = useOfflineSchemaReady();
 
-  const graphqlFetch = useMemo<GraphQLFetch>(() => (query, variables) => getHttpClient().request(query, variables), []);
+  const graphqlFetch = useMemo<GraphQLFetch>(
+    () => (query, variables) => getOfflineSyncHttpClient().request(query, variables),
+    [],
+  );
   const drainQueue = useCallback(
     () => drainMutationQueue(db, queryClient, graphqlFetch),
     [db, queryClient, graphqlFetch],

--- a/packages/mobile/src/sync/__tests__/sync-status.test.ts
+++ b/packages/mobile/src/sync/__tests__/sync-status.test.ts
@@ -55,6 +55,32 @@ describe('sync-status store', () => {
     expect(status.lastSyncedAt).toBe(fixedNow);
   });
 
+  it('interrupted idle clears isSyncing without stamping lastSyncedAt', () => {
+    const previousSuccessAt = 1_700_000_000_000;
+    const interruptedAt = previousSuccessAt + 60_000;
+    const now = vi.spyOn(Date, 'now').mockReturnValue(previousSuccessAt);
+    setSyncProgress({ phase: 'idle', currentTable: null, documentsProcessed: 10 });
+
+    now.mockReturnValue(interruptedAt);
+    setSyncProgress({ phase: 'bootstrap', currentTable: 'kilter:1:5', documentsProcessed: 0 });
+    setSyncProgress({
+      phase: 'idle',
+      currentTable: null,
+      documentsProcessed: 0,
+      interrupted: true,
+    });
+
+    const status = getSyncStatusSnapshot();
+    expect(status.isSyncing).toBe(false);
+    expect(status.lastSyncedAt).toBe(previousSuccessAt);
+    expect(status.progress).toEqual({
+      phase: 'idle',
+      currentTable: null,
+      documentsProcessed: 0,
+      interrupted: true,
+    });
+  });
+
   it('keeps the prior lastSyncedAt across a subsequent non-idle frame', () => {
     const firstSync = 1_700_000_000_000;
     vi.spyOn(Date, 'now').mockReturnValue(firstSync);

--- a/packages/mobile/src/sync/sync-status.ts
+++ b/packages/mobile/src/sync/sync-status.ts
@@ -15,7 +15,7 @@ export type SyncStatus = {
   progress: SyncProgress | null;
   /** Whether a sync cycle is mid-flight (progress emitted, not yet idle). */
   isSyncing: boolean;
-  /** Epoch ms of the last cycle that reached the idle phase, or null. */
+  /** Epoch ms of the last cycle that reached a successful idle phase, or null. */
   lastSyncedAt: number | null;
   /**
    * Advances after each bootstrap scope settles. Consumers that read bootstrap
@@ -58,12 +58,12 @@ export function getSyncStatusSnapshot(): SyncStatus {
 /**
  * Publish a progress frame from a running pull. Wire this as pullSync's
  * `onProgress`. The terminal `phase: 'idle'` frame flips `isSyncing` off and —
- * unless it is the scheduler's `failed` frame after a thrown cycle — stamps
- * `lastSyncedAt`; every other frame keeps `isSyncing` true.
+ * unless it is a failed or lifecycle-interrupted cycle — stamps `lastSyncedAt`;
+ * every other frame keeps `isSyncing` true.
  */
 export function setSyncProgress(progress: SyncProgress): void {
   const reachedIdle = progress.phase === 'idle';
-  const completed = reachedIdle && !progress.failed;
+  const completed = reachedIdle && !progress.failed && !progress.interrupted;
   currentStatus = {
     progress,
     isSyncing: !reachedIdle,

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -595,6 +595,16 @@ export const SHARED_EVENTS = {
   // 'reset' | 'probe_failed' }. Deduped once-per-launch-per-verdict in the
   // mobile binding, because the engine evaluates on every foreground.
   OfflineSyncCoverageEvaluated: 'Offline Sync Coverage Evaluated',
+  // Offline sync — a whole drain+pull cycle threw before reaching its idle
+  // frame. The scheduler retries these after a bounded delay, but without this
+  // event a device could show several downloaded artifacts followed by silence
+  // and production telemetry could not distinguish a transport timeout from a
+  // SQLite/import defect. Props: { phase, currentTable, documentsProcessed,
+  // expected, status, errorKind, offlineEngineEnabled }. `currentTable` is null
+  // during global deletion work; `expected` is true for transport-shaped
+  // failures. Raw exception text stays in Sentry rather than analytics; an
+  // unchanged signature is emitted at most once per five minutes.
+  OfflineSyncCycleFailed: 'Offline Sync Cycle Failed',
   // Offline sync — the local SQLite setup lost the write lock at launch and a
   // later retry won, so offline storage came up after all. Fired at most once
   // per process, only when attempt 1 failed (a clean launch stays silent).

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -293,6 +293,7 @@
     "offline": {
       "available": "Offline verfügbar",
       "pending": "Wartet auf Download",
+      "finalizing": "Download wird abgeschlossen…",
       "bootstrapping": "Board wird geladen…",
       "bootstrapPreparing": "Download wird vorbereitet…",
       "bootstrapDownloading": "{{done}} von {{total}} geladen",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -293,6 +293,7 @@
     "offline": {
       "available": "Available offline",
       "pending": "Waiting to download",
+      "finalizing": "Finishing download…",
       "bootstrapping": "Downloading board…",
       "bootstrapPreparing": "Preparing download…",
       "bootstrapDownloading": "Downloading {{done}} of {{total}}",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -293,6 +293,7 @@
     "offline": {
       "available": "Disponible sin conexión",
       "pending": "Esperando para descargar",
+      "finalizing": "Finalizando la descarga…",
       "bootstrapping": "Descargando el plafón…",
       "bootstrapPreparing": "Preparando la descarga…",
       "bootstrapDownloading": "Descargando {{done}} de {{total}}",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -293,6 +293,7 @@
     "offline": {
       "available": "Disponible hors ligne",
       "pending": "En attente de téléchargement",
+      "finalizing": "Finalisation du téléchargement…",
       "bootstrapping": "Téléchargement de la board…",
       "bootstrapPreparing": "Préparation du téléchargement…",
       "bootstrapDownloading": "Téléchargement de {{done}} sur {{total}}",

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -121,6 +121,7 @@ export {
   SnapshotPermanentMissError,
   SnapshotWatermarkRegressionError,
   SnapshotArtifactTruncatedError,
+  SnapshotBackgroundTransferInterruptedError,
 } from './sync/snapshot-bootstrap';
 export type {
   SnapshotSource,

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-failure-reason.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-failure-reason.test.ts
@@ -12,6 +12,7 @@ import {
   SnapshotPermanentMissError,
   SnapshotWatermarkRegressionError,
   SnapshotArtifactTruncatedError,
+  SnapshotBackgroundTransferInterruptedError,
 } from '../snapshot-bootstrap';
 
 describe('classifySnapshotBootstrapFailure', () => {
@@ -82,6 +83,15 @@ describe('classifySnapshotBootstrapFailure', () => {
         new Error('snapshot bootstrap: board_climbs row_count 900 != actual 12 (truncated artifact?)'),
       ),
     ).toBe('artifact-invalid');
+  });
+
+  it('buckets a background-task decode marker by its stable error name', () => {
+    const localMarker = new SnapshotBackgroundTransferInterruptedError('cannot decode raw data');
+    const crossBundleMarker = new Error('cannot decode raw data');
+    crossBundleMarker.name = 'SnapshotBackgroundTransferInterruptedError';
+
+    expect(classifySnapshotBootstrapFailure(localMarker)).toBe('background-transfer-decode');
+    expect(classifySnapshotBootstrapFailure(crossBundleMarker)).toBe('background-transfer-decode');
   });
 
   it('buckets a dropped connection as network', () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/bootstrap-retry.test.ts
@@ -32,7 +32,7 @@ import {
   type BootstrapFailureKind,
   type BootstrapRetryState,
 } from '../bootstrap-retry';
-import { SnapshotArtifactTruncatedError } from '../snapshot-bootstrap';
+import { SnapshotArtifactTruncatedError, SnapshotBackgroundTransferInterruptedError } from '../snapshot-bootstrap';
 import { runMigrations } from '../../db/migrations';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 
@@ -90,6 +90,15 @@ describe('classifyBootstrapFailure', () => {
     expect(classifyBootstrapFailure({ cause, stage: 'download' })).toBe('transport');
     // At the IMPORT stage every failure is artifact-attributable, unchanged.
     expect(classifyBootstrapFailure({ cause, stage: 'import' })).toBe('structural-artifact');
+  });
+
+  it('routes a background-transfer marker to transport by its stable error name', () => {
+    const localMarker = new SnapshotBackgroundTransferInterruptedError('cannot decode raw data');
+    const crossBundleMarker = new Error('cannot decode raw data');
+    crossBundleMarker.name = 'SnapshotBackgroundTransferInterruptedError';
+
+    expect(classifyBootstrapFailure({ cause: localMarker, stage: 'download' })).toBe('transport');
+    expect(classifyBootstrapFailure({ cause: crossBundleMarker, stage: 'download' })).toBe('transport');
   });
 
   it('attributes an unclassifiable download failure to the DEVICE, not the artifact', () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.integration.test.ts
@@ -21,6 +21,9 @@
 // violates the DDL's NOT NULL. (Both proven by the drift tests below.)
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { QueryInvalidator } from '../../database';
 
 // Capture schema-drift telemetry through the injected reporter seam.
@@ -39,6 +42,7 @@ import { runMigrations } from '../../db/migrations';
 import { ensureMutationQueueTable } from '../../mutation-queue/schema';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 import { getDeletionsCoverageAt } from '../deletions-coverage';
+import { setCheckpoint } from '../checkpoints';
 import { DELETIONS_COVERAGE_EPOCH_FLOOR_MS } from '../retention';
 import { TABLE_CONFIGS } from '../table-config';
 
@@ -592,6 +596,36 @@ describe('sync layer — real-DDL integration', () => {
       );
     }
 
+    it('the current-cursor write acquires the writer lock inside SQLite deferred BEGIN', async () => {
+      const lockTestDirectory = mkdtempSync(join(tmpdir(), 'deletion-page-writer-lock-'));
+      const lockTestPath = join(lockTestDirectory, 'offline.db');
+      const lockOwner = createTestDatabase(lockTestPath);
+      await runMigrations(lockOwner);
+      const competingWriter = createTestDatabase(lockTestPath);
+
+      try {
+        await lockOwner.withExclusiveTransactionAsync(async (transaction) => {
+          // This is the same first write processDeletions uses before its epoch
+          // guard. Expo/node:sqlite both enter the callback under deferred BEGIN;
+          // INSERT OR REPLACE upgrades it to the sole main-DB writer.
+          await setCheckpoint(transaction, 'checkpoint:deletions', DEFAULT_CURSOR);
+
+          await expect(
+            competingWriter.runAsync('DELETE FROM sync_meta WHERE key = ?', ['checkpoint:deletions']),
+          ).rejects.toThrow(/busy|locked/i);
+        });
+
+        // Once the owner commits, the queued purge-shaped write can proceed.
+        await expect(
+          competingWriter.runAsync('DELETE FROM sync_meta WHERE key = ?', ['checkpoint:deletions']),
+        ).resolves.toMatchObject({ changes: 1 });
+      } finally {
+        lockOwner.close();
+        competingWriter.close();
+        rmSync(lockTestDirectory, { recursive: true, force: true });
+      }
+    });
+
     it('deletes a 1-segment tick (record_id = uuid), a 3-segment favorite, and a 3-segment stat row', async () => {
       // Seed the three target rows directly (deletion is independent of how a row
       // arrived). board_climb_stats local PK is (board_type, climb_uuid, angle).
@@ -696,6 +730,38 @@ describe('sync layer — real-DDL integration', () => {
       expect(
         await db.getFirstAsync('SELECT climb_uuid FROM user_favorites WHERE climb_uuid = ?', ['oldfav-climb']),
       ).toBeNull();
+    });
+
+    it('rolls back the whole deletion page and its checkpoint when one tombstone fails', async () => {
+      await seedTick('tick-atomic-1');
+      await seedTick('tick-atomic-2');
+      await db.execAsync(`
+        CREATE TRIGGER fail_second_atomic_delete
+        BEFORE DELETE ON boardsesh_ticks
+        WHEN OLD.uuid = 'tick-atomic-2'
+        BEGIN
+          SELECT RAISE(ABORT, 'forced deletion page failure');
+        END;
+      `);
+
+      const deletions: DeletionRecord[] = [
+        { tableName: 'boardsesh_ticks', recordId: 'tick-atomic-1', deletedAt: '2099-01-01T00:00:00Z' },
+        { tableName: 'boardsesh_ticks', recordId: 'tick-atomic-2', deletedAt: '2099-01-01T00:00:01Z' },
+      ];
+
+      await expect(
+        pullSync(db, queryClient, makeSingleTableFetch({ queryName: 'syncTicks', documents: [], deletions })),
+      ).rejects.toThrow(/forced deletion page failure/);
+
+      // The first DELETE ran before the trigger aborted the second. It is back
+      // because both tombstones and the page cursor share one transaction.
+      expect(
+        await db.getFirstAsync('SELECT uuid FROM boardsesh_ticks WHERE uuid = ?', ['tick-atomic-1']),
+      ).not.toBeNull();
+      expect(
+        await db.getFirstAsync('SELECT uuid FROM boardsesh_ticks WHERE uuid = ?', ['tick-atomic-2']),
+      ).not.toBeNull();
+      expect(await readCheckpoint(db, 'checkpoint:deletions')).toBeNull();
     });
   });
 

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -25,7 +25,7 @@ vi.mock('../table-config', async () => {
   return actual;
 });
 
-import { pullSync } from '../pull-client';
+import { pullSync, type SyncProgress } from '../pull-client';
 import { setSigningOut, setBackgrounded, beginGlobalPurge } from '../../mutation-queue/drainer';
 import { getCheckpoint, setCheckpoint, getCheckpointKey, markScopeDownloadComplete } from '../checkpoints';
 import { TABLE_CONFIGS, USER_DATA_TABLES, BOARD_DATA_TABLES } from '../table-config';
@@ -943,18 +943,27 @@ describe('pullSync', () => {
     // Sentry BOARDSESH-AN: a SQLite call dispatched right as iOS suspends the
     // process crashed natively. Mirrors the sign-out guard above.
     setupGraphqlFetchForAllTables();
+    const progressFrames: SyncProgress[] = [];
     setBackgrounded(true);
     try {
-      await pullSync(db, queryClient, graphqlFetch);
+      await pullSync(db, queryClient, graphqlFetch, { onProgress: (progress) => progressFrames.push(progress) });
       expect(graphqlFetch).not.toHaveBeenCalled();
       expect(sqlCalls.filter((call) => call.sql.startsWith('INSERT OR REPLACE'))).toHaveLength(0);
       expect(setCheckpoint).not.toHaveBeenCalled();
+      expect(progressFrames.at(-1)).toEqual({
+        phase: 'idle',
+        currentTable: null,
+        documentsProcessed: 0,
+        interrupted: true,
+      });
+      expect(progressFrames.filter((progress) => progress.phase === 'idle')).toHaveLength(1);
     } finally {
       setBackgrounded(false);
     }
   });
 
   it('stops mid-cycle when the app backgrounds while a page is on the wire', async () => {
+    const progressFrames: SyncProgress[] = [];
     graphqlFetch.mockImplementation(async (query: string) => {
       if (query.includes('syncDeletions')) {
         return makeDeletionsResult([], false);
@@ -973,7 +982,7 @@ describe('pullSync', () => {
     });
 
     try {
-      await pullSync(db, queryClient, graphqlFetch);
+      await pullSync(db, queryClient, graphqlFetch, { onProgress: (progress) => progressFrames.push(progress) });
 
       // The page already in flight when backgrounding was detected must not be
       // upserted, and its checkpoint must not advance.
@@ -983,6 +992,13 @@ describe('pullSync', () => {
         String(args[1]).includes('boardsesh_ticks'),
       );
       expect(tickCheckpointWrites).toHaveLength(0);
+      expect(progressFrames.at(-1)).toEqual({
+        phase: 'idle',
+        currentTable: null,
+        documentsProcessed: 0,
+        interrupted: true,
+      });
+      expect(progressFrames.filter((progress) => progress.phase === 'idle')).toHaveLength(1);
     } finally {
       setBackgrounded(false);
     }

--- a/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/pull-client.test.ts
@@ -26,7 +26,7 @@ vi.mock('../table-config', async () => {
 });
 
 import { pullSync } from '../pull-client';
-import { setSigningOut, setBackgrounded } from '../../mutation-queue/drainer';
+import { setSigningOut, setBackgrounded, beginGlobalPurge } from '../../mutation-queue/drainer';
 import { getCheckpoint, setCheckpoint, getCheckpointKey, markScopeDownloadComplete } from '../checkpoints';
 import { TABLE_CONFIGS, USER_DATA_TABLES, BOARD_DATA_TABLES } from '../table-config';
 
@@ -473,6 +473,111 @@ describe('pullSync', () => {
     expect(deleteCalls[0].params).toEqual(['kilter', 'climb-uuid', '40', '2024-06-01T00:00:00Z']);
   });
 
+  it('applies a deletion page and its checkpoint in one exclusive transaction', async () => {
+    const pageCursor = { updatedAt: '2024-06-01T00:00:02Z', syncSeq: '22' };
+    graphqlFetch.mockImplementation(async (query: string) => {
+      if (query.includes('syncDeletions')) {
+        return makeDeletionsResult(
+          [
+            { tableName: 'boardsesh_ticks', recordId: 'uuid-1', deletedAt: '2024-06-01T00:00:01Z' },
+            { tableName: 'boardsesh_ticks', recordId: 'uuid-2', deletedAt: '2024-06-01T00:00:02Z' },
+          ],
+          false,
+          pageCursor,
+        );
+      }
+      for (const config of Object.values(TABLE_CONFIGS)) {
+        if (query.includes(config.queryName)) return makeSyncResult(config.queryName, [], false);
+      }
+      throw new Error(`Unexpected query: ${query}`);
+    });
+
+    await pullSync(db, queryClient, graphqlFetch);
+
+    expect((db.withExclusiveTransactionAsync as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+    expect(mockTxn.runAsync).toHaveBeenCalledTimes(2);
+    expect(setCheckpoint).toHaveBeenNthCalledWith(1, mockTxn, 'checkpoint:deletions', {
+      updatedAt: '1970-01-01T00:00:00.000Z',
+      syncSeq: '0',
+    });
+    expect(setCheckpoint).toHaveBeenNthCalledWith(2, mockTxn, 'checkpoint:deletions', pageCursor);
+  });
+
+  it('abandons a queued deletion page when a global purge finishes before its transaction starts', async () => {
+    (db.getFirstAsync as ReturnType<typeof vi.fn>).mockImplementation(async (_sql: string, params: unknown[]) =>
+      params[0] === 'deletions-coverage' ? { value: String(Date.now()) } : null,
+    );
+    (db.withExclusiveTransactionAsync as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (callback: (transaction: typeof mockTxn) => Promise<void>) => {
+        // Models the callback waiting behind a global purge's SQLite lock: its
+        // post-fetch guard already passed, then the wipe completes before this
+        // transaction gets a chance to perform its first write.
+        beginGlobalPurge();
+        await callback(mockTxn);
+      },
+    );
+    graphqlFetch.mockImplementation(async (query: string) => {
+      if (query.includes('syncDeletions')) {
+        return makeDeletionsResult(
+          [{ tableName: 'boardsesh_ticks', recordId: 'wiped-tick', deletedAt: '2024-06-01T00:00:00Z' }],
+          false,
+        );
+      }
+      for (const config of Object.values(TABLE_CONFIGS)) {
+        if (query.includes(config.queryName)) return makeSyncResult(config.queryName, [], false);
+      }
+      throw new Error(`Unexpected query: ${query}`);
+    });
+
+    await pullSync(db, queryClient, graphqlFetch);
+
+    expect(mockTxn.runAsync).not.toHaveBeenCalled();
+    expect(setCheckpoint).toHaveBeenCalledTimes(1);
+    expect(setCheckpoint).not.toHaveBeenCalledWith(mockTxn, 'checkpoint:deletions', {
+      updatedAt: '2024-06-01T00:00:00Z',
+      syncSeq: '1',
+    });
+    expect(
+      sqlCalls.some(
+        (call) => call.sql.includes('INSERT OR REPLACE INTO sync_meta') && call.params[0] === 'deletions-coverage',
+      ),
+    ).toBe(false);
+  });
+
+  it('abandons a deletion page when a global purge lands while its deferred transaction acquires the writer lock', async () => {
+    (db.getFirstAsync as ReturnType<typeof vi.fn>).mockImplementation(async (_sql: string, params: unknown[]) =>
+      params[0] === 'deletions-coverage' ? { value: String(Date.now()) } : null,
+    );
+    (setCheckpoint as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
+      // Models the purge winning the writer-lock race after callback entry. The
+      // checkpoint write waits for it, then the post-lock epoch guard must abort
+      // before a tombstone or the fetched page cursor can be written.
+      beginGlobalPurge();
+    });
+    graphqlFetch.mockImplementation(async (query: string) => {
+      if (query.includes('syncDeletions')) {
+        return makeDeletionsResult(
+          [{ tableName: 'boardsesh_ticks', recordId: 'wiped-tick', deletedAt: '2024-06-01T00:00:00Z' }],
+          false,
+        );
+      }
+      for (const config of Object.values(TABLE_CONFIGS)) {
+        if (query.includes(config.queryName)) return makeSyncResult(config.queryName, [], false);
+      }
+      throw new Error(`Unexpected query: ${query}`);
+    });
+
+    await pullSync(db, queryClient, graphqlFetch);
+
+    expect(setCheckpoint).toHaveBeenCalledTimes(1);
+    expect(mockTxn.runAsync).not.toHaveBeenCalled();
+    expect(
+      sqlCalls.some(
+        (call) => call.sql.includes('INSERT OR REPLACE INTO sync_meta') && call.params[0] === 'deletions-coverage',
+      ),
+    ).toBe(false);
+  });
+
   it('skips deletion when PK part count mismatches', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -746,6 +851,31 @@ describe('pullSync', () => {
 
     expect(logbookKeyCount).toBeGreaterThanOrEqual(1);
     expect(userTicksKeyCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('invalidates a committed deletion page before a later page request fails', async () => {
+    let deletionRequestCount = 0;
+    graphqlFetch.mockImplementation(async (query: string) => {
+      if (query.includes('syncDeletions')) {
+        deletionRequestCount += 1;
+        if (deletionRequestCount === 1) {
+          return makeDeletionsResult(
+            [{ tableName: 'boardsesh_ticks', recordId: 'uuid-1', deletedAt: '2024-06-01T00:00:00Z' }],
+            true,
+          );
+        }
+        throw new Error('page two transport failed');
+      }
+      throw new Error(`Unexpected query: ${query}`);
+    });
+
+    await expect(pullSync(db, queryClient, graphqlFetch)).rejects.toThrow('page two transport failed');
+
+    const invalidatedKeys = (queryClient.invalidateQueries as ReturnType<typeof vi.fn>).mock.calls.map(
+      (args: unknown[]) => (args[0] as { queryKey: string[] }).queryKey,
+    );
+    expect(invalidatedKeys).toContainEqual(['logbook']);
+    expect(invalidatedKeys).toContainEqual(['userTicks']);
   });
 
   it('calls getCheckpointKey with the full scope key for per-board tables', async () => {

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -108,6 +108,9 @@ type ArtifactSpec = {
   statsRowCountOverride?: number;
   climbsDdl?: string;
   statsDdl?: string;
+  builtAt?: string;
+  /** Optional metadata-only replay boundary; omitted to model an old artifact. */
+  deletionsReplayFrom?: string;
 };
 
 /** Builds a gzip-free SQLite artifact carrying board_climbs + stats + meta. */
@@ -160,12 +163,13 @@ function buildArtifact(spec: ArtifactSpec): void {
     );
     const formatVersion = spec.formatVersion ?? 1;
     const schemaVersion = spec.schemaVersion ?? LATEST_SCHEMA_VERSION;
+    const builtAt = spec.builtAt ?? '2026-06-01T00:00:00.000Z';
     meta.run(
       'board_climbs',
       spec.climbsWatermark.updatedAt,
       spec.climbsWatermark.syncSeq,
       spec.climbsRowCountOverride ?? spec.climbs.length,
-      '2026-06-01T00:00:00.000Z',
+      builtAt,
       schemaVersion,
       formatVersion,
     );
@@ -174,10 +178,13 @@ function buildArtifact(spec: ArtifactSpec): void {
       spec.statsWatermark.updatedAt,
       spec.statsWatermark.syncSeq,
       spec.statsRowCountOverride ?? spec.stats.length,
-      '2026-06-01T00:00:00.000Z',
+      builtAt,
       schemaVersion,
       formatVersion,
     );
+    if (spec.deletionsReplayFrom) {
+      meta.run('sync_deletions', spec.deletionsReplayFrom, '0', 0, builtAt, schemaVersion, formatVersion);
+    }
   } finally {
     db.close();
   }
@@ -731,6 +738,27 @@ describe('bootstrapScopeFromSnapshot', () => {
     await expect(
       bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),
     ).rejects.toThrow(/row_count/);
+    expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
+  });
+
+  it('rejects inconsistent embedded snapshot_meta built_at timestamps', async () => {
+    const filePath = join(workDir, 'inconsistent-built-at.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [],
+      climbsWatermark: CLIMBS_WATERMARK,
+      statsWatermark: STATS_WATERMARK,
+    });
+    const artifact = new DatabaseSync(filePath);
+    artifact
+      .prepare('UPDATE snapshot_meta SET built_at = ? WHERE table_name = ?')
+      .run('2026-06-01T00:00:01.000Z', 'board_climb_stats');
+    artifact.close();
+
+    await expect(
+      bootstrapScopeFromSnapshot({ db, scope: SCOPE_KILTER_5, scopeKey: 'kilter:1:5', filePath }),
+    ).rejects.toThrow(/inconsistent snapshot_meta built_at/);
     expect(await getCheckpoint(db, 'checkpoint:board_climbs:kilter:1:5')).toBeNull();
   });
 
@@ -2536,7 +2564,34 @@ describe('pullSync onScopeDownloadComplete', () => {
 // ---------------------------------------------------------------------------
 
 describe('deletions checkpoint rewind on bootstrap', () => {
-  it('rewinds the deletions checkpoint to min(watermarks) when it sits ahead of the snapshot', async () => {
+  it('uses the export-transaction replay boundary instead of a quiet layout row watermark', async () => {
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, { updatedAt: '2026-09-01T00:00:00Z', syncSeq: '5000' });
+
+    const filePath = join(workDir, 'transaction-boundary-rewind.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      // This layout has been quiet for a month. Replaying from this row cursor
+      // would needlessly scan a month of global tombstones.
+      climbsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+      statsWatermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' },
+      // The exporter captured this from the SAME REPEATABLE READ transaction,
+      // after subtracting its stability window.
+      deletionsReplayFrom: '2026-05-31T23:59:30.000Z',
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual({
+      updatedAt: '2026-05-31T23:59:30.000Z',
+      syncSeq: '0',
+    });
+  });
+
+  it('falls back to min(watermarks) for an old artifact without deletion replay metadata', async () => {
     // Deletions already advanced well past the snapshot's watermark.
     await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, { updatedAt: '2026-09-01T00:00:00Z', syncSeq: '5000' });
 
@@ -2556,6 +2611,57 @@ describe('deletions checkpoint rewind on bootstrap', () => {
 
     // Rewound to the OLDER (climbs) timestamp, with deletion-domain seq 0 so
     // tombstones at exactly that timestamp are replayed too.
+    expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual({
+      updatedAt: '2026-05-01T00:00:00Z',
+      syncSeq: '0',
+    });
+  });
+
+  it('falls back to min(watermarks) when deletion replay metadata is malformed', async () => {
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, { updatedAt: '2026-09-01T00:00:00Z', syncSeq: '5000' });
+
+    const filePath = join(workDir, 'malformed-transaction-boundary.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+      statsWatermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' },
+      deletionsReplayFrom: '2026-05-31T23:59:30.000Z',
+    });
+    const artifact = new DatabaseSync(filePath);
+    artifact
+      .prepare('UPDATE snapshot_meta SET watermark_sync_seq = ? WHERE table_name = ?')
+      .run('not-zero', 'sync_deletions');
+    artifact.close();
+
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
+    expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual({
+      updatedAt: '2026-05-01T00:00:00Z',
+      syncSeq: '0',
+    });
+  });
+
+  it('falls back to min(watermarks) when the replay boundary is after artifact built_at', async () => {
+    await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, { updatedAt: '2026-09-01T00:00:00Z', syncSeq: '5000' });
+
+    const filePath = join(workDir, 'future-transaction-boundary.db');
+    buildArtifact({
+      filePath,
+      climbs: [{ uuid: 'c1', compatibleSizeIds: [5] }],
+      stats: [{ climbUuid: 'c1', angle: 40 }],
+      climbsWatermark: { updatedAt: '2026-05-01T00:00:00Z', syncSeq: '10' },
+      statsWatermark: { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' },
+      builtAt: '2026-06-01T00:00:00.000Z',
+      deletionsReplayFrom: '2026-06-01T00:00:01.000Z',
+    });
+    const source = makeSnapshotSource({ manifest: makeManifest([makeEntry()]), fileForEntry: () => filePath });
+    const { fetch } = makeGraphqlFetch();
+    await pullSync(db, noopQueryClient(), fetch, { enabledBoards: ['kilter:1:5'], snapshotSource: source });
+
     expect(await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY)).toEqual({
       updatedAt: '2026-05-01T00:00:00Z',
       syncSeq: '0',

--- a/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/snapshot-bootstrap.test.ts
@@ -29,6 +29,7 @@ import {
   BOOTSTRAP_METADATA_QUERY,
   BOOTSTRAP_METADATA_PATTERNS,
   SnapshotPermanentMissError,
+  SnapshotBackgroundTransferInterruptedError,
   SnapshotSchemaStaleError,
   type SnapshotSource,
 } from '../snapshot-bootstrap';
@@ -4700,10 +4701,12 @@ describe('pullSync grades bootstrap', () => {
     expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
   });
 
-  it('a grades download that fails during a teardown does not burn a grades attempt', async () => {
+  it('interrupts the cycle when a grades download rejects after backgrounding and foregrounding', async () => {
     // The grades artifact only ever gets three tries, and a pocketed phone was
     // spending them: three screen locks left a Kilter board crawling grades over
-    // GraphQL for the life of the install (issue #4390).
+    // GraphQL for the life of the install (issue #4390). AppState can already be
+    // active by the time the native rejection reaches JS, so the transfer must
+    // carry its latched teardown verdict out to the parent cycle.
     const climbsPath = join(workDir, 'grades-teardown-climbs.db');
     buildArtifact({
       filePath: climbsPath,
@@ -4717,26 +4720,46 @@ describe('pullSync grades bootstrap', () => {
       downloadArtifact: vi.fn(async () => ({ filePath: climbsPath })),
       downloadGradesArtifact: vi.fn(async () => {
         setBackgrounded(true);
+        setBackgrounded(false);
         throw new Error('The network connection was lost.');
       }),
       deleteArtifact: vi.fn(async () => {}),
     } as unknown as SnapshotSource;
     const onSnapshotBootstrapError = vi.fn();
+    const progressFrames: SyncProgress[] = [];
+    const { fetch } = makeGraphqlFetch();
 
     try {
-      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      await pullSync(db, noopQueryClient(), fetch, {
         enabledBoards: ['kilter:1:5'],
         snapshotSource: source,
         onSnapshotBootstrapError,
+        onProgress: (progress) => progressFrames.push(progress),
       });
     } finally {
       setBackgrounded(false);
     }
 
+    // The main artifact landed before grades began, and stays imported.
+    expect(await countRows('board_climbs')).toBe(1);
     expect(await getGradesBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
     expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
       expect.objectContaining({ stage: 'grades-download', attempt: 0, aborted: true, reason: 'aborted-background' }),
     );
+    expect(
+      fetch.mock.calls.some(([query]) =>
+        ['syncDeletions', 'syncClimbs', 'syncClimbStats', 'syncClimbGrades'].some((field) =>
+          String(query).includes(field),
+        ),
+      ),
+    ).toBe(false);
+    expect(progressFrames.at(-1)).toEqual({
+      phase: 'idle',
+      currentTable: null,
+      documentsProcessed: 0,
+      interrupted: true,
+    });
+    expect(progressFrames.filter((progress) => progress.phase === 'idle')).toHaveLength(1);
   });
 
   it('stops trying grades once its own attempt budget is spent', async () => {
@@ -5072,43 +5095,44 @@ describe('pullSync bootstrap funnel invariant', () => {
     expect(await getBootstrapAttempts(db, 'kilter:1:5')).toBe(0);
   });
 
-  it('does not burn an attempt when a backgrounded phone returns before the abort is handled', async () => {
-    // The race a review flagged on #4345: the teardown flags are LIVE, so a phone
-    // that woke between our own AbortController firing and the throw being
-    // handled read as "no teardown" — and the download we cancelled ourselves was
-    // settled as a real transport failure, burning an attempt and scheduling a
-    // cooldown. A pocketed phone is not a failure (#4326's taxonomy), so the
-    // reason is now latched at the moment we abort.
+  it('ends the cycle as interrupted when a suspended transfer rejects after the phone foregrounds', async () => {
+    // Background URLSession work is allowed to continue, but the OS can still
+    // kill the transfer while the process is suspended. The phone may foreground
+    // before that rejection reaches JS, so the suspension window — not the live
+    // AppState flag — must stop this stale cycle before deletions or paged pulls.
     const filePath = join(workDir, 'backgrounded-then-foregrounded.db');
     buildScopeArtifact(filePath);
+    let seenSignal: AbortSignal | undefined;
     const source: SnapshotSource = {
       fetchManifest: async () => makeManifest([makeEntry()]),
       downloadArtifact: async (_entry, options) => {
-        // Backgrounding notifies the teardown listeners synchronously, which is
-        // what aborts the transfer.
+        seenSignal = options?.signal;
         setBackgrounded(true);
-        expect(options?.signal?.aborted).toBe(true);
-        // ...and the climber pulls the phone back out before the rejection is
-        // handled, so every live flag reads clean at the check below.
         setBackgrounded(false);
-        throw new Error('Aborted');
+        throw new Error('The network connection was lost.');
       },
       deleteArtifact: vi.fn(async () => {}),
     };
     const onSnapshotBootstrapError = vi.fn();
     const onBootstrapRetryScheduled = vi.fn();
+    const progressFrames: SyncProgress[] = [];
+    const { fetch } = makeGraphqlFetch();
 
     try {
-      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      await pullSync(db, noopQueryClient(), fetch, {
         enabledBoards: ['kilter:1:5'],
         snapshotSource: source,
         onSnapshotBootstrapError,
         onBootstrapRetryScheduled,
+        onProgress: (progress) => progressFrames.push(progress),
       });
     } finally {
       setBackgrounded(false);
     }
 
+    // Kept outside the downloader: an assertion thrown inside that callback is
+    // intentionally caught as a download failure and cannot prove anything.
+    expect(seenSignal?.aborted).toBe(false);
     expect(onSnapshotBootstrapError).toHaveBeenCalledTimes(1);
     expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -5126,6 +5150,105 @@ describe('pullSync bootstrap funnel invariant', () => {
     const { state } = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
     expect(state.transportFailures).toBe(0);
     expect(state.structuralFailures).toBe(0);
+    expect(progressFrames.at(-1)).toEqual({
+      phase: 'idle',
+      currentTable: null,
+      documentsProcessed: 0,
+      interrupted: true,
+    });
+    expect(progressFrames.filter((progress) => progress.phase === 'idle')).toHaveLength(1);
+    expect(
+      fetch.mock.calls.some(([query]) =>
+        ['syncDeletions', 'syncClimbs', 'syncClimbStats', 'syncClimbGrades'].some((field) =>
+          String(query).includes(field),
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('charges a typed background-task marker to transport when AppState is active', async () => {
+    const marker = new SnapshotBackgroundTransferInterruptedError('cannot decode raw data');
+    const source: SnapshotSource = {
+      fetchManifest: async () => makeManifest([makeEntry()]),
+      downloadArtifact: async () => {
+        throw marker;
+      },
+      deleteArtifact: vi.fn(async () => {}),
+    };
+    const onSnapshotBootstrapError = vi.fn();
+    const onBootstrapRetryScheduled = vi.fn();
+    const progressFrames: SyncProgress[] = [];
+
+    await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      enabledBoards: ['kilter:1:5'],
+      snapshotSource: source,
+      onSnapshotBootstrapError,
+      onBootstrapRetryScheduled,
+      onProgress: (progress) => progressFrames.push(progress),
+      now: () => BASE_NOW,
+      random: () => 0,
+    });
+
+    const { state } = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(state.transportFailures).toBe(1);
+    expect(state.backgroundPauses).toBe(0);
+    expect(onBootstrapRetryScheduled).toHaveBeenCalledWith(
+      expect.objectContaining({ failureKind: 'transport', transportFailures: 1 }),
+    );
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'background-transfer-decode',
+        expected: true,
+        aborted: false,
+        attempt: 1,
+      }),
+    );
+    expect(progressFrames.at(-1)).toEqual(expect.objectContaining({ phase: 'idle', currentTable: null }));
+    expect(progressFrames.at(-1)?.interrupted).toBeUndefined();
+  });
+
+  it('treats the typed marker as a bounded background pause while the suspension window stays open', async () => {
+    const source: SnapshotSource = {
+      fetchManifest: async () => makeManifest([makeEntry()]),
+      downloadArtifact: async () => {
+        setBackgrounded(true);
+        setBackgrounded(false);
+        throw new SnapshotBackgroundTransferInterruptedError('cannot decode raw data');
+      },
+      deleteArtifact: vi.fn(async () => {}),
+    };
+    const onSnapshotBootstrapError = vi.fn();
+    const onBootstrapRetryScheduled = vi.fn();
+    const progressFrames: SyncProgress[] = [];
+
+    try {
+      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+        enabledBoards: ['kilter:1:5'],
+        snapshotSource: source,
+        onSnapshotBootstrapError,
+        onBootstrapRetryScheduled,
+        onProgress: (progress) => progressFrames.push(progress),
+        now: () => BASE_NOW,
+        random: () => 0,
+      });
+    } finally {
+      setBackgrounded(false);
+    }
+
+    const { state } = await readBootstrapRetryState(db, 'kilter:1:5', { now: BASE_NOW, random: () => 0 }, false);
+    expect(state.backgroundPauses).toBe(1);
+    expect(state.transportFailures).toBe(0);
+    expect(onBootstrapRetryScheduled).not.toHaveBeenCalled();
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'aborted-background',
+        aborted: true,
+        attempt: 0,
+      }),
+    );
+    expect(progressFrames.at(-1)).toEqual(
+      expect.objectContaining({ phase: 'idle', currentTable: null, interrupted: true }),
+    );
   });
 
   it('emits exactly one terminal event for a download that genuinely failed', async () => {
@@ -5390,18 +5513,41 @@ describe('pullSync bootstrap purge scoping', () => {
       setBackgrounded(true);
       return result;
     };
+    const onSnapshotBootstrapError = vi.fn();
+    const progressFrames: SyncProgress[] = [];
+    const { fetch } = makeGraphqlFetch();
 
     try {
-      await pullSync(db, noopQueryClient(), makeGraphqlFetch().fetch, {
+      await pullSync(db, noopQueryClient(), fetch, {
         enabledBoards: [KILTER_KEY],
         snapshotSource: source,
+        onSnapshotBootstrapError,
+        onProgress: (progress) => progressFrames.push(progress),
       });
     } finally {
       setBackgrounded(false);
     }
 
+    expect(await countRows('board_climbs')).toBe(1);
     expect(await getCheckpoint(db, `checkpoint:board_climb_grades:${KILTER_KEY}`)).toBeNull();
     expect(await getGradesBootstrapAttempts(db, KILTER_KEY)).toBe(0);
+    expect(onSnapshotBootstrapError).toHaveBeenCalledWith(
+      expect.objectContaining({ stage: 'grades-download', attempt: 0, aborted: true, reason: 'aborted-background' }),
+    );
+    expect(
+      fetch.mock.calls.some(([query]) =>
+        ['syncDeletions', 'syncClimbs', 'syncClimbStats', 'syncClimbGrades'].some((field) =>
+          String(query).includes(field),
+        ),
+      ),
+    ).toBe(false);
+    expect(progressFrames.at(-1)).toEqual({
+      phase: 'idle',
+      currentTable: null,
+      documentsProcessed: 0,
+      interrupted: true,
+    });
+    expect(progressFrames.filter((progress) => progress.phase === 'idle')).toHaveLength(1);
   });
 
   // THE FUNNEL INVARIANT under `break` → `continue`: every Started still gets

--- a/packages/shared/offline-sync/src/sync/__tests__/sync-scheduler.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/sync-scheduler.test.ts
@@ -305,6 +305,45 @@ describe('sync-scheduler', () => {
     expect(mockPullSync).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps retry and failed-idle lifecycle intact when the cycle-error reporter throws', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-15T00:00:00.000Z'));
+    try {
+      const cycleError = new Error('pull failed');
+      const reporterError = new Error('telemetry failed');
+      const drainQueue: DrainQueue = vi.fn().mockRejectedValueOnce(cycleError).mockResolvedValue(undefined);
+      const onProgress = vi.fn();
+      const onCycleError = vi.fn(() => {
+        throw reporterError;
+      });
+      const stop = startSyncScheduler(
+        mockDb,
+        createMockQueryClient(),
+        mockGraphqlFetch,
+        getEnabledBoards,
+        drainQueue,
+        createFakeTriggers().triggers,
+        { onCycleError, onProgress },
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(onCycleError).toHaveBeenCalledWith(cycleError);
+      expect(onProgress).toHaveBeenCalledWith({
+        phase: 'idle',
+        currentTable: null,
+        documentsProcessed: 0,
+        failed: true,
+      });
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(drainQueue).toHaveBeenCalledTimes(2);
+      expect(mockPullSync).toHaveBeenCalledTimes(1);
+      stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('startSyncScheduler runs an initial cycle and wires the injected triggers', async () => {
     const drainQueue: DrainQueue = vi.fn().mockResolvedValue(undefined);
     const queryClient = createMockQueryClient();

--- a/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
@@ -47,6 +47,8 @@ export type SnapshotBootstrapFailureReason =
   | 'artifact-invalid'
   /** The transfer finished but the body was the wrong length — a cut-short response, not corrupt bytes. */
   | 'artifact-truncated'
+  /** iOS's background URLSession could not decode the response body; retry as transport. */
+  | 'background-transfer-decode'
   /** Offline, or the connection dropped. The normal state of a phone on a plane. */
   | 'network'
   /** Nothing above matched — the bucket that should stay near zero. */
@@ -85,6 +87,7 @@ export function classifySnapshotBootstrapFailure(cause: unknown): SnapshotBootst
   if (name === 'SnapshotWatermarkRegressionError') return 'watermark-regression';
   if (name === 'SnapshotPermanentMissError') return 'permanent-miss';
   if (name === 'SnapshotArtifactTruncatedError') return 'artifact-truncated';
+  if (name === 'SnapshotBackgroundTransferInterruptedError') return 'background-transfer-decode';
 
   if (classifySqliteLockError(cause).locked) return 'database-locked';
 

--- a/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-retry.ts
@@ -198,6 +198,12 @@ export function classifyBootstrapFailure(input: {
   stage: 'manifest' | 'download' | 'import';
 }): BootstrapFailureKind {
   if (input.stage === 'import') return 'structural-artifact';
+  // Keep this module dependency-neutral: snapshot-bootstrap imports the retry
+  // constants below at module initialization time. The mobile adapter converts
+  // iOS's background URLSession decode failure into this stable error name.
+  if (input.cause instanceof Error && input.cause.name === 'SnapshotBackgroundTransferInterruptedError') {
+    return 'transport';
+  }
   // A short body is a cut-short RESPONSE, so it belongs on the transport ladder
   // (3 tries, cleared by any success) rather than `structural-device`, where two
   // occurrences would durably settle the scope onto the paged crawl with no

--- a/packages/shared/offline-sync/src/sync/checkpoints.ts
+++ b/packages/shared/offline-sync/src/sync/checkpoints.ts
@@ -54,23 +54,23 @@ function toSeqBigInt(rawSeq: string): bigint {
 }
 
 /**
- * Lower the deletions checkpoint to `watermark.updatedAt` when it currently sits AHEAD of
- * it, leaving it untouched otherwise. A scope warmed from a snapshot re-introduces
- * board rows as of the snapshot's (older) watermark; if the global deletions
- * cursor had already advanced past that point in an earlier cycle, any board-row
- * deletions in the window `(watermark, deletions-head]` were consumed while those
- * rows were absent and would never re-apply to the freshly-imported ones — a
- * stale, already-deleted climb would linger. Rewinding makes the next deletions
- * pull re-scan that window against the imported rows. A missing (fresh) deletions
- * checkpoint is already at the epoch, behind any watermark, so it is left alone.
+ * Lower the deletions checkpoint to `replayFrom.updatedAt` when it currently sits
+ * AHEAD of it, leaving it untouched otherwise. A scope warmed from a snapshot
+ * re-introduces board rows from an older database view; if the global deletions
+ * cursor had already advanced past that view in an earlier cycle, tombstones
+ * consumed while those rows were absent would never re-apply to the freshly
+ * imported ones. Rewinding makes the next deletions pull re-scan that window.
+ * New artifacts provide a conservative export-transaction boundary; older
+ * artifacts use their scoped row watermark. A missing (fresh) deletions
+ * checkpoint is already at the epoch, behind either target, so it is left alone.
  *
  * Deletions page on `(deleted_at, sync_deletions.id)`, not board-table
  * `sync_seq`, so the rewind target uses sequence `0` to include every tombstone
  * at the exact snapshot timestamp.
  */
-export async function rewindDeletionsCheckpoint(db: SqlExecutor, watermark: SyncCheckpoint): Promise<void> {
+export async function rewindDeletionsCheckpoint(db: SqlExecutor, replayFrom: SyncCheckpoint): Promise<void> {
   const current = await getCheckpoint(db, DELETIONS_CHECKPOINT_KEY);
-  const deletionCursorWatermark = { updatedAt: watermark.updatedAt, syncSeq: '0' };
+  const deletionCursorWatermark = { updatedAt: replayFrom.updatedAt, syncSeq: '0' };
   if (!current) return;
   if (compareCheckpoints(current, deletionCursorWatermark) > 0) {
     await setCheckpoint(db, DELETIONS_CHECKPOINT_KEY, deletionCursorWatermark);

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -126,6 +126,12 @@ export type SyncProgress = {
    */
   failed?: boolean;
   /**
+   * Set when an expected lifecycle guard ended the cycle (background, sign-out,
+   * purge, or lost connectivity). Like `failed`, it clears live UI without
+   * claiming the cycle reached the sync tail.
+   */
+  interrupted?: boolean;
+  /**
    * Live snapshot download/import detail (issue #4311). Only ever attached to a
    * `phase: 'bootstrap'` frame whose `currentTable` IS the scope key it
    * describes, so a row matches it exactly the way it already matches the
@@ -925,6 +931,10 @@ const MAX_MANIFEST_WAIT_FAILURES = 2;
 const MANIFEST_FAIL_OPEN_RETRY_DELAY_MS = 5 * 60_000;
 const manifestFailureCounts = new WeakMap<OfflineDatabase, { wipeEpoch: number; count: number }>();
 
+function isBackgroundTransferDecodeError(cause: unknown): boolean {
+  return cause instanceof Error && cause.name === 'SnapshotBackgroundTransferInterruptedError';
+}
+
 function settleManifestPublicationStateOnce(
   db: OfflineDatabase,
   resolution: ManifestResolution,
@@ -996,7 +1006,7 @@ async function settleBootstrapFailure(
 }> {
   const { state, cause, stage, builtAt, now, random } = input;
   const failureKind = classifyBootstrapFailure({ cause, stage });
-  const expected = isNetworkError(cause);
+  const expected = isNetworkError(cause) || isBackgroundTransferDecodeError(cause);
   if (stage === 'manifest') {
     // The manifest is one global object shared by every scope in this cycle.
     // Charging a per-scope budget for a bad response can terminal every board
@@ -1154,7 +1164,7 @@ async function runBootstrapPhase(params: {
   options: SyncOptions | undefined;
   now: () => number;
   random: () => number;
-}): Promise<{ skipPagedPull: Set<string> }> {
+}): Promise<{ skipPagedPull: Set<string>; cycleInterrupted: boolean }> {
   const {
     db,
     queryClient,
@@ -1269,6 +1279,7 @@ async function runBootstrapPhase(params: {
   const isOnUnmeteredNetwork = options?.isOnUnmeteredNetwork ?? (() => true);
 
   const skipPagedPull = new Set<string>();
+  let cycleInterrupted = false;
   const manifestCache: ManifestResolutionCache = {};
   type LayoutDownloadRecord = {
     file: SnapshotArtifactHandle | null;
@@ -1322,26 +1333,42 @@ async function runBootstrapPhase(params: {
    * counter, and the worst case is that the scope crawls grades exactly as it
    * does today.
    */
-  const importGradesForScope = async (scope: BoardScope, entry: SnapshotManifestEntry): Promise<void> => {
+  const importGradesForScope = async (
+    scope: BoardScope,
+    entry: SnapshotManifestEntry,
+  ): Promise<TeardownVerdict['kind'] | null> => {
     const gradesArtifact = entry.grades;
-    if (!gradesArtifact || !source.downloadGradesArtifact) return;
+    if (!gradesArtifact || !source.downloadGradesArtifact) return null;
     // A grades artifact built at an older client schema would NULL-fill columns
     // this app added and then stamp the cursor past them — same permanent-miss
     // rule the whole-layout artifact gets.
-    if (!isSnapshotEntryUsable(gradesArtifact)) return;
-    if ((await getGradesBootstrapAttempts(db, scope.scopeKey)) >= MAX_GRADES_BOOTSTRAP_ATTEMPTS) return;
+    if (!isSnapshotEntryUsable(gradesArtifact)) return null;
+    if ((await getGradesBootstrapAttempts(db, scope.scopeKey)) >= MAX_GRADES_BOOTSTRAP_ATTEMPTS) return null;
 
     // One artifact serves every size of a layout, which is exactly why the purge
     // namespace is keyed the same way — the two must never drift.
     const layoutKey = purgeNamespaceKey(scope);
     let gradesDownload = gradesDownloadByLayout.get(layoutKey);
     if (gradesDownload === undefined) {
+      const preDownloadVerdict = teardownVerdict(scope.scopeKey);
+      if (preDownloadVerdict) return preDownloadVerdict.kind;
+
+      // A background→foreground transition can complete before the native
+      // promise rejects. Latch teardown only for a DEAD transfer; a successful
+      // grades file may still be imported when the app is active again, just
+      // like the retained whole-layout download above.
+      let latchedDownloadVerdict: TeardownVerdict | null = null;
+      const unsubscribeGradesTeardown = onTeardown(() => {
+        latchedDownloadVerdict ??= teardownVerdict(scope.scopeKey);
+      });
       let downloadCause: unknown = null;
       try {
         gradesDownload = (await source.downloadGradesArtifact(gradesArtifact)) ?? null;
       } catch (error) {
         gradesDownload = null;
         downloadCause = error;
+      } finally {
+        unsubscribeGradesTeardown();
       }
       // A NULL return counts exactly as a throw does. `SnapshotSource` lets a
       // source signal "unusable this cycle" either way (see downloadArtifact's
@@ -1358,11 +1385,11 @@ async function runBootstrapPhase(params: {
         // Scope-aware (issue #4370): another board's removal never charges this
         // layout a grades attempt, and never masks a real grades failure as an
         // abort either.
-        const gradesTeardown = teardownVerdict(scope.scopeKey);
+        const gradesTeardown = teardownVerdict(scope.scopeKey) ?? latchedDownloadVerdict;
         if (gradesTeardown) {
           reportBootstrapAbort(scope.scopeKey, 'grades-download', gradesTeardown.reason, downloadCause);
           gradesDownloadByLayout.set(layoutKey, null);
-          return;
+          return gradesTeardown.kind;
         }
         const attempt = await recordGradesBootstrapAttempt(db, scope.scopeKey);
         onSnapshotBootstrapError?.({
@@ -1376,8 +1403,12 @@ async function runBootstrapPhase(params: {
       gradesDownloadByLayout.set(layoutKey, gradesDownload);
       if (gradesDownload) gradesArtifactPaths.add(gradesDownload.filePath);
     }
-    if (!gradesDownload) return;
-    if (isSigningOut() || hasPurgeLanded(purgeToken, purgeNamespaceKey(scope)) || isBackgrounded()) return;
+    if (!gradesDownload) return null;
+    const preImportVerdict = teardownVerdict(scope.scopeKey);
+    if (preImportVerdict) {
+      reportBootstrapAbort(scope.scopeKey, 'grades-download', preImportVerdict.reason, null);
+      return preImportVerdict.kind;
+    }
 
     try {
       const { rowsImported } = await bootstrapScopeGradesFromSnapshot({
@@ -1400,8 +1431,12 @@ async function runBootstrapPhase(params: {
       }
     } catch (error) {
       // A wipe rolls the transaction back; no checkpoint, nothing to count.
-      if (error instanceof SnapshotWipedError || isSigningOut() || hasPurgeLanded(purgeToken, purgeNamespaceKey(scope)))
-        return;
+      const importVerdict = teardownVerdict(scope.scopeKey);
+      if (error instanceof SnapshotWipedError || importVerdict) {
+        const resolvedVerdict = importVerdict ?? { reason: 'aborted-wipe' as const, kind: 'cycle' as const };
+        reportBootstrapAbort(scope.scopeKey, 'grades-import', resolvedVerdict.reason, error);
+        return resolvedVerdict.kind;
+      }
       const attempt = await recordGradesBootstrapAttempt(db, scope.scopeKey);
       onSnapshotBootstrapError?.({
         scopeKey: scope.scopeKey,
@@ -1411,6 +1446,7 @@ async function runBootstrapPhase(params: {
         expected: false,
       });
     }
+    return null;
   };
 
   const reportSettledFailure = (
@@ -1473,7 +1509,10 @@ async function runBootstrapPhase(params: {
       try {
         const loopTopVerdict = teardownVerdict(scope.scopeKey);
         if (loopTopVerdict) {
-          if (loopTopVerdict.kind === 'cycle') break;
+          if (loopTopVerdict.kind === 'cycle') {
+            cycleInterrupted = true;
+            break;
+          }
           continue;
         }
 
@@ -1569,7 +1608,10 @@ async function runBootstrapPhase(params: {
               const retrofitResolution = await resolveManifestOnce(source, manifestCache);
               const retrofitVerdict = teardownVerdict(scope.scopeKey);
               if (retrofitVerdict) {
-                if (retrofitVerdict.kind === 'cycle') break;
+                if (retrofitVerdict.kind === 'cycle') {
+                  cycleInterrupted = true;
+                  break;
+                }
                 continue;
               }
               settleManifestPublicationStateOnce(db, retrofitResolution, manifestCache, { countError: false });
@@ -1577,7 +1619,14 @@ async function runBootstrapPhase(params: {
                 retrofitResolution.status === 'ok'
                   ? findSnapshotEntry(retrofitResolution.manifest, scope.boardType, scope.layoutId)
                   : null;
-              if (retrofitEntry) await importGradesForScope(scope, retrofitEntry);
+              if (retrofitEntry) {
+                const gradesVerdict = await importGradesForScope(scope, retrofitEntry);
+                if (gradesVerdict === 'cycle') {
+                  cycleInterrupted = true;
+                  break;
+                }
+                if (gradesVerdict === 'scope') continue;
+              }
             }
           }
           continue;
@@ -1604,7 +1653,10 @@ async function runBootstrapPhase(params: {
         // writes to SQLite or leads to one further down.
         const manifestVerdict = teardownVerdict(scope.scopeKey);
         if (manifestVerdict) {
-          if (manifestVerdict.kind === 'cycle') break;
+          if (manifestVerdict.kind === 'cycle') {
+            cycleInterrupted = true;
+            break;
+          }
           continue;
         }
         // Manifest retry bookkeeping is intentionally deferred until AFTER the
@@ -1766,7 +1818,10 @@ async function runBootstrapPhase(params: {
         const preDownloadVerdict = teardownVerdict(scope.scopeKey);
         if (preDownloadVerdict) {
           reportBootstrapAbort(scope.scopeKey, 'download', preDownloadVerdict.reason, null);
-          if (preDownloadVerdict.kind === 'cycle') break;
+          if (preDownloadVerdict.kind === 'cycle') {
+            cycleInterrupted = true;
+            break;
+          }
           continue;
         }
 
@@ -1896,13 +1951,15 @@ async function runBootstrapPhase(params: {
           // cannot relabel it), or the OS suspension plausibly killed it. The
           // second test is deliberately narrow: the suspension window must still
           // be open (no byte since the app backgrounded) AND the cause must be
-          // network-shaped, which is what a suspension kill produces
-          // ("The network connection was lost", a timeout, a SocketException)
-          // and what a disk-full, an HTTP 500 or a programmer error is not.
+          // transport-shaped: either a network loss/timeout or iOS background
+          // URLSession's exact response-decoding interruption. A disk-full,
+          // HTTP 500, or programmer error still spends its real budget.
           if (!cachedDownload.file) {
+            const suspensionKilledTransfer =
+              suspensionWindowOpen &&
+              (isNetworkError(cachedDownload.cause) || isBackgroundTransferDecodeError(cachedDownload.cause));
             cachedDownload.abortedReason =
-              selfAbortedReason ??
-              (suspensionWindowOpen && isNetworkError(cachedDownload.cause) ? 'aborted-background' : null);
+              selfAbortedReason ?? (suspensionKilledTransfer ? 'aborted-background' : null);
           }
           cachedDownload.downloadMs = Date.now() - downloadStartedAt;
           downloadByLayout.set(layoutKey, cachedDownload);
@@ -2003,7 +2060,10 @@ async function runBootstrapPhase(params: {
           }
           // A purge of ONLY this scope's namespace stops this board and leaves
           // every other download in the cycle running (issue #4370).
-          if (downloadVerdict.kind === 'cycle') break;
+          if (downloadVerdict.kind === 'cycle') {
+            cycleInterrupted = true;
+            break;
+          }
           continue;
         }
         const download = cachedDownload.file;
@@ -2134,7 +2194,12 @@ async function runBootstrapPhase(params: {
           // Grades ride a second, small artifact and a second short exclusive
           // transaction, right after the climbs/stats one. See
           // importGradesForScope — every failure here is free.
-          await importGradesForScope(scope, entry);
+          const gradesVerdict = await importGradesForScope(scope, entry);
+          if (gradesVerdict === 'cycle') {
+            cycleInterrupted = true;
+            break;
+          }
+          if (gradesVerdict === 'scope') continue;
           // Not skipped: the board-data phase delta-pulls from the watermark
           // checkpoints and fires markScopeDownloadComplete through the tail logic.
         } catch (error) {
@@ -2153,7 +2218,10 @@ async function runBootstrapPhase(params: {
               : teardownVerdict(scope.scopeKey);
           if (importVerdict) {
             reportBootstrapAbort(scope.scopeKey, 'import', importVerdict.reason, error);
-            if (importVerdict.kind === 'cycle') break;
+            if (importVerdict.kind === 'cycle') {
+              cycleInterrupted = true;
+              break;
+            }
             continue;
           }
           if (error instanceof SnapshotSchemaStaleError) {
@@ -2276,7 +2344,7 @@ async function runBootstrapPhase(params: {
     }
   }
 
-  return { skipPagedPull };
+  return { skipPagedPull, cycleInterrupted };
 }
 
 /**
@@ -2429,10 +2497,21 @@ export async function pullSync(
   graphqlFetch: <T>(query: string, variables?: Record<string, unknown>) => Promise<T>,
   options?: SyncOptions,
 ): Promise<void> {
+  let totalDocuments = 0;
+  const reportInterruptedCycle = (): undefined => {
+    options?.onProgress?.({
+      phase: 'idle',
+      currentTable: null,
+      documentsProcessed: totalDocuments,
+      interrupted: true,
+    });
+    return undefined;
+  };
+
   // Mirrors drainMutationQueue's entry guard: don't even start the snapshot
   // bootstrap phase below (which runs before the first cycleAborted() check)
   // when the app is already backgrounded.
-  if (isBackgrounded()) return;
+  if (isBackgrounded()) return reportInterruptedCycle();
 
   // Offline: every request this cycle would make is already lost, and the
   // bootstrap phase would spend a Sentry event per enabled-but-undownloaded
@@ -2440,7 +2519,7 @@ export async function pullSync(
   // edge and the next foreground both retrigger a cycle. Same posture as
   // drainMutationQueue's `if (!options.isOnline()) return`.
   const isOnline = options?.isOnline ?? (() => true);
-  if (!isOnline()) return;
+  if (!isOnline()) return reportInterruptedCycle();
 
   // Captured ONCE for the whole cycle and threaded into every phase, so a wipe or a
   // purge aborts exactly the work it can invalidate rather than just whichever table
@@ -2487,11 +2566,10 @@ export async function pullSync(
   // The phase can spend a probe and a multi-table wipe; the bootstrap phase below
   // starts downloading before the deletions phase's own cycleAborted(), so check
   // here rather than let a teardown that landed during it kick off a download.
-  if (cycleAborted()) return;
+  if (cycleAborted()) return reportInterruptedCycle();
 
   const enabledBoards = options?.enabledBoards ?? [];
   const onProgress = options?.onProgress;
-  let totalDocuments = 0;
 
   // Parse the enabled scope keys once; malformed keys are dropped (a stray value
   // can't crash the pull) so both the bootstrap phase and the paged board loop
@@ -2577,6 +2655,11 @@ export async function pullSync(
       random: options.random ?? Math.random,
     });
     skipBootstrapPagedPull = bootstrapPhase.skipPagedPull;
+    // The bootstrap phase latches lifecycle teardown across its long native
+    // awaits. If the app foregrounds again before the rejected download is
+    // handled, the live outer guard is already clear; do not let that stale
+    // cycle continue into deletions or paged pulls.
+    if (bootstrapPhase.cycleInterrupted) return reportInterruptedCycle();
   }
 
   // Deletions FIRST, table pulls second. This ordering is what makes a
@@ -2585,7 +2668,7 @@ export async function pullSync(
   // Applied after the pulls, a tombstone sharing the recreated row's timestamp
   // would delete data this cycle just wrote, and the strict > cursor would
   // never fetch it again.
-  if (cycleAborted()) return;
+  if (cycleAborted()) return reportInterruptedCycle();
   onProgress?.({ phase: 'deletions', currentTable: null, documentsProcessed: 0 });
   const deletionsResult = await processDeletions(db, queryClient, graphqlFetch, purgeToken, (deletionsProcessed) => {
     totalDocuments = deletionsProcessed;
@@ -2598,7 +2681,7 @@ export async function pullSync(
 
   let allUserTablesReachedTail = true;
   for (const tableName of USER_DATA_TABLES) {
-    if (cycleAborted()) return;
+    if (cycleAborted()) return reportInterruptedCycle();
     onProgress?.({ phase: 'user_data', currentTable: tableName, documentsProcessed: totalDocuments });
     const baseCount = totalDocuments;
     const userTableResult = await syncTable(
@@ -2626,7 +2709,7 @@ export async function pullSync(
   // Guarded, symmetric to the scope-complete block below: the last user table's
   // in-page check is one await back, so a global wipe landing in that window
   // would otherwise stamp `user_data_complete` over data that is being deleted.
-  if (cycleAborted()) return;
+  if (cycleAborted()) return reportInterruptedCycle();
   if (allUserTablesReachedTail) await markUserDataComplete(db);
 
   // Each enabled board is a "boardType:layoutId:sizeId" scope key (already parsed
@@ -2649,7 +2732,7 @@ export async function pullSync(
     // side: it is the last code that can still see the Started marker before
     // deleting it, and it de-dups against the bootstrap phase's own
     // `aborted-wipe` through the purge generation.
-    if (cycleAborted()) return;
+    if (cycleAborted()) return reportInterruptedCycle();
     if (scopePurged(boardScope)) continue;
     const scopeKey = boardScope.scopeKey;
     // No-op when the bootstrap phase already stamped this scope; the paged-only
@@ -2667,7 +2750,7 @@ export async function pullSync(
     // phase already announced is a no-op here thanks to the durable marker, so
     // it keeps its 'snapshot' intent and its artifact size.
     await emitScopeDownloadStartOnce({ scopeKey, pathIntent: 'paged', artifactBytes: null });
-    if (cycleAborted()) return;
+    if (cycleAborted()) return reportInterruptedCycle();
     if (scopePurged(boardScope)) continue;
     // A scope whose bootstrap failed this cycle (with attempts still left) skips
     // its paged pull: a first-page checkpoint would permanently disqualify the
@@ -2675,7 +2758,7 @@ export async function pullSync(
     if (skipBootstrapPagedPull.has(scopeKey)) continue;
     let allTablesReachedTail = true;
     for (const tableName of BOARD_DATA_TABLES) {
-      if (cycleAborted()) return;
+      if (cycleAborted()) return reportInterruptedCycle();
       if (scopePurged(boardScope)) {
         // Not `continue` on the OUTER loop's terms: clearing the flag is what
         // stops the completion block below from being reached through this
@@ -2747,13 +2830,13 @@ export async function pullSync(
     // landing in that window would queue this write BEHIND the delete. The
     // table-loop's `allTablesReachedTail = false` never runs after the FINAL
     // table, so it cannot cover this.
-    if (cycleAborted()) return;
+    if (cycleAborted()) return reportInterruptedCycle();
     if (scopePurged(boardScope)) continue;
     if (allTablesReachedTail) {
       const wasScopeComplete = await isScopeDownloadComplete(db, scopeKey);
       // Checked again after the read, so the window between the decision and the
       // write is one statement rather than one await.
-      if (cycleAborted()) return;
+      if (cycleAborted()) return reportInterruptedCycle();
       if (scopePurged(boardScope)) continue;
       // Clears the persisted start stamp as well as writing the complete marker.
       await markScopeDownloadComplete(db, scopeKey);

--- a/packages/shared/offline-sync/src/sync/pull-client.ts
+++ b/packages/shared/offline-sync/src/sync/pull-client.ts
@@ -754,8 +754,10 @@ async function processDeletions(
   let cursor: SyncCursorInput | undefined = checkpoint
     ? { updatedAt: checkpoint.updatedAt, syncSeq: checkpoint.syncSeq }
     : undefined;
+  const epochCursor: SyncCursorInput = { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' };
   let totalProcessed = 0;
-  const invalidatedKeys = new Set<string>();
+
+  class DeletionPageAbortedError extends Error {}
 
   // See syncTable: catch a wipe that ran while a page was on the wire, and why the
   // token is the cycle's rather than one captured here.
@@ -780,71 +782,112 @@ async function processDeletions(
     // the backend returns deletions:[] with hasMore:true (I2).
     if (result.deletions.length === 0) break;
 
-    for (const deletion of result.deletions) {
-      const config = TABLE_CONFIGS[deletion.tableName];
-      if (!config) continue;
+    // Apply one fetched page and its cursor atomically. The old one-autocommit-
+    // per-tombstone path made a large replay expensive and exposed a crash gap:
+    // some rows could be deleted while the page checkpoint stayed behind. One
+    // exclusive transaction gives SQLite one lock/commit per page and ensures a
+    // failed tombstone rolls the entire page back for a clean retry.
+    const pageInvalidatedKeys = new Set<string>();
+    try {
+      await db.withExclusiveTransactionAsync(async (transaction) => {
+        await applyBusyTimeout(transaction);
 
-      const pkColumns = config.primaryKeyColumns;
-
-      // Resurrection guard: a tombstone must not delete a row NEWER than the
-      // deletion (delete-then-re-add on another device — the re-added row and
-      // the stale tombstone can arrive in the same pull). Rows the tombstone
-      // post-dates are deleted; ties delete too (same-transaction recreate),
-      // which converges because deletions are applied BEFORE the table pulls.
-      const hasUpdatedAt = config.localColumns.includes('updated_at');
-      const guardClause = hasUpdatedAt ? ' AND (updated_at IS NULL OR updated_at <= ?)' : '';
-      const guardParams = hasUpdatedAt ? [deletion.deletedAt] : [];
-
-      if (pkColumns.length === 1) {
-        const deleteResult = await db.runAsync(
-          `DELETE FROM ${deletion.tableName} WHERE ${pkColumns[0]} = ?${guardClause}`,
-          [deletion.recordId, ...guardParams],
-        );
-        // Local cascade: the server's whole-playlist delete cascades
-        // playlist_climbs in Postgres but deliberately emits NO child
-        // tombstones (see 0144's NULL-parent guard), and the local SQLite has
-        // no FK cascade — without this, a deleted playlist's climb rows would
-        // accumulate as invisible orphans forever. Gated on the parent delete
-        // actually removing a row so a resurrection-guarded (stale) playlist
-        // tombstone doesn't strip a live playlist's climbs.
-        if (deletion.tableName === 'playlists' && (deleteResult?.changes ?? 0) > 0) {
-          await db.runAsync(`DELETE FROM playlist_climbs WHERE playlist_uuid = ?`, [deletion.recordId]);
+        // Expo opens this wrapper with deferred BEGIN: entering the callback is
+        // NOT writer-lock ownership. Re-writing the page's current cursor (or
+        // creating the epoch cursor on page one) is the first real main-DB write,
+        // so it waits behind a purge and then acquires SQLite's RESERVED writer
+        // lock. If the purge won, the guard immediately rolls this write back.
+        // If we won, a purge cannot finish until this transaction commits or
+        // rolls back. This closes the queue gap where a stale page could otherwise
+        // commit after a wipe that landed between callback entry and first DELETE.
+        await setCheckpoint(transaction, checkpointKey, cursor ?? epochCursor);
+        if (isSigningOut() || hasPurgeLanded(purgeToken) || isBackgrounded()) {
+          throw new DeletionPageAbortedError();
         }
-      } else {
-        // Backend encodes composite PKs as exactly N colon-separated segments
-        // matching primaryKeyColumns order (e.g. "kilter:uuid:40" for
-        // board_climb_stats with PK [board_type, climb_uuid, angle]). The split
-        // must produce exactly pkColumns.length parts — if not, skip the deletion
-        // rather than silently deleting the wrong row.
-        const recordIdParts = deletion.recordId.split(':');
-        if (recordIdParts.length !== pkColumns.length) {
-          console.warn(
-            `[Sync] Skipping deletion: expected ${pkColumns.length} PK parts for ${deletion.tableName}, got ${recordIdParts.length} from "${deletion.recordId}"`,
-          );
-          continue;
-        }
-        const whereClause = pkColumns.map((col) => `${col} = ?`).join(' AND ');
-        await db.runAsync(`DELETE FROM ${deletion.tableName} WHERE ${whereClause}${guardClause}`, [
-          ...recordIdParts,
-          ...guardParams,
-        ]);
-      }
 
-      for (const key of config.invalidateKeys) {
-        invalidatedKeys.add(JSON.stringify(key));
-      }
+        for (const deletion of result.deletions) {
+          const config = TABLE_CONFIGS[deletion.tableName];
+          if (!config) continue;
+
+          const pkColumns = config.primaryKeyColumns;
+
+          // Resurrection guard: a tombstone must not delete a row NEWER than the
+          // deletion (delete-then-re-add on another device — the re-added row and
+          // the stale tombstone can arrive in the same pull). Rows the tombstone
+          // post-dates are deleted; ties delete too (same-transaction recreate),
+          // which converges because deletions are applied BEFORE the table pulls.
+          const hasUpdatedAt = config.localColumns.includes('updated_at');
+          const guardClause = hasUpdatedAt ? ' AND (updated_at IS NULL OR updated_at <= ?)' : '';
+          const guardParams = hasUpdatedAt ? [deletion.deletedAt] : [];
+
+          if (pkColumns.length === 1) {
+            const deleteResult = await transaction.runAsync(
+              `DELETE FROM ${deletion.tableName} WHERE ${pkColumns[0]} = ?${guardClause}`,
+              [deletion.recordId, ...guardParams],
+            );
+            // Local cascade: the server's whole-playlist delete cascades
+            // playlist_climbs in Postgres but deliberately emits NO child
+            // tombstones (see 0144's NULL-parent guard), and the local SQLite has
+            // no FK cascade — without this, a deleted playlist's climb rows would
+            // accumulate as invisible orphans forever. Gated on the parent delete
+            // actually removing a row so a resurrection-guarded (stale) playlist
+            // tombstone doesn't strip a live playlist's climbs.
+            if (deletion.tableName === 'playlists' && (deleteResult?.changes ?? 0) > 0) {
+              await transaction.runAsync(`DELETE FROM playlist_climbs WHERE playlist_uuid = ?`, [deletion.recordId]);
+            }
+          } else {
+            // Backend encodes composite PKs as exactly N colon-separated segments
+            // matching primaryKeyColumns order (e.g. "kilter:uuid:40" for
+            // board_climb_stats with PK [board_type, climb_uuid, angle]). The split
+            // must produce exactly pkColumns.length parts — if not, skip the deletion
+            // rather than silently deleting the wrong row.
+            const recordIdParts = deletion.recordId.split(':');
+            if (recordIdParts.length !== pkColumns.length) {
+              console.warn(
+                `[Sync] Skipping deletion: expected ${pkColumns.length} PK parts for ${deletion.tableName}, got ${recordIdParts.length} from "${deletion.recordId}"`,
+              );
+              continue;
+            }
+            const whereClause = pkColumns.map((col) => `${col} = ?`).join(' AND ');
+            await transaction.runAsync(`DELETE FROM ${deletion.tableName} WHERE ${whereClause}${guardClause}`, [
+              ...recordIdParts,
+              ...guardParams,
+            ]);
+          }
+
+          for (const key of config.invalidateKeys) {
+            pageInvalidatedKeys.add(JSON.stringify(key));
+          }
+        }
+
+        // A purge/background transition may start while we hold the writer lock.
+        // Roll back before publishing the page cursor so the purge can take the
+        // lock next; if it starts after this guard, it necessarily runs after our
+        // commit and clears this cursor itself.
+        if (isSigningOut() || hasPurgeLanded(purgeToken) || isBackgrounded()) {
+          throw new DeletionPageAbortedError();
+        }
+        await setCheckpoint(transaction, checkpointKey, result.cursor);
+      });
+    } catch (error) {
+      if (error instanceof DeletionPageAbortedError) return { reachedTail: false };
+      throw error;
     }
 
-    await setCheckpoint(db, checkpointKey, result.cursor);
+    // Invalidate immediately after this page commits. Deferring all keys until
+    // the stream tail meant page N could commit and advance its checkpoint,
+    // then a later request could fail before those deleted rows were evicted
+    // from React Query. The retry resumes after page N, so that stale UI would
+    // otherwise survive for the rest of the app process.
+    for (const serializedKey of pageInvalidatedKeys) {
+      queryClient.invalidateQueries({ queryKey: JSON.parse(serializedKey) as string[] });
+    }
+
     totalProcessed += result.deletions.length;
     onProgress?.(totalProcessed);
 
     cursor = { updatedAt: result.cursor.updatedAt, syncSeq: result.cursor.syncSeq };
     hasMore = result.hasMore;
-  }
-
-  for (const serializedKey of invalidatedKeys) {
-    queryClient.invalidateQueries({ queryKey: JSON.parse(serializedKey) as string[] });
   }
 
   // Both loop exits mean the server has nothing more past this cursor:
@@ -1070,9 +1113,10 @@ async function resolveManifestOnce(
  *     artifact, and before #4313's fix the scope stayed eligible and pulled the
  *     whole ~100 MB again every cycle, forever. Reported at full severity because
  *     it means the export's scope filter and the client's disagree.
- *   - success → mark done, rewind deletions to min(watermarks), clear the
- *     consecutive-transport counter; the paged pull runs normally, now a ~1-day
- *     delta from the scoped watermark checkpoints.
+ *   - success → mark done, rewind deletions to the artifact's conservative
+ *     export-transaction boundary (or min scoped watermarks for old artifacts),
+ *     clear the consecutive-transport counter; the paged pull runs normally,
+ *     now a ~1-day delta from the scoped watermark checkpoints.
  *
  * WORST-CASE LIFETIME SPEND per scope: 3 transport + 2 structural + 2 for the
  * single re-armed structural round = 7 artifact downloads, each separated by at
@@ -2039,9 +2083,10 @@ async function runBootstrapPhase(params: {
         const importStartedAt = Date.now();
         try {
           // Imports the scope's rows, stamps both table checkpoints, and rewinds
-          // the global deletions cursor to the older table watermark — all in one
-          // transaction, so no crash point can separate the imported rows from
-          // the tombstone-replay window that must cover them.
+          // the global deletions cursor to the artifact's safe deletion boundary
+          // (or the older scoped-table watermark for legacy artifacts) — all in
+          // one transaction, so no crash point can separate the imported rows
+          // from the tombstone-replay window that must cover them.
           const imported = await bootstrapScopeFromSnapshot({
             db,
             scope,

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -776,9 +776,66 @@ type SnapshotMetaRow = {
   watermark_updated_at: string;
   watermark_sync_seq: string;
   row_count: number;
+  built_at: string;
   schema_version: number;
   format_version: number;
 };
+
+const DELETIONS_SNAPSHOT_META_TABLE = 'sync_deletions';
+
+type VerifiedSnapshotMeta = {
+  builtAt: string;
+  /**
+   * Optional for backwards compatibility. Artifacts published before this
+   * metadata row shipped fall back to the older scoped-row watermark rewind.
+   */
+  deletionsReplayFrom: SyncCheckpoint | null;
+};
+
+function normalizeSnapshotTimestamp(rawTimestamp: unknown): string | null {
+  if (typeof rawTimestamp !== 'string') return null;
+  const timestampMs = Date.parse(rawTimestamp);
+  return Number.isFinite(timestampMs) ? new Date(timestampMs).toISOString() : null;
+}
+
+/**
+ * Read the optional metadata-only sync_deletions row. Any defect degrades to
+ * the legacy scoped-watermark rewind instead of rejecting an otherwise valid
+ * artifact: old artifacts have no row, and a boundary after artifact builtAt is
+ * unsafe. This preserves the legacy scoped-watermark behaviour for already
+ * published artifacts; new live gzip exports are gated on carrying this row.
+ */
+async function readDeletionsReplayFrom(
+  db: SqlExecutor,
+  alias: string,
+  artifactBuiltAt: string,
+): Promise<SyncCheckpoint | null> {
+  const meta = await db.getFirstAsync<SnapshotMetaRow>(
+    `SELECT table_name, watermark_updated_at, watermark_sync_seq, row_count, built_at, schema_version, format_version
+     FROM ${alias}.snapshot_meta WHERE table_name = ?`,
+    [DELETIONS_SNAPSHOT_META_TABLE],
+  );
+  if (!meta) return null;
+
+  const metaBuiltAt = normalizeSnapshotTimestamp(meta.built_at);
+  const replayFrom = normalizeSnapshotTimestamp(meta.watermark_updated_at);
+  const replayFromMs = replayFrom ? Date.parse(replayFrom) : Number.NaN;
+  const artifactBuiltAtMs = Date.parse(artifactBuiltAt);
+  if (
+    meta.table_name !== DELETIONS_SNAPSHOT_META_TABLE ||
+    meta.format_version !== SNAPSHOT_MANIFEST_FORMAT_VERSION ||
+    meta.schema_version < LATEST_SCHEMA_VERSION ||
+    meta.row_count !== 0 ||
+    String(meta.watermark_sync_seq) !== '0' ||
+    metaBuiltAt !== artifactBuiltAt ||
+    !replayFrom ||
+    replayFromMs > artifactBuiltAtMs
+  ) {
+    return null;
+  }
+
+  return { updatedAt: replayFrom, syncSeq: '0' };
+}
 
 /**
  * Thrown when the artifact was built at an older client schema version than this
@@ -824,19 +881,23 @@ export class SnapshotWatermarkRegressionError extends Error {
 /**
  * Read + validate the artifact's `snapshot_meta`: every snapshot table present,
  * `format_version` matching this client, `schema_version` not older than this
- * client's schema, and each recorded `row_count` equal to the artifact's ACTUAL
- * table count (a truncated/partial download is caught here before any row is
- * imported). Artifact-level watermarks are validation/export metadata; the
- * imported scope's checkpoints are computed from scoped artifact rows.
+ * client's schema, one consistent parseable `built_at`, and each recorded
+ * `row_count` equal to the artifact's ACTUAL table count (a truncated/partial
+ * download is caught here before any row is imported). Artifact-level
+ * watermarks are validation/export metadata; the imported scope's checkpoints
+ * are computed from scoped artifact rows. A valid optional sync_deletions meta
+ * row supplies the narrower replay boundary; missing/malformed rows fall back
+ * to the legacy scoped-watermark rewind.
  */
 async function verifySnapshotMeta(
   db: SqlExecutor,
   alias: string = SNAPSHOT_ALIAS,
   tables: readonly string[] = SNAPSHOT_TABLES,
-): Promise<void> {
+): Promise<VerifiedSnapshotMeta> {
+  let artifactBuiltAt: string | null = null;
   for (const tableName of tables) {
     const meta = await db.getFirstAsync<SnapshotMetaRow>(
-      `SELECT table_name, watermark_updated_at, watermark_sync_seq, row_count, schema_version, format_version
+      `SELECT table_name, watermark_updated_at, watermark_sync_seq, row_count, built_at, schema_version, format_version
        FROM ${alias}.snapshot_meta WHERE table_name = ?`,
       [tableName],
     );
@@ -851,6 +912,14 @@ async function verifySnapshotMeta(
     if (meta.schema_version < LATEST_SCHEMA_VERSION) {
       throw new SnapshotSchemaStaleError(meta.schema_version);
     }
+    const rowBuiltAt = normalizeSnapshotTimestamp(meta.built_at);
+    if (!rowBuiltAt) {
+      throw new Error(`snapshot bootstrap: invalid snapshot_meta built_at for ${tableName}`);
+    }
+    if (artifactBuiltAt !== null && artifactBuiltAt !== rowBuiltAt) {
+      throw new Error(`snapshot bootstrap: inconsistent snapshot_meta built_at for ${tableName}`);
+    }
+    artifactBuiltAt = rowBuiltAt;
     const actual = await db.getFirstAsync<{ n: number }>(`SELECT COUNT(*) AS n FROM ${alias}.${tableName}`);
     const actualCount = actual?.n ?? 0;
     if (actualCount !== meta.row_count) {
@@ -859,6 +928,12 @@ async function verifySnapshotMeta(
       );
     }
   }
+
+  if (!artifactBuiltAt) throw new Error('snapshot bootstrap: snapshot_meta did not contain a built_at');
+  return {
+    builtAt: artifactBuiltAt,
+    deletionsReplayFrom: await readDeletionsReplayFrom(db, alias, artifactBuiltAt),
+  };
 }
 
 // --- Bootstrap ----------------------------------------------------------------
@@ -916,6 +991,7 @@ export async function bootstrapScopeFromSnapshot(params: {
   const purgeKey = purgeNamespaceKey(scope);
 
   let watermarks: Record<SnapshotTableName, SyncCheckpoint> | null = null;
+  let deletionsReplayFrom: SyncCheckpoint | null = null;
   let imported = { climbsImported: 0, statsImported: 0 };
   try {
     await db.withExclusiveTransactionAsync(async (txn) => {
@@ -935,7 +1011,8 @@ export async function bootstrapScopeFromSnapshot(params: {
           );
         }
 
-        await verifySnapshotMeta(txn);
+        const snapshotMeta = await verifySnapshotMeta(txn);
+        deletionsReplayFrom = snapshotMeta.deletionsReplayFrom;
         watermarks = await scopedWatermarks(txn, scope);
 
         // Refuse BEFORE the exclusive transaction opens, so a regression writes
@@ -971,17 +1048,26 @@ export async function bootstrapScopeFromSnapshot(params: {
       await setCheckpoint(txn, getCheckpointKey('board_climbs', scopeKey), watermarks.board_climbs);
       await setCheckpoint(txn, getCheckpointKey('board_climb_stats', scopeKey), watermarks.board_climb_stats);
 
-      // Rewind the global deletions cursor to the OLDER of the two table
-      // watermarks IN THE SAME transaction as the import: once the board
+      // Rewind the global deletions cursor IN THE SAME transaction as the
+      // import: once the board
       // checkpoints exist this scope is never bootstrap-eligible again, so a
       // crash between the import commit and a separate rewind would leave
-      // board-row deletions in `(watermark, deletions-head]` permanently
+      // board-row deletions in `(replay boundary, deletions-head]` permanently
       // unreplayed against the imported rows.
+      //
+      // New artifacts carry a metadata-only sync_deletions row whose timestamp
+      // is the oldest of run builtAt, the export transaction's stability
+      // boundary, and every visible same-role active transaction start. That
+      // covers a long DELETE transaction which was invisible to the artifact's
+      // REPEATABLE READ snapshot but later commits with an older deleted_at.
+      // Old/malformed artifacts retain the pre-existing min(scoped watermarks)
+      // compatibility path. New live gzip exports refuse publication without
+      // the stronger boundary above.
       const minWatermark =
         compareCheckpoints(watermarks.board_climbs, watermarks.board_climb_stats) <= 0
           ? watermarks.board_climbs
           : watermarks.board_climb_stats;
-      await rewindDeletionsCheckpoint(txn, minWatermark);
+      await rewindDeletionsCheckpoint(txn, deletionsReplayFrom ?? minWatermark);
     });
   } finally {
     // On expo the wrapper's connection teardown already detached; this covers

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -309,6 +309,20 @@ export class SnapshotArtifactTruncatedError extends Error {
   }
 }
 
+/**
+ * The iOS background URLSession was interrupted while decoding a response body.
+ * Expo surfaces NSURLErrorCannotDecodeRawData as English prose without a stable
+ * code, so the mobile adapter converts that one platform-shaped error into this
+ * renderer-independent signal. It belongs on the bounded transport retry
+ * ladder, not the structural artifact/device budget.
+ */
+export class SnapshotBackgroundTransferInterruptedError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'SnapshotBackgroundTransferInterruptedError';
+  }
+}
+
 // --- Attempt / done markers (sync_meta, NOT under the checkpoint: prefix so the
 // sign-out checkpoint wipe leaves them alone, matching the board rows they
 // describe, which survive as the shared cache) ---------------------------------

--- a/packages/shared/offline-sync/src/sync/sync-scheduler.ts
+++ b/packages/shared/offline-sync/src/sync/sync-scheduler.ts
@@ -61,10 +61,8 @@ export type SchedulerOptions = {
    */
   isOnline?: () => boolean;
   /**
-   * Called when a sync cycle throws. A failed cycle is routine for offline
-   * users (the reconnect trigger retries), so the mobile adapter passes a
-   * dev-only console.warn — production neither spams the console nor reports
-   * expected network errors as handled exceptions.
+   * Called when a sync cycle throws. Observational only: a reporter that throws
+   * is swallowed so it cannot suppress the failed-idle frame or the retry wake.
    */
   onCycleError?: (error: unknown) => void;
   /** Threaded through to pullSync — see SchemaDriftReporter. */
@@ -200,7 +198,12 @@ async function runSync(request: SyncRunRequest): Promise<void> {
         retryAt: Date.now() + CYCLE_ERROR_RETRY_DELAY_MS,
       });
     }
-    options?.onCycleError?.(error);
+    try {
+      options?.onCycleError?.(error);
+    } catch {
+      // Telemetry is observational. A broken reporter must never strand the
+      // scheduler in the exact failed cycle it was trying to describe.
+    }
     // pullSync only emits its terminal `idle` frame on success, so a throw mid-pull
     // would leave the Settings status row stuck on "Downloading…". Emit idle here so
     // the in-flight flag always clears — marked `failed` so the status store does


### PR DESCRIPTION
## Summary

Fixes the multi-board offline download handoff observed in production after every CDN artifact had completed, plus the background-session recovery issue reproduced during field QA.

The first field trace showed Kilter OG completing in 32 seconds, followed by six successfully transferred board snapshots with no scope completion. A quiet So iLL snapshot rewound the shared deletion cursor far enough to replay 9,086 tombstones. The client applied each tombstone in its own SQLite commit before it could finish any board, while inactive imported boards rendered as “Waiting to download.”

The follow-up iOS trace showed a background URLSession fail after 73 seconds with `cannot decode raw data`. The client classified that native transport interruption as a structural device fault, scheduled an eight-hour fast-path cooldown, then hid an active paged crawl behind the static “Faster download interrupted” spinner. Expected background exits could also leave the progress store latched even after the scheduler stopped working.

This change:

- commits each 500-row deletion page atomically and invalidates its affected queries as soon as that page lands
- embeds a conservative, transaction-aware deletion replay boundary in new snapshots so fresh imports replay only the safe post-snapshot tail
- refuses to replace live gzip artifacts when that boundary cannot be proven
- adds a 30-second deadline and bounded retry/telemetry for offline GraphQL cycles
- treats iOS background-session decode interruptions as bounded background pauses or transport retries, never six-hour structural faults
- terminalizes every expected background/offline/purge exit without falsely stamping a successful sync time
- shows live paged-fallback counts instead of hiding real work behind an interruption spinner
- shows snapshot-imported boards as “Finishing download…” while shared cleanup or another board runs
- documents and verifies a mandatory full live-gzip refresh across every layout after deployment

The legacy artifact fallback remains compatible, but only newly verified live gzip artifacts carry the stronger long-transaction replay guarantee.

## Release Notes

Download several boards for offline use without getting stuck after the snapshot finishes.
Pocketing your phone now resumes the download cleanly, and a slower fallback shows real progress instead of an interrupted spinner.

## Test plan

- `vp run test:mobile` — 670 files / 6,459 tests passed
- `vp run test:offline-sync` — 32 files / 716 tests passed
- Focused background-recovery matrix — 8 files / 394 tests passed
- Snapshot exporter run suite — 43/43 passed independently
- Snapshot exporter golden suite — 15/15 passed
- Mobile and offline-sync typechecks — passed
- `vp run check:mobile-bundle` — iOS and Android passed
- Scoped `vp check` and pre-commit checks — passed
- `git diff --check` — passed

Physical simulator validation was not run in this Linux environment. The recovery path was verified against the tester's PostHog trace from the PR OTA on a physical iPhone.

## Rollout

After this reaches `main` and the production OTA deploy succeeds, run an unfiltered gzip snapshot export and verify every manifest entry contains valid `sync_deletions` metadata before field testing multi-board downloads.
