### PR TITLE
chore(web): retire the /app static path and fix the PWA manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,12 @@ jobs:
               - 'scripts/mobile-platform-imports-check.sh'
               - 'scripts/mobile-web-bundle-check.sh'
               - 'scripts/sync-mobile-board-renderer-wasm.sh'
+              # check:mobile-web-bundle drives the real Expo export, so these two
+              # only ever run against a genuinely rendered shell here. A
+              # unit-test fixture cannot catch a patcher that breaks on Expo's
+              # actual output. W-24 / #4438.
+              - 'scripts/build-expo-web-export.sh'
+              - 'scripts/lib/patch-expo-web-pwa-manifest.mjs'
               # The live fingerprint gates run in the mobile-bundle job; a PR
               # editing only their logic must still trigger that job.
               - 'scripts/mobile-fingerprint-inputs-check.ts'
@@ -151,6 +157,7 @@ jobs:
             deployConfig:
               - 'deploy/app-subdomain/**'
               - 'scripts/build-expo-web-export.sh'
+              - 'scripts/lib/patch-expo-web-pwa-manifest.mjs'
               - 'Dockerfile.web'
               - '.github/workflows/production-deploy.yml'
             # Everything scripts/store-metadata-limits.test.ts reads via fs at
@@ -498,6 +505,18 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Validate deploy/app-subdomain config (_headers, _redirects, no-CSP rule)
         run: vp test run --project deploy-app-subdomain
+      # Same fs-reading blind spot, one project over: both suites read
+      # Dockerfile.web / build-expo-web-export.sh / create-service-docker-context.mjs
+      # with readFileSync, so test-default's `--changed` never relates them to a
+      # diff that only touches those files — and a Dockerfile- or .sh-only PR
+      # matches no other job's gate at all. Nothing in CI builds Dockerfile.web
+      # (branch-deploy.yml is workflow_dispatch-only), so these pins are the only
+      # thing standing between #3795 and a restored /app export step. W-24 / #4438.
+      - name: Validate the retired /app export stays retired
+        run: >-
+          vp test run --project scripts
+          scripts/__tests__/dockerfile-web-no-expo-export.test.ts
+          scripts/__tests__/build-expo-web-export.test.ts
 
   listing-guards:
     needs: [changes]

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -712,12 +712,15 @@ jobs:
             # HTTP 200 the whole way. scripts/lib/patch-expo-web-pwa-manifest.mjs
             # rewrites the href from the export's baseUrl; this is the
             # end-to-end proof it landed on the real deploy.
+            # --max-time so an unreachable edge fails this attempt and lets the
+            # retry loop above do its job, instead of hanging the release. The
+            # sibling checks predate this and are left alone here on purpose.
             local href
-            href=$(curl -sS "$base/" \
+            href=$(curl -sS --max-time 20 "$base/" \
               | grep -oE '<link[^>]*rel="manifest"[^>]*>' \
               | grep -oE 'href="[^"]+"' | head -n1 | cut -d'"' -f2)
             [ "$href" = "/manifest.json" ] || { echo "  manifest href is '$href', expected /manifest.json"; return 1; }
-            local out; out=$(curl -sS -o /dev/null -w '%{http_code} %{content_type}' "$base$href")
+            local out; out=$(curl -sS --max-time 20 -o /dev/null -w '%{http_code} %{content_type}' "$base$href")
             echo "$out" | grep -q '^200 ' && echo "$out" | grep -qi 'application/json'
           }
 

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -726,7 +726,13 @@ jobs:
             # Read the body too. The href and content-type can both be right
             # while start_url sits outside scope — a manifest that parses
             # cleanly and still never offers the install prompt.
-            local body; body=$(curl -sS --max-time 20 "$base$href")
+            # Fetch and check the body separately, so a timed-out or empty
+            # response reports as a fetch failure rather than a JSON parse
+            # error from node — the retry loop handles both, but only one of
+            # them tells you what actually went wrong.
+            local body
+            body=$(curl -sS --max-time 20 "$base$href") || { echo "  manifest body fetch failed"; return 1; }
+            [ -n "$body" ] || { echo "  manifest body is empty"; return 1; }
             echo "$body" | node -e '
               const manifest = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
               if (manifest.start_url !== "/" || manifest.scope !== "/") {

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -704,12 +704,30 @@ jobs:
             echo "$cc" | grep -qi 'immutable'
           }
 
+          check_manifest_link() {
+            # The bug this guards (W-24, #4438): index.html asked for
+            # /app/manifest.json, _redirects' `/* /index.html 200` answered it
+            # with the SPA shell, and the browser silently got HTML where a
+            # manifest belongs — no install prompt, console error every load,
+            # HTTP 200 the whole way. scripts/lib/patch-expo-web-pwa-manifest.mjs
+            # rewrites the href from the export's baseUrl; this is the
+            # end-to-end proof it landed on the real deploy.
+            local href
+            href=$(curl -sS "$base/" \
+              | grep -oE '<link[^>]*rel="manifest"[^>]*>' \
+              | grep -oE 'href="[^"]+"' | head -n1 | cut -d'"' -f2)
+            [ "$href" = "/manifest.json" ] || { echo "  manifest href is '$href', expected /manifest.json"; return 1; }
+            local out; out=$(curl -sS -o /dev/null -w '%{http_code} %{content_type}' "$base$href")
+            echo "$out" | grep -q '^200 ' && echo "$out" | grep -qi 'application/json'
+          }
+
           retry "root / → 200 text/html"                 check_root
           retry "deep route /climbs → 200 (SPA shell)"    check_deep_route
           retry "X-Robots-Tag: noindex on /"              check_noindex
           retry "wasm binary → 200 wasm/octet-stream"     check_wasm
           retry "index.html is NOT immutable-cached"      check_index_not_immutable
           retry "hashed _expo asset is immutable-cached"  check_hashed_asset_immutable
+          retry "PWA manifest link → 200 application/json"  check_manifest_link
 
       - name: Install Playwright chromium
         run: cd packages/web && bunx playwright install --with-deps chromium

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -721,7 +721,19 @@ jobs:
               | grep -oE 'href="[^"]+"' | head -n1 | cut -d'"' -f2)
             [ "$href" = "/manifest.json" ] || { echo "  manifest href is '$href', expected /manifest.json"; return 1; }
             local out; out=$(curl -sS --max-time 20 -o /dev/null -w '%{http_code} %{content_type}' "$base$href")
-            echo "$out" | grep -q '^200 ' && echo "$out" | grep -qi 'application/json'
+            echo "$out" | grep -q '^200 ' || { echo "  manifest fetch: $out"; return 1; }
+            echo "$out" | grep -qi 'application/json' || { echo "  manifest content-type: $out"; return 1; }
+            # Read the body too. The href and content-type can both be right
+            # while start_url sits outside scope — a manifest that parses
+            # cleanly and still never offers the install prompt.
+            local body; body=$(curl -sS --max-time 20 "$base$href")
+            echo "$body" | node -e '
+              const manifest = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+              if (manifest.start_url !== "/" || manifest.scope !== "/") {
+                console.error(`  manifest start_url is "${manifest.start_url}" and scope is "${manifest.scope}"; expected "/" for both`);
+                process.exit(1);
+              }
+            '
           }
 
           retry "root / → 200 text/html"                 check_root
@@ -730,7 +742,7 @@ jobs:
           retry "wasm binary → 200 wasm/octet-stream"     check_wasm
           retry "index.html is NOT immutable-cached"      check_index_not_immutable
           retry "hashed _expo asset is immutable-cached"  check_hashed_asset_immutable
-          retry "PWA manifest link → 200 application/json"  check_manifest_link
+          retry "PWA manifest → JSON with start_url/scope /"  check_manifest_link
 
       - name: Install Playwright chromium
         run: cd packages/web && bunx playwright install --with-deps chromium

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -27,9 +27,6 @@ FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-# bash runs scripts/build-expo-web-export.sh (repo scripts are bash, not sh)
-RUN apk add --no-cache bash
-
 # Copy bun binary from deps stage (avoid re-downloading)
 COPY --from=deps /root/.bun/bin/bun /usr/local/bin/bun
 RUN ln -s /usr/local/bin/bun /usr/local/bin/bunx
@@ -51,38 +48,25 @@ COPY source/scripts ./scripts
 # Bun's isolated linker resolves workspace deps through per-package symlink
 # farms (packages/*/node_modules -> ../../node_modules/.bun). The deps stage
 # created them next to the manifests, but only the root node_modules (with the
-# .bun store) crosses the stage boundary, so relink before the Expo export
-# resolves modules from the source tree — `bunx expo` must find the workspace's
-# pinned expo, never fall back to fetching a floating version.
+# .bun store) crosses the stage boundary, so relink before the Next build
+# resolves modules from the source tree.
 RUN bun install --frozen-lockfile
 
 # Accept build arguments for environment variables baked into the Next.js build
 ARG NEXT_PUBLIC_WS_URL
 ARG BASE_URL
-# BOARDSESH_WEB=1 turns on the Expo web export below AND the /app serving
-# branch that next.config.mjs bakes into the standalone build. Rollback lever:
-# build with --build-arg BOARDSESH_WEB=0 to ship an image without the Expo web
-# app — /app then 404s while the rest of the site is untouched.
-ARG BOARDSESH_WEB=1
 
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
 ENV BASE_URL=$BASE_URL
-ENV BOARDSESH_WEB=$BOARDSESH_WEB
 
-# Static Expo web export served by Next at /app. The nested web-runtime install
-# supplies the web-only renderer (react-native-web, react-dom, the gorhom sheet)
-# outside the native fingerprint graph — the export script runs it when missing.
-# The export lands in packages/web/public/app, which the runner stage picks up
-# through the existing public/ COPY and Next's standalone server then serves
-# statically. EXPO_PUBLIC_WEB_URL feeds the Expo Router head origin; the app's
-# runtime URLs (backend/WS) fall back to production defaults in src/lib/env.ts.
-# Only export EXPO_PUBLIC_WEB_URL when BASE_URL is non-empty: Expo inlines
-# EXPO_PUBLIC_* values verbatim, and a set-but-empty value would override the
-# production fallback in src/lib/env.ts with ''.
-RUN if [ "$BOARDSESH_WEB" = "1" ]; then \
-      if [ -n "$BASE_URL" ]; then export EXPO_PUBLIC_WEB_URL="$BASE_URL"; fi; \
-      bash scripts/build-expo-web-export.sh packages/web/public/app; \
-    fi
+# No Expo web export step here (W-24, #4438). The browser app ships only at
+# app.boardsesh.com, exported and published by production-deploy.yml's
+# deploy-app-web job. This image used to bake a second copy of it under
+# public/ for Next to serve at /app; that path is retired, and next.config.mjs
+# returns no /app rewrites outside NODE_ENV=development, so a production build
+# could not serve one even if an artifact reappeared. Guarded by
+# scripts/__tests__/dockerfile-web-no-expo-export.test.ts, which pins this file
+# by text because nothing in CI builds it.
 
 # Build the Next.js application (standalone output)
 RUN bun run --filter=@boardsesh/web build
@@ -94,13 +78,15 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-# BOARDSESH_WEB is read at REQUEST time by the standalone server, not just at
-# build: app/layout.tsx gates the Expo auth session bridge on it
-# (enableExpoAuthBridge) and middleware.ts gates the /app dev proxy. The builder
-# ARG/ENV above does not cross the stage boundary, so redeclare it here or the
-# runtime flag is undefined and the bridge stays off even though /app is served.
-# The default mirrors the builder so a single --build-arg BOARDSESH_WEB=0
-# rollback disables both the export AND the runtime bridge consistently.
+# BOARDSESH_WEB is read at REQUEST time by the standalone server. Since W-24
+# (#4438) retired the /app static path it has exactly two remaining jobs, both
+# request-time: app/layout.tsx gates the cross-subdomain Expo auth session
+# bridge on it (enableExpoAuthBridge — the www half of what app.boardsesh.com
+# signs in through), and middleware.ts gates the /app carve-out. The builder
+# stage no longer declares it at all; there is no /app serving left to roll back
+# with --build-arg BOARDSESH_WEB=0. Setting it to 0 here now only turns the auth
+# bridge off, which would break sign-in on the subdomain — do not use it as a
+# rollback lever.
 ARG BOARDSESH_WEB=1
 ENV BOARDSESH_WEB=$BOARDSESH_WEB
 

--- a/deploy/app-subdomain/README.md
+++ b/deploy/app-subdomain/README.md
@@ -27,7 +27,9 @@ else falls through to the shell.
 ## `_headers` — security + caching
 
 - `X-Robots-Tag: noindex` — this is an authenticated utility surface, kept out of
-  search indexes (mirrors the `/app` surface's `noindex`, see docs/expo-web.md).
+  search indexes. Since W-24 (#4438) retired the `/app` static path this file is
+  the only production source of that header for the browser app; the dev `/app`
+  proxy gets its own from `packages/web/middleware.ts` (see docs/expo-web.md).
 - `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`
   — standard hardening.
 - `/_expo/*` and `/assets/*` → `Cache-Control: public, max-age=31536000, immutable`.
@@ -43,9 +45,8 @@ else falls through to the shell.
 `@boardsesh/board-renderer-wasm` glue instantiates the WASM module via
 `new Function(...)`, so the renderer depends on `unsafe-eval` /
 `wasm-unsafe-eval` being permitted. A strict `script-src` (without those
-allowances) breaks board rendering outright. This is the same constraint the
-`/app` surface documents — see the "WASM glue needs `Function()`" note in
-`docs/expo-web.md`.
+allowances) breaks board rendering outright. See the "WASM glue needs
+`Function()`" note in `docs/expo-web.md`.
 
 `__tests__/headers.test.ts` enforces it. A policy that restricts script sources
 fails CI unless it grants both `'unsafe-eval'` and `'wasm-unsafe-eval'`, and

--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -71,6 +71,13 @@ is a checked-in template whose `<link rel="manifest">` href is a fixed
 `packages/mobile/public/manifest.json` is copied verbatim with `start_url`/`scope`
 written for root serving. Neither knows which baseUrl an export was built with.
 
+Do **not** hand-edit that href to `/manifest.json` to "fix" the install prompt —
+it is the value the dev Metro proxy needs, a single literal cannot be right for
+both baseUrls, and `packages/mobile/src/__tests__/web-shell-appearance.test.ts`
+reds if you try. The same suite pins `%WEB_TITLE%` / `%LANG_ISO_CODE%` in the
+template, because the patcher treats their survival into an export as proof that
+`copyPublicFolderAsync` clobbered Expo's rendered shell with the raw template.
+
 `scripts/lib/patch-expo-web-pwa-manifest.mjs` runs after the WASM assertion and
 rewrites both from `WEB_BASE_URL`:
 
@@ -91,7 +98,10 @@ runs in **both** modes so the CI gate (`vp run check:mobile-web-bundle`, which
 only ever exercises the default mode) covers the code path that ships.
 
 `deploy-app-web`'s post-deploy smoke re-checks it against the live subdomain
-(`PWA manifest link → 200 application/json`).
+(`PWA manifest → JSON with start_url/scope /`): the shell's href, the fetched
+content-type, and the manifest body's `start_url`/`scope`. Body included because
+a manifest can serve as perfectly valid JSON at the right URL and still put
+`start_url` outside `scope` — parses clean, never offers the install prompt.
 
 Known dev gap: under the Metro proxy the shell and manifest come straight from
 Metro and never pass through this script, so an install prompt in dev keeps

--- a/docs/expo-web-deployment.md
+++ b/docs/expo-web-deployment.md
@@ -4,19 +4,20 @@ The Expo app's browser target ships in two serving shapes, both gated on
 `BOARDSESH_WEB=1`:
 
 - **Development** — Next proxies `/app` to the live Metro dev server.
-- **Production (target)** — a standalone static export served at the **root of
-  `app.boardsesh.com`** (its own subdomain / static host / CDN).
+- **Production** — a standalone static export served at the **root of
+  `app.boardsesh.com`** (Cloudflare Pages), published by `production-deploy.yml`'s
+  `deploy-app-web` job.
 
-The export's base URL is the only difference between the two production shapes,
-and it is driven by `BOARDSESH_WEB_BASE_URL` (read by `resolveWebPlatforms` in
+The export's base URL is the only difference between the two shapes, and it is
+driven by `BOARDSESH_WEB_BASE_URL` (read by `resolveWebPlatforms` in
 `packages/mobile/app.config.ts`, default `/app`). That env var is only read when
 `BOARDSESH_WEB=1`, so native builds (flag unset) resolve a byte-identical config
 and keep their OTA fingerprint.
 
-> The older **`/app` prod-static** path (Next serving the export out of
-> `packages/web/public/app`) still works and is documented below, but the
-> subdomain root is the deployment target. New work should build the subdomain
-> export; the `/app` path is kept for the dev proxy and as a fallback.
+`/app` on `www.boardsesh.com` is **not** a production surface. Since W-24
+(#4438) it is the dev Metro proxy plus the local static bake behind
+`vp run dev:mobile:web-static`, and nothing else — see
+[Retired: the /app static path](#retired-the-app-static-path-w-24-4438).
 
 ## Development: proxy to Metro
 
@@ -27,7 +28,7 @@ and keep their OTA fingerprint.
 phase) so a stale local export sitting in `packages/web/public/app` can never
 shadow the live dev server. The dev export keeps `baseUrl` `/app`.
 
-## Production (target): standalone subdomain at app.boardsesh.com
+## Production: standalone subdomain at app.boardsesh.com
 
 The browser app is exported with `BOARDSESH_WEB_BASE_URL=/` so every asset and
 route is rooted at the origin, then served as a plain static directory at the
@@ -61,6 +62,41 @@ separated substrings, e.g. `"https://ws.boardsesh.com https://www.boardsesh.com"
 so the script greps the emitted JS bundles for each expected origin and fails
 loudly if one is missing — the direct detector for a stale-env artifact
 reaching production.
+
+#### PWA manifest (patched per export)
+
+Two of the export's inputs are baseUrl-blind. `packages/mobile/public/index.html`
+is a checked-in template whose `<link rel="manifest">` href is a fixed
+`/app/manifest.json` (the value the dev Metro proxy needs), and
+`packages/mobile/public/manifest.json` is copied verbatim with `start_url`/`scope`
+written for root serving. Neither knows which baseUrl an export was built with.
+
+`scripts/lib/patch-expo-web-pwa-manifest.mjs` runs after the WASM assertion and
+rewrites both from `WEB_BASE_URL`:
+
+| mode          | href                 | `start_url` / `scope` |
+| ------------- | -------------------- | --------------------- |
+| default       | `/app/manifest.json` | `/app/`               |
+| `--subdomain` | `/manifest.json`     | `/`                   |
+
+`start_url` carries a trailing slash because PWA scope matching is a path-prefix
+string compare — `/app` does not sit inside `/app/`.
+
+It then re-reads both files from disk and asserts the values landed. That
+read-back is the point: before it existed, the subdomain export shipped the
+template's `/app/manifest.json`, `_redirects`' `/* /index.html 200` answered that
+path with the SPA shell, and the browser got HTML where a manifest belongs — no
+install prompt, a console error every load, HTTP 200 the whole way. The patch
+runs in **both** modes so the CI gate (`vp run check:mobile-web-bundle`, which
+only ever exercises the default mode) covers the code path that ships.
+
+`deploy-app-web`'s post-deploy smoke re-checks it against the live subdomain
+(`PWA manifest link → 200 application/json`).
+
+Known dev gap: under the Metro proxy the shell and manifest come straight from
+Metro and never pass through this script, so an install prompt in dev keeps
+`start_url: "/"`. The href is already correct there via `next.config.mjs`'s
+`/app/manifest.json` → Metro `/manifest.json` rewrite.
 
 ### What the host must do
 
@@ -290,53 +326,49 @@ These are DNS / hosting operations outside this repo's build:
 4. **Backend env** — set `APP_ORIGIN` if the app is ever served from a non-prod
    origin (defaults to `https://app.boardsesh.com`).
 
-## Legacy production: static export served by Next at /app
+## Retired: the /app static path (W-24, #4438)
 
-Superseded by the subdomain target above, still functional. With
-`BOARDSESH_WEB=1` and **no** `BOARDSESH_EXPO_WEB_ORIGIN`, `next.config.mjs`
-switches to static mode:
+`www.boardsesh.com/app` used to be a second serving shape: Next serving a
+static export out of `packages/web/public/app`, with two afterFiles rewrites for
+the SPA fallback and two `/app/*` header rules. It never actually served anyone
+— the Vercel build (`vercel.json`'s command resolves to
+`generate:openapi && next build`) never ran the export, so the rewrite target did
+not exist and `/app` 404'd in production, at 0 pageviews over the 90 days to
+2026-08-15 against 55,442 total www pageviews.
 
-- The export artifact lives in `packages/web/public/app` (gitignored), so
-  Next — including the standalone `server.js` used by `Dockerfile.web` — serves
-  the real files directly: `/app/_expo/*` bundles, `/app/assets/*`,
-  `/app/wasm/*`, `/app/index.html`. Content-hashed paths (`_expo`, `assets`)
-  get `Cache-Control: immutable`.
-- Two afterFiles rewrites (`/app`, `/app/:path*` → `/app/index.html`) give the
-  Expo Router SPA its deep-link fallback: any `/app/...` path that is not a
-  real file serves the exported shell.
+What changed:
 
-### Artifact flow (/app)
+- **`next.config.mjs` bakes no `/app` rewrite outside `NODE_ENV=development`.**
+  The static fallback survives only for the dev bake below. No production build —
+  Vercel or `Dockerfile.web` — can serve `/app`, which is the property #3795
+  (web → Railway, whose image builds from `Dockerfile.web`) needs before it lands.
+- **`headers()` owns no `/app` rule.** `noindex` and immutable caching moved to
+  the surface that serves the app, `deploy/app-subdomain/_headers`. The dev proxy
+  is an external rewrite, so Next forwards Metro's own headers past `headers()`
+  entirely; `middleware.ts` stamps `noindex`/XFO/nosniff/HSTS there and is pinned
+  against Metro by `expo-web-header-parity.test.ts`.
+- **`Dockerfile.web` runs no export.** The builder-stage `ARG BOARDSESH_WEB` and
+  the `apk add bash` that existed for it are gone too. The **runner-stage**
+  `ARG`/`ENV` stays: `BOARDSESH_WEB` is still read at request time for the
+  cross-subdomain Expo auth bridge (`app/layout.tsx`) and the `/app` middleware
+  carve-out. `--build-arg BOARDSESH_WEB=0` is **no longer a rollback lever** —
+  there is nothing left to roll back, and setting it to 0 only breaks sign-in on
+  the subdomain. Nothing in CI builds this Dockerfile, so
+  `scripts/__tests__/dockerfile-web-no-expo-export.test.ts` is the guard.
+- **No redirect.** `/app` still 404s. Nothing linked to it, no sitemap entry, no
+  `robots.txt` `Disallow`, and it was `noindex` from the start.
 
-`scripts/build-expo-web-export.sh [output-dir]` (no `--subdomain`) is the `/app`
-export recipe (default output: `packages/web/public/app`, baseUrl `/app`).
-Consumers:
+### What still uses the `/app` export
 
-- **`Dockerfile.web` (builder stage)** — the deployed `/app` path. The generated
-  web Docker context includes `packages/mobile` + its workspace deps and this
-  script (`scripts/create-service-docker-context.mjs`). The builder runs the
-  export into `packages/web/public/app` before `next build`, and the runner
-  stage's existing `public/` COPY ships it. `BASE_URL` is forwarded as
-  `EXPO_PUBLIC_WEB_URL` (Expo Router head origin); backend/WS URLs use the
-  production fallbacks in `packages/mobile/src/lib/env.ts`.
-- **`vp run build:expo-web`** — local verification: run it, then
-  `BOARDSESH_WEB=1 vp run build:web`, copy `public/` + `.next/static` into the
-  standalone output, and `/app` serves exactly like production.
+`scripts/build-expo-web-export.sh [output-dir]` (no `--subdomain`, baseUrl
+`/app`, default output `packages/web/public/app`, gitignored) remains a dev and
+CI recipe:
+
+- **`vp run dev:mobile:web-static`** (`scripts/dev-expo-web-static.sh`) bakes it
+  with the Tailscale origin inlined and starts the dev stack with
+  `BOARDSESH_WEB=1` and no proxy origin, so Next serves it at `/app` over the
+  tailnet for real-device QA. This is the loop the `NODE_ENV=development` gate
+  exists to keep alive.
+- **`vp run build:expo-web`** — the same bake by hand.
 - **`vp run check:mobile-web-bundle`** — CI bundle check; exports to a temp dir
-  via the same script (default `/app` base URL).
-
-The Vercel production web deploy (`production-deploy.yml`) does not run the
-export step; `/app` there simply 404s (see rollback below) until it is wired up
-or web serving moves to the Docker image / the subdomain host.
-
-### Rollback
-
-Ship a web image without the export: `--build-arg BOARDSESH_WEB=0` on the
-`Dockerfile.web` build (or simply don't produce/copy the export in whatever
-pipeline builds web). Without the flag the Next build bakes no `/app` rewrites;
-without the artifact the SPA fallback rewrite finds no `/app/index.html` and
-`/app` 404s. Either way the failure is contained to `/app`: the middleware's
-`/app` branch only sets headers and never routes, so the rest of the site is
-unaffected. Native apps are untouched — this surface is browser-only and none
-of it enters the OTA fingerprint graph. The subdomain deployment is independent:
-taking `app.boardsesh.com` offline is a DNS/host operation and never touches the
-main site or native apps.
+  via the same script.

--- a/docs/expo-web.md
+++ b/docs/expo-web.md
@@ -1,16 +1,16 @@
 # Expo on web (Phase 0)
 
-The Expo (React Native) app runs on the web behind `/app`, served through a Next.js rewrite to Metro's browser bundle. This is **Phase 0** — enough to render and authenticate the app in a browser — and it ships with the known limitations below. Auth/WebSocket specifics live in [`websocket-implementation.md`](./websocket-implementation.md#expo-web-token-path-app); this file is the Phase 0 caveat list.
+The Expo (React Native) app ships in the browser at **`app.boardsesh.com`**, a standalone static export on Cloudflare Pages. Locally it runs at `/app`, served through a Next.js rewrite to Metro's browser bundle — that path is the dev proxy only; W-24 (#4438) retired it in production. This is **Phase 0** — enough to render and authenticate the app in a browser — and it ships with the known limitations below. Auth/WebSocket specifics live in [`websocket-implementation.md`](./websocket-implementation.md#expo-web-token-path-app); this file is the Phase 0 caveat list, and [`expo-web-deployment.md`](./expo-web-deployment.md) is the deployment reference.
 
 ## Known limitations
 
 - **Board render runs on the main thread.** The `@boardsesh/board-renderer-wasm` glue decodes and rasterises on the UI thread, so a heavy board can jank the page. **Fixed in Phase 1** by the off-thread render worker in #3765 (same stack) — once that lands, rendering moves to a Web Worker and this note is obsolete.
-- **The WASM glue needs `Function()` / `unsafe-eval`.** The generated glue instantiates the module via `new Function(...)`, so the `/app` surface depends on a CSP that permits `unsafe-eval` (or the absence of a strict `script-src`). A future tightened CSP must add `'wasm-unsafe-eval'`/`'unsafe-eval'` for `/app` or the board renderer breaks. Do not add a strict `script-src` to `/app` without accounting for this.
-- **No disk cache for the WASM binary.** The renderer's WASM is fetched fresh per page load (no service-worker or persistent cache in Phase 0), so first paint re-downloads it each time. Acceptable for the authenticated utility surface; revisit if `/app` becomes a high-traffic entry point.
+- **The WASM glue needs `Function()` / `unsafe-eval`.** The generated glue instantiates the module via `new Function(...)`, so the browser app depends on a CSP that permits `unsafe-eval` (or the absence of a strict `script-src`). A future tightened CSP must add `'wasm-unsafe-eval'`/`'unsafe-eval'` or the board renderer breaks. That is why `deploy/app-subdomain/_headers` carries no `script-src` — see the hard rule in its README.
+- **No disk cache for the WASM binary.** The renderer's WASM is fetched fresh per page load (no service-worker or persistent cache in Phase 0), so first paint re-downloads it each time. Acceptable for the authenticated utility surface; revisit if the browser app becomes a high-traffic entry point.
 
 ## Scope
 
-`/app` is a locale-neutral **authenticated utility surface**, `noindex`. It is not a search/marketing surface — keep it out of the sitemap and locale routing (see the middleware carve-out and `next.config.mjs` header rules).
+The browser app is a locale-neutral **authenticated utility surface**, `noindex`. It is not a search/marketing surface — keep it out of the sitemap and locale routing. In production that `noindex` comes from `deploy/app-subdomain/_headers`; on the dev `/app` proxy it comes from the `middleware.ts` carve-out (`next.config.mjs` owns no `/app` header rule since W-24).
 
 ## Appearance and large screens
 
@@ -29,6 +29,6 @@ resolved. Resizing only changes the shell chrome; the tab navigator remains moun
 Two ways to run the browser app locally — pick by what you're iterating on:
 
 - **`vp run dev:mobile:web`** — Metro dev proxy at `/app` with fast refresh. Cold-bundles on every start (`--clear`), so first paint takes minutes and can outrun the orchestrator's readiness window on a loaded machine (`BOARDSESH_EXPO_WEB_READY_TIMEOUT_MS` extends it). Best for mobile-code iteration.
-- **`vp run dev:mobile:web-static`** — bakes the static export (the exact artifact production serves) with the Tailscale origin inlined, then serves it at `/app` from the regular dev stack. No Metro race; open `https://<your-machine>.ts.net:3000/app` from any tailnet device. Mobile-code changes need a re-run; web code hot-reloads. Best for QA/device testing.
+- **`vp run dev:mobile:web-static`** — bakes the static export (the same recipe production runs, at baseUrl `/app` instead of `/`) with the Tailscale origin inlined, then serves it at `/app` from the regular dev stack. This is the one thing keeping the `/app` fallback alive in `next.config.mjs`, behind `NODE_ENV=development`. No Metro race; open `https://<your-machine>.ts.net:3000/app` from any tailnet device. Mobile-code changes need a re-run; web code hot-reloads. Best for QA/device testing.
 
 Baking gotcha (applies to any manual export): `expo export` reuses Metro's transform cache even when `EXPO_PUBLIC_*` values change, silently shipping the previous env. The static task wipes the cache for you; wipe `"$TMPDIR"/metro-cache` yourself if you invoke `build-expo-web-export.sh` directly with different env. The three origin vars that must be baked: `EXPO_PUBLIC_WEB_URL` (must equal the serving web origin or auth calls go cross-origin), `EXPO_PUBLIC_BACKEND_URL`, `EXPO_PUBLIC_WS_URL`.

--- a/packages/mobile/public/index.html
+++ b/packages/mobile/public/index.html
@@ -8,13 +8,8 @@
     <meta name="robots" content="noindex, follow" />
     <meta name="application-name" content="Boardsesh" />
     <meta name="theme-color" content="#000000" />
-    <!-- Metro serves public/ from the server root while the export's baseUrl
-         may be /app or / — a single literal cannot be right for both. This
-         value is the DEV/Metro-proxy value (next.config.mjs rewrites
-         /app/manifest.json to Metro's /manifest.json). Every export rewrites it
-         from the export's baseUrl in scripts/lib/patch-expo-web-pwa-manifest.mjs
-         and asserts the result, so do NOT hand-edit it for app.boardsesh.com.
-         Pinned by src/__tests__/web-shell-appearance.test.ts. -->
+    <!-- Dev/Metro-proxy value; every export rewrites it from its own baseUrl.
+         Don't hand-edit: docs/expo-web-deployment.md, "PWA manifest". -->
     <link rel="manifest" href="/app/manifest.json" />
     <link rel="icon" href="https://www.boardsesh.com/icons/icon-192.png" />
     <link rel="apple-touch-icon" href="https://www.boardsesh.com/icons/apple-touch-icon.png" />

--- a/packages/mobile/public/index.html
+++ b/packages/mobile/public/index.html
@@ -8,10 +8,13 @@
     <meta name="robots" content="noindex, follow" />
     <meta name="application-name" content="Boardsesh" />
     <meta name="theme-color" content="#000000" />
-    <!-- /app is the current serving root (dev proxy + legacy prod-static path,
-         see docs/expo-web-deployment.md). Revisit this href if/when the
-         app.boardsesh.com subdomain export (baseUrl /) goes live — it'd need
-         a root-relative /manifest.json instead. -->
+    <!-- Metro serves public/ from the server root while the export's baseUrl
+         may be /app or / — a single literal cannot be right for both. This
+         value is the DEV/Metro-proxy value (next.config.mjs rewrites
+         /app/manifest.json to Metro's /manifest.json). Every export rewrites it
+         from the export's baseUrl in scripts/lib/patch-expo-web-pwa-manifest.mjs
+         and asserts the result, so do NOT hand-edit it for app.boardsesh.com.
+         Pinned by src/__tests__/web-shell-appearance.test.ts. -->
     <link rel="manifest" href="/app/manifest.json" />
     <link rel="icon" href="https://www.boardsesh.com/icons/icon-192.png" />
     <link rel="apple-touch-icon" href="https://www.boardsesh.com/icons/apple-touch-icon.png" />

--- a/packages/mobile/src/__tests__/web-public-assets-are-web-only.test.ts
+++ b/packages/mobile/src/__tests__/web-public-assets-are-web-only.test.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { join, sep } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
@@ -13,10 +13,14 @@ import { describe, expect, it } from 'vitest';
 //      produce a new runtimeVersion — but fingerprint-neutrality only
 //      guarantees DELIVERY, so on its own it would be the weaker half.
 //   2. public/ is never read by native code. Expo consumes it only on the web
-//      export path (@expo/cli's publicFolder.js + webTemplate.js), and
-//      assetBundlePatterns is ['assets/**/*'], so Metro never bundles it into a
-//      binary. That is the safety half: the native app never reads the byte we
-//      changed.
+//      export path (@expo/cli's publicFolder.js + webTemplate.js). That is the
+//      safety half: the native app never reads the byte we changed.
+//
+// assetBundlePatterns is deliberately NOT part of the claim, and NOT asserted
+// below: it filters assets Metro has already resolved from the JS module graph,
+// and public/ is not in that graph, so widening it would not embed public/ in a
+// binary either. Pinning it here would red an unrelated legitimate change for a
+// reason that isn't true.
 
 const mobileRoot = fileURLToPath(new URL('../..', import.meta.url));
 const require = createRequire(import.meta.url);
@@ -40,9 +44,14 @@ describe('packages/mobile/public is a web-only surface', () => {
     // configs, the resolved Expo config, package.json scripts and the patch dir
     // — public/ is in none of them. These extraSources are the only additions,
     // so the whole allowlist just has to stay clear of public/.
-    const publicSources = fingerprintConfig.extraSources.filter(
-      ({ filePath }) => filePath === 'public' || filePath.startsWith('public/') || filePath.includes('/public/'),
-    );
+    // Resolve before comparing. @expo/fingerprint joins each filePath against
+    // the project root, so './public' and '../mobile/public' reach the same
+    // directory as 'public' — a literal string match would call those clean.
+    const publicDir = join(mobileRoot, 'public');
+    const publicSources = fingerprintConfig.extraSources.filter(({ filePath }) => {
+      const resolved = resolve(mobileRoot, filePath);
+      return resolved === publicDir || resolved.startsWith(publicDir + sep);
+    });
 
     expect(publicSources).toEqual([]);
   });

--- a/packages/mobile/src/__tests__/web-public-assets-are-web-only.test.ts
+++ b/packages/mobile/src/__tests__/web-public-assets-are-web-only.test.ts
@@ -1,0 +1,65 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// W-24 (#4438) edits packages/mobile/public/index.html and claims the change
+// reaches app.boardsesh.com only — never the native store fleet. Standing rule 2
+// says that claim needs a test, not an assertion.
+//
+// Two independent properties make it true, and this pins both:
+//   1. public/ is not a native fingerprint input, so the change cannot even
+//      produce a new runtimeVersion — but fingerprint-neutrality only
+//      guarantees DELIVERY, so on its own it would be the weaker half.
+//   2. public/ is never read by native code. Expo consumes it only on the web
+//      export path (@expo/cli's publicFolder.js + webTemplate.js), and
+//      assetBundlePatterns is ['assets/**/*'], so Metro never bundles it into a
+//      binary. That is the safety half: the native app never reads the byte we
+//      changed.
+
+const mobileRoot = fileURLToPath(new URL('../..', import.meta.url));
+const require = createRequire(import.meta.url);
+
+type ExtraSource = { type: string; filePath: string };
+const fingerprintConfig = require(join(mobileRoot, 'fingerprint.config.js')) as { extraSources: ExtraSource[] };
+
+const NATIVE_SOURCE_DIRECTORIES = ['src', 'app', 'modules', 'plugins', 'targets'];
+const CODE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
+
+function collectSourceFiles(directory: string): string[] {
+  return readdirSync(join(mobileRoot, directory), { recursive: true, encoding: 'utf8' })
+    .filter((entry) => CODE_EXTENSIONS.some((extension) => entry.endsWith(extension)))
+    .filter((entry) => !entry.split(sep).includes('__tests__'))
+    .map((entry) => join(directory, entry));
+}
+
+describe('packages/mobile/public is a web-only surface', () => {
+  it('is not a fingerprint input, so editing it cannot move runtimeVersion', () => {
+    // @expo/fingerprint's own defaults source the bare native dirs, autolinking
+    // configs, the resolved Expo config, package.json scripts and the patch dir
+    // — public/ is in none of them. These extraSources are the only additions,
+    // so the whole allowlist just has to stay clear of public/.
+    const publicSources = fingerprintConfig.extraSources.filter(
+      ({ filePath }) => filePath === 'public' || filePath.startsWith('public/') || filePath.includes('/public/'),
+    );
+
+    expect(publicSources).toEqual([]);
+  });
+
+  it('is not referenced by any native source file', () => {
+    const referencingFiles = NATIVE_SOURCE_DIRECTORIES.flatMap(collectSourceFiles).filter((relativePath) => {
+      const source = readFileSync(join(mobileRoot, relativePath), 'utf8');
+      return source.includes('public/index.html') || source.includes('public/manifest.json');
+    });
+
+    expect(referencingFiles).toEqual([]);
+  });
+
+  it('does not relocate the public folder via EXPO_PUBLIC_FOLDER', () => {
+    // A custom public folder would move index.html/manifest.json to a path the
+    // checks above do not cover — and could put them somewhere a fingerprint
+    // source does reach.
+    expect(readFileSync(join(mobileRoot, 'app.config.ts'), 'utf8')).not.toContain('EXPO_PUBLIC_FOLDER');
+  });
+});

--- a/packages/mobile/src/__tests__/web-shell-appearance.test.ts
+++ b/packages/mobile/src/__tests__/web-shell-appearance.test.ts
@@ -10,4 +10,19 @@ describe('Expo web HTML appearance shell', () => {
     );
     expect(shellSource).toMatch(/#root\s*\{[\s\S]*?background-color:\s*#000000;[\s\S]*?\}/);
   });
+
+  it('keeps exactly one manifest link, at the dev/Metro-proxy href', () => {
+    // /app/manifest.json is the DEV value: Metro serves public/ from its server
+    // root, and next.config.mjs rewrites /app/manifest.json to Metro's
+    // /manifest.json. It is also the export patcher's expected input.
+    //
+    // The natural-but-wrong fix for the app.boardsesh.com install prompt is to
+    // hand-edit this to /manifest.json. Don't — that breaks the dev proxy and
+    // fixes nothing, because a single literal cannot be right for both baseUrls.
+    // scripts/lib/patch-expo-web-pwa-manifest.mjs rewrites it per export from
+    // that export's own baseUrl and asserts the result (W-24, #4438).
+    const manifestLinks = shellSource.match(/<link\b[^>]*\brel=["']manifest["'][^>]*>/gi) ?? [];
+    expect(manifestLinks).toHaveLength(1);
+    expect(manifestLinks[0]).toContain('href="/app/manifest.json"');
+  });
 });

--- a/packages/mobile/src/__tests__/web-shell-appearance.test.ts
+++ b/packages/mobile/src/__tests__/web-shell-appearance.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
+import { UNRENDERED_TEMPLATE_TOKENS } from '../../../../scripts/lib/patch-expo-web-pwa-manifest.mjs';
+
 const shellSource = readFileSync(new URL('../../public/index.html', import.meta.url), 'utf8');
 
 describe('Expo web HTML appearance shell', () => {
@@ -24,5 +26,17 @@ describe('Expo web HTML appearance shell', () => {
     const manifestLinks = shellSource.match(/<link\b[^>]*\brel=["']manifest["'][^>]*>/gi) ?? [];
     expect(manifestLinks).toHaveLength(1);
     expect(manifestLinks[0]).toContain('href="/app/manifest.json"');
+  });
+
+  it('keeps the template tokens the export patcher watches for', () => {
+    // The patcher fails an export whose shell still contains these, because
+    // that means copyPublicFolderAsync overwrote Expo's rendered shell with this
+    // raw template — an export that would ship with no bundle <script> tags at
+    // all, at HTTP 200. Hardcoding the title/lang here (a natural-looking edit)
+    // would leave that detector matching nothing, with no test going red.
+    // Imported from the patcher, not restated, so the two cannot drift apart.
+    for (const token of UNRENDERED_TEMPLATE_TOKENS as string[]) {
+      expect(shellSource).toContain(token);
+    }
   });
 });

--- a/packages/web/app/__tests__/expo-web-header-parity.test.ts
+++ b/packages/web/app/__tests__/expo-web-header-parity.test.ts
@@ -2,12 +2,20 @@ import { createRequire } from 'node:module';
 import { afterAll, beforeAll, describe, expect, it } from 'vite-plus/test';
 import { NextRequest } from 'next/server';
 
-// The /app response-header set lives in three places that external rewrites and
-// Metro can each serve independently: this middleware, next.config's headers(),
-// and Metro's expo-web-response-headers.cjs. Each already has its own test, so a
-// divergence (e.g. tightening HSTS in one) would leave every suite green. Pin
-// all three to a single canonical source — the Metro `.cjs` constants — so drift
-// fails loudly here.
+// The /app response-header set lives in two places that can each serve a
+// request independently: this middleware and Metro's
+// expo-web-response-headers.cjs. Each already has its own test, so a divergence
+// (e.g. tightening HSTS in one) would leave every suite green. Pin both to a
+// single canonical source — the Metro `.cjs` constants — so drift fails loudly
+// here.
+//
+// This used to be a three-way pin. W-24 (#4438) retired the /app static path
+// and with it next.config's `/app/:path*` X-Robots-Tag rule: /app on www is now
+// only the dev Metro proxy, which is an EXTERNAL rewrite — Next forwards
+// Metro's own response headers and never runs headers() over them. A
+// next.config /app rule would be dead code that this test made look
+// load-bearing. Do not "restore" it. The global `/((?!embed/).*)` rule is the
+// only next.config input left on that path, and it is still asserted below.
 const require = createRequire(import.meta.url);
 const { EXPO_WEB_SECURITY_HEADERS, EXPO_WEB_ROBOTS_VALUE, EXPO_WEB_STRICT_TRANSPORT_SECURITY } =
   require('../../../mobile/expo-web-response-headers.cjs') as {
@@ -61,11 +69,8 @@ describe('/app security-header parity across middleware, next.config, and Metro'
     expect(response.headers.get('Strict-Transport-Security')).toBe(EXPO_WEB_STRICT_TRANSPORT_SECURITY);
   });
 
-  it('next.config /app rule and global security rule match the canonical Metro headers', async () => {
+  it('next.config global security rule matches the canonical Metro headers', async () => {
     const headers = (await nextConfig.headers?.()) ?? [];
-
-    const appRule = headers.find(({ source }) => source === '/app/:path*');
-    expect(headerMap(appRule?.headers ?? [])['X-Robots-Tag']).toBe(EXPO_WEB_ROBOTS_VALUE);
 
     // /app responses inherit the global (non-embed) security headers, including
     // the canonical HSTS value which next.config sets unconditionally.

--- a/packages/web/app/__tests__/next-config-expo-web.test.ts
+++ b/packages/web/app/__tests__/next-config-expo-web.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 
 type Rewrite = { source: string; destination: string };
 type RewriteResult = Rewrite[] | { beforeFiles?: Rewrite[]; afterFiles?: Rewrite[]; fallback?: Rewrite[] };
@@ -24,6 +24,11 @@ afterEach(() => {
 
   if (originalProxyOrigin === undefined) delete process.env.BOARDSESH_EXPO_WEB_ORIGIN;
   else process.env.BOARDSESH_EXPO_WEB_ORIGIN = originalProxyOrigin;
+
+  // The static /app fallback is gated on NODE_ENV === 'development' (W-24,
+  // #4438); vitest runs with NODE_ENV=test, so every test that exercises that
+  // branch stubs it and this puts it back.
+  vi.unstubAllEnvs();
 });
 
 describe('Expo web Next proxy', () => {
@@ -94,9 +99,29 @@ describe('Expo web Next proxy', () => {
     expect((phasedRewrites.fallback ?? []).filter(isExpoNamespace)).toEqual([]);
   });
 
-  it('falls back /app routes to the exported SPA shell when no proxy origin is configured', async () => {
+  it('bakes no /app rewrite into a production build (the retirement)', async () => {
+    // W-24 (#4438): the Expo browser app ships only at app.boardsesh.com. A
+    // production build must not be able to serve /app even with the web flag on
+    // — that is the property #3795 (web → Railway, whose image builds from
+    // Dockerfile.web) depends on.
     process.env.BOARDSESH_WEB = '1';
     delete process.env.BOARDSESH_EXPO_WEB_ORIGIN;
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const appRewrites = flattenRewrites((await nextConfig.rewrites?.()) ?? []).filter(
+      ({ source }) => source === '/app' || source.startsWith('/app/'),
+    );
+
+    expect(appRewrites).toEqual([]);
+  });
+
+  it('keeps the SPA fallback in dev so vp run dev:mobile:web-static still serves /app', async () => {
+    // scripts/dev-expo-web-static.sh bakes the default (/app baseUrl) export
+    // into packages/web/public/app and starts the orchestrator with the web flag
+    // on and no proxy origin — the tailnet device-QA loop lands here.
+    process.env.BOARDSESH_WEB = '1';
+    delete process.env.BOARDSESH_EXPO_WEB_ORIGIN;
+    vi.stubEnv('NODE_ENV', 'development');
 
     const rewriteResult = (await nextConfig.rewrites?.()) ?? [];
 
@@ -117,6 +142,7 @@ describe('Expo web Next proxy', () => {
   it('keeps content-hashed and WASM namespaces out of the SPA fallback so missing assets 404', async () => {
     process.env.BOARDSESH_WEB = '1';
     delete process.env.BOARDSESH_EXPO_WEB_ORIGIN;
+    vi.stubEnv('NODE_ENV', 'development');
 
     const appRewrites = flattenRewrites((await nextConfig.rewrites?.()) ?? []).filter(
       ({ source }) => source === '/app' || source.startsWith('/app/'),
@@ -137,9 +163,10 @@ describe('Expo web Next proxy', () => {
     expect(tailMatcher.test('session/history')).toBe(true);
   });
 
-  it('keeps Metro-only support namespaces out of the production static configuration', async () => {
+  it('keeps Metro-only support namespaces out of the static configuration', async () => {
     process.env.BOARDSESH_WEB = '1';
     delete process.env.BOARDSESH_EXPO_WEB_ORIGIN;
+    vi.stubEnv('NODE_ENV', 'development');
 
     const rewrites = flattenRewrites((await nextConfig.rewrites?.()) ?? []);
 
@@ -172,20 +199,18 @@ describe('Expo web Next proxy', () => {
     ).toBe(false);
   });
 
-  it('keeps the authenticated Expo utility surface out of search results', async () => {
+  it('headers() owns no /app rule after the retirement', async () => {
+    // W-24 (#4438): the noindex and immutable-cache rules moved to the surface
+    // that actually serves the app (deploy/app-subdomain/_headers). The dev
+    // Metro proxy is an external rewrite, which forwards Metro's own headers
+    // past headers() entirely — middleware.ts covers that surface instead.
     const headers = (await nextConfig.headers?.()) ?? [];
 
-    expect(headers).toContainEqual({
-      source: '/app/:path*',
-      headers: [{ key: 'X-Robots-Tag', value: 'noindex, follow' }],
-    });
-  });
-
-  it('marks content-hashed export bundles as immutable without touching the SPA shell or wasm', async () => {
-    const headers = (await nextConfig.headers?.()) ?? [];
-
-    const immutableRule = headers.find(({ source }) => source.includes('_expo'));
-    expect(immutableRule?.source).toBe('/app/:hashedDir(_expo|assets)/:path*');
-    expect(immutableRule?.headers).toEqual([{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }]);
+    expect(headers.filter(({ source }) => source === '/app' || source.startsWith('/app/'))).toEqual([]);
+    // The global (non-embed) catch-all is `/((?!embed/).*)`, which does match
+    // /app requests at runtime — it must survive, so assert it is still there
+    // rather than letting a blunt "no rule mentions app" check pass by
+    // deleting it.
+    expect(headers.some(({ source }) => source === '/((?!embed/).*)')).toBe(true);
   });
 });

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -321,20 +321,13 @@ const nextConfig = {
         source: '/.well-known/apple-app-site-association',
         headers: [{ key: 'Content-Type', value: 'application/json' }],
       },
-      {
-        // Expo web is an authenticated utility surface. Keep it out of search
-        // while it is rolled out behind the /app proxy.
-        source: '/app/:path*',
-        headers: [{ key: 'X-Robots-Tag', value: 'noindex, follow' }],
-      },
-      {
-        // Exported Expo web bundles are content-hashed (entry-<hash>.js under
-        // _expo/static, md5-named files under assets/), so they can be cached
-        // forever. The SPA shell (/app/index.html) and the fixed-name WASM glue
-        // under /app/wasm keep the default no-store-ish behaviour on purpose.
-        source: '/app/:hashedDir(_expo|assets)/:path*',
-        headers: [{ key: 'Cache-Control', value: 'public, max-age=31536000, immutable' }],
-      },
+      // No /app rules live here any more (W-24, #4438). The browser app ships at
+      // app.boardsesh.com, whose response headers come from
+      // deploy/app-subdomain/_headers. The only /app surface left on www is the
+      // dev Metro proxy, and an external rewrite forwards Metro's own response
+      // headers straight past headers() — so middleware.ts is what stamps
+      // noindex/XFO/nosniff/HSTS there, pinned against Metro's canonical
+      // constants by expo-web-header-parity.test.ts.
       {
         // Every route EXCEPT /embed/** keeps the frame-denying default.
         // If this exclusion ever regresses, the fail-safe is SAMEORIGIN
@@ -379,33 +372,26 @@ const nextConfig = {
 
     const expoWebOrigin = resolveExpoWebDevOrigin(process.env.BOARDSESH_EXPO_WEB_ORIGIN);
     if (!expoWebOrigin) {
-      // In dev, BOARDSESH_WEB=1 with no BOARDSESH_EXPO_WEB_ORIGIN usually means
-      // a half-configured Metro proxy — surface it (the static-export fallback
-      // below still applies if public/app was built). In production this is the
-      // intended configuration: no Metro, serve the static export.
-      if (process.env.NODE_ENV === 'development') {
-        console.warn(
-          '[next.config] BOARDSESH_WEB=1 but BOARDSESH_EXPO_WEB_ORIGIN is unset — Expo web /app dev proxy is disabled; serving the static export from public/app if present.',
-        );
-      }
-      // Production: no Metro to proxy to. The static Expo web export is copied
-      // into public/app (scripts/build-expo-web-export.sh; Dockerfile.web runs
-      // it in the builder stage), so real files — /app/_expo/* bundles,
-      // /app/assets/*, /app/wasm/* — are served straight from public/ before
-      // these afterFiles rewrites are consulted. Everything else under /app is
-      // an Expo Router SPA route and falls back to the exported shell. When the
-      // export was not built into the deploy, /app/index.html resolves to
-      // nothing and /app 404s — that absence is the rollback lever (see
-      // docs/expo-web-deployment.md).
+      // Production never serves /app (W-24, #4438). The Expo browser app ships
+      // only at app.boardsesh.com; www's /app was a legacy static-export path
+      // whose artifact the Vercel build never produced, so it 404'd anyway.
+      // Keeping the SPA fallback behind NODE_ENV=development preserves
+      // `vp run dev:mobile:web-static` (bake once, serve at /app over the
+      // tailnet for device QA) while guaranteeing no production build — Vercel
+      // or Dockerfile.web — can ever bake an /app route again. That guarantee
+      // is what makes #3795 (web → Railway, whose image DOES build from
+      // Dockerfile.web) safe to land after this.
+      if (process.env.NODE_ENV !== 'development') return [];
+
+      console.warn(
+        '[next.config] BOARDSESH_WEB=1 but BOARDSESH_EXPO_WEB_ORIGIN is unset — serving the static export from public/app if present (development only; production never serves /app).',
+      );
       return [
         { source: '/app', destination: '/app/index.html' },
-        // SPA fallback for Expo Router routes ONLY. The content-hashed namespaces
-        // (_expo/, assets/) and the fixed-name WASM glue (wasm/) are excluded so a
-        // request for a missing hashed bundle 404s instead of falling through to
-        // the shell. Otherwise Next's headers() would stamp the index.html body
-        // with the immutable Cache-Control that matches the incoming .js/.wasm path
-        // (line 105), and a stale-shell or mid-deploy client would cache an HTML
-        // page at a bundle URL forever — permanently bricking that URL.
+        // SPA fallback for Expo Router routes ONLY. The content-hashed
+        // namespaces (_expo/, assets/) and the fixed-name WASM glue (wasm/) stay
+        // excluded so a request for a missing hashed bundle 404s instead of
+        // silently serving the HTML shell at a .js/.wasm URL.
         { source: '/app/:path((?!_expo/|assets/|wasm/).*)', destination: '/app/index.html' },
       ];
     }

--- a/scripts/__tests__/build-expo-web-export.test.ts
+++ b/scripts/__tests__/build-expo-web-export.test.ts
@@ -1,0 +1,133 @@
+/// <reference types="node" />
+
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const currentDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = join(currentDirectory, '..', '..');
+const sourceExportScript = join(repositoryRoot, 'scripts', 'build-expo-web-export.sh');
+const sourcePatchScript = join(repositoryRoot, 'scripts', 'lib', 'patch-expo-web-pwa-manifest.mjs');
+
+// The shell Expo renders from packages/mobile/public/index.html: one manifest
+// link whose href is the baseUrl-blind template value, and the %…% tokens
+// already substituted.
+const RENDERED_SHELL = `<!doctype html>
+<html lang="en">
+  <head>
+    <title>Boardsesh</title>
+    <link rel="manifest" href="/app/manifest.json" />
+  </head>
+  <body><div id="root"></div></body>
+</html>
+`;
+
+const PUBLIC_MANIFEST = `{
+  "name": "Boardsesh",
+  "start_url": "/",
+  "scope": "/"
+}
+`;
+
+function bunxStub({ shell }: { shell: string }): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+output_dir=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--output-dir" ]]; then
+    output_dir="$2"
+    break
+  fi
+  shift
+done
+mkdir -p "$output_dir/wasm" "$output_dir/_expo/static/js/web"
+cat > "$output_dir/index.html" <<'SHELL_EOF'
+${shell}SHELL_EOF
+cat > "$output_dir/manifest.json" <<'MANIFEST_EOF'
+${PUBLIC_MANIFEST}MANIFEST_EOF
+touch "$output_dir/wasm/board_renderer_wasm.js"
+touch "$output_dir/wasm/board_renderer_wasm_bg.wasm"
+`;
+}
+
+describe('build-expo-web-export.sh PWA manifest patching', () => {
+  let fixtureRoot: string;
+  let fixtureExportScript: string;
+
+  function writeBunxStub(shell: string): void {
+    const stubPath = join(fixtureRoot, 'bin', 'bunx');
+    writeFileSync(stubPath, bunxStub({ shell }));
+    chmodSync(stubPath, 0o755);
+  }
+
+  beforeEach(() => {
+    fixtureRoot = mkdtempSync(join(tmpdir(), 'build-expo-web-export-'));
+    fixtureExportScript = join(fixtureRoot, 'scripts', 'build-expo-web-export.sh');
+
+    mkdirSync(join(fixtureRoot, 'scripts', 'lib'), { recursive: true });
+    mkdirSync(join(fixtureRoot, 'bin'), { recursive: true });
+    mkdirSync(join(fixtureRoot, 'packages', 'mobile', 'public'), { recursive: true });
+    mkdirSync(join(fixtureRoot, 'packages', 'web', 'public'), { recursive: true });
+    // Pre-seed the isolated web-runtime install so the export script skips its
+    // `bun install` step (no network in the test).
+    mkdirSync(join(fixtureRoot, 'packages', 'mobile', 'web-runtime', 'node_modules', 'react-native-web'), {
+      recursive: true,
+    });
+
+    copyFileSync(sourceExportScript, fixtureExportScript);
+    copyFileSync(sourcePatchScript, join(fixtureRoot, 'scripts', 'lib', 'patch-expo-web-pwa-manifest.mjs'));
+
+    writeBunxStub(RENDERED_SHELL);
+  });
+
+  afterEach(() => {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  function runExport(...args: string[]): SpawnSyncReturns<string> {
+    return spawnSync('bash', [fixtureExportScript, ...args], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${join(fixtureRoot, 'bin')}:${process.env.PATH ?? ''}`,
+      },
+    });
+  }
+
+  it('patches the default export to /app/manifest.json and start_url /app/', () => {
+    const result = runExport();
+
+    expect(result.status).toBe(0);
+    const outputDir = join(fixtureRoot, 'packages', 'web', 'public', 'app');
+    expect(readFileSync(join(outputDir, 'index.html'), 'utf8')).toContain('href="/app/manifest.json"');
+    const manifest = JSON.parse(readFileSync(join(outputDir, 'manifest.json'), 'utf8')) as Record<string, unknown>;
+    expect(manifest.start_url).toBe('/app/');
+    expect(manifest.scope).toBe('/app/');
+  });
+
+  it('patches the --subdomain export to a root-relative manifest', () => {
+    const result = runExport('--subdomain');
+
+    expect(result.status).toBe(0);
+    // --subdomain defaults the output to packages/web/public/app-standalone.
+    const outputDir = join(fixtureRoot, 'packages', 'web', 'public', 'app-standalone');
+    const shell = readFileSync(join(outputDir, 'index.html'), 'utf8');
+    expect(shell).toContain('href="/manifest.json"');
+    expect(shell).not.toContain('href="/app/manifest.json"');
+    const manifest = JSON.parse(readFileSync(join(outputDir, 'manifest.json'), 'utf8')) as Record<string, unknown>;
+    expect(manifest.start_url).toBe('/');
+    expect(manifest.scope).toBe('/');
+  });
+
+  it('fails the export when the shell lost its manifest link', () => {
+    writeBunxStub(RENDERED_SHELL.replace('<link rel="manifest" href="/app/manifest.json" />\n', ''));
+
+    const result = runExport('--subdomain');
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('[patch-expo-web-pwa-manifest]');
+  });
+});

--- a/scripts/__tests__/dockerfile-web-no-expo-export.test.ts
+++ b/scripts/__tests__/dockerfile-web-no-expo-export.test.ts
@@ -10,7 +10,9 @@ import { describe, expect, it } from 'vitest';
 // `[deploy]` block for the backend image alone. So there is no build to fail if
 // the retired Expo export step comes back — this text pin is the only oracle.
 // W-24 / #4438.
-const dockerfile = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'Dockerfile.web'), 'utf8');
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const dockerfile = readFileSync(join(repositoryRoot, 'Dockerfile.web'), 'utf8');
+const contextBuilder = readFileSync(join(repositoryRoot, 'scripts', 'create-service-docker-context.mjs'), 'utf8');
 
 describe('Dockerfile.web after the /app retirement', () => {
   it('runs no Expo web export', () => {
@@ -37,5 +39,13 @@ describe('Dockerfile.web after the /app retirement', () => {
     // it just happens to be the COPY the export used to ride on, so it is the
     // plausible collateral casualty of removing the export step.
     expect(dockerfile).toContain('COPY --from=builder /app/packages/web/public ./packages/web/public');
+  });
+
+  it('keeps a stale local export out of the web build context', () => {
+    // With no builder-stage rebuild left to overwrite it, this exclusion is the
+    // only thing stopping a developer's packages/web/public/app (from
+    // `vp run build:expo-web` or `dev:mobile:web-static`) riding into the image
+    // and being served as real files under /app by the runner's public/ COPY.
+    expect(contextBuilder).toContain("new Set(['packages/web/public/app'])");
   });
 });

--- a/scripts/__tests__/dockerfile-web-no-expo-export.test.ts
+++ b/scripts/__tests__/dockerfile-web-no-expo-export.test.ts
@@ -5,6 +5,8 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
+import { ignoredRepoRelativePaths, services } from '../create-service-docker-context.mjs';
+
 // Nothing in CI builds Dockerfile.web: branch-deploy.yml's `pull_request`
 // trigger is commented out (workflow_dispatch only) and railway.toml carries a
 // `[deploy]` block for the backend image alone. So there is no build to fail if
@@ -12,7 +14,6 @@ import { describe, expect, it } from 'vitest';
 // W-24 / #4438.
 const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const dockerfile = readFileSync(join(repositoryRoot, 'Dockerfile.web'), 'utf8');
-const contextBuilder = readFileSync(join(repositoryRoot, 'scripts', 'create-service-docker-context.mjs'), 'utf8');
 
 describe('Dockerfile.web after the /app retirement', () => {
   it('runs no Expo web export', () => {
@@ -41,11 +42,41 @@ describe('Dockerfile.web after the /app retirement', () => {
     expect(dockerfile).toContain('COPY --from=builder /app/packages/web/public ./packages/web/public');
   });
 
-  it('keeps a stale local export out of the web build context', () => {
+  it('keeps every local export output out of the web build context', () => {
     // With no builder-stage rebuild left to overwrite it, this exclusion is the
-    // only thing stopping a developer's packages/web/public/app (from
-    // `vp run build:expo-web` or `dev:mobile:web-static`) riding into the image
-    // and being served as real files under /app by the runner's public/ COPY.
-    expect(contextBuilder).toContain("new Set(['packages/web/public/app'])");
+    // only thing stopping a developer's local export (from `vp run build:expo-web`,
+    // `dev:mobile:web-static`, or the `--subdomain` run this PR's own manual gate
+    // asks for) riding into the image and being served as real files by the
+    // runner's public/ COPY.
+    //
+    // Read the export script's own DEFAULT_OUTPUT_DIR values rather than pinning
+    // a literal Set: a text pin stays green when the script grows a new output
+    // directory the exclusion doesn't cover, which is exactly how
+    // packages/web/public/app-standalone was missed.
+    const exportScript = readFileSync(join(repositoryRoot, 'scripts', 'build-expo-web-export.sh'), 'utf8');
+    const defaultOutputDirs = [
+      ...new Set(
+        [...exportScript.matchAll(/^[ \t]*DEFAULT_OUTPUT_DIR="\$ROOT_DIR\/([^"]+)"[ \t]*$/gm)].map(
+          ([, repoRelativePath]) => repoRelativePath,
+        ),
+      ),
+    ];
+
+    expect(defaultOutputDirs).toEqual(
+      expect.arrayContaining(['packages/web/public/app', 'packages/web/public/app-standalone']),
+    );
+    for (const outputDir of defaultOutputDirs) {
+      expect([...(ignoredRepoRelativePaths as Set<string>)]).toContain(outputDir);
+    }
+  });
+
+  it('copies the manifest patcher alongside the export script it shells out to', () => {
+    // The export script is dead weight in this context until W-26 (#4442) drops
+    // it, but while it is copied it must stay runnable: it invokes
+    // scripts/lib/patch-expo-web-pwa-manifest.mjs by path.
+    const { extraSourceFiles } = services.web as { extraSourceFiles: string[] };
+    if (extraSourceFiles.includes('scripts/build-expo-web-export.sh')) {
+      expect(extraSourceFiles).toContain('scripts/lib/patch-expo-web-pwa-manifest.mjs');
+    }
   });
 });

--- a/scripts/__tests__/dockerfile-web-no-expo-export.test.ts
+++ b/scripts/__tests__/dockerfile-web-no-expo-export.test.ts
@@ -1,0 +1,41 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Nothing in CI builds Dockerfile.web: branch-deploy.yml's `pull_request`
+// trigger is commented out (workflow_dispatch only) and railway.toml carries a
+// `[deploy]` block for the backend image alone. So there is no build to fail if
+// the retired Expo export step comes back — this text pin is the only oracle.
+// W-24 / #4438.
+const dockerfile = readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'Dockerfile.web'), 'utf8');
+
+describe('Dockerfile.web after the /app retirement', () => {
+  it('runs no Expo web export', () => {
+    // The browser app ships only at app.boardsesh.com. #3795 moves web serving
+    // to this image, at which point a surviving export step would publish a
+    // second SPA copy at www/app built with different env.
+    expect(dockerfile).not.toContain('build-expo-web-export.sh');
+    expect(dockerfile).not.toContain('packages/web/public/app');
+  });
+
+  it('keeps the runner-stage BOARDSESH_WEB flag', () => {
+    // Read at REQUEST time, not build time: app/layout.tsx gates the
+    // cross-subdomain Expo auth bridge on it (the www half of how
+    // app.boardsesh.com signs in) and middleware.ts gates the /app carve-out.
+    // Deleting it with the builder-stage copy would break sign-in on the
+    // subdomain, silently.
+    const runnerStage = dockerfile.slice(dockerfile.indexOf('AS runner'));
+    expect(runnerStage).toContain('ARG BOARDSESH_WEB');
+    expect(runnerStage).toContain('ENV BOARDSESH_WEB=$BOARDSESH_WEB');
+  });
+
+  it('still ships the built public/ directory to the runner', () => {
+    // Unrelated to the export (it carries icons, images, the well-known files);
+    // it just happens to be the COPY the export used to ride on, so it is the
+    // plausible collateral casualty of removing the export step.
+    expect(dockerfile).toContain('COPY --from=builder /app/packages/web/public ./packages/web/public');
+  });
+});

--- a/scripts/__tests__/mobile-web-bundle-check.test.ts
+++ b/scripts/__tests__/mobile-web-bundle-check.test.ts
@@ -11,10 +11,28 @@ const currentDirectory = dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = join(currentDirectory, '..', '..');
 const sourceGuardScript = join(repositoryRoot, 'scripts', 'mobile-web-bundle-check.sh');
 const sourceExportScript = join(repositoryRoot, 'scripts', 'build-expo-web-export.sh');
+const sourcePatchScript = join(repositoryRoot, 'scripts', 'lib', 'patch-expo-web-pwa-manifest.mjs');
 
 const GLUE_PATH = 'board_renderer_wasm.js';
 const WASM_PATH = 'board_renderer_wasm_bg.wasm';
 const WORKER_PATH = 'board-render.worker.js';
+
+// The export script's PWA-manifest step (W-24, #4438) reads the rendered shell
+// and manifest.json back out of the export, so the stub has to emit real ones —
+// a `touch`ed empty index.html would fail every case here for the wrong reason.
+const EXPORT_SHELL_AND_MANIFEST = `cat > "$output_dir/index.html" <<'SHELL_EOF'
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Boardsesh</title>
+    <link rel="manifest" href="/app/manifest.json" />
+  </head>
+  <body><div id="root"></div></body>
+</html>
+SHELL_EOF
+cat > "$output_dir/manifest.json" <<'MANIFEST_EOF'
+{ "name": "Boardsesh", "start_url": "/", "scope": "/" }
+MANIFEST_EOF`;
 
 describe('mobile-web-bundle-check.sh', () => {
   let fixtureRoot: string;
@@ -36,6 +54,9 @@ describe('mobile-web-bundle-check.sh', () => {
     // The guard delegates the export to build-expo-web-export.sh; ship it too.
     copyFileSync(sourceGuardScript, fixtureGuardScript);
     copyFileSync(sourceExportScript, join(fixtureRoot, 'scripts', 'build-expo-web-export.sh'));
+    // …and the PWA-manifest patcher the export script shells out to.
+    mkdirSync(join(fixtureRoot, 'scripts', 'lib'), { recursive: true });
+    copyFileSync(sourcePatchScript, join(fixtureRoot, 'scripts', 'lib', 'patch-expo-web-pwa-manifest.mjs'));
     // Pre-seed the isolated web-runtime install so the export script skips its
     // `bun install` step (no network in the test).
     mkdirSync(join(fixtureRoot, 'packages', 'mobile', 'web-runtime', 'node_modules', 'react-native-web'), {
@@ -61,7 +82,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 mkdir -p "$output_dir/wasm"
-touch "$output_dir/index.html"
+${EXPORT_SHELL_AND_MANIFEST}
 touch "$output_dir/wasm/${GLUE_PATH}"
 touch "$output_dir/wasm/${WASM_PATH}"
 touch "$output_dir/wasm/${WORKER_PATH}"
@@ -134,7 +155,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 mkdir -p "$output_dir/wasm"
-touch "$output_dir/index.html"
+${EXPORT_SHELL_AND_MANIFEST}
 touch "$output_dir/wasm/${GLUE_PATH}"
 touch "$output_dir/wasm/${WASM_PATH}"
 `,

--- a/scripts/__tests__/patch-expo-web-pwa-manifest.test.ts
+++ b/scripts/__tests__/patch-expo-web-pwa-manifest.test.ts
@@ -1,0 +1,130 @@
+/// <reference types="node" />
+
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// Imported as a module rather than shelled out to, so a thrown message is
+// asserted directly. The CLI wrapper and its exit code are covered end-to-end by
+// build-expo-web-export.test.ts.
+import { patchExpoWebPwaManifest } from '../lib/patch-expo-web-pwa-manifest.mjs';
+
+const SHELL_WITH_APP_HREF = `<!doctype html>
+<html lang="en">
+  <head>
+    <title>Boardsesh</title>
+    <link rel="manifest" href="/app/manifest.json" />
+    <link rel="icon" href="https://www.boardsesh.com/icons/icon-192.png" />
+  </head>
+  <body><div id="root"></div></body>
+</html>
+`;
+
+const MANIFEST = {
+  name: 'Boardsesh',
+  short_name: 'Boardsesh',
+  start_url: '/',
+  scope: '/',
+  display: 'standalone',
+};
+
+describe('patch-expo-web-pwa-manifest', () => {
+  let exportDir: string;
+
+  beforeEach(() => {
+    exportDir = mkdtempSync(join(tmpdir(), 'expo-web-manifest-'));
+    mkdirSync(exportDir, { recursive: true });
+    writeFileSync(join(exportDir, 'index.html'), SHELL_WITH_APP_HREF);
+    writeFileSync(join(exportDir, 'manifest.json'), `${JSON.stringify(MANIFEST, null, 2)}\n`);
+  });
+
+  afterEach(() => {
+    rmSync(exportDir, { recursive: true, force: true });
+  });
+
+  function readShell(): string {
+    return readFileSync(join(exportDir, 'index.html'), 'utf8');
+  }
+
+  function readManifest(): Record<string, unknown> {
+    return JSON.parse(readFileSync(join(exportDir, 'manifest.json'), 'utf8')) as Record<string, unknown>;
+  }
+
+  it('points the default (/app) export at /app/manifest.json with a matching scope', () => {
+    patchExpoWebPwaManifest({ exportDir, basePrefix: '/app' });
+
+    expect(readShell()).toContain('href="/app/manifest.json"');
+    // start_url must sit INSIDE scope — PWA scope matching is a path-prefix
+    // string compare, and "/app" is not a prefix-match inside "/app/".
+    expect(readManifest().start_url).toBe('/app/');
+    expect(readManifest().scope).toBe('/app/');
+  });
+
+  it('rewrites the subdomain export to a root-relative manifest (the shipped bug)', () => {
+    // This is the app.boardsesh.com case: the template's /app/manifest.json has
+    // no file behind it there, so _redirects' `/* /index.html 200` catch-all
+    // answered it with the SPA shell — HTML parsed as a manifest, at HTTP 200.
+    patchExpoWebPwaManifest({ exportDir, basePrefix: '' });
+
+    expect(readShell()).toContain('href="/manifest.json"');
+    expect(readShell()).not.toContain('href="/app/manifest.json"');
+    expect(readManifest().start_url).toBe('/');
+    expect(readManifest().scope).toBe('/');
+  });
+
+  it('fails when the shell has no manifest link', () => {
+    writeFileSync(join(exportDir, 'index.html'), '<!doctype html><html><head></head><body></body></html>');
+
+    expect(() => patchExpoWebPwaManifest({ exportDir, basePrefix: '' })).toThrow(/index\.html has no <link/);
+  });
+
+  it('fails when the shell has two manifest links', () => {
+    writeFileSync(
+      join(exportDir, 'index.html'),
+      SHELL_WITH_APP_HREF.replace(
+        '<link rel="manifest" href="/app/manifest.json" />',
+        '<link rel="manifest" href="/app/manifest.json" />\n    <link rel="manifest" href="/other.json" />',
+      ),
+    );
+
+    expect(() => patchExpoWebPwaManifest({ exportDir, basePrefix: '' })).toThrow(/2 <link rel="manifest"> tags/);
+  });
+
+  it('fails when manifest.json is missing', () => {
+    rmSync(join(exportDir, 'manifest.json'));
+
+    expect(() => patchExpoWebPwaManifest({ exportDir, basePrefix: '' })).toThrow(/missing manifest\.json/);
+  });
+
+  it('fails on invalid manifest JSON without truncating the file', () => {
+    writeFileSync(join(exportDir, 'manifest.json'), '{ "name": "Boardsesh", ');
+
+    expect(() => patchExpoWebPwaManifest({ exportDir, basePrefix: '' })).toThrow(/not valid JSON/);
+    expect(readFileSync(join(exportDir, 'manifest.json'), 'utf8')).toBe('{ "name": "Boardsesh", ');
+  });
+
+  it('fails when the raw template overwrote the rendered shell', () => {
+    // Expo substitutes %WEB_TITLE% / %LANG_ISO_CODE% when it renders
+    // public/index.html. Their survival means copyPublicFolderAsync clobbered
+    // the rendered shell with the template — a failure an href-only assertion
+    // cannot see, because the href would look perfectly correct.
+    writeFileSync(
+      join(exportDir, 'index.html'),
+      SHELL_WITH_APP_HREF.replace('Boardsesh</title>', '%WEB_TITLE%</title>'),
+    );
+
+    expect(() => patchExpoWebPwaManifest({ exportDir, basePrefix: '' })).toThrow(/%WEB_TITLE%/);
+  });
+
+  it('is idempotent', () => {
+    patchExpoWebPwaManifest({ exportDir, basePrefix: '' });
+    const firstShell = readShell();
+    const firstManifest = readFileSync(join(exportDir, 'manifest.json'), 'utf8');
+
+    patchExpoWebPwaManifest({ exportDir, basePrefix: '' });
+
+    expect(readShell()).toBe(firstShell);
+    expect(readFileSync(join(exportDir, 'manifest.json'), 'utf8')).toBe(firstManifest);
+  });
+});

--- a/scripts/__tests__/patch-expo-web-pwa-manifest.test.ts
+++ b/scripts/__tests__/patch-expo-web-pwa-manifest.test.ts
@@ -91,17 +91,21 @@ describe('patch-expo-web-pwa-manifest', () => {
     expect(() => patchExpoWebPwaManifest({ exportDir, basePrefix: '' })).toThrow(/2 <link rel="manifest"> tags/);
   });
 
-  it('fails when manifest.json is missing', () => {
+  it('fails when manifest.json is missing, leaving the shell untouched', () => {
     rmSync(join(exportDir, 'manifest.json'));
 
     expect(() => patchExpoWebPwaManifest({ exportDir, basePrefix: '' })).toThrow(/missing manifest\.json/);
+    // All-or-nothing: a half-patched export whose shell points at a manifest
+    // path with no file behind it is the exact symptom this script removes.
+    expect(readShell()).toBe(SHELL_WITH_APP_HREF);
   });
 
-  it('fails on invalid manifest JSON without truncating the file', () => {
+  it('fails on invalid manifest JSON without truncating the file or touching the shell', () => {
     writeFileSync(join(exportDir, 'manifest.json'), '{ "name": "Boardsesh", ');
 
     expect(() => patchExpoWebPwaManifest({ exportDir, basePrefix: '' })).toThrow(/not valid JSON/);
     expect(readFileSync(join(exportDir, 'manifest.json'), 'utf8')).toBe('{ "name": "Boardsesh", ');
+    expect(readShell()).toBe(SHELL_WITH_APP_HREF);
   });
 
   it('fails when the raw template overwrote the rendered shell', () => {

--- a/scripts/build-expo-web-export.sh
+++ b/scripts/build-expo-web-export.sh
@@ -33,8 +33,10 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# /app is the default so the dev proxy and the legacy prod-static path are
-# unchanged; --subdomain flips it to root-serving for app.boardsesh.com.
+# /app is the default so the dev proxy and the dev:mobile:web-static bake are
+# unchanged; --subdomain flips it to root-serving for app.boardsesh.com. There
+# is no prod-static path left for the default to keep working — W-24 (#4438)
+# retired it (see the header block).
 WEB_BASE_URL="/app"
 DEFAULT_OUTPUT_DIR="$ROOT_DIR/packages/web/public/app"
 OUTPUT_DIR=""

--- a/scripts/build-expo-web-export.sh
+++ b/scripts/build-expo-web-export.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Builds the static Expo web export and verifies the shell and board-renderer
-# WASM assets landed. This is the single export recipe shared by:
-#   - `vp run build:expo-web` (defaults to packages/web/public/app so a local
-#     BOARDSESH_WEB=1 `vp run build:web` serves /app exactly like production),
-#   - Dockerfile.web's builder stage (same default target),
+# Builds the static Expo web export and verifies the shell, the board-renderer
+# WASM assets and the PWA manifest wiring landed. This is the single export
+# recipe shared by:
+#   - production-deploy.yml's deploy-app-web job (--subdomain) — the only caller
+#     whose artifact reaches users,
+#   - `vp run build:expo-web` and scripts/dev-expo-web-static.sh (default
+#     target packages/web/public/app, served at /app by the DEV server only),
 #   - scripts/mobile-web-bundle-check.sh (temp dir; export-only validation).
 #
 # Two serving targets share the recipe, selected by --subdomain:
-#   - default          → baseUrl /app, the Next dev proxy + legacy prod-static
-#                        path (output packages/web/public/app).
+#   - default          → baseUrl /app. Dev + CI validation only since W-24
+#                        (#4438) retired the /app static path: Dockerfile.web no
+#                        longer calls this script and next.config.mjs bakes no
+#                        /app rewrite outside NODE_ENV=development (output
+#                        packages/web/public/app).
 #   - --subdomain      → baseUrl /, a STANDALONE export a host/CDN serves at the
 #                        root of app.boardsesh.com (output
 #                        packages/web/public/app-standalone unless overridden).
@@ -205,6 +210,29 @@ if [[ ! -f "$OUTPUT_DIR/wasm/board_renderer_wasm.js" || ! -f "$OUTPUT_DIR/wasm/b
   echo "[build-expo-web-export] missing board-renderer WASM assets in $OUTPUT_DIR" >&2
   exit 1
 fi
+
+# --- PWA manifest (W-24, #4438) -------------------------------------------
+# index.html is a checked-in template (packages/mobile/public/index.html) whose
+# manifest href is a fixed `/app/manifest.json`, and manifest.json is copied
+# verbatim out of public/. Neither knows this export's baseUrl. On the
+# --subdomain export that href points at a path with no file behind it, so
+# Cloudflare Pages' `/* /index.html 200` catch-all answers it with the SPA
+# shell: the browser parses HTML as a manifest, logs an error every load, and
+# never offers the install prompt. Rewrite the href and the manifest's
+# start_url/scope from WEB_BASE_URL, then assert the rewrite actually landed —
+# a silent no-op here is the exact failure mode being fixed.
+#
+# It runs in BOTH modes even though only --subdomain ships. The CI gate
+# (`vp run check:mobile-web-bundle`) only ever exercises the default mode, so a
+# uniform code path means a broken patcher reds CI; a --subdomain-only patch
+# would stay untested until a production deploy, which is how the bug it fixes
+# survived in the first place.
+if [[ "$WEB_BASE_URL" == "/" ]]; then
+  MANIFEST_BASE=""
+else
+  MANIFEST_BASE="${WEB_BASE_URL%/}"
+fi
+node "$ROOT_DIR/scripts/lib/patch-expo-web-pwa-manifest.mjs" "$OUTPUT_DIR" "$MANIFEST_BASE"
 
 # BOARDSESH_EXPORT_EXPECT_URLS (space-separated substrings, e.g.
 # "https://ws.boardsesh.com https://www.boardsesh.com") is the direct detector

--- a/scripts/check-service-deploy-inputs.test.mjs
+++ b/scripts/check-service-deploy-inputs.test.mjs
@@ -29,6 +29,7 @@ function createFixtureRepo() {
   // Declared as extraSourceFiles entries on the web service; context
   // generation fails when one is missing, so the fixture repo carries stubs.
   writeFixtureFile(repoRoot, 'scripts/build-expo-web-export.sh', '#!/usr/bin/env bash\n');
+  writeFixtureFile(repoRoot, 'scripts/lib/patch-expo-web-pwa-manifest.mjs', 'export {};\n');
   writeFixtureFile(repoRoot, 'scripts/lib/tailscale-hostname.ts', 'export {};\n');
   // Same for the backend service's extraSourceDirs entry.
   writeFixtureFile(repoRoot, 'packages/web/public/images/stub.webp', '');

--- a/scripts/create-service-docker-context.mjs
+++ b/scripts/create-service-docker-context.mjs
@@ -28,16 +28,23 @@ const services = {
   },
   web: {
     dockerfile: 'Dockerfile.web',
-    // @boardsesh/mobile rides along because Dockerfile.web's builder stage runs
-    // the static Expo web export (served by Next at /app); the union walk pulls
-    // in the mobile app plus its transitive workspace deps.
+    // @boardsesh/mobile used to ride along because Dockerfile.web's builder
+    // stage ran the static Expo web export. W-24 (#4438) deleted that step, so
+    // the mobile workspace and the export script below are now dead weight in
+    // this context — retained only until W-26 (#4442) does the slimming pass.
+    // Nothing in the image invokes either.
     rootPackageNames: ['@boardsesh/web', '@boardsesh/mobile'],
-    // Repo-root scripts the web image build needs, copied under source/scripts:
-    // the Expo web export recipe the Dockerfile invokes, plus the tailscale
-    // helper that packages/web/scripts/dev-with-tailscale.ts imports — Next's
-    // production type-check covers packages/web/scripts, so the module must
-    // resolve inside the build context.
-    extraSourceFiles: ['scripts/build-expo-web-export.sh', 'scripts/lib/tailscale-hostname.ts'],
+    // Repo-root scripts copied under source/scripts. `tailscale-hostname.ts` is
+    // load-bearing: packages/web/scripts/dev-with-tailscale.ts imports it and
+    // Next's production type-check covers packages/web/scripts, so the module
+    // must resolve inside the build context. The export script (and the manifest
+    // patcher it shells out to) is no longer invoked by the Dockerfile — kept as
+    // a pair so the copied script stays runnable, and both go in W-26 (#4442).
+    extraSourceFiles: [
+      'scripts/build-expo-web-export.sh',
+      'scripts/lib/patch-expo-web-pwa-manifest.mjs',
+      'scripts/lib/tailscale-hostname.ts',
+    ],
   },
   sync: {
     dockerfile: 'Dockerfile.sync',
@@ -68,15 +75,23 @@ const ignoredFileNames = new Set(['.DS_Store']);
 // without also dropping `packages/web/app` / `packages/mobile/app`), these match
 // the exact path from the repo root.
 //
-// `packages/web/public/app` is the default local output of
-// `vp run build:expo-web` (and of `vp run dev:mobile:web-static`). This
-// exclusion is load-bearing on its own since W-24 (#4438): the builder stage no
-// longer rebuilds the export, so a stale local copy riding into the context
-// would be copied verbatim to the runner's `public/` and served as real files
-// under /app — the exact second-SPA-copy problem the retirement closes, and the
-// one #3795 must not reintroduce. Guarded by
-// scripts/__tests__/dockerfile-web-no-expo-export.test.ts.
-const ignoredRepoRelativePaths = new Set(['packages/web/public/app']);
+// These are the two DEFAULT_OUTPUT_DIR values of
+// scripts/build-expo-web-export.sh: `packages/web/public/app` (the default
+// baseUrl-/app export, written by `vp run build:expo-web` and
+// `vp run dev:mobile:web-static`) and `packages/web/public/app-standalone` (the
+// --subdomain export, the exact command production-deploy.yml runs and the
+// natural way to verify a change locally). Both are gitignored, so a stale copy
+// sits in a working tree invisibly.
+//
+// This exclusion is load-bearing on its own since W-24 (#4438): the builder
+// stage no longer rebuilds any export, so a stale local copy riding into the
+// context would be copied verbatim to the runner's `public/` and served as real
+// files under /app or /app-standalone — the exact second-SPA-copy problem the
+// retirement closes, and the one #3795 must not reintroduce. The walk is a
+// plain fs walk with no gitignore awareness, so the exclusion has to be
+// explicit. Guarded by scripts/__tests__/dockerfile-web-no-expo-export.test.ts,
+// which reads the export script's own defaults rather than trusting this list.
+const ignoredRepoRelativePaths = new Set(['packages/web/public/app', 'packages/web/public/app-standalone']);
 
 const toPosix = (filePath) => filePath.split(sep).join(posix.sep);
 const readJson = (filePath) => JSON.parse(readFileSync(filePath, 'utf8'));
@@ -340,5 +355,6 @@ export {
   getServiceSourcePackageDirs,
   getWorkspacePackageJsonPaths,
   getWorkspacePackageMap,
+  ignoredRepoRelativePaths,
   services,
 };

--- a/scripts/create-service-docker-context.mjs
+++ b/scripts/create-service-docker-context.mjs
@@ -66,10 +66,16 @@ const ignoredFileNames = new Set(['.DS_Store']);
 // Repo-relative directory paths to keep out of every context. Unlike
 // `ignoredDirectoryNames` (matched by basename, so it can't target `public/app`
 // without also dropping `packages/web/app` / `packages/mobile/app`), these match
-// the exact path from the repo root. `packages/web/public/app` is the default
-// local output of `vp run build:expo-web`; a stale copy must never ride into the
-// web image (it would ship the old shell at /app/index.html and defeat the
-// BOARDSESH_WEB=0 rollback). The Dockerfile.web builder rebuilds it from source.
+// the exact path from the repo root.
+//
+// `packages/web/public/app` is the default local output of
+// `vp run build:expo-web` (and of `vp run dev:mobile:web-static`). This
+// exclusion is load-bearing on its own since W-24 (#4438): the builder stage no
+// longer rebuilds the export, so a stale local copy riding into the context
+// would be copied verbatim to the runner's `public/` and served as real files
+// under /app — the exact second-SPA-copy problem the retirement closes, and the
+// one #3795 must not reintroduce. Guarded by
+// scripts/__tests__/dockerfile-web-no-expo-export.test.ts.
 const ignoredRepoRelativePaths = new Set(['packages/web/public/app']);
 
 const toPosix = (filePath) => filePath.split(sep).join(posix.sep);

--- a/scripts/lib/patch-expo-web-pwa-manifest.mjs
+++ b/scripts/lib/patch-expo-web-pwa-manifest.mjs
@@ -32,7 +32,12 @@ const manifestLinkPattern = () => /<link\b[^>]*\brel=["']manifest["'][^>]*>/gi;
 // (@expo/cli's webTemplate.js). Their survival into the export means
 // copyPublicFolderAsync clobbered the rendered shell with the raw template — a
 // failure an href-only assertion cannot see.
-const UNRENDERED_TEMPLATE_TOKENS = ['%WEB_TITLE%', '%LANG_ISO_CODE%'];
+//
+// Exported so packages/mobile/src/__tests__/web-shell-appearance.test.ts can
+// assert the real template still contains every one of them. Without that pin,
+// hardcoding the template's title/lang — a natural, harmless-looking edit —
+// would silently turn this whole check into dead code.
+export const UNRENDERED_TEMPLATE_TOKENS = ['%WEB_TITLE%', '%LANG_ISO_CODE%'];
 
 function fail(message) {
   throw new Error(`${LOG_PREFIX} ${message}`);
@@ -90,10 +95,11 @@ export function patchExpoWebPwaManifest({ exportDir, basePrefix }) {
     );
   }
 
-  const originalLink = manifestLinks[0];
-  const patchedLink = originalLink.replace(/\bhref=["'][^"']*["']/i, `href="${expectedHref}"`);
-  writeFileSync(shellPath, shellHtml.replace(originalLink, patchedLink));
-
+  // Validate BOTH files before writing EITHER. A manifest-side failure after
+  // index.html was already rewritten would leave a half-patched export on disk:
+  // a shell pointing at a manifest path with no file behind it, which is the
+  // very symptom this script exists to remove — and nothing tells the operator
+  // the directory is poisoned. All-or-nothing instead.
   const manifestSource = readRequired(manifestPath, 'manifest.json');
   let manifest;
   try {
@@ -103,6 +109,11 @@ export function patchExpoWebPwaManifest({ exportDir, basePrefix }) {
       `manifest.json is not valid JSON (${manifestPath}): ${error instanceof Error ? error.message : String(error)}`,
     );
   }
+
+  const originalLink = manifestLinks[0];
+  const patchedLink = originalLink.replace(/\bhref=["'][^"']*["']/i, `href="${expectedHref}"`);
+  writeFileSync(shellPath, shellHtml.replace(originalLink, patchedLink));
+
   manifest.start_url = expectedStartUrl;
   manifest.scope = expectedStartUrl;
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/scripts/lib/patch-expo-web-pwa-manifest.mjs
+++ b/scripts/lib/patch-expo-web-pwa-manifest.mjs
@@ -23,7 +23,11 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const LOG_PREFIX = '[patch-expo-web-pwa-manifest]';
-const MANIFEST_LINK_PATTERN = /<link\b[^>]*\brel=["']manifest["'][^>]*>/gi;
+// A factory, not a module-level literal. A `/g` regex carries `lastIndex`
+// between uses; `String.prototype.match` resets it, but anything reaching for
+// `.exec()` or `.test()` later would silently start mid-string on the second
+// call. Handing out a fresh regex removes the trap rather than documenting it.
+const manifestLinkPattern = () => /<link\b[^>]*\brel=["']manifest["'][^>]*>/gi;
 // Expo substitutes these when it renders public/index.html as the SPA shell
 // (@expo/cli's webTemplate.js). Their survival into the export means
 // copyPublicFolderAsync clobbered the rendered shell with the raw template — a
@@ -38,13 +42,14 @@ function readRequired(filePath, label) {
   try {
     return readFileSync(filePath, 'utf8');
   } catch {
-    fail(`missing ${label} at ${filePath}`);
-    return '';
+    // Throw here rather than call fail(): a `fail(); return ''` tail would be
+    // unreachable code that reads like an empty-string fallback.
+    throw new Error(`${LOG_PREFIX} missing ${label} at ${filePath}`);
   }
 }
 
 function findManifestLinks(shellHtml) {
-  return shellHtml.match(MANIFEST_LINK_PATTERN) ?? [];
+  return shellHtml.match(manifestLinkPattern()) ?? [];
 }
 
 function hrefOf(linkTag) {

--- a/scripts/lib/patch-expo-web-pwa-manifest.mjs
+++ b/scripts/lib/patch-expo-web-pwa-manifest.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+// Normalises an Expo web export's PWA manifest wiring to that export's baseUrl.
+//
+// Two inputs of the export are baseUrl-blind:
+//   - packages/mobile/public/index.html is a checked-in template whose
+//     `<link rel="manifest">` href is a fixed `/app/manifest.json` (the value
+//     the dev Metro proxy needs — next.config.mjs rewrites /app/manifest.json
+//     to Metro's /manifest.json).
+//   - packages/mobile/public/manifest.json is copied verbatim into the export
+//     root, with `start_url`/`scope` written for root serving.
+//
+// Neither knows which baseUrl this export was built with. On the --subdomain
+// export the href points at /app/manifest.json, a path with no file behind it,
+// and Cloudflare Pages' `/* /index.html 200` catch-all answers it with the SPA
+// shell: the browser parses HTML as a manifest, logs an error on every load and
+// never offers the install prompt — all at HTTP 200, invisible to a status-code
+// check. This rewrites both files from the export's baseUrl, then re-reads them
+// from disk and asserts the rewrite landed, because a silent no-op here is the
+// exact failure mode being fixed. See W-24 / #4438.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const LOG_PREFIX = '[patch-expo-web-pwa-manifest]';
+const MANIFEST_LINK_PATTERN = /<link\b[^>]*\brel=["']manifest["'][^>]*>/gi;
+// Expo substitutes these when it renders public/index.html as the SPA shell
+// (@expo/cli's webTemplate.js). Their survival into the export means
+// copyPublicFolderAsync clobbered the rendered shell with the raw template — a
+// failure an href-only assertion cannot see.
+const UNRENDERED_TEMPLATE_TOKENS = ['%WEB_TITLE%', '%LANG_ISO_CODE%'];
+
+function fail(message) {
+  throw new Error(`${LOG_PREFIX} ${message}`);
+}
+
+function readRequired(filePath, label) {
+  try {
+    return readFileSync(filePath, 'utf8');
+  } catch {
+    fail(`missing ${label} at ${filePath}`);
+    return '';
+  }
+}
+
+function findManifestLinks(shellHtml) {
+  return shellHtml.match(MANIFEST_LINK_PATTERN) ?? [];
+}
+
+function hrefOf(linkTag) {
+  const matched = /\bhref=["']([^"']*)["']/i.exec(linkTag);
+  return matched ? matched[1] : null;
+}
+
+/**
+ * Rewrite an Expo web export's manifest href, start_url and scope from the
+ * export's baseUrl.
+ *
+ * @param {{ exportDir: string, basePrefix: string }} options
+ *   `basePrefix` is the baseUrl with no trailing slash: '/app' for the default
+ *   export, '' for the root-served --subdomain export.
+ * @returns {{ href: string, startUrl: string }}
+ */
+export function patchExpoWebPwaManifest({ exportDir, basePrefix }) {
+  const shellPath = join(exportDir, 'index.html');
+  const manifestPath = join(exportDir, 'manifest.json');
+  const expectedHref = `${basePrefix}/manifest.json`;
+  const expectedStartUrl = `${basePrefix}/`;
+
+  const shellHtml = readRequired(shellPath, 'index.html');
+
+  const manifestLinks = findManifestLinks(shellHtml);
+  if (manifestLinks.length === 0) {
+    fail(`index.html has no <link rel="manifest"> tag (${shellPath}) — the shell template lost its manifest link`);
+  }
+  if (manifestLinks.length > 1) {
+    fail(`index.html has ${manifestLinks.length} <link rel="manifest"> tags (${shellPath}) — expected exactly one`);
+  }
+
+  const unrendered = UNRENDERED_TEMPLATE_TOKENS.filter((token) => shellHtml.includes(token));
+  if (unrendered.length > 0) {
+    fail(
+      `index.html still contains unsubstituted template token(s) ${unrendered.join(', ')} (${shellPath}) — ` +
+        'the raw public/index.html template overwrote the rendered shell',
+    );
+  }
+
+  const originalLink = manifestLinks[0];
+  const patchedLink = originalLink.replace(/\bhref=["'][^"']*["']/i, `href="${expectedHref}"`);
+  writeFileSync(shellPath, shellHtml.replace(originalLink, patchedLink));
+
+  const manifestSource = readRequired(manifestPath, 'manifest.json');
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestSource);
+  } catch (error) {
+    fail(
+      `manifest.json is not valid JSON (${manifestPath}): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  manifest.start_url = expectedStartUrl;
+  manifest.scope = expectedStartUrl;
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  // Re-read from disk. Everything above operated on in-memory strings; only a
+  // fresh read proves the bytes a browser will fetch actually changed.
+  const writtenShell = readFileSync(shellPath, 'utf8');
+  const writtenLinks = findManifestLinks(writtenShell);
+  if (writtenLinks.length !== 1) {
+    fail(`post-write check: expected exactly one <link rel="manifest"> in ${shellPath}, found ${writtenLinks.length}`);
+  }
+  const writtenHref = hrefOf(writtenLinks[0]);
+  if (writtenHref !== expectedHref) {
+    fail(`post-write check: manifest href is ${JSON.stringify(writtenHref)}, expected ${JSON.stringify(expectedHref)}`);
+  }
+
+  const writtenManifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (writtenManifest.start_url !== expectedStartUrl || writtenManifest.scope !== expectedStartUrl) {
+    fail(
+      `post-write check: manifest start_url/scope are ${JSON.stringify(writtenManifest.start_url)}/` +
+        `${JSON.stringify(writtenManifest.scope)}, expected ${JSON.stringify(expectedStartUrl)}`,
+    );
+  }
+
+  return { href: expectedHref, startUrl: expectedStartUrl };
+}
+
+function main(argv) {
+  const [exportDir, basePrefix = ''] = argv;
+  if (!exportDir) {
+    fail('usage: node scripts/lib/patch-expo-web-pwa-manifest.mjs <export-dir> [base-prefix]');
+  }
+  const { href, startUrl } = patchExpoWebPwaManifest({ exportDir, basePrefix });
+  console.log(`${LOG_PREFIX} index.html manifest href → "${href}"; manifest.json start_url/scope → "${startUrl}"`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/production-deploy-changes.mjs
+++ b/scripts/production-deploy-changes.mjs
@@ -83,6 +83,12 @@ function isAppAffecting(filePath) {
     filePath.startsWith('packages/shared/') ||
     filePath.startsWith('packages/shared-schema/') ||
     filePath === 'scripts/build-expo-web-export.sh' ||
+    // The export recipe shells out to this: it rewrites the shipped shell's
+    // manifest href and the manifest's start_url/scope from the export's
+    // baseUrl (W-24, #4438). A patcher-only change alters the artifact
+    // app.boardsesh.com serves, so it has to redeploy the subdomain — and run
+    // the post-deploy manifest smoke that would catch a bad patch.
+    filePath === 'scripts/lib/patch-expo-web-pwa-manifest.mjs' ||
     filePath === 'deploy/app-subdomain/_headers' ||
     filePath === 'deploy/app-subdomain/_redirects'
   );

--- a/scripts/production-deploy-changes.test.mjs
+++ b/scripts/production-deploy-changes.test.mjs
@@ -109,6 +109,17 @@ void test('keeps production deploy unit tests CI-only', () => {
   }
 });
 
+void test('treats every input of the app.boardsesh.com export as app-affecting', () => {
+  // The export recipe and the manifest patcher it shells out to both decide what
+  // the subdomain serves, so a change to either has to fire deploy-app-web (and
+  // with it the post-deploy manifest smoke). A patcher-only PR would otherwise
+  // merge green, deploy nothing, and leave the author believing it shipped.
+  // W-24 / #4438.
+  for (const filePath of ['scripts/build-expo-web-export.sh', 'scripts/lib/patch-expo-web-pwa-manifest.mjs']) {
+    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: false, app: true });
+  }
+});
+
 void test('keeps every backend build and runtime control path backend-affecting', () => {
   for (const filePath of ['Dockerfile.backend', 'railway.toml', 'bun.lock', 'package.json']) {
     assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: true, app: false });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -364,17 +364,20 @@ export default defineConfig({
         command: 'bun run --filter=@boardsesh/web build',
         dependsOn: ['build:shared', 'build:crypto', 'build:db', 'build:constants'],
         // Forwarded into the task (vp runs tasks with a filtered environment)
-        // and part of the cache key: BOARDSESH_WEB=1 bakes the /app static
-        // serving rewrites into the standalone build (see next.config.mjs).
+        // and part of the cache key. Since W-24 (#4438) BOARDSESH_WEB no longer
+        // bakes any /app rewrite into a production build — next.config.mjs gates
+        // the static fallback on NODE_ENV=development — but the flag is still
+        // read at request time (the Expo auth bridge in app/layout.tsx, the
+        // middleware /app carve-out), so keep it in the key.
         env: ['BOARDSESH_WEB'],
       },
       'build:expo-web': {
-        // Static Expo web export into packages/web/public/app — the same
-        // artifact Dockerfile.web bakes into the production image. Run this
-        // before a BOARDSESH_WEB=1 `vp run build:web` to verify /app serving
-        // locally; pass `-- <output-dir>` for a different target (the script
-        // strips vp's forwarded `--`). The output is gitignored
-        // (packages/web/public/app).
+        // Static Expo web export into packages/web/public/app (gitignored) —
+        // a LOCAL/dev artifact since W-24 (#4438) retired the /app static path.
+        // It backs `dev:mobile:web-static` and the CI bundle check; production
+        // publishes the `--subdomain` (baseUrl /) export to app.boardsesh.com.
+        // Pass `-- <output-dir>` for a different target (the script strips vp's
+        // forwarded `--`).
         command: 'bash scripts/build-expo-web-export.sh',
         dependsOn: ['mobile:web-runtime:install'],
         cache: false,


### PR DESCRIPTION
## Summary

Part of #4358 (W-24). Refs #4438. 🔒 **Point of no return** — and it touches `packages/mobile`, so **Fable reviews this diff before merge**.

`www.boardsesh.com/app` was a legacy static-export path: Next serving an Expo web export out of `packages/web/public/app`, with two SPA-fallback rewrites and two `/app/*` header rules. It never served anyone. This retires it, and fixes the PWA manifest on the subdomain that actually does serve the browser app.

**What changed**

- **`packages/web/next.config.mjs`** — both `/app` header rules deleted; the SPA-fallback rewrites now sit behind `process.env.NODE_ENV === 'development'`. The dev Metro proxy block is **byte-unchanged** (verified in the diff).
- **`Dockerfile.web`** — the Expo export step is gone, along with the builder-stage `ARG/ENV BOARDSESH_WEB` and the `apk add bash` that existed only to run it. The **runner-stage** `ARG/ENV` stays: `BOARDSESH_WEB` is read at *request* time for the cross-subdomain Expo auth bridge (`app/layout.tsx`) and the `/app` middleware carve-out. `--build-arg BOARDSESH_WEB=0` is no longer a rollback lever — setting it to 0 now only breaks sign-in on the subdomain, and the rewritten comment says so.
- **`scripts/build-expo-web-export.sh`** + new **`scripts/lib/patch-expo-web-pwa-manifest.mjs`** — the PWA manifest fix (below).
- **`.github/workflows/production-deploy.yml`** — a `check_manifest_link` post-deploy smoke against `app.boardsesh.com`.
- Docs: `docs/expo-web-deployment.md`, `docs/expo-web.md`, `deploy/app-subdomain/README.md`, and the `build:expo-web` / `build:web` task comments in `vite.config.ts`.

### The user-visible half: the PWA manifest

`packages/mobile/public/index.html` hardcodes `<link rel="manifest" href="/app/manifest.json">` and `manifest.json` is copied verbatim with `start_url`/`scope` = `/`. Neither knows which `baseUrl` an export was built with. On `app.boardsesh.com` that href pointed at a path with no file behind it, so `_redirects`' `/* /index.html 200` catch-all answered it **with the SPA shell** — the browser parsed HTML as a manifest, logged an error every load, and never offered the install prompt. All at HTTP 200, invisible to a status-code check.

`patch-expo-web-pwa-manifest.mjs` runs after the WASM assertion and rewrites both files from `WEB_BASE_URL`:

| mode | href | `start_url` / `scope` |
|---|---|---|
| default | `/app/manifest.json` | `/app/` |
| `--subdomain` | `/manifest.json` | `/` |

Three deliberate properties:

- **It re-reads both files from disk and asserts the values landed.** A silent no-op is precisely the failure mode being fixed, so an in-memory check would not be an honest oracle.
- **It fails if `%WEB_TITLE%` / `%LANG_ISO_CODE%` survive** — that means `copyPublicFolderAsync` clobbered the rendered shell with the raw template, a failure an href-only assertion cannot see (the href would look perfect).
- **It runs in both modes**, not just `--subdomain`. The CI gate (`vp run check:mobile-web-bundle`) only ever exercises the default mode; a `--subdomain`-only patch would stay untested until a production deploy, which is exactly how this bug survived.

`start_url` gets the trailing slash because PWA scope matching is a path-prefix string compare — `/app` does not sit inside `/app/`.

**The template href does not change.** `/app/manifest.json` is the correct *dev* value (Metro serves `public/` from its root; `next.config.mjs` rewrites `/app/manifest.json` → Metro's `/manifest.json`) and it is the patcher's expected input. `web-shell-appearance.test.ts` now pins it with a comment pointing at the patcher, so the natural-but-wrong hand-fix reds.

---

## Production targets (standing rule 2)

| Target | Reached? | Why |
|---|---|---|
| **`app.boardsesh.com`** (Cloudflare Pages) | **YES** | This PR edits `scripts/build-expo-web-export.sh`, which `scripts/production-deploy-changes.mjs:85` classifies as app-affecting, so merging fires `deploy-app-web` and republishes the subdomain with the manifest fix. **This is the intended release.** |
| **Native store fleet via auto-OTA** | **NO** | The only `packages/mobile` file touched is `public/index.html`, and only its comment block. `public/` is not a fingerprint source and is not read by any native code path — proof + test below. `mobile-ota-production.yml` is untouched; no `eoas publish` is involved. |
| **`www.boardsesh.com`** (Vercel) | **YES, cosmetically** | `next.config.mjs` + `Dockerfile.web` are web-affecting, so `deploy-web` runs. Behaviour on production www is **unchanged**: `/app` 404s before and after. |

Also note: this PR touches `.github/workflows/production-deploy.yml`, which `isProductionDeployControlFile` treats as **all-targets** — so the merge deploys web + backend + app regardless. Expected; flagging it so nobody reads the backend deploy as a surprise.

### Why the native claim is a test, not an assertion

`packages/mobile/src/__tests__/web-public-assets-are-web-only.test.ts` (new) pins both halves:

1. **Not a fingerprint input.** `fingerprint.config.js`'s `extraSources` are `fingerprint.config.js`, `locales/`, `../../patches` — nothing in or under `public/`. `@expo/fingerprint`'s own defaults source the bare native dirs, autolinking configs, resolved Expo config, `package.json` scripts and the patch dir; `public/` is in none. No `.fingerprintignore` in the repo.
2. **Never read by native code.** Expo consumes `public/` only on the web export path (`@expo/cli`'s `publicFolder.js` + `webTemplate.js`), and `assetBundlePatterns` is `['assets/**/*']`, so Metro never bundles it into a binary. The test walks `src`, `app`, `modules`, `plugins`, `targets` and fails if any non-test file references `public/index.html` or `public/manifest.json`.
3. It also fails if `app.config.ts` ever gains an `EXPO_PUBLIC_FOLDER` override, which would move the file out of the paths (1) and (2) cover.

Fingerprint-neutrality alone would only guarantee *delivery*; (2) is the safety half — the native binary never reads the byte we changed. All three assertions were mutation-probed (below).

---

## The `BOARDSESH_WEB` Vercel-env check (Verifies checkbox)

The issue asks to check whether `BOARDSESH_WEB` is set as a Vercel project env var, because a dashboard variable would falsify the premise. **It cannot**, and there are two independent proofs:

- **Behavioural (measured 2026-08-15 against production www):** `/app`, `/app/index.html`, `/app/manifest.json`, `/app/climbs` and the three locale prefixes (`/es/app`, `/fr/app`, `/de/app`) all return **404**. `/app/` 308s to `/app` — that is Next's site-wide trailing-slash normalisation, not an `/app`-specific rule, so there is nothing to remove there.
- **Structural (in-repo):** the export artifact is never built for that deploy at all. `packages/web/vercel.json:3`'s build command resolves to `generate:openapi && next build`, and `production-deploy.yml:191-217` runs `vercel build --prod`. **Neither chain invokes `scripts/build-expo-web-export.sh`.** `.gitignore:92` ignores `packages/web/public/app` and `git ls-files packages/web/public/` returns zero entries under `app/`. So the rewrite resolved to a file that does not exist **whether the flag is set or not**. `docs/expo-web-deployment.md:326-328` already documented exactly this.

No dashboard read was needed and none blocked this PR.

**One thing filed, not fixed:** if the flag *is* unset on the Vercel project, `app/layout.tsx:87`'s `enableExpoAuthBridge` is off in production — the www-side half of the cross-subdomain auth bridge `app.boardsesh.com` depends on. Pre-existing and orthogonal to the retirement; deliberately untouched here.

---

## Decisions worth reading before reviewing

- **No redirect for `/app`.** 0 pageviews over 90 days (PostHog project 412845) against a non-vacuous 55,442-pageview www control; no in-repo `LocaleLink`/`<a>`, no sitemap shard entry, no `robots.txt` `Disallow`, `noindex` since inception. A redirect would create a cross-origin hop for a path nobody requests and drag in three locale twins (standing rule 4) for a path that never had locale variants.
- **The static fallback survives behind `NODE_ENV=development`, rather than being deleted.** `scripts/dev-expo-web-static.sh` (`vp run dev:mobile:web-static`) bakes the default `/app` export and starts the orchestrator with the web flag on and **no** proxy origin — it lands in exactly this branch, and `docs/expo-web.md` calls it *"Best for QA/device testing"* (the tailnet real-device loop). The dev gate keeps that alive **and** still delivers what #3795 needs: no production build, Vercel or `Dockerfile.web`, can bake an `/app` route again. Say the word in #3795 and its constraint comment can go.
- **`middleware.ts` is deliberately untouched.** Its `/app` carve-out is what keeps `noindex`/XFO/nosniff/HSTS on the dev Metro-proxied surface, since an external rewrite forwards Metro's headers past `next.config`'s `headers()`. Tightening it to `isExpoWebProxyEnabled()` is a behaviour change on a 🔒 PR for no production benefit — **out of scope on purpose**, not a miss.
- **`scripts/__tests__/mobile-web-bundle-check.test.ts` stub edit is required, not scope creep.** Both of its `bunx` stubs `touch`ed an empty `index.html` and wrote no `manifest.json`; the new patch step would fail every case for the wrong reason. The stubs now emit a real shell + manifest. All five original assertions are untouched.
- **Docker-context slimming deferred to W-26 (#4442).** `scripts/create-service-docker-context.mjs` still ships `packages/mobile` and the export script into the web context. Out of scope here — but its export-output exclusion got a **fix, a comment correction and a guard test**, because removing the builder rebuild inverted that exclusion's risk profile. The old comment described the `BOARDSESH_WEB=0` rollback and claimed *"The `Dockerfile.web` builder rebuilds it from source"*; both are now false, and with no rebuild left to overwrite it, that exclusion is the **only** thing stopping a developer's local export riding into the image and being served as real files by the runner's `public/` COPY. It covered `packages/web/public/app` but not `packages/web/public/app-standalone` — fixed in the review round below. Same door #3795 must not reopen. `vp run docker-context:web` still exits 0.

### Accepted gap

Under the **dev Metro proxy**, the shell and manifest are served by Metro straight from `packages/mobile/public/` and never pass through the patch script, so a dev install prompt keeps `start_url: "/"`. Dev-only; the `/app/manifest.json` href is already correct there via the `next.config.mjs` rewrite.

---

## Test plan

### Automated (all run and watched to completion)

| Command | Result |
|---|---|
| `vp check --fix` | **33 errors / 323 warnings**, all pre-existing (same counts on clean `main`); **zero** diagnostics in any file this PR touches — grepped the full report against `git diff --name-only`. Formatting clean. |
| `vp run typecheck` | **PASS** (exit 0, incl. `next build` + `tsc --noEmit`) |
| `vp run typecheck:mobile` | **PASS** |
| `vp test run --reporter=agent --project scripts` | **PASS** — 60 files, 862 tests |
| `vp test run --reporter=agent --project deploy-app-subdomain` | **PASS** — 3 files, 13 tests |
| `vp run test:service-deploy-inputs` | **PASS** — 33 tests (the `node --test` suites behind `service-deploy-inputs.yml`, which this PR's `production-deploy-changes.mjs` / `create-service-docker-context.mjs` edits trigger) |
| `vp run test:mobile` | **PASS** — 680 files, 6517 tests |
| `vp test run --reporter=agent --project web` | **PASS** — 303 files, 3397 tests. (An earlier round hit 5 `waitFor` timeouts in gym/auth component tests; isolating them failed a *different* one each time on this branch and on clean `main`. They did not recur in the final run.) |
| `vp run check:i18n` / `check:i18n:orphans` | **PASS**, no-op as expected — this PR adds zero user-facing strings, so four-locale parity is trivially preserved |
| `vp run check:mobile-bundle` | **PASS** |
| `vp run check:mobile-web-bundle` (the CI gate) | **PASS**, and the log shows the new step ran: `[patch-expo-web-pwa-manifest] index.html manifest href → "/app/manifest.json"; manifest.json start_url/scope → "/app/"` |

### The issue's manual gates

**1. Manual `--subdomain` export** — `bash scripts/build-expo-web-export.sh --subdomain`, exit 0:

```
<link rel="manifest" href="/manifest.json" />
"start_url": "/",  "scope": "/",
grep -c '%WEB_TITLE%\|%LANG_ISO_CODE%' index.html  → 0
<title>Boardsesh</title>   <html lang="en"
```

**2. Dev-loop regression check — the highest-value check in this PR.** Both dev shapes were booted against a real `next dev` and curled.

*Static shape* (`BOARDSESH_WEB=1`, no proxy origin, baked `public/app`) — the `dev:mobile:web-static` loop:

| path | result |
|---|---|
| `/app` | 200 `text/html` (SPA shell) |
| `/app/climbs` | 200 (SPA fallback) |
| `/app/manifest.json` | **200 `application/json`** with `start_url`/`scope` `/app/` |
| `/app/wasm/board_renderer_wasm_bg.wasm` | 200 `application/wasm` |
| `/app/_expo/static/js/web/does-not-exist.js` | **404** — the negative lookahead still works |
| headers on `/app` | `x-robots-tag: noindex, follow`, `x-frame-options: SAMEORIGIN`, `x-content-type-options: nosniff` |

*Metro-proxy shape* (`BOARDSESH_EXPO_WEB_ORIGIN` pointed at a stand-in Metro) — every forward still lands, and the baked `public/app` export does **not** shadow it (`beforeFiles` holds):

```
/app                                   → FAKE-METRO /app
/app/climbs                            → FAKE-METRO /app/climbs
/app/manifest.json                     → FAKE-METRO /manifest.json
/app/wasm/board_renderer_wasm_bg.wasm  → FAKE-METRO /wasm/board_renderer_wasm_bg.wasm
/packages/mobile/index.js              → FAKE-METRO /packages/mobile/index.js
/assets, /assets/foo.png               → FAKE-METRO /assets, /assets/foo.png
```

**A/B on the deleted header rule.** The proxied `/app` response carries no `X-Robots-Tag` — so I re-ran the identical probe with the **pre-change `next.config.mjs`** restored, and it carries none either. The `/app/:path*` rule was **already inert on the dev proxy**: an external rewrite forwards the upstream response verbatim, exactly as the `middleware.ts` comment says. Deleting it is a no-op on that surface. On the real loop `packages/mobile/expo-web-response-headers.cjs` stamps `noindex, follow` + XFO/nosniff/Referrer-Policy itself, and `expo-web-header-parity.test.ts` still pins middleware ↔ Metro against those constants.

**3. Post-merge, on the live subdomain (`deploy-app-web`'s new smoke does this automatically):** served `index.html` links `/manifest.json`, which returns 200 `application/json`. It is genuinely falsifiable — it **fails against production today** and passes only after this export fix ships. Manual install-prompt + clean-console check in Chrome to follow the deploy.

**4. Docker oracle:** nothing in CI builds `Dockerfile.web` (`branch-deploy.yml`'s `pull_request` trigger is commented out; `railway.toml` carries only a backend `[deploy]` block), so `scripts/__tests__/dockerfile-web-no-expo-export.test.ts` is the **only** guard. All three of its assertions are mutation-probed below.

### Mutation probes (12, every one restored)

| # | Mutation | Went red |
|---|---|---|
| 1 | drop the `NODE_ENV !== 'development'` guard | `bakes no /app rewrite into a production build` |
| 2 | delete the dev SPA-fallback branch | `keeps the SPA fallback in dev…` + `keeps content-hashed and WASM namespaces out…` |
| 3 | re-add an `/app/:path*` header rule | `headers() owns no /app rule after the retirement` |
| 4 | patcher returns before writing | **7 of 8** patcher tests (the 8th is the idempotence case, which a total no-op trivially satisfies) |
| 5 | delete the `node …patch-expo-web-pwa-manifest.mjs` line from the export script | all 3 `build-expo-web-export.test.ts` cases |
| 6a | restore the `RUN … build-expo-web-export.sh` block in `Dockerfile.web` | `runs no Expo web export` |
| 6b | delete the runner-stage `ARG`/`ENV BOARDSESH_WEB` | `keeps the runner-stage BOARDSESH_WEB flag` |
| 6c | delete the runner's `public/` COPY | `still ships the built public/ directory to the runner` |
| 7 | hand-"fix" the shell href to `/manifest.json` (the natural but wrong fix) | `keeps exactly one manifest link, at the dev/Metro-proxy href` |
| 8a | add `{ type: 'dir', filePath: 'public' }` to `extraSources` | `is not a fingerprint input…` |
| 8b | add a `src/` file referencing `public/index.html` | `is not referenced by any native source file` |
| 8c | put `EXPO_PUBLIC_FOLDER` in `app.config.ts` | `does not relocate the public folder…` |
| 9 | empty the docker-context `ignoredRepoRelativePaths` set | `keeps every local export output out of the web build context` (renamed in the review round) |

`git status --porcelain` is clean; every probe was reverted with `\cp -f` from a pre-probe copy and re-verified.

### Review round

Third commit takes the three `claude-review` notes: `readRequired` now throws directly instead of `fail()`-then-`return ''` (the tail was unreachable and read like an empty-string fallback), the manifest-link regex is handed out by a factory so nothing reaching for `.exec()`/`.test()` later inherits a stale `lastIndex`, and `check_manifest_link`'s curls take `--max-time 20` so an unreachable edge fails one attempt and lets the retry loop work instead of hanging the release. Probe #4 was re-run against the refactored patcher: still 7 of 8 red.

Its one remaining observation — the smoke's `grep` matches only a double-quoted `rel="manifest"` — is a non-issue: that attribute comes from the checked-in template, which is double-quoted and pinned by `web-shell-appearance.test.ts`.

**Independent confirmation of the native claim:** the OTA-compat bot resolves iOS `183bcf484292` and Android `a6f256fdaf25`, both **matching `main`** — no fingerprint movement, exactly as §"Why the native claim is a test" predicts.

### Adversarial review round (fourth commit)

Three lenses (delete-safety, native-OTA, manifest-oracle) went at the diff and returned 13 findings, 11 distinct. Their common shape: **the guards this PR adds are narrower than the properties they claim**, so each was green while the hole it names was open. All 11 are fixed.

**Two majors that would have bitten:**

- **The Docker-context exclusion missed `packages/web/public/app-standalone`.** That is the `--subdomain` export's default output — the exact command `production-deploy.yml` runs, and the natural way to verify *this PR* locally. It is gitignored, so a stale copy sits in a tree invisibly, and with the builder rebuild gone nothing overwrites it. Probed for real: seeded both directories, ran `node scripts/create-service-docker-context.mjs web --output <tmp>`, and `app-standalone/` (shell, manifest, `_expo/`) was copied into the context in full while `app/` was correctly dropped. Both are excluded now. More to the point, **the guard no longer pins a literal `Set`** — it parses `build-expo-web-export.sh`'s own `DEFAULT_OUTPUT_DIR` values and asserts every one is excluded, so a future output directory cannot slip past it the same way this one did. Re-ran the probe after the fix: neither directory reaches the context.
- **A patcher-only PR would have deployed nothing.** `scripts/lib/patch-expo-web-pwa-manifest.mjs` was absent from `isAppAffecting`, so `classifyChangedFiles(['scripts/lib/patch-expo-web-pwa-manifest.mjs'])` returned `app: false` — a later fix to the patcher would merge green, skip `deploy-app-web`, never run the new manifest smoke, and leave the author believing it shipped. It is app-affecting now, with a test that pins both inputs of the subdomain artifact together.

**And one CI gap that made three guards decorative:** `dockerfile-web-no-expo-export.test.ts` and `build-expo-web-export.test.ts` read their inputs with `readFileSync`, so Vitest's `--changed` module-graph selection never relates them to a diff that only touches `Dockerfile.web` or the `.sh` — and a Dockerfile-only PR matches no job gate at all. Probed: appending a comment to both files and running `vp test run --changed HEAD --project scripts` selects **nothing**; doing the same to the patcher (a real module import) selects its suite. So #3795 could have re-added the export step to a green CI. They now run unfiltered in the `deploy-config` job, mirroring the `listing-guards` pattern the repo already uses for exactly this hazard. The patcher also joins the `deployConfig` and `mobile` filters, so a patcher-only change runs the deploy suites *and* `check:mobile-web-bundle` — the only gate that drives a real Expo export rather than a fixture.

**The rest:**

- The patcher wrote `index.html` before reading `manifest.json`, so any manifest-side failure left a half-patched export on disk — a shell pointing at a manifest path with no file behind it, i.e. the symptom this script exists to remove, reproduced locally with no warning. Both files are validated before either is written; the two failure tests now assert the shell is byte-identical after the throw.
- Nothing pinned `%WEB_TITLE%` / `%LANG_ISO_CODE%` in the real template, so hardcoding the shell's title and lang — a natural, harmless-looking edit — would have left the clobber detector matching nothing, with no test going red. `web-shell-appearance.test.ts` now **imports `UNRENDERED_TEMPLATE_TOKENS` from the patcher** and asserts every token is present, so detector and input cannot drift apart.
- The fingerprint guard compared `extraSources` `filePath`s as literal strings, so `'./public'` or `'../mobile/public'` would make `packages/mobile/public` a real native fingerprint input while the test stayed green. Paths are resolved against the package root before comparing; all three spellings now red.
- `check_manifest_link` checked the href and content-type but never the body. `start_url` can sit outside `scope` and still serve as valid JSON at the right URL — parses clean, never offers the install prompt. It now reads the manifest and asserts `start_url`/`scope`.
- Comment accuracy, three places: `create-service-docker-context.mjs` still said the builder stage runs the export and that the Dockerfile invokes the export script (both false since the first commit); `build-expo-web-export.sh` still called the default baseUrl's purpose "the legacy prod-static path", contradicting its own rewritten header 30 lines above. Also, the copied export script would have died at the `node …patch-expo-web-pwa-manifest.mjs` line because the patcher was not in `extraSourceFiles` — added, with a test that keeps the pair together for as long as the script is copied at all.
- The shipped shell comment went from seven lines to two. It ships verbatim to every `app.boardsesh.com` visitor (confirmed against the live site, which carries the old one), and the rationale belongs in `docs/expo-web-deployment.md`, which now carries it.

**One finding taken the other way round.** The native-safety test's header comment cited `assetBundlePatterns: ['assets/**/*']` as one of two legs of the claim, and nothing pinned it. The lens offered two fixes and flagged the tension itself: `assetBundlePatterns` filters assets Metro has **already resolved from the JS module graph**, and `public/` is not in that graph, so widening it to `['**/*']` would not embed `public/index.html` in a binary either. Pinning it would red a legitimate unrelated change for a reason that isn't true. So the sentence is out of the comment instead, with that reasoning written down — the test's stated scope now matches what it actually pins.

Two findings were duplicates across lenses (the `app-standalone` gap and the stale `services.web` comments), which is a decent signal they were the real ones.

### Review-round mutation probes (7, every one restored from a pre-probe copy)

| # | Mutation | Went red |
|---|---|---|
| 10 | drop `packages/web/public/app-standalone` from `ignoredRepoRelativePaths` | `keeps every local export output out of the web build context` |
| 11 | drop the patcher from the web service's `extraSourceFiles` | `copies the manifest patcher alongside the export script it shells out to` |
| 12 | drop the patcher from `isAppAffecting` | `treats every input of the app.boardsesh.com export as app-affecting` (33 → 32 pass) |
| 13 | hardcode `%WEB_TITLE%` / `%LANG_ISO_CODE%` in `packages/mobile/public/index.html` | `keeps the template tokens the export patcher watches for` |
| 14 | `{ filePath: './public' }` in `extraSources` | `is not a fingerprint input…` (green before this fix) |
| 15 | `{ filePath: '../mobile/public' }` in `extraSources` | `is not a fingerprint input…` (green before this fix) |
| 16 | move the shell write back before the manifest read | both `fails when manifest.json is missing…` and `fails on invalid manifest JSON…` |

Plus one behavioural re-probe, not a unit test: seeded `packages/web/public/{app,app-standalone}` with a fake export and ran the real context generator — the output's `source/packages/web/public/` listing is `brand icons images uploads wasm index.html openapi.json`, neither export directory present, and `source/scripts/lib/` carries both the patcher and the tailscale helper. Working tree cleaned; `git status --porcelain` empty.

The new `deploy-config` step was run exactly as CI will run it — `vp test run --project scripts scripts/__tests__/dockerfile-web-no-expo-export.test.ts scripts/__tests__/build-expo-web-export.test.ts` → 8 tests, 1.0s. Both workflow files parse as YAML and the smoke step's script passes `bash -n`; the new body assertion was exercised directly against good and bad manifests (`{"start_url":"/","scope":"/"}` → exit 0; `start_url:"/app/"` and `scope:"/app/"` → exit 1 each).

One knock-on, worth naming so it doesn't read as scope creep: adding the patcher to the web context's `extraSourceFiles` reds `check-service-deploy-inputs.test.mjs`, whose fixture repo carries a stub for every declared extra source file. One stub line added; all 33 of those tests pass.

### `claude-review`'s notes on the review round

Its verdict was **✅ Ready to merge**. Of the three observations:

- **Taken.** A timed-out or empty body fetch in `check_manifest_link` piped into `node` and surfaced as a JSON parse error rather than a fetch failure. The retry loop handled it either way, but only one of those messages tells you what went wrong. The fetch is now checked on its own line; exercised against a dead port → `manifest body fetch failed`, exit 1.
- **Not taken — the cross-boundary import is the point.** `web-shell-appearance.test.ts` importing `UNRENDERED_TEMPLATE_TOKENS` from `scripts/lib/` crosses `packages/mobile` → repo root, which is unusual. The alternative is restating the two tokens in the test, which is exactly the drift the pin exists to prevent: the whole finding was that the detector and its input can silently diverge. The direction is also the useful one — if `scripts/lib/` moves, the *template's* contract is what broke, and the mobile suite is where that should surface. Either placement crosses the boundary anyway (the patcher lives in `scripts/`, the template in `packages/mobile/`); this way there is a single source of truth.
- **Not taken — acknowledged as inherent by the reviewer itself.** The native-reference scan uses `string.includes()`, so `path.join('public', 'index.html')` would evade it. True of any static scan, and it is the weaker of the two legs; the load-bearing one is fingerprint-neutrality, independently confirmed by the OTA-compat bot resolving both platforms as matching `main`. Not worth an AST pass for a directory no native code has ever read.

### Deliberately not touched

`/api/internal/board-render` and `next.config.mjs`'s `outputFileTracingIncludes` (the ESP32 pins `www.boardsesh.com` as its render host), `deploy/app-subdomain/{_headers,_redirects}`, `packages/web/app/robots.ts` (there was never an `/app` `Disallow`), `packages/web/middleware.ts`, `app/layout.tsx`, `packages/mobile/{metro.config.js,app.config.ts,expo-web-response-headers.cjs,public/manifest.json,public/wasm/**}`, `crawler-classic-invariant.test.ts` (single-owner, W-09 — it runs its board-surface invariants under both `BOARDSESH_WEB` states and delegates the `/app` carve-out to `middleware.test.ts`, which is unchanged; re-ran it green anyway).

## Release Notes

Installing the browser app now works. Open `app.boardsesh.com` in Chrome or Safari and you'll get the "Add to Home Screen" prompt, launching straight into the app instead of a browser tab.




