### PR TITLE
perf(web): bound front-door reads and fail loud when the database is slow

### DIFF
--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -99,6 +99,80 @@ off) rather than reaching into postgres.js's backoff.
 The connect-retry tests pin their pools to `backoff: () => 0` so they measure this
 wrapper's loop rather than that ramp.
 
+## Front-door read deadlines and pool sizing (#4461)
+
+The connect retry above bounds a _failed_ connect. It does nothing about a
+_saturated_ pool, and that is the failure the climb sitemaps invite: postgres.js
+has no acquire timeout, and its internal queue is unbounded and untimed
+(`postgres/src/index.js:341`). A statement that cannot get a connection waits
+forever, so many concurrent SSR renders against a slow database look like a hang
+rather than an error.
+
+`packages/web/app/lib/db/read-deadline.ts` bounds one read client-side. It races
+the pending query against a timer, rejects with `DbReadTimeoutError`
+(`code: 'DB_READ_TIMEOUT'`) when the timer wins, and calls `query.cancel()` the
+way the health probe does, so a timed-out statement does not fire later against
+a recovered pool. It is wired at the four front-door reads only — the two
+statements behind `getClimb`, the all-angles stats select, and the shared climb
+search — and deliberately **not** inside `withConnectRetry` or `packages/db`,
+where it would change behaviour for the backend, the sync runners and every
+script.
+
+### What the reader sees when it fires
+
+| condition                           | before                               | after                                                   |
+| ----------------------------------- | ------------------------------------ | ------------------------------------------------------- |
+| climb row absent                    | 404                                  | 404 (unchanged — now for the right reason)              |
+| read fails or deadlines, climb page | hung to the platform limit, then 404 | 500 at ~6 s; the CDN stale window keeps serving readers |
+| read fails or deadlines, list page  | 200 with zero climbs                 | 500 at ~6 s; same CDN window                            |
+| backend GraphQL wedged              | climb page hung indefinitely         | similar climbs / beta links render empty at 3 s         |
+
+The 5xx is the point. Google retries a 5xx and keeps the URL, while a 404 — or a
+200 with nothing on it — on a sitemapped URL reads as "drop this page".
+
+### Budgets
+
+| knob                      | default | meaning                                                                                  |
+| ------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `DB_READ_DEADLINE_MS`     | 6000    | web front door: wall clock for one read (queue wait + connect + execute)                 |
+| `DB_POOL_MAX`             | 10      | postgres.js `max`, clamped to a floor of 2                                               |
+| `DB_POOL_IDLE_TIMEOUT_S`  | 30      | seconds an idle connection is held open                                                  |
+| `DB_STATEMENT_TIMEOUT_MS` | unset   | emits a `statement_timeout` startup parameter — **off by default**, see the hazard below |
+
+6000 sits deliberately below `DB_CONNECT_RETRY_BUDGET_MS` (10000): during a
+brownout the front door should shed load rather than spend a second and third
+connect attempt holding a pool slot while a crawler waits.
+
+The pool knobs default to the values that used to be hard-coded, so nothing
+changes for a deployment that does not set them. They exist because peak
+server-side connections scale with **instance count × connections held idle**,
+not with per-instance `max` — a fleet of serverless instances each sitting on a
+few idle connections for 30 s is the term that grows during a crawl burst.
+Lowering `DB_POOL_MAX` and `DB_POOL_IDLE_TIMEOUT_S` on a serverless deployment
+shrinks that footprint; raising `max` never helps.
+
+### The `statement_timeout` hazard
+
+`DB_STATEMENT_TIMEOUT_MS` ships off. PgBouncer in transaction-pooling mode
+rejects startup parameters that are not in `ignore_startup_parameters`, and
+`statement_timeout` is not among the defaults — so setting it against a pooled
+`DATABASE_URL` fails _every connection_ instead of bounding one query. Two
+paths, chosen by what the URL actually points at:
+
+- **Direct Postgres** — set `DB_STATEMENT_TIMEOUT_MS` on the deployment.
+- **Pooled (PgBouncer) URL** — do it database-side instead, with
+  `ALTER ROLE <app_role> SET statement_timeout = '8s'`, which passes through a
+  pooler transparently.
+
+`psql "$DATABASE_URL" -c 'show pool_mode;'` tells you which you have: a direct
+Postgres errors, PgBouncer answers.
+
+### There is no web health probe
+
+`/health` and `/health/db` below are **backend** endpoints. `packages/web` has
+none, so during a web-pool incident `/health/db` stays green and says nothing
+about the surface that is actually failing. That gap is not filled here.
+
 ## Where the retry is wired
 
 `createDb()` / `createReadDb()` hand drizzle a retry-wrapped view of the pool

--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -109,39 +109,78 @@ forever, so many concurrent SSR renders against a slow database look like a hang
 rather than an error.
 
 `packages/web/app/lib/db/read-deadline.ts` bounds one read client-side. It races
-the pending query against a timer, rejects with `DbReadTimeoutError`
-(`code: 'DB_READ_TIMEOUT'`) when the timer wins, and calls `query.cancel()` the
-way the health probe does, so a timed-out statement does not fire later against
-a recovered pool. It is wired at the four front-door reads only — the two
-statements behind `getClimb`, the all-angles stats select, and the shared climb
-search — and deliberately **not** inside `withConnectRetry` or `packages/db`,
-where it would change behaviour for the backend, the sync runners and every
-script.
+the pending query against a timer and rejects with `DbReadTimeoutError`
+(`code: 'DB_READ_TIMEOUT'`) when the timer wins. It is wired at the four
+front-door reads only — the two statements behind `getClimb`, the all-angles
+stats select, and the shared climb search — and deliberately **not** inside
+`withConnectRetry` or `packages/db`, where it would change behaviour for the
+backend, the sync runners and every script.
+
+**Cancellation covers three of the four.** On a timeout the helper calls
+`query.cancel()` the way the health probe does, so a timed-out statement does not
+fire later against a recovered pool. That only works for raw postgres.js
+queries. The list front door's search is drizzle-issued and exposes no
+`.cancel()`, so there the deadline sheds the _caller_ while the statement runs to
+completion still holding its connection. Worth knowing mid-incident: shedding
+list renders does not immediately hand connections back.
+
+Cancelling a **queued** query is free — postgres.js removes it from the queue and
+rejects it locally. Cancelling one that is already **executing** opens a
+brand-new connection to send the cancel request, against a database that is by
+construction already struggling, and postgres.js keeps that connection's promise
+internally (`Query.cancel()` returns `null`), so a failure to open it surfaces as
+an unhandled rejection the runtime logs. Accepted: a zombie statement firing
+against a recovered pool is worse than a log line.
+
+**One budget per request, not per statement.** The climb page issues three reads
+in sequence, so three independent 6 s deadlines would be an ~18 s request
+ceiling — the opposite of shedding load. `app/lib/db/request-read-budget.ts`
+puts one deadline timestamp in React's per-render `cache` scope and hands each
+read whatever the earlier ones left, floored at 500 ms. Outside a render scope
+(scripts, unit tests) React's `cache` is a passthrough and each read gets its own
+deadline.
 
 ### What the reader sees when it fires
 
-| condition                           | before                               | after                                                   |
-| ----------------------------------- | ------------------------------------ | ------------------------------------------------------- |
-| climb row absent                    | 404                                  | 404 (unchanged — now for the right reason)              |
-| read fails or deadlines, climb page | hung to the platform limit, then 404 | 500 at ~6 s; the CDN stale window keeps serving readers |
-| read fails or deadlines, list page  | 200 with zero climbs                 | 500 at ~6 s; same CDN window                            |
-| backend GraphQL wedged              | climb page hung indefinitely         | similar climbs / beta links render empty at 3 s         |
+| condition                           | before                               | after                                           |
+| ----------------------------------- | ------------------------------------ | ----------------------------------------------- |
+| climb row absent                    | 404                                  | 404 (unchanged — now for the right reason)      |
+| board slug resolves to nothing      | 404                                  | 404 (unchanged)                                 |
+| read fails or deadlines, climb page | hung to the platform limit, then 404 | 500 at ~6 s per request                         |
+| read fails or deadlines, list page  | 200 with zero climbs                 | 500 at ~6 s                                     |
+| backend `boardBySlug` fails, `/b/…` | 404                                  | 500                                             |
+| backend GraphQL wedged              | climb page hung indefinitely         | similar climbs / beta links render empty at 3 s |
 
 The 5xx is the point. Google retries a 5xx and keeps the URL, while a 404 — or a
 200 with nothing on it — on a sitemapped URL reads as "drop this page".
+
+**The CDN does not hide it, and that is fine.** `stale-while-revalidate` only
+cushions a URL whose `age` has already passed `s-maxage`: climb views are covered
+for age 1 h–7 h, list front doors for 24 h–7 d, and Vercel supports no
+`stale-if-error`. A cold-MISS crawl of a long-tail sitemap URL therefore sees the
+500 directly. The asymmetry that matters is what happens next: 5xx is **not** a
+cacheable status on Vercel, so it is never pinned, whereas the 404 this replaces
+**is** cacheable — one blip used to stick a 404 in the CDN for a full `s-maxage`.
+
+A genuinely missing climb is also not negatively cached: `fetchClimbFromDb`
+throws a private not-found error inside `unstable_cache` (which never stores a
+rejection) and the caller turns it back into `null`, so a climb crawled minutes
+before its import lands recovers on the next request rather than 404-ing for the
+rest of the hour-long entry.
 
 ### Budgets
 
 | knob                      | default | meaning                                                                                  |
 | ------------------------- | ------- | ---------------------------------------------------------------------------------------- |
-| `DB_READ_DEADLINE_MS`     | 6000    | web front door: wall clock for one read (queue wait + connect + execute)                 |
+| `DB_READ_DEADLINE_MS`     | 6000    | web front door: wall clock for one _request's_ reads (queue wait + connect + execute)    |
 | `DB_POOL_MAX`             | 10      | postgres.js `max`, clamped to a floor of 2                                               |
-| `DB_POOL_IDLE_TIMEOUT_S`  | 30      | seconds an idle connection is held open                                                  |
+| `DB_POOL_IDLE_TIMEOUT_S`  | 30      | seconds an idle connection is held open; `0` means "never close one" and is not clamped  |
 | `DB_STATEMENT_TIMEOUT_MS` | unset   | emits a `statement_timeout` startup parameter — **off by default**, see the hazard below |
 
 6000 sits deliberately below `DB_CONNECT_RETRY_BUDGET_MS` (10000): during a
 brownout the front door should shed load rather than spend a second and third
-connect attempt holding a pool slot while a crawler waits.
+connect attempt holding a pool slot while a crawler waits. That comparison only
+holds because the budget is per request — see the shared-budget note above.
 
 The pool knobs default to the values that used to be hard-coded, so nothing
 changes for a deployment that does not set them. They exist because peak

--- a/packages/backend/src/__tests__/db-pool-exhaustion.test.ts
+++ b/packages/backend/src/__tests__/db-pool-exhaustion.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vite-plus/test';
+import postgres from 'postgres';
+import { getWorkerDatabaseUrl } from './worker-db';
+
+/**
+ * The bounded-wait oracle for #4461, against a live Postgres.
+ *
+ * postgres.js has no acquire timeout: once every connection in the pool is
+ * busy, further statements sit in an unbounded, untimed internal queue. That is
+ * what turns a crawl burst into a hang rather than an error, and it is the
+ * property `withReadDeadline` exists to bound. Asserting a config value ("max
+ * is 4") would prove nothing about it, so this drives a real pool into
+ * saturation and measures what the callers see.
+ *
+ * The helper lives in `packages/web` on purpose — #4461 rules it must NOT go
+ * into `packages/db`, which would change behaviour for the backend, the sync
+ * runners and every script. The backend project is the only Vitest project in
+ * this repo with a live Postgres, so the test has to reach across. The
+ * specifier is computed rather than a literal so `tsc --rootDir src` never
+ * tries to type-link a file outside this package.
+ */
+const READ_DEADLINE_MODULE = new URL('../../../web/app/lib/db/read-deadline.ts', import.meta.url).href;
+
+type ReadDeadlineModule = {
+  withReadDeadline: <T>(label: string, pending: PromiseLike<T> & { cancel?: () => unknown }, ms?: number) => Promise<T>;
+  DbReadTimeoutError: new (label: string, ms: number) => Error & { code: string };
+};
+
+/** Far longer than the deadline, so a statement that survives it cannot be mistaken for one that completed. */
+const SLEEP_SECONDS = 30;
+const DEADLINE_MS = 1500;
+const POOL_MAX = 2;
+const CONCURRENT_READS = 6;
+
+async function activeSleepCount(admin: postgres.Sql, databaseName: string): Promise<number> {
+  const rows = await admin`
+    SELECT count(*)::int AS count
+    FROM pg_stat_activity
+    WHERE datname = ${databaseName}
+      AND state = 'active'
+      AND query LIKE '%pg_sleep%'
+      AND pid <> pg_backend_pid()
+  `;
+  return rows[0]?.count ?? 0;
+}
+
+describe('front-door read deadline under pool exhaustion', () => {
+  it('fails every saturated read fast instead of draining the queue serially', async () => {
+    const { withReadDeadline, DbReadTimeoutError } = (await import(
+      /* @vite-ignore */ READ_DEADLINE_MODULE
+    )) as ReadDeadlineModule;
+
+    const url = getWorkerDatabaseUrl();
+    const databaseName = new URL(url).pathname.slice(1);
+    // `backoff: () => 0` keeps postgres.js's own connect pacing out of the
+    // measurement, the same way the connect-retry tests do.
+    const pool = postgres(url, { max: POOL_MAX, backoff: () => 0, onnotice: () => {} });
+    const admin = postgres(url, { max: 1, onnotice: () => {} });
+
+    try {
+      const startedAt = Date.now();
+      const outcomes = await Promise.allSettled(
+        Array.from({ length: CONCURRENT_READS }, (_, index) =>
+          withReadDeadline(`saturation-${index}`, pool`SELECT pg_sleep(${SLEEP_SECONDS})`, DEADLINE_MS),
+        ),
+      );
+      const elapsedMs = Date.now() - startedAt;
+
+      // Serially draining 6 reads through a pool of 2 would take three rounds
+      // of SLEEP_SECONDS. Everything must instead land on the deadline.
+      expect(elapsedMs).toBeLessThan(DEADLINE_MS * 2);
+
+      const timedOut = outcomes.filter(
+        (outcome) => outcome.status === 'rejected' && outcome.reason instanceof DbReadTimeoutError,
+      );
+      expect(timedOut).toHaveLength(CONCURRENT_READS);
+
+      // The two statements that reached the server must be cancelled, not left
+      // to fire when the pool recovers. Poll briefly: the cancel is a separate
+      // connection and Postgres tears the backend down asynchronously.
+      let remaining = await activeSleepCount(admin, databaseName);
+      const cancelDeadline = Date.now() + 2000;
+      while (remaining > 0 && Date.now() < cancelDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        remaining = await activeSleepCount(admin, databaseName);
+      }
+      expect(remaining).toBe(0);
+    } finally {
+      await pool.end({ timeout: 5 });
+      await admin.end({ timeout: 5 });
+    }
+  });
+});

--- a/packages/backend/src/__tests__/shutdown.unit.test.ts
+++ b/packages/backend/src/__tests__/shutdown.unit.test.ts
@@ -84,9 +84,29 @@ describe('shutdown: ordering', () => {
 });
 
 describe('pool configuration', () => {
-  it('idle_timeout is 30 seconds', () => {
-    const source = readFileSync(resolve(ROOT, '../db/src/client/postgres.ts'), 'utf-8');
-    expect(source).toContain('idle_timeout: 30');
+  // Was a grep of postgres.ts for the literal `idle_timeout: 30`. #4461 made
+  // both knobs env-derived (`DB_POOL_MAX` / `DB_POOL_IDLE_TIMEOUT_S`, defaults
+  // unchanged), which would have left that grep green-but-meaningless. Assert
+  // on the options postgres-js actually resolved instead — the backend must
+  // keep the pre-#4461 sizing unless someone sets the env vars on it, which
+  // only the Vercel project is expected to do.
+  it('keeps the pre-#4461 pool defaults when the env knobs are unset', async () => {
+    const { createPool, closePool } = await import('@boardsesh/db/client');
+    const previousMax = process.env.DB_POOL_MAX;
+    const previousIdle = process.env.DB_POOL_IDLE_TIMEOUT_S;
+    delete process.env.DB_POOL_MAX;
+    delete process.env.DB_POOL_IDLE_TIMEOUT_S;
+
+    await closePool();
+    try {
+      const { max, idle_timeout: idleTimeout } = createPool().options;
+      expect(max).toBe(10);
+      expect(idleTimeout).toBe(30);
+    } finally {
+      await closePool();
+      if (previousMax !== undefined) process.env.DB_POOL_MAX = previousMax;
+      if (previousIdle !== undefined) process.env.DB_POOL_IDLE_TIMEOUT_S = previousIdle;
+    }
   });
 });
 

--- a/packages/backend/src/__tests__/shutdown.unit.test.ts
+++ b/packages/backend/src/__tests__/shutdown.unit.test.ts
@@ -90,23 +90,76 @@ describe('pool configuration', () => {
   // on the options postgres-js actually resolved instead — the backend must
   // keep the pre-#4461 sizing unless someone sets the env vars on it, which
   // only the Vercel project is expected to do.
-  it('keeps the pre-#4461 pool defaults when the env knobs are unset', async () => {
+  //
+  // These overlap `packages/db/src/client/__tests__/postgres.test.ts` on
+  // purpose. `packages/db` is not a Vitest project and the only db test CI runs
+  // is the migration-journal one, so knob assertions living only there would be
+  // inert in CI. The backend project runs on every PR.
+  async function poolOptionsWith(env: Record<string, string | undefined>) {
     const { createPool, closePool } = await import('@boardsesh/db/client');
-    const previousMax = process.env.DB_POOL_MAX;
-    const previousIdle = process.env.DB_POOL_IDLE_TIMEOUT_S;
-    delete process.env.DB_POOL_MAX;
-    delete process.env.DB_POOL_IDLE_TIMEOUT_S;
+    const previous: Record<string, string | undefined> = {};
+    for (const [name, value] of Object.entries(env)) {
+      previous[name] = process.env[name];
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
 
     await closePool();
     try {
-      const { max, idle_timeout: idleTimeout } = createPool().options;
-      expect(max).toBe(10);
-      expect(idleTimeout).toBe(30);
+      return createPool().options;
     } finally {
       await closePool();
-      if (previousMax !== undefined) process.env.DB_POOL_MAX = previousMax;
-      if (previousIdle !== undefined) process.env.DB_POOL_IDLE_TIMEOUT_S = previousIdle;
+      for (const [name, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
     }
+  }
+
+  it('keeps the pre-#4461 pool defaults when the env knobs are unset', async () => {
+    const { max, idle_timeout: idleTimeout } = await poolOptionsWith({
+      DB_POOL_MAX: undefined,
+      DB_POOL_IDLE_TIMEOUT_S: undefined,
+    });
+
+    expect(max).toBe(10);
+    expect(idleTimeout).toBe(30);
+  });
+
+  it('honours the per-deployment knobs when they are set', async () => {
+    const { max, idle_timeout: idleTimeout } = await poolOptionsWith({
+      DB_POOL_MAX: '4',
+      DB_POOL_IDLE_TIMEOUT_S: '10',
+    });
+
+    expect(max).toBe(4);
+    expect(idleTimeout).toBe(10);
+  });
+
+  it('clamps DB_POOL_MAX to the two-connection floor and falls back on garbage', async () => {
+    // getClimb issues two sequential statements; a pool of one serialises every
+    // front-door render behind a single connection.
+    expect((await poolOptionsWith({ DB_POOL_MAX: '1' })).max).toBe(2);
+    expect((await poolOptionsWith({ DB_POOL_MAX: 'abc' })).max).toBe(10);
+  });
+
+  it('lets DB_POOL_IDLE_TIMEOUT_S=0 mean "never close an idle connection"', async () => {
+    // postgres.js reads a falsy idle_timeout as disabled. Clamping it up to 1
+    // would turn "hold connections open" into a teardown every second.
+    expect((await poolOptionsWith({ DB_POOL_IDLE_TIMEOUT_S: '0' })).idle_timeout).toBe(0);
+  });
+
+  it('ships with no statement_timeout startup parameter', async () => {
+    // PgBouncer in transaction-pooling mode rejects unknown startup parameters,
+    // so enabling this against a pooled URL fails every connection rather than
+    // bounding one query. See docs/db-connectivity.md.
+    const options = await poolOptionsWith({ DB_STATEMENT_TIMEOUT_MS: undefined });
+    expect(options.connection.statement_timeout).toBeUndefined();
+  });
+
+  it('emits statement_timeout only when DB_STATEMENT_TIMEOUT_MS is set', async () => {
+    const options = await poolOptionsWith({ DB_STATEMENT_TIMEOUT_MS: '8000' });
+    expect(options.connection.statement_timeout).toBe(8000);
   });
 });
 

--- a/packages/db/src/client/__tests__/postgres.test.ts
+++ b/packages/db/src/client/__tests__/postgres.test.ts
@@ -92,6 +92,13 @@ void describe('postgres client', () => {
       assert.equal(options.max, 10);
     });
 
+    void it('keeps DB_POOL_IDLE_TIMEOUT_S=0 as "never close an idle connection"', async () => {
+      // postgres.js treats a falsy idle_timeout as disabled, so 0 is meaningful
+      // and must not be clamped up the way DB_POOL_MAX is.
+      const options = await poolOptionsWith({ DB_POOL_IDLE_TIMEOUT_S: '0' });
+      assert.equal(options.idle_timeout, 0);
+    });
+
     void it('emits no statement_timeout startup parameter by default', async () => {
       // PgBouncer in transaction-pooling mode rejects unknown startup
       // parameters, so this must stay off until the Railway URL is confirmed

--- a/packages/db/src/client/__tests__/postgres.test.ts
+++ b/packages/db/src/client/__tests__/postgres.test.ts
@@ -44,6 +44,68 @@ void describe('postgres client', () => {
     });
   });
 
+  void describe('per-deployment pool knobs', () => {
+    // Asserts on the options postgres-js actually resolved, not on the source
+    // text of postgres.ts. A source grep goes green-but-meaningless the moment
+    // the value stops being a literal.
+    async function poolOptionsWith(env: Record<string, string | undefined>) {
+      const { createPool, closePool } = await import('../postgres');
+      const previous: Record<string, string | undefined> = {};
+      for (const [name, value] of Object.entries(env)) {
+        previous[name] = process.env[name];
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+      await closePool();
+      try {
+        return createPool().options;
+      } finally {
+        await closePool();
+        for (const [name, value] of Object.entries(previous)) {
+          if (value === undefined) delete process.env[name];
+          else process.env[name] = value;
+        }
+      }
+    }
+
+    void it('defaults to the values that were hard-coded before the knobs existed', async () => {
+      const options = await poolOptionsWith({ DB_POOL_MAX: undefined, DB_POOL_IDLE_TIMEOUT_S: undefined });
+      assert.equal(options.max, 10);
+      assert.equal(options.idle_timeout, 30);
+    });
+
+    void it('honours DB_POOL_MAX and DB_POOL_IDLE_TIMEOUT_S', async () => {
+      const options = await poolOptionsWith({ DB_POOL_MAX: '4', DB_POOL_IDLE_TIMEOUT_S: '10' });
+      assert.equal(options.max, 4);
+      assert.equal(options.idle_timeout, 10);
+    });
+
+    void it('clamps DB_POOL_MAX to the two-connection floor', async () => {
+      // getClimb issues two sequential statements; a pool of one serialises
+      // every front-door render behind a single connection.
+      const options = await poolOptionsWith({ DB_POOL_MAX: '1' });
+      assert.equal(options.max, 2);
+    });
+
+    void it('falls back to the default when DB_POOL_MAX is not a number', async () => {
+      const options = await poolOptionsWith({ DB_POOL_MAX: 'abc' });
+      assert.equal(options.max, 10);
+    });
+
+    void it('emits no statement_timeout startup parameter by default', async () => {
+      // PgBouncer in transaction-pooling mode rejects unknown startup
+      // parameters, so this must stay off until the Railway URL is confirmed
+      // direct. See docs/db-connectivity.md.
+      const options = await poolOptionsWith({ DB_STATEMENT_TIMEOUT_MS: undefined });
+      assert.equal(options.connection.statement_timeout, undefined);
+    });
+
+    void it('emits statement_timeout when DB_STATEMENT_TIMEOUT_MS is set', async () => {
+      const options = await poolOptionsWith({ DB_STATEMENT_TIMEOUT_MS: '8000' });
+      assert.equal(options.connection.statement_timeout, 8000);
+    });
+  });
+
   void describe('read replica fallback', () => {
     void it('createReadDb returns the primary db when READ_REPLICA_URL is unset', async () => {
       const previous = process.env.READ_REPLICA_URL;

--- a/packages/db/src/client/postgres.ts
+++ b/packages/db/src/client/postgres.ts
@@ -30,6 +30,16 @@ export const DEFAULT_POOL_IDLE_TIMEOUT_S = 30;
  * a single connection. Clamp rather than trust a typo in a dashboard.
  */
 export const MIN_POOL_MAX = 2;
+/**
+ * The idle knob has no floor, on purpose. postgres.js reads a falsy
+ * `idle_timeout` as "never close an idle connection" (`connection.js`'s
+ * `timer()` returns a no-op pair for `!seconds`), which is a meaningful setting
+ * and the pre-knob behaviour of several drivers. Clamping `0` up to `1` would
+ * turn "hold connections open" into "tear one down a second after it goes idle"
+ * — the opposite of the request, and a TCP+TLS+startup round trip on the front
+ * of most requests.
+ */
+export const MIN_POOL_IDLE_TIMEOUT_S = 0;
 
 /**
  * Mirrors `readEnvInt` in connect-retry.ts: a missing or unparseable value falls
@@ -61,7 +71,7 @@ function readPoolInt(name: string, fallback: number, minimum: number): number {
 function basePoolOptions() {
   return {
     max: readPoolInt('DB_POOL_MAX', DEFAULT_POOL_MAX, MIN_POOL_MAX),
-    idle_timeout: readPoolInt('DB_POOL_IDLE_TIMEOUT_S', DEFAULT_POOL_IDLE_TIMEOUT_S, 1),
+    idle_timeout: readPoolInt('DB_POOL_IDLE_TIMEOUT_S', DEFAULT_POOL_IDLE_TIMEOUT_S, MIN_POOL_IDLE_TIMEOUT_S),
     connect_timeout: 30,
     prepare: false,
     ...statementTimeoutOption(),

--- a/packages/db/src/client/postgres.ts
+++ b/packages/db/src/client/postgres.ts
@@ -20,16 +20,71 @@ const sqlLogger = process.env.DEBUG_SQL === 'true' ? new QueryLogger() : undefin
 
 const fullSchema = { ...schema, ...relations };
 
-// `prepare: false` is required when the target is PgBouncer in transaction
-// pooling mode (Railway's pooled URL): backends are reused across transactions
-// so per-connection prepared statement caches collide. The flag is a safe no-op
-// against direct PostgreSQL.
-const BASE_POOL_OPTIONS = {
-  max: 10,
-  idle_timeout: 30,
-  connect_timeout: 30,
-  prepare: false,
-} as const;
+/** Pool size when `DB_POOL_MAX` is unset — unchanged from before the knob existed. */
+export const DEFAULT_POOL_MAX = 10;
+/** Seconds an idle connection is held when `DB_POOL_IDLE_TIMEOUT_S` is unset. */
+export const DEFAULT_POOL_IDLE_TIMEOUT_S = 30;
+/**
+ * `getClimb` issues two sequential statements and drizzle's connect-retry can
+ * hold a slot while it re-dials, so a pool of one serialises everything behind
+ * a single connection. Clamp rather than trust a typo in a dashboard.
+ */
+export const MIN_POOL_MAX = 2;
+
+/**
+ * Mirrors `readEnvInt` in connect-retry.ts: a missing or unparseable value falls
+ * back, a parseable one is clamped to `minimum`.
+ */
+function readPoolInt(name: string, fallback: number, minimum: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(minimum, parsed);
+}
+
+/**
+ * Per-deployment pool knobs. Both default to the values that were hard-coded
+ * here before, so backend, sync jobs and scripts are unchanged unless the env
+ * var is set — today only the Vercel project is expected to set them, because
+ * peak server-side connections scale with *instance count* × held-idle
+ * connections, not with per-instance `max`.
+ *
+ * `prepare: false` is required when the target is PgBouncer in transaction
+ * pooling mode (Railway's pooled URL): backends are reused across transactions
+ * so per-connection prepared statement caches collide. The flag is a safe no-op
+ * against direct PostgreSQL.
+ *
+ * Read at pool-construction time rather than module load so a process that
+ * rebuilds its pool (tests, HMR) picks up the current environment.
+ */
+function basePoolOptions() {
+  return {
+    max: readPoolInt('DB_POOL_MAX', DEFAULT_POOL_MAX, MIN_POOL_MAX),
+    idle_timeout: readPoolInt('DB_POOL_IDLE_TIMEOUT_S', DEFAULT_POOL_IDLE_TIMEOUT_S, 1),
+    connect_timeout: 30,
+    prepare: false,
+    ...statementTimeoutOption(),
+  };
+}
+
+/**
+ * `DB_STATEMENT_TIMEOUT_MS` emits a `statement_timeout` startup parameter.
+ * Deliberately OFF by default: PgBouncer in transaction-pooling mode rejects
+ * startup parameters that are not in `ignore_startup_parameters`, and
+ * `statement_timeout` is not allowed there by default — so turning this on
+ * against a pooled URL fails *every* connection rather than bounding one query.
+ * Against a pooler, set it on the role instead:
+ * `ALTER ROLE <app_role> SET statement_timeout = '8s'`. See docs/db-connectivity.md.
+ */
+function statementTimeoutOption(): { connection?: { statement_timeout: number } } {
+  const raw = process.env.DB_STATEMENT_TIMEOUT_MS;
+  if (!raw) return {};
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return {};
+  // Unitless `statement_timeout` is milliseconds to PostgreSQL.
+  return { connection: { statement_timeout: parsed } };
+}
 
 const LOCAL_HOST_PATTERN = /@(localhost|127\.0\.0\.1|\[::1\]|postgres|postgres-test)(:|\/|$)/;
 const TAILSCALE_IPV4_PATTERN = /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./;
@@ -63,7 +118,8 @@ function buildPoolOptions(connectionString: string) {
   // silently degrade to plaintext against Railway. Local docker and generated
   // tailnet dev DB URLs stay plain.
   const isLocal = LOCAL_HOST_PATTERN.test(connectionString) || isPlaintextDevelopmentDatabase(connectionString);
-  return isLocal ? BASE_POOL_OPTIONS : { ...BASE_POOL_OPTIONS, ssl: 'require' as const };
+  const options = basePoolOptions();
+  return isLocal ? options : { ...options, ssl: 'require' as const };
 }
 
 // Cache the pool/db on globalThis so Next.js HMR re-evaluating this module in

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/list/page.tsx
@@ -67,9 +67,10 @@ export async function generateMetadata(props: {
       robots,
     });
   } catch {
-    // A board config the slug tables and the DB both fail to resolve. The page
-    // body 404s on the same request; claim no canonical for a URL that has no
-    // board behind it.
+    // A board config the slug tables and the DB both fail to resolve. Claim no
+    // canonical for a URL that has no board behind it. On the same request the
+    // page body 404s for an unresolvable config or an out-of-range `?page`, and
+    // 500s if the read itself failed (#4461) — metadata never decides that.
     return createPageMetadata({
       title: t('metadata.list.fallbackTitle'),
       description: t('metadata.list.fallbackDescription'),

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * The mass-deindexing guard.
+ *
+ * A climb URL that is in the sitemap must answer 404 only when the climb is
+ * genuinely gone. When the read fails — a saturated pool, a read deadline, a
+ * dead database — it has to be a 5xx, because Google retries a 5xx and keeps
+ * the URL while a 404 tells it to drop the page. This page used to end its
+ * catch in `notFound()`, which collapsed both cases into 404.
+ */
+const NOT_FOUND_DIGEST = 'NEXT_HTTP_ERROR_FALLBACK;404';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw Object.assign(new Error('NEXT_NOT_FOUND'), { digest: NOT_FOUND_DIGEST });
+  }),
+  permanentRedirect: vi.fn(() => {
+    throw Object.assign(new Error('NEXT_REDIRECT'), { digest: 'NEXT_REDIRECT;replace;/x;308;' });
+  }),
+}));
+
+vi.mock('@/app/lib/data/queries', () => ({
+  getClimb: vi.fn(),
+  getClimbStatsForAllAngles: vi.fn(async () => []),
+  getLayouts: vi.fn(() => []),
+  getSizes: vi.fn(() => []),
+  getSets: vi.fn(() => []),
+}));
+
+vi.mock('@/app/lib/data/front-door-data.server', () => ({
+  getFrontDoorSimilarClimbs: vi.fn(async () => []),
+  getFrontDoorBetaLinks: vi.fn(async () => []),
+}));
+
+vi.mock('@/app/lib/url-utils.server', () => ({
+  parseRouteParams: vi.fn(async () => ({
+    parsedParams: {
+      board_name: 'kilter',
+      layout_id: 8,
+      size_id: 10,
+      set_ids: [1, 2],
+      angle: 40,
+      climb_uuid: 'climb-uuid-1',
+    },
+    isNumericFormat: false,
+  })),
+}));
+
+vi.mock('@/app/lib/board-utils', () => ({
+  getBoardDetailsForBoard: vi.fn(() => ({ board_name: 'kilter' })),
+}));
+
+vi.mock('@/app/lib/url-utils', () => ({
+  buildCanonicalClimbViewUrl: vi.fn(() => '/kilter/original/12x12/screw_bolt/40/view/x'),
+  isUuidOnly: vi.fn(() => false),
+  constructClimbViewUrlWithSlugs: vi.fn(() => '/x'),
+  tryConstructSlugViewUrl: vi.fn(() => '/x'),
+}));
+
+vi.mock('@/app/components/board-renderer/util', () => ({
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb'),
+  buildOverlayUrl: vi.fn(() => '/api/internal/board-render'),
+}));
+
+vi.mock('@/app/lib/warm-overlay-cache', () => ({
+  scheduleOverlayWarming: vi.fn(),
+  FRONT_DOOR_WARM_LIMIT: 6,
+}));
+
+vi.mock('@/app/components/climb-front-door/climb-front-door', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({ t: (key: string) => key, locale: 'en-US' })),
+}));
+
+vi.mock('@/app/lib/seo/metadata', () => ({
+  createPageMetadata: vi.fn((input: unknown) => input),
+}));
+
+import { notFound } from 'next/navigation';
+import { getClimb } from '@/app/lib/data/queries';
+import ClimbViewPage from '../page';
+import { DbReadTimeoutError } from '@/app/lib/db/read-deadline';
+
+const props = {
+  params: Promise.resolve({
+    board_name: 'kilter',
+    layout_id: 'original',
+    size_id: '12x12',
+    set_ids: 'screw_bolt',
+    angle: '40',
+    climb_uuid: 'climb-uuid-1',
+  }),
+} as unknown as Parameters<typeof ClimbViewPage>[0];
+
+describe('climb view read-failure status (config-tuple tree)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('404s when the climb genuinely does not exist', async () => {
+    vi.mocked(getClimb).mockResolvedValue(null);
+
+    await expect(ClimbViewPage(props)).rejects.toMatchObject({ digest: NOT_FOUND_DIGEST });
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('rethrows a read deadline instead of 404-ing an indexed URL', async () => {
+    vi.mocked(getClimb).mockRejectedValue(new DbReadTimeoutError('climb-select', 6000));
+
+    await expect(ClimbViewPage(props)).rejects.toBeInstanceOf(DbReadTimeoutError);
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('rethrows any other read failure instead of 404-ing an indexed URL', async () => {
+    vi.mocked(getClimb).mockRejectedValue(new Error('connection terminated unexpectedly'));
+
+    await expect(ClimbViewPage(props)).rejects.toThrow('connection terminated unexpectedly');
+    expect(notFound).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
@@ -100,9 +100,11 @@ const props = {
 } as unknown as Parameters<typeof ClimbViewPage>[0];
 
 describe('climb view read-failure status (config-tuple tree)', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   it('404s when the climb genuinely does not exist', async () => {
@@ -112,11 +114,22 @@ describe('climb view read-failure status (config-tuple tree)', () => {
     expect(notFound).toHaveBeenCalled();
   });
 
+  it('does not log a 404 as an error', async () => {
+    vi.mocked(getClimb).mockResolvedValue(null);
+
+    await expect(ClimbViewPage(props)).rejects.toMatchObject({ digest: NOT_FOUND_DIGEST });
+    // Stale sitemap entries and legacy-URL 308s are routine and high-volume on
+    // the crawl path. Logging them at error level buries the read failures this
+    // catch exists to surface.
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
   it('rethrows a read deadline instead of 404-ing an indexed URL', async () => {
     vi.mocked(getClimb).mockRejectedValue(new DbReadTimeoutError('climb-select', 6000));
 
     await expect(ClimbViewPage(props)).rejects.toBeInstanceOf(DbReadTimeoutError);
     expect(notFound).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalled();
   });
 
   it('rethrows any other read failure instead of 404-ing an indexed URL', async () => {
@@ -124,5 +137,6 @@ describe('climb view read-failure status (config-tuple tree)', () => {
 
     await expect(ClimbViewPage(props)).rejects.toThrow('connection terminated unexpectedly');
     expect(notFound).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalled();
   });
 });

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -28,6 +28,14 @@ export async function generateMetadata(props: { params: Promise<BoardRouteParame
     const { parsedParams } = await parseRouteParams(params);
     const boardDetails = getBoardDetailsForBoard(parsedParams);
     const currentClimb = await getClimb(parsedParams);
+    if (!currentClimb) {
+      return createPageMetadata({
+        title: t('metadata.view.fallbackTitle'),
+        description: t('metadata.view.fallbackDescription'),
+        locale,
+        robots: { index: false, follow: true },
+      });
+    }
 
     const climbName = resolveClimbDisplayName(currentClimb.name, boardDetails.board_name);
     const climbGrade = currentClimb.difficulty || 'Unknown Grade';
@@ -161,12 +169,15 @@ export default async function ClimbViewPage(props: { params: Promise<BoardRouteP
       </>
     );
   } catch (error) {
-    // Re-throw Next.js internal errors (permanentRedirect, notFound, etc.) so they
-    // are handled correctly instead of being replaced by a 404.
-    if (error !== null && typeof error === 'object' && 'digest' in error) {
-      throw error;
-    }
+    // Everything reaches the error boundary, which is a 500. Next.js internals
+    // (permanentRedirect, notFound) carry a digest and get their own handling;
+    // a read failure is genuinely a 5xx and must say so. This used to end in
+    // `notFound()`, which meant a saturated pool or a dead database emitted a
+    // 404 on an indexed climb URL — at sitemap scale, an instruction to
+    // deindex. Google retries a 5xx and keeps the URL; that is the property
+    // that matters here. `notFound()` above still fires for a climb that really
+    // is not there.
     console.error('Error fetching results or climb:', error);
-    notFound();
+    throw error;
   }
 }

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -177,7 +177,14 @@ export default async function ClimbViewPage(props: { params: Promise<BoardRouteP
     // deindex. Google retries a 5xx and keeps the URL; that is the property
     // that matters here. `notFound()` above still fires for a climb that really
     // is not there.
-    console.error('Error fetching results or climb:', error);
+    //
+    // A digest is control flow, not a failure: `needsSlugRedirect` fires a 308
+    // on every legacy/uuid-only URL and `notFound()` fires on every stale
+    // sitemap entry, both routine and both high-volume on the crawl path.
+    // Logging them would bury the brownout signal this catch exists to surface.
+    if (!(error !== null && typeof error === 'object' && 'digest' in error)) {
+      console.error('Error fetching results or climb:', error);
+    }
     throw error;
   }
 }

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * Same contract as the config-tuple twin: 404 only for a climb that is really
+ * gone, 5xx for a read that failed. See the sibling test under
+ * `app/[board_name]/…/view/[climb_uuid]/__tests__/` for the full rationale.
+ */
+const NOT_FOUND_DIGEST = 'NEXT_HTTP_ERROR_FALLBACK;404';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(() => {
+    throw Object.assign(new Error('NEXT_NOT_FOUND'), { digest: NOT_FOUND_DIGEST });
+  }),
+}));
+
+vi.mock('@/app/lib/data/queries', () => ({
+  getClimb: vi.fn(),
+  getClimbStatsForAllAngles: vi.fn(async () => []),
+}));
+
+vi.mock('@/app/lib/data/front-door-data.server', () => ({
+  getFrontDoorSimilarClimbs: vi.fn(async () => []),
+  getFrontDoorBetaLinks: vi.fn(async () => []),
+}));
+
+vi.mock('@/app/lib/board-slug-utils', () => ({
+  resolveBoardBySlug: vi.fn(async () => ({ id: 'board-1', isUnlisted: false, isPublic: true })),
+  boardToRouteParams: vi.fn(() => ({
+    board_name: 'kilter',
+    layout_id: 8,
+    size_id: 10,
+    set_ids: [1, 2],
+    angle: 40,
+  })),
+}));
+
+vi.mock('@/app/lib/board-utils', () => ({
+  getBoardDetailsForBoard: vi.fn(() => ({ board_name: 'kilter' })),
+}));
+
+vi.mock('@/app/lib/url-utils', () => ({
+  buildCanonicalClimbViewUrl: vi.fn(() => '/kilter/original/12x12/screw_bolt/40/view/x'),
+  extractUuidFromSlug: vi.fn(() => 'climb-uuid-1'),
+}));
+
+vi.mock('@/app/components/board-renderer/util', () => ({
+  buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb'),
+  buildOverlayUrl: vi.fn(() => '/api/internal/board-render'),
+}));
+
+vi.mock('@/app/lib/warm-overlay-cache', () => ({
+  scheduleOverlayWarming: vi.fn(),
+  FRONT_DOOR_WARM_LIMIT: 6,
+}));
+
+vi.mock('@/app/components/climb-front-door/climb-front-door', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({ t: (key: string) => key, locale: 'en-US' })),
+}));
+
+vi.mock('@/app/lib/seo/metadata', () => ({
+  createPageMetadata: vi.fn((input: unknown) => input),
+}));
+
+import { notFound } from 'next/navigation';
+import { getClimb } from '@/app/lib/data/queries';
+import BoardSlugViewPage from '../page';
+import { DbReadTimeoutError } from '@/app/lib/db/read-deadline';
+
+const props = {
+  params: Promise.resolve({ board_slug: 'marcos-garage', angle: '40', climb_uuid: 'a-climb-climb-uuid-1' }),
+} as unknown as Parameters<typeof BoardSlugViewPage>[0];
+
+describe('climb view read-failure status (/b slug tree)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('404s when the climb genuinely does not exist', async () => {
+    vi.mocked(getClimb).mockResolvedValue(null);
+
+    await expect(BoardSlugViewPage(props)).rejects.toMatchObject({ digest: NOT_FOUND_DIGEST });
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('rethrows a read deadline instead of 404-ing an indexed URL', async () => {
+    vi.mocked(getClimb).mockRejectedValue(new DbReadTimeoutError('climb-select', 6000));
+
+    await expect(BoardSlugViewPage(props)).rejects.toBeInstanceOf(DbReadTimeoutError);
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('rethrows any other read failure instead of 404-ing an indexed URL', async () => {
+    vi.mocked(getClimb).mockRejectedValue(new Error('connection terminated unexpectedly'));
+
+    await expect(BoardSlugViewPage(props)).rejects.toThrow('connection terminated unexpectedly');
+    expect(notFound).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/read-failure-status.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@/app/lib/seo/metadata', () => ({
 
 import { notFound } from 'next/navigation';
 import { getClimb } from '@/app/lib/data/queries';
+import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import BoardSlugViewPage from '../page';
 import { DbReadTimeoutError } from '@/app/lib/db/read-deadline';
 
@@ -78,9 +79,11 @@ const props = {
 } as unknown as Parameters<typeof BoardSlugViewPage>[0];
 
 describe('climb view read-failure status (/b slug tree)', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   it('404s when the climb genuinely does not exist', async () => {
@@ -88,6 +91,25 @@ describe('climb view read-failure status (/b slug tree)', () => {
 
     await expect(BoardSlugViewPage(props)).rejects.toMatchObject({ digest: NOT_FOUND_DIGEST });
     expect(notFound).toHaveBeenCalled();
+    // Control flow, not a failure. A 404 per stale sitemap entry in the error
+    // log is exactly the volume that hides a real brownout.
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('404s when the board slug resolves cleanly to nothing', async () => {
+    vi.mocked(resolveBoardBySlug).mockResolvedValueOnce(null);
+
+    await expect(BoardSlugViewPage(props)).rejects.toMatchObject({ digest: NOT_FOUND_DIGEST });
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('rethrows a failed board-slug lookup instead of 404-ing an indexed URL', async () => {
+    // The first read on the request, and it sits above the try — a backend blip
+    // used to become a 404 that Vercel then CDN-cached for up to 24 hours.
+    vi.mocked(resolveBoardBySlug).mockRejectedValueOnce(new Error('boardBySlug lookup failed with HTTP 502'));
+
+    await expect(BoardSlugViewPage(props)).rejects.toThrow('HTTP 502');
+    expect(notFound).not.toHaveBeenCalled();
   });
 
   it('rethrows a read deadline instead of 404-ing an indexed URL', async () => {

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
@@ -151,8 +151,12 @@ export default async function BoardSlugViewPage(props: BoardSlugViewPageProps) {
   } catch (error) {
     // Same contract as the config-tuple twin: a missing climb is the
     // `notFound()` above, a failed read is a 500. Swallowing a brownout into a
-    // 404 on an indexed URL reads as "delete this page".
-    console.error('Error fetching climb view:', error);
+    // 404 on an indexed URL reads as "delete this page". A digest is Next.js
+    // control flow (the `notFound()` above), not a failure — logging it would
+    // bury the brownout signal under routine 404s.
+    if (!(error !== null && typeof error === 'object' && 'digest' in error)) {
+      console.error('Error fetching climb view:', error);
+    }
     throw error;
   }
 }

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx
@@ -41,6 +41,14 @@ export async function generateMetadata(props: BoardSlugViewPageProps): Promise<M
 
     const boardDetails = getBoardDetailsForBoard(parsedParams);
     const currentClimb = await getClimb(parsedParams);
+    if (!currentClimb) {
+      return createPageMetadata({
+        title: t('metadata.view.fallbackTitle'),
+        description: t('metadata.view.fallbackDescription'),
+        locale,
+        robots: { index: false, follow: true },
+      });
+    }
 
     const climbName = resolveClimbDisplayName(currentClimb.name, boardDetails.board_name);
     const climbGrade = currentClimb.difficulty || 'Unknown Grade';
@@ -141,10 +149,10 @@ export default async function BoardSlugViewPage(props: BoardSlugViewPageProps) {
       </>
     );
   } catch (error) {
-    if (error !== null && typeof error === 'object' && 'digest' in error) {
-      throw error;
-    }
+    // Same contract as the config-tuple twin: a missing climb is the
+    // `notFound()` above, a failed read is a 500. Swallowing a brownout into a
+    // 404 on an indexed URL reads as "delete this page".
     console.error('Error fetching climb view:', error);
-    notFound();
+    throw error;
   }
 }

--- a/packages/web/app/lib/__tests__/board-slug-utils.test.ts
+++ b/packages/web/app/lib/__tests__/board-slug-utils.test.ts
@@ -118,6 +118,32 @@ describe('resolveBoardBySlug', () => {
     expect(new Headers(anonymousRequest?.headers).get('Authorization')).toBeNull();
   });
 
+  // Every caller turns `null` into `notFound()`, and Vercel CDN-caches a 404 for
+  // the length of the front door's `s-maxage`. A failed read must never look
+  // like "no such board".
+  it('throws instead of returning null when the backend fetch rejects', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('fetch failed'));
+
+    await expect(resolveBoardBySlug(publicBoard.slug)).rejects.toThrow('fetch failed');
+  });
+
+  it('throws instead of returning null on a non-2xx backend response', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('bad gateway', { status: 502 }));
+
+    await expect(resolveBoardBySlug(publicBoard.slug)).rejects.toThrow(/HTTP 502/);
+  });
+
+  it('throws instead of returning null on a 200 carrying GraphQL errors', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ errors: [{ message: 'read deadline exceeded' }], data: { boardBySlug: null } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await expect(resolveBoardBySlug(publicBoard.slug)).rejects.toThrow(/GraphQL errors/);
+  });
+
   it('does not let an anonymous miss cross into a later authenticated request', async () => {
     getServerAuthTokenMock.mockResolvedValueOnce(undefined).mockResolvedValueOnce('signed-session-token');
     fetchMock.mockResolvedValueOnce(graphQlResponse(null)).mockResolvedValueOnce(graphQlResponse(privateBoard));

--- a/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
+++ b/packages/web/app/lib/__tests__/warm-overlay-cache.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/app/components/board-renderer/util', () => ({
   buildOgBoardRenderUrl: vi.fn(() => 'https://ws.boardsesh.com/og/climb?og'),
 }));
 
-import { warmOverlays } from '../warm-overlay-cache';
+import { FRONT_DOOR_WARM_LIMIT, warmOverlays } from '../warm-overlay-cache';
 import { buildOgBoardRenderUrl } from '@/app/components/board-renderer/util';
 
 type WarmOverlaysArg = Parameters<typeof warmOverlays>[0];
@@ -28,8 +28,11 @@ describe('warmOverlays', () => {
   it('warms both the overlay and the absolute og image on the full climb-view path', async () => {
     await warmOverlays({ boardDetails, climbs, variant: 'full' });
 
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/api/internal/board-render?overlay'));
-    expect(fetch).toHaveBeenCalledWith('https://ws.boardsesh.com/og/climb?og');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/internal/board-render?overlay'),
+      expect.anything(),
+    );
+    expect(fetch).toHaveBeenCalledWith('https://ws.boardsesh.com/og/climb?og', expect.anything());
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 
@@ -37,7 +40,10 @@ describe('warmOverlays', () => {
     await warmOverlays({ boardDetails, climbs, variant: 'thumbnail' });
 
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/api/internal/board-render?overlay'));
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/internal/board-render?overlay'),
+      expect.anything(),
+    );
     expect(buildOgBoardRenderUrl).not.toHaveBeenCalled();
   });
 
@@ -47,12 +53,32 @@ describe('warmOverlays', () => {
     await warmOverlays({ boardDetails, climbs, variant: 'full' });
 
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).not.toHaveBeenCalledWith('/api/og/climb?relative');
+    expect(fetch).not.toHaveBeenCalledWith('/api/og/climb?relative', expect.anything());
   });
 
   it('swallows fetch failures instead of rejecting', async () => {
     vi.mocked(fetch).mockRejectedValue(new Error('network down'));
 
     await expect(warmOverlays({ boardDetails, climbs, variant: 'full' })).resolves.toBeUndefined();
+  });
+
+  it('warms only FRONT_DOOR_WARM_LIMIT rows of a full list page', async () => {
+    const fiftyClimbs = Array.from({ length: 50 }, (_, index) => ({ frames: `p1r${index}` }));
+
+    await warmOverlays({ boardDetails, climbs: fiftyClimbs, variant: 'thumbnail', maxImages: FRONT_DOOR_WARM_LIMIT });
+
+    // Each warm target is a same-origin CPU-bound WASM render. 50 rows at the
+    // old default of 20 made one crawled list page cost 20 extra invocations.
+    expect(FRONT_DOOR_WARM_LIMIT).toBe(6);
+    expect(fetch).toHaveBeenCalledTimes(6);
+  });
+
+  it('bounds every warm fetch with an abort signal', async () => {
+    await warmOverlays({ boardDetails, climbs, variant: 'thumbnail' });
+
+    // A warm request that never settles keeps the serverless instance — and the
+    // pool connections it is holding — alive past the response it rode in on.
+    const [, requestInit] = vi.mocked(fetch).mock.calls[0];
+    expect(requestInit?.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/packages/web/app/lib/board-slug-utils.ts
+++ b/packages/web/app/lib/board-slug-utils.ts
@@ -33,6 +33,15 @@ export type ResolvedBoard = {
  * is what #4087 changes: it forwards the viewer's token and splits the cache so
  * `boardBySlug` can mask a private board. Until it lands, `isPublic` here is
  * only good enough to drive `noindex` — never to decide what a page renders.
+ *
+ * `null` means one thing only: the backend answered cleanly and there is no such
+ * board (or it is masked from this viewer). Every failure — a rejected fetch, a
+ * non-2xx, a 200 carrying GraphQL `errors` — throws, because every caller turns
+ * `null` into `notFound()`. Swallowing a wedged backend into `null` put a 404 on
+ * `/b/{slug}/{angle}/list` and `/b/{slug}/{angle}/view/{uuid}`, and 404 is on
+ * Vercel's cacheable-status list — one blip pinned a cached 404 on an indexed
+ * front door for the length of its `s-maxage` (24 h on lists). A 5xx is never
+ * CDN-cached, and Google retries it and keeps the URL.
  */
 export const resolveBoardBySlug = cache(async (slug: string): Promise<ResolvedBoard | null> => {
   const url = getGraphQLHttpUrl();
@@ -58,33 +67,40 @@ export const resolveBoardBySlug = cache(async (slug: string): Promise<ResolvedBo
     }
   `;
 
-  try {
-    const authToken = await getServerAuthToken();
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (authToken) {
-      headers.Authorization = `Bearer ${authToken}`;
-    }
-
-    // Authenticated responses can contain private boards, so they must never
-    // enter the shared data cache. Anonymous responses remain safely reusable.
-    const cacheOptions = authToken ? { cache: 'no-store' as const } : { next: { revalidate: 300 } };
-
-    const response = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ query, variables: { slug } }),
-      ...cacheOptions,
-    });
-
-    if (!response.ok) {
-      return null;
-    }
-
-    const data = await response.json();
-    return data?.data?.boardBySlug ?? null;
-  } catch {
-    return null;
+  const authToken = await getServerAuthToken();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (authToken) {
+    headers.Authorization = `Bearer ${authToken}`;
   }
+
+  // Authenticated responses can contain private boards, so they must never
+  // enter the shared data cache. Anonymous responses remain safely reusable.
+  const cacheOptions = authToken ? { cache: 'no-store' as const } : { next: { revalidate: 300 } };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query, variables: { slug } }),
+    ...cacheOptions,
+  });
+
+  if (!response.ok) {
+    throw new Error(`[board-slug] boardBySlug lookup for "${slug}" failed with HTTP ${response.status}`);
+  }
+
+  const payload = (await response.json()) as {
+    data?: { boardBySlug?: ResolvedBoard | null } | null;
+    errors?: unknown[];
+  };
+
+  // A 200 carrying `errors` is the shape a backend read deadline produces, and
+  // `data.boardBySlug` is `null` alongside it — indistinguishable from a real
+  // miss unless we look at `errors`.
+  if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+    throw new Error(`[board-slug] boardBySlug lookup for "${slug}" returned GraphQL errors`);
+  }
+
+  return payload.data?.boardBySlug ?? null;
 });
 
 /**

--- a/packages/web/app/lib/data/__tests__/climb-missing-not-cached.test.ts
+++ b/packages/web/app/lib/data/__tests__/climb-missing-not-cached.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * A missing climb must not be negatively cached.
+ *
+ * `getClimb` answers `null` for a row that is not there, and the page turns that
+ * into a 404. If that `null` were returned from *inside* `unstable_cache` it
+ * would be stored for the full hour, so a climb a crawler reached minutes before
+ * its import landed would keep 404-ing until the entry expired. The executor
+ * throws instead, and `unstable_cache` does not store rejections.
+ *
+ * The mock therefore has to behave like the real thing on both paths: memoise a
+ * resolved value, store nothing for a rejection.
+ */
+const { mockSqlTag, cacheStore, rows } = vi.hoisted(() => ({
+  mockSqlTag: vi.fn(),
+  cacheStore: new Map<string, unknown>(),
+  rows: { climbRow: null as unknown },
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache:
+    <T extends (...args: unknown[]) => Promise<unknown>>(fn: T, keyParts: string[]) =>
+    async (...args: Parameters<T>) => {
+      const key = `${keyParts.join('|')}::${JSON.stringify(args)}`;
+      if (cacheStore.has(key)) return cacheStore.get(key);
+      const value = await fn(...args);
+      cacheStore.set(key, value);
+      return value;
+    },
+}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  sql: mockSqlTag,
+  rowsFromResult: <T>(result: unknown): T[] => (Array.isArray(result) ? (result as T[]) : []),
+}));
+
+import { getClimb } from '../queries';
+
+const params = {
+  board_name: 'kilter' as const,
+  layout_id: 8,
+  size_id: 10,
+  set_ids: [1, 2],
+  angle: 40,
+  climb_uuid: 'climb-uuid-cache',
+};
+
+function queueReads(): void {
+  mockSqlTag.mockResolvedValueOnce([]); // alias lookup: no alias
+  mockSqlTag.mockResolvedValueOnce(rows.climbRow ? [rows.climbRow] : []);
+}
+
+describe('missing climbs are not negatively cached', () => {
+  beforeEach(() => {
+    mockSqlTag.mockReset();
+    cacheStore.clear();
+    rows.climbRow = null;
+  });
+
+  it('re-reads the database on the next request for a climb that was not there', async () => {
+    queueReads();
+    await expect(getClimb(params)).resolves.toBeNull();
+
+    queueReads();
+    await expect(getClimb(params)).resolves.toBeNull();
+
+    // Four statements: two reads, neither of them cached.
+    expect(mockSqlTag).toHaveBeenCalledTimes(4);
+  });
+
+  it('recovers as soon as the row lands', async () => {
+    queueReads();
+    await expect(getClimb(params)).resolves.toBeNull();
+
+    rows.climbRow = { uuid: params.climb_uuid, name: 'Freshly Imported', characteristics: null, description: '' };
+    queueReads();
+
+    const climb = await getClimb(params);
+    expect(climb?.name).toBe('Freshly Imported');
+  });
+
+  it('still caches a climb that exists', async () => {
+    rows.climbRow = { uuid: params.climb_uuid, name: 'Cached Climb', characteristics: null, description: '' };
+    queueReads();
+    await getClimb(params);
+    await getClimb(params);
+
+    expect(mockSqlTag).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/app/lib/data/__tests__/climb-request-dedupe.test.ts
+++ b/packages/web/app/lib/data/__tests__/climb-request-dedupe.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * `generateMetadata` and the page body both read the climb, and Next renders
+ * them concurrently. `unstable_cache` has no in-flight single-flight, so on a
+ * cold key both used to miss and both used to run the alias lookup and the climb
+ * select — four statements where two would do, on the six-figure crawl surface
+ * W-23 submits.
+ *
+ * React's `cache` is a per-render memo in a Server Component but a plain
+ * passthrough in the client build vitest resolves, so this file substitutes a
+ * real memo for it. That is what makes the dedupe — and the per-request read
+ * budget that rides the same scope — assertable at all.
+ */
+const { mockSqlTag, rowsFromResultMock, deadlineBudgets, clock, requestScopes } = vi.hoisted(() => ({
+  mockSqlTag: vi.fn(async () => []),
+  rowsFromResultMock: <T>(result: unknown): T[] => (Array.isArray(result) ? (result as T[]) : []),
+  deadlineBudgets: [] as number[],
+  clock: { now: 1_000_000 },
+  /** Every memo the mocked `cache` handed out, so a test can start a fresh request. */
+  requestScopes: [] as Map<string, unknown>[],
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    cache: <Args extends unknown[], Result>(fn: (...args: Args) => Result) => {
+      const memo = new Map<string, unknown>();
+      requestScopes.push(memo);
+      return (...args: Args): Result => {
+        const key = JSON.stringify(args);
+        if (!memo.has(key)) memo.set(key, fn(...args));
+        return memo.get(key) as Result;
+      };
+    },
+  };
+});
+
+vi.mock('next/cache', () => ({
+  unstable_cache:
+    <T extends (...args: unknown[]) => unknown>(fn: T) =>
+    (...args: Parameters<T>) =>
+      fn(...args),
+}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  sql: mockSqlTag,
+  rowsFromResult: rowsFromResultMock,
+}));
+
+vi.mock('@/app/lib/db/read-deadline', () => ({
+  FRONT_DOOR_READ_DEADLINE_MS: 6000,
+  DEFAULT_READ_DEADLINE_MS: 6000,
+  parseReadDeadlineMs: () => 6000,
+  DbReadTimeoutError: class DbReadTimeoutError extends Error {},
+  withReadDeadline: async <T>(_label: string, pending: PromiseLike<T>, ms: number) => {
+    deadlineBudgets.push(ms);
+    // Each read costs a second of wall clock, so a shared budget visibly shrinks.
+    clock.now += 1000;
+    return pending;
+  },
+}));
+
+import { getClimb, getClimbStatsForAllAngles } from '../queries';
+
+const params = {
+  board_name: 'kilter' as const,
+  layout_id: 8,
+  size_id: 10,
+  set_ids: [1, 2],
+  angle: 40,
+  climb_uuid: 'climb-uuid-dedupe',
+};
+
+/** The `/b` tree builds its own params object at each entry point. */
+const equivalentParams = { ...params };
+
+function startNewRequest(): void {
+  for (const memo of requestScopes) memo.clear();
+  deadlineBudgets.length = 0;
+}
+
+describe('climb front door per-request dedupe', () => {
+  beforeEach(() => {
+    mockSqlTag.mockClear();
+    clock.now = 1_000_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => clock.now);
+    startNewRequest();
+  });
+
+  it('reads the climb once for two calls with equal primitives', async () => {
+    // The two entry points of the `/b` tree build separate objects — the reason
+    // the memo keys on primitives rather than on the params object.
+    await Promise.all([getClimb(params), getClimb(equivalentParams)]);
+
+    expect(mockSqlTag).toHaveBeenCalledTimes(2);
+  });
+
+  it('a full climb-page data pass costs exactly three statements', async () => {
+    // Models the route: metadata's read, the body's read, then the angle table.
+    await getClimb(params);
+    await getClimb(equivalentParams);
+    await getClimbStatsForAllAngles(params);
+
+    expect(mockSqlTag).toHaveBeenCalledTimes(3);
+  });
+
+  it('still reads a different climb separately', async () => {
+    await getClimb(params);
+    await getClimb({ ...params, climb_uuid: 'another-climb' });
+
+    expect(mockSqlTag).toHaveBeenCalledTimes(4);
+  });
+
+  it('shares one read budget across the request instead of restarting it per statement', async () => {
+    await getClimb(params);
+    await getClimbStatsForAllAngles(params);
+
+    // Three reads, one budget: the alias lookup gets the full 6 s and each later
+    // read gets what the earlier ones left. A per-statement deadline hands all
+    // three the same 6000, which makes the request's real ceiling ~18 s.
+    expect(deadlineBudgets).toEqual([6000, 5000, 4000]);
+  });
+
+  it('starts a fresh budget on the next request', async () => {
+    await getClimb(params);
+    expect(deadlineBudgets).toEqual([6000, 5000]);
+
+    startNewRequest();
+
+    await getClimb(params);
+    expect(deadlineBudgets).toEqual([6000, 5000]);
+  });
+});

--- a/packages/web/app/lib/data/__tests__/front-door-data-timeout.test.ts
+++ b/packages/web/app/lib/data/__tests__/front-door-data-timeout.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * The caller-side half of the backend deadline. The unit test on
+ * `createCachedGraphQLQuery` stays green if either call site drops its fourth
+ * argument, which is the inert-guard shape this campaign keeps hitting.
+ */
+const { createCachedGraphQLQueryMock, factoryCalls } = vi.hoisted(() => {
+  const factoryCalls: unknown[][] = [];
+  return {
+    factoryCalls,
+    createCachedGraphQLQueryMock: vi.fn((...args: unknown[]) => {
+      factoryCalls.push(args);
+      return async () => ({ similarClimbs: [], betaLinks: [] });
+    }),
+  };
+});
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/app/lib/graphql/server-cached-client', () => ({
+  createCachedGraphQLQuery: createCachedGraphQLQueryMock,
+}));
+
+import { getFrontDoorBetaLinks, getFrontDoorSimilarClimbs } from '../front-door-data.server';
+
+/** Shorter than the 6 s DB deadline: these sections are supplementary. */
+const EXPECTED_BACKEND_TIMEOUT_MS = 3000;
+
+describe('front-door backend calls carry a deadline', () => {
+  beforeEach(() => {
+    factoryCalls.length = 0;
+    createCachedGraphQLQueryMock.mockClear();
+  });
+
+  it('bounds the similar-climbs read', async () => {
+    await getFrontDoorSimilarClimbs({ boardType: 'kilter', layoutId: 8, climbUuid: 'climb-1', angle: 40 });
+
+    expect(factoryCalls[0]?.[3]).toBe(EXPECTED_BACKEND_TIMEOUT_MS);
+  });
+
+  it('bounds the beta-links read', async () => {
+    await getFrontDoorBetaLinks({ boardType: 'kilter', climbUuid: 'climb-1' });
+
+    expect(factoryCalls[0]?.[3]).toBe(EXPECTED_BACKEND_TIMEOUT_MS);
+  });
+});

--- a/packages/web/app/lib/data/__tests__/front-door-fanout.test.ts
+++ b/packages/web/app/lib/data/__tests__/front-door-fanout.test.ts
@@ -79,12 +79,8 @@ describe('climb front door statement budget', () => {
     expect(mockSqlTag).toHaveBeenCalledTimes(1);
   });
 
-  it('a full climb-page data pass costs exactly three statements', async () => {
-    // Mirrors the page: the climb first (the redirect branch needs its name),
-    // then the angle table alongside the two backend calls.
-    await getClimb(params);
-    await getClimbStatsForAllAngles(params);
-
-    expect(mockSqlTag).toHaveBeenCalledTimes(3);
-  });
+  // The whole-page budget lives in `climb-request-dedupe.test.ts`, where React's
+  // `cache` is a real memo. Asserting 3 here would be arithmetic on the two
+  // cases above (2 + 1) and would pin the number while being unable to tell the
+  // deduped page pass from the un-deduped one — the regression that matters.
 });

--- a/packages/web/app/lib/data/__tests__/front-door-fanout.test.ts
+++ b/packages/web/app/lib/data/__tests__/front-door-fanout.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * A statement budget for the climb front door.
+ *
+ * The crawl surface W-23 submits is six figures of climb URLs, so the number of
+ * Postgres round trips one cold render costs is a load-bearing number, not an
+ * implementation detail. This counts them and asserts the alias lookup and the
+ * climb select stay strictly sequential (one connection at a time), so nobody
+ * re-inflates the fan-out without the budget going red.
+ */
+const { mockSqlTag, rowsFromResultMock, inFlight } = vi.hoisted(() => {
+  const inFlight = { current: 0, max: 0 };
+  const mockSqlTag = vi.fn(() => {
+    inFlight.current += 1;
+    inFlight.max = Math.max(inFlight.max, inFlight.current);
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        inFlight.current -= 1;
+        resolve([]);
+      }, 0);
+    });
+  });
+  const rowsFromResultMock = <T>(result: unknown): T[] => {
+    if (Array.isArray(result)) return result as T[];
+    throw new TypeError('Expected postgres-js query result to be a row array');
+  };
+  return { mockSqlTag, rowsFromResultMock, inFlight };
+});
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache:
+    <T extends (...args: unknown[]) => unknown>(fn: T) =>
+    (...args: Parameters<T>) =>
+      fn(...args),
+}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  sql: mockSqlTag,
+  rowsFromResult: rowsFromResultMock,
+}));
+
+import { getClimb, getClimbStatsForAllAngles } from '../queries';
+
+const params = {
+  board_name: 'kilter' as const,
+  layout_id: 8,
+  size_id: 10,
+  set_ids: [1, 2],
+  angle: 40,
+  climb_uuid: 'climb-uuid-budget',
+};
+
+describe('climb front door statement budget', () => {
+  beforeEach(() => {
+    mockSqlTag.mockClear();
+    inFlight.current = 0;
+    inFlight.max = 0;
+  });
+
+  it('getClimb costs exactly two statements', async () => {
+    await getClimb(params);
+    expect(mockSqlTag).toHaveBeenCalledTimes(2);
+  });
+
+  it('getClimb runs its alias lookup and climb select sequentially', async () => {
+    await getClimb(params);
+    // The climb select needs the alias result, so max concurrency is 1. If this
+    // ever becomes 2 the two statements were fired together against different
+    // uuids — the alias resolution would be silently dropped.
+    expect(inFlight.max).toBe(1);
+  });
+
+  it('getClimbStatsForAllAngles costs exactly one statement', async () => {
+    await getClimbStatsForAllAngles(params);
+    expect(mockSqlTag).toHaveBeenCalledTimes(1);
+  });
+
+  it('a full climb-page data pass costs exactly three statements', async () => {
+    // Mirrors the page: the climb first (the redirect branch needs its name),
+    // then the angle table alongside the two backend calls.
+    await getClimb(params);
+    await getClimbStatsForAllAngles(params);
+
+    expect(mockSqlTag).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/web/app/lib/data/__tests__/list-page-data.server.test.ts
+++ b/packages/web/app/lib/data/__tests__/list-page-data.server.test.ts
@@ -3,12 +3,6 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 vi.mock('server-only', () => ({}));
 
-// `fetchListPageData` (the sibling helper) pulls in NextAuth, which pulls in the
-// db client at module load. The front-door helper under test never touches a
-// session, so stub the chain rather than requiring a DATABASE_URL.
-vi.mock('next-auth/next', () => ({ getServerSession: vi.fn(async () => null) }));
-vi.mock('@/app/lib/auth/auth-options', () => ({ authOptions: {} }));
-
 vi.mock('@/app/lib/db/queries/climbs/search-climbs', () => ({
   cachedSearchClimbs: vi.fn(),
 }));

--- a/packages/web/app/lib/data/__tests__/list-page-data.server.test.ts
+++ b/packages/web/app/lib/data/__tests__/list-page-data.server.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+// `fetchListPageData` (the sibling helper) pulls in NextAuth, which pulls in the
+// db client at module load. The front-door helper under test never touches a
+// session, so stub the chain rather than requiring a DATABASE_URL.
+vi.mock('next-auth/next', () => ({ getServerSession: vi.fn(async () => null) }));
+vi.mock('@/app/lib/auth/auth-options', () => ({ authOptions: {} }));
+
+vi.mock('@/app/lib/db/queries/climbs/search-climbs', () => ({
+  cachedSearchClimbs: vi.fn(),
+}));
+
+vi.mock('@/app/lib/board-utils', () => ({
+  getBoardDetailsForBoard: vi.fn(() => ({ board_name: 'kilter' })),
+}));
+
+vi.mock('@/app/components/board-renderer/util', () => ({
+  buildOverlayUrl: vi.fn(() => '/api/internal/board-render?overlay'),
+}));
+
+vi.mock('@/app/lib/warm-overlay-cache', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/app/lib/warm-overlay-cache')>();
+  return { ...actual, scheduleOverlayWarming: vi.fn() };
+});
+
+import { cachedSearchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
+import { FRONT_DOOR_WARM_LIMIT, scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
+import { fetchFrontDoorListPage } from '../list-page-data.server';
+import type { ParsedBoardRouteParameters } from '@/app/lib/types';
+
+const parsedParams: ParsedBoardRouteParameters = {
+  board_name: 'kilter',
+  layout_id: 8,
+  size_id: 10,
+  set_ids: [1, 2],
+  angle: 40,
+};
+
+describe('fetchFrontDoorListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('rethrows a failed search instead of rendering a 200 with an empty list', async () => {
+    // A sitemapped URL answering 200-with-nothing is read as legitimate thin
+    // content and dropped; a 5xx is retried and the URL is kept.
+    vi.mocked(cachedSearchClimbs).mockRejectedValue(new Error('connection terminated unexpectedly'));
+
+    await expect(fetchFrontDoorListPage(parsedParams, 1)).rejects.toThrow('connection terminated unexpectedly');
+  });
+
+  it('caps the overlay warm fan-out at FRONT_DOOR_WARM_LIMIT', async () => {
+    const climbs = Array.from({ length: 50 }, (_, index) => ({ frames: `p1r${index}` }));
+    vi.mocked(cachedSearchClimbs).mockResolvedValue({
+      climbs: climbs as never,
+      hasMore: true,
+    });
+
+    await fetchFrontDoorListPage(parsedParams, 1);
+
+    // The caller-side half of the cap. The unit test on `warmOverlays` alone
+    // would stay green with the call site unchanged — an inert guard.
+    expect(scheduleOverlayWarming).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'thumbnail', maxImages: FRONT_DOOR_WARM_LIMIT }),
+    );
+  });
+});

--- a/packages/web/app/lib/data/__tests__/queries.test.ts
+++ b/packages/web/app/lib/data/__tests__/queries.test.ts
@@ -1,6 +1,13 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { getClimb } from '../queries';
+import type { Climb } from '@/app/lib/types';
+
+/** `getClimb` resolves `null` for a genuinely missing row; these cases all expect a hit. */
+function assertClimb(climb: Climb | null): Climb {
+  if (!climb) throw new Error('expected getClimb to resolve a climb row');
+  return climb;
+}
 
 const { mockSqlTag, rowsFromResultMock } = vi.hoisted(() => {
   const mockSqlTag = vi.fn();
@@ -57,14 +64,16 @@ describe('getClimb', () => {
       },
     ]);
 
-    const climb = await getClimb({
-      board_name: 'kilter',
-      layout_id: 8,
-      size_id: 10,
-      set_ids: [1, 2],
-      angle: 40,
-      climb_uuid: 'climb-uuid-1',
-    });
+    const climb = assertClimb(
+      await getClimb({
+        board_name: 'kilter',
+        layout_id: 8,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+        climb_uuid: 'climb-uuid-1',
+      }),
+    );
 
     expect(mockSqlTag).toHaveBeenCalledTimes(2);
     expect(climb.uuid).toBe('climb-uuid-1');
@@ -102,14 +111,16 @@ describe('getClimb', () => {
       },
     ]);
 
-    const climb = await getClimb({
-      board_name: 'kilter',
-      layout_id: 1,
-      size_id: 10,
-      set_ids: [1, 2],
-      angle: 40,
-      climb_uuid: 'climb-uuid-2',
-    });
+    const climb = assertClimb(
+      await getClimb({
+        board_name: 'kilter',
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 2],
+        angle: 40,
+        climb_uuid: 'climb-uuid-2',
+      }),
+    );
 
     expect(climb.layoutId).toBe(1);
     expect(climb.boardType).toBe('kilter');
@@ -144,14 +155,16 @@ describe('getClimb', () => {
       },
     ]);
 
-    const climb = await getClimb({
-      board_name: 'tension',
-      layout_id: 1,
-      size_id: 10,
-      set_ids: [1],
-      angle: 40,
-      climb_uuid: 'climb-uuid-3',
-    });
+    const climb = assertClimb(
+      await getClimb({
+        board_name: 'tension',
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1],
+        angle: 40,
+        climb_uuid: 'climb-uuid-3',
+      }),
+    );
 
     expect(climb.boardType).toBe('tension');
     expect(climb.difficulty).toBe('7a/V6');
@@ -185,14 +198,16 @@ describe('getClimb', () => {
       },
     ]);
 
-    const climb = await getClimb({
-      board_name: 'moonboard',
-      layout_id: 3,
-      size_id: 1,
-      set_ids: [1],
-      angle: 40,
-      climb_uuid: 'old-alias-uuid-9', // a bookmarked link to the now-delisted row
-    });
+    const climb = assertClimb(
+      await getClimb({
+        board_name: 'moonboard',
+        layout_id: 3,
+        size_id: 1,
+        set_ids: [1],
+        angle: 40,
+        climb_uuid: 'old-alias-uuid-9', // a bookmarked link to the now-delisted row
+      }),
+    );
 
     expect(mockSqlTag).toHaveBeenCalledTimes(2);
     // The climb query (2nd call) must have queried by the RESOLVED canonical
@@ -203,5 +218,24 @@ describe('getClimb', () => {
     expect(climbQueryValues).toContain('canonical-uuid-9');
     expect(climbQueryValues).not.toContain('old-alias-uuid-9');
     expect(climb.uuid).toBe('canonical-uuid-9');
+  });
+
+  it('resolves null when no row matches, instead of throwing on an undefined row', async () => {
+    mockSqlTag.mockResolvedValueOnce([]); // alias lookup: no alias
+    mockSqlTag.mockResolvedValueOnce([]); // climb select: no such climb
+
+    const climb = await getClimb({
+      board_name: 'kilter',
+      layout_id: 8,
+      size_id: 10,
+      set_ids: [1, 2],
+      angle: 40,
+      climb_uuid: 'does-not-exist',
+    });
+
+    // The distinction the pages depend on: null means "no such climb" (404), a
+    // rejection means "could not read" (500). Before this, dereferencing the
+    // undefined row threw, and the page turned that throw into a 404 as well.
+    expect(climb).toBeNull();
   });
 });

--- a/packages/web/app/lib/data/front-door-data.server.ts
+++ b/packages/web/app/lib/data/front-door-data.server.ts
@@ -24,6 +24,13 @@ import type { BoardName } from '@/app/lib/types';
 
 const SIMILAR_CLIMBS_REVALIDATE_SECONDS = 3600;
 const BETA_LINKS_REVALIDATE_SECONDS = 3600;
+/**
+ * Wall-clock ceiling on each backend round trip. Both callers already degrade to
+ * an empty section, so this turns "the page hangs behind a wedged backend" into
+ * "the page renders without that section". Shorter than the DB read deadline:
+ * these two sections are supplementary, the climb itself is not.
+ */
+const FRONT_DOOR_BACKEND_TIMEOUT_MS = 3000;
 
 type SimilarClimbsQueryVariables = {
   input: {
@@ -48,6 +55,7 @@ export async function getFrontDoorSimilarClimbs(params: {
     SIMILAR_CLIMBS_QUERY,
     'similar-climbs',
     SIMILAR_CLIMBS_REVALIDATE_SECONDS,
+    FRONT_DOOR_BACKEND_TIMEOUT_MS,
   );
 
   try {
@@ -77,6 +85,7 @@ export async function getFrontDoorBetaLinks(params: { boardType: BoardName; clim
     GET_BETA_LINKS,
     `beta-links-${params.climbUuid}`,
     BETA_LINKS_REVALIDATE_SECONDS,
+    FRONT_DOOR_BACKEND_TIMEOUT_MS,
   );
 
   try {

--- a/packages/web/app/lib/data/list-page-data.server.ts
+++ b/packages/web/app/lib/data/list-page-data.server.ts
@@ -1,97 +1,12 @@
 import 'server-only';
 
-import { getServerSession } from 'next-auth/next';
 import type { BoardDetails, Climb, ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
 import { cachedSearchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
-import { hasUserSpecificFilters } from '@/app/lib/list-page-cache';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
-import { resolveSsrInitialPageSize } from '@/app/lib/climb-list-constants';
-import { authOptions } from '@/app/lib/auth/auth-options';
 import { FRONT_DOOR_WARM_LIMIT, scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
 import { buildOverlayUrl } from '@/app/components/board-renderer/util';
-import { DEFAULT_SEARCH_PARAMS, parsedRouteSearchParamsToSearchParams } from '@/app/lib/url-utils';
+import { DEFAULT_SEARCH_PARAMS } from '@/app/lib/url-utils';
 import { FRONT_DOOR_PAGE_SIZE } from '@/app/lib/seo/list-page-robots';
-
-export type ListPageData = {
-  boardDetails: BoardDetails;
-  searchResponse: { climbs: Climb[]; hasMore: boolean };
-  /** Pre-resolved overlay URL for the first climb so the page can `<link rel="preload">` it. */
-  preloadUrl: string | null;
-};
-
-/**
- * Shared server-side fetch for the board climbs list — used by the canonical
- * `/list` route and the short `/b/{slug}/{angle}/list` route. The two
- * `/view/{climb_uuid}` routes intentionally do NOT call this; they pass
- * `initialClimbs=[]` and let React Query load the list asynchronously so the
- * drawer can paint immediately on SSR without waiting on the catalog query.
- *
- * Returns `null` if board details can't be resolved — callers should `notFound()`.
- */
-export async function fetchListPageData(
-  parsedParams: ParsedBoardRouteParameters,
-  rawSearchParams: SearchRequestPagination,
-): Promise<ListPageData | null> {
-  const searchParamsObject = parsedRouteSearchParamsToSearchParams(rawSearchParams);
-  searchParamsObject.pageSize = resolveSsrInitialPageSize(
-    Number(searchParamsObject.page),
-    Number(searchParamsObject.pageSize),
-  );
-  searchParamsObject.page = 0;
-
-  const hasProgressFilters = hasUserSpecificFilters(searchParamsObject);
-
-  const isDefaultSearch =
-    !searchParamsObject.gradeAccuracy &&
-    !searchParamsObject.minGrade &&
-    !searchParamsObject.maxGrade &&
-    !searchParamsObject.minAscents &&
-    !searchParamsObject.minRating &&
-    !searchParamsObject.name &&
-    (!searchParamsObject.settername || searchParamsObject.settername.length === 0) &&
-    (searchParamsObject.sortBy || 'ascents') === 'ascents' &&
-    (searchParamsObject.sortOrder || 'desc') === 'desc' &&
-    !searchParamsObject.onlyTallClimbs &&
-    !searchParamsObject.onlyWideClimbs &&
-    !searchParamsObject.onlyWithBetaVideos &&
-    (!searchParamsObject.holdsFilter || Object.keys(searchParamsObject.holdsFilter).length === 0) &&
-    !hasProgressFilters;
-
-  let boardDetails: BoardDetails;
-  try {
-    boardDetails = getBoardDetailsForBoard(parsedParams);
-  } catch (error) {
-    console.error('Error resolving board details:', error);
-    return null;
-  }
-
-  let userId: string | undefined;
-  if (hasProgressFilters) {
-    const session = await getServerSession(authOptions);
-    userId = session?.user?.id;
-  }
-
-  let searchResponse: { climbs: Climb[]; hasMore: boolean };
-  try {
-    searchResponse = await cachedSearchClimbs(parsedParams, searchParamsObject, isDefaultSearch, userId, {
-      cacheable: !hasProgressFilters,
-    });
-  } catch (error) {
-    console.error(
-      'Error fetching climb search results (degrading to empty results for SSR):',
-      { boardName: parsedParams.board_name },
-      error,
-    );
-    searchResponse = { climbs: [], hasMore: false };
-  }
-
-  scheduleOverlayWarming({ boardDetails, climbs: searchResponse.climbs, variant: 'thumbnail' });
-
-  const firstClimb = searchResponse.climbs[0];
-  const preloadUrl = firstClimb?.frames ? buildOverlayUrl(boardDetails, firstClimb.frames, true) : null;
-
-  return { boardDetails, searchResponse, preloadUrl };
-}
 
 export type FrontDoorListPage = {
   boardDetails: BoardDetails;
@@ -105,12 +20,7 @@ export type FrontDoorListPage = {
  * The `/list` front door's fetch: exactly one page of `FRONT_DOOR_PAGE_SIZE`
  * climbs at the default sort (most ascents first), no filters, no session.
  *
- * Deliberately NOT `fetchListPageData`. That one pins `page = 0` and derives
- * its page size from `resolveSsrInitialPageSize` — an aggregated 0..N window
- * sized for an infinite-scrolling client list, which can neither serve `?page=3`
- * nor hand back a clean 50-row slice.
- *
- * It also never calls `getServerSession`. `middleware.ts` puts a shared
+ * It never calls `getServerSession`. `middleware.ts` puts a shared
  * `s-maxage` on these URLs with no session split, on the premise that they are
  * personalization-free; reading the cookie here would be the first step toward
  * caching one viewer's page for everyone.

--- a/packages/web/app/lib/data/list-page-data.server.ts
+++ b/packages/web/app/lib/data/list-page-data.server.ts
@@ -7,7 +7,7 @@ import { hasUserSpecificFilters } from '@/app/lib/list-page-cache';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { resolveSsrInitialPageSize } from '@/app/lib/climb-list-constants';
 import { authOptions } from '@/app/lib/auth/auth-options';
-import { scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
+import { FRONT_DOOR_WARM_LIMIT, scheduleOverlayWarming } from '@/app/lib/warm-overlay-cache';
 import { buildOverlayUrl } from '@/app/components/board-renderer/util';
 import { DEFAULT_SEARCH_PARAMS, parsedRouteSearchParamsToSearchParams } from '@/app/lib/url-utils';
 import { FRONT_DOOR_PAGE_SIZE } from '@/app/lib/seo/list-page-robots';
@@ -143,15 +143,28 @@ export async function fetchFrontDoorListPage(
     // applied — which is what lets the query ride the shared cache.
     searchResponse = await cachedSearchClimbs(parsedParams, searchParams, true, undefined, { cacheable: true });
   } catch (error) {
+    // Rethrow, deliberately. This used to degrade to an empty list, which
+    // rendered a 200 with zero climbs on a sitemapped URL — Google reads that
+    // as legitimate thin content and drops the page, where a 5xx makes it
+    // retry and keep the URL. The CDN's stale-while-revalidate window keeps
+    // serving the last good copy meanwhile.
     console.error(
-      'Error fetching front-door climbs (degrading to empty results for SSR):',
+      'Error fetching front-door climbs:',
       { boardName: parsedParams.board_name, page: zeroBasedPage },
       error,
     );
-    searchResponse = { climbs: [], hasMore: false };
+    throw error;
   }
 
-  scheduleOverlayWarming({ boardDetails, climbs: searchResponse.climbs, variant: 'thumbnail' });
+  // 50 climbs × one same-origin WASM render each is a 20× invocation amplifier
+  // on the page whose whole purpose is to be crawled. Six covers what a reader
+  // sees before scrolling; the rest warm lazily on demand.
+  scheduleOverlayWarming({
+    boardDetails,
+    climbs: searchResponse.climbs,
+    variant: 'thumbnail',
+    maxImages: FRONT_DOOR_WARM_LIMIT,
+  });
 
   const firstClimb = searchResponse.climbs[0];
   const preloadUrl = firstClimb?.frames ? buildOverlayUrl(boardDetails, firstClimb.frames, true) : null;

--- a/packages/web/app/lib/data/queries.ts
+++ b/packages/web/app/lib/data/queries.ts
@@ -15,6 +15,20 @@ import type { Climb, ParsedBoardRouteParametersWithUuid, BoardName, LayoutId, Si
 import { getSizesForLayoutId, getAllLayouts, getSetsForLayoutAndSize } from '@/app/lib/board-constants';
 import { isNoMatchClimb, isNoMatch } from '@/app/lib/no-match-climb';
 import { withReadDeadline } from '@/app/lib/db/read-deadline';
+import { remainingReadBudgetMs } from '@/app/lib/db/request-read-budget';
+
+/**
+ * Thrown by the cached executor for a genuinely missing row, and translated back
+ * to `null` outside the cache. `unstable_cache` never stores a rejection, so a
+ * climb the crawler reached before the import finished re-reads on the next
+ * request instead of answering 404 for the rest of the hour-long entry.
+ */
+class ClimbRowMissingError extends Error {
+  constructor(climbUuid: string) {
+    super(`[db] no climb row for ${climbUuid}`);
+    this.name = 'ClimbRowMissingError';
+  }
+}
 
 // Resolves an old/bookmarked/shared climb link through board_climb_aliases:
 // a climb that's since been merged into another (e.g. the MoonBoard
@@ -33,23 +47,25 @@ async function resolveCanonicalClimbUuidWeb(boardName: BoardName, climbUuid: str
       WHERE board_type = ${boardName} AND alias_uuid = ${climbUuid}
       LIMIT 1
     `,
+      remainingReadBudgetMs(),
     ),
   );
   return result[0]?.canonical_uuid ?? climbUuid;
 }
 
 /**
- * Returns `null` when no row matches — a genuinely missing climb. Anything else
- * (a saturated pool, a read deadline, a dead database) throws, so the page can
- * tell "this climb does not exist" from "we could not answer right now". The
- * two used to be indistinguishable, and both rendered a 404 on an indexed URL.
+ * Throws `ClimbRowMissingError` when no row matches — a genuinely missing climb,
+ * which the caller turns back into `null`. Anything else (a saturated pool, a
+ * read deadline, a dead database) throws its own error, so the page can tell
+ * "this climb does not exist" from "we could not answer right now". The two used
+ * to be indistinguishable, and both rendered a 404 on an indexed URL.
  */
 async function fetchClimbFromDb(
   boardName: BoardName,
   layoutId: LayoutId,
   angle: number,
   requestedClimbUuid: string,
-): Promise<Climb | null> {
+): Promise<Climb> {
   const climbUuid = await resolveCanonicalClimbUuidWeb(boardName, requestedClimbUuid);
 
   // Direct-by-UUID lookups intentionally do NOT filter `frames_count = 1`.
@@ -78,10 +94,11 @@ async function fetchClimbFromDb(
         AND climbs.uuid = ${climbUuid}
         limit 1
       `,
+      remainingReadBudgetMs(),
     ),
   );
   const row = result[0];
-  if (!row) return null;
+  if (!row) throw new ClimbRowMissingError(climbUuid);
   return {
     ...row,
     difficulty: getGradeLabel(row.difficulty_id),
@@ -97,12 +114,27 @@ async function fetchClimbFromDb(
  * text, so passing a stable module-level function with explicit primitive
  * arguments (the pattern `search-climbs.ts` documents) keeps the key derivation
  * deterministic instead of resting on a fresh closure per request.
+ *
+ * The miss is translated from a rejection to `null` out here, on purpose: a
+ * `null` returned from inside would be stored for the full hour, so a climb
+ * crawled minutes before its import landed would keep 404-ing until the entry
+ * expired. `unstable_cache` does not store rejections.
  */
-function cachedClimbFetch(boardName: BoardName, layoutId: LayoutId, angle: number, climbUuid: string) {
-  return unstable_cache(fetchClimbFromDb, ['climb', boardName, String(layoutId), climbUuid, String(angle)], {
-    revalidate: 3600,
-    tags: [`climb-${climbUuid}`],
-  })(boardName, layoutId, angle, climbUuid);
+async function cachedClimbFetch(
+  boardName: BoardName,
+  layoutId: LayoutId,
+  angle: number,
+  climbUuid: string,
+): Promise<Climb | null> {
+  try {
+    return await unstable_cache(fetchClimbFromDb, ['climb', boardName, String(layoutId), climbUuid, String(angle)], {
+      revalidate: 3600,
+      tags: [`climb-${climbUuid}`],
+    })(boardName, layoutId, angle, climbUuid);
+  } catch (error) {
+    if (error instanceof ClimbRowMissingError) return null;
+    throw error;
+  }
 }
 
 /**
@@ -159,6 +191,7 @@ async function fetchClimbStatsForAllAnglesFromDb(
     AND climb_stats.climb_uuid = ${climbUuid}
     ORDER BY climb_stats.angle ASC
   `,
+      remainingReadBudgetMs(),
     ),
   );
   return result.map((row) => ({

--- a/packages/web/app/lib/data/queries.ts
+++ b/packages/web/app/lib/data/queries.ts
@@ -5,6 +5,7 @@
  * performant.
  */
 import 'server-only';
+import { cache } from 'react';
 import { unstable_cache } from 'next/cache';
 // oxlint-disable-next-line no-restricted-imports -- raw postgres-js sql usage; migrate to drizzle
 import { rowsFromResult, sql } from '@/app/lib/db/db';
@@ -13,6 +14,7 @@ import { getGradeLabel } from '@boardsesh/db/queries';
 import type { Climb, ParsedBoardRouteParametersWithUuid, BoardName, LayoutId, Size } from '../types';
 import { getSizesForLayoutId, getAllLayouts, getSetsForLayoutAndSize } from '@/app/lib/board-constants';
 import { isNoMatchClimb, isNoMatch } from '@/app/lib/no-match-climb';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 // Resolves an old/bookmarked/shared climb link through board_climb_aliases:
 // a climb that's since been merged into another (e.g. the MoonBoard
@@ -24,27 +26,43 @@ import { isNoMatchClimb, isNoMatch } from '@/app/lib/no-match-climb';
 // takes a drizzle db handle and this file's queries are raw postgres-js sql).
 async function resolveCanonicalClimbUuidWeb(boardName: BoardName, climbUuid: string): Promise<string> {
   const result = rowsFromResult<{ canonical_uuid: string }>(
-    await sql`
+    await withReadDeadline(
+      'climb-alias',
+      sql`
       SELECT canonical_uuid FROM board_climb_aliases
       WHERE board_type = ${boardName} AND alias_uuid = ${climbUuid}
       LIMIT 1
     `,
+    ),
   );
   return result[0]?.canonical_uuid ?? climbUuid;
 }
 
-async function fetchClimbFromDb(params: ParsedBoardRouteParametersWithUuid): Promise<Climb> {
-  const climbUuid = await resolveCanonicalClimbUuidWeb(params.board_name, params.climb_uuid);
+/**
+ * Returns `null` when no row matches — a genuinely missing climb. Anything else
+ * (a saturated pool, a read deadline, a dead database) throws, so the page can
+ * tell "this climb does not exist" from "we could not answer right now". The
+ * two used to be indistinguishable, and both rendered a 404 on an indexed URL.
+ */
+async function fetchClimbFromDb(
+  boardName: BoardName,
+  layoutId: LayoutId,
+  angle: number,
+  requestedClimbUuid: string,
+): Promise<Climb | null> {
+  const climbUuid = await resolveCanonicalClimbUuidWeb(boardName, requestedClimbUuid);
 
   // Direct-by-UUID lookups intentionally do NOT filter `frames_count = 1`.
   // Search/dedupe still skip multi-frame climbs (see queries/climbs/*),
   // but the player needs to be able to render them when a URL points at one.
   const result = rowsFromResult<Climb & { difficulty_id: number | null }>(
-    await sql`
+    await withReadDeadline(
+      'climb-select',
+      sql`
         SELECT climbs.uuid, climbs.setter_username, climbs.user_id as "userId", climbs.name, climbs.description,
         climbs.layout_id as "layoutId", climbs.board_type as "boardType",
         climbs.frames, climbs.frames_count as "framesCount", climbs.frames_pace as "framesPace",
-        COALESCE(climb_stats.angle, ${params.angle}) as angle, COALESCE(climb_stats.ascensionist_count, 0) as ascensionist_count,
+        COALESCE(climb_stats.angle, ${angle}) as angle, COALESCE(climb_stats.ascensionist_count, 0) as ascensionist_count,
         ROUND(climb_stats.display_difficulty::numeric, 0) as difficulty_id,
         ROUND(climb_stats.quality_average::numeric, 2) as quality_average,
         ROUND(climb_stats.difficulty_average::numeric - climb_stats.display_difficulty::numeric, 2) AS difficulty_error,
@@ -53,15 +71,17 @@ async function fetchClimbFromDb(params: ParsedBoardRouteParametersWithUuid): Pro
         FROM board_climbs climbs
         LEFT JOIN board_climb_stats climb_stats
           ON climb_stats.climb_uuid = climbs.uuid
-          AND climb_stats.angle = ${params.angle}
-          AND climb_stats.board_type = ${params.board_name}
-        WHERE climbs.board_type = ${params.board_name}
-        AND climbs.layout_id = ${params.layout_id}
+          AND climb_stats.angle = ${angle}
+          AND climb_stats.board_type = ${boardName}
+        WHERE climbs.board_type = ${boardName}
+        AND climbs.layout_id = ${layoutId}
         AND climbs.uuid = ${climbUuid}
         limit 1
       `,
+    ),
   );
   const row = result[0];
+  if (!row) return null;
   return {
     ...row,
     difficulty: getGradeLabel(row.difficulty_id),
@@ -69,16 +89,41 @@ async function fetchClimbFromDb(params: ParsedBoardRouteParametersWithUuid): Pro
   } as Climb;
 }
 
-export async function getClimb(params: ParsedBoardRouteParametersWithUuid): Promise<Climb> {
-  const cachedFn = unstable_cache(
-    async () => fetchClimbFromDb(params),
-    ['climb', params.board_name, String(params.layout_id), params.climb_uuid, String(params.angle)],
-    {
-      revalidate: 3600,
-      tags: [`climb-${params.climb_uuid}`],
-    },
-  );
-  return cachedFn();
+/**
+ * `unstable_cache` is constructed per call because its `tags` carry the climb
+ * uuid — a module-level instance could only hold one static tag set, and a
+ * uuid-keyed registry of instances would grow without bound on a crawl. What
+ * *is* hoisted is the executor: `unstable_cache` keys on the callback's source
+ * text, so passing a stable module-level function with explicit primitive
+ * arguments (the pattern `search-climbs.ts` documents) keeps the key derivation
+ * deterministic instead of resting on a fresh closure per request.
+ */
+function cachedClimbFetch(boardName: BoardName, layoutId: LayoutId, angle: number, climbUuid: string) {
+  return unstable_cache(fetchClimbFromDb, ['climb', boardName, String(layoutId), climbUuid, String(angle)], {
+    revalidate: 3600,
+    tags: [`climb-${climbUuid}`],
+  })(boardName, layoutId, angle, climbUuid);
+}
+
+/**
+ * React-`cache`d on primitives, so `generateMetadata` and the page body share
+ * one read per request. `unstable_cache` has no in-flight single-flight and
+ * Next renders the two concurrently, so on a cold key both used to miss and
+ * both used to run the alias lookup and the climb select — four statements
+ * where two would do.
+ * Keying on primitives (rather than the params object) makes the dedupe work in
+ * the `/b/{slug}` tree too, where the two entry points build their own objects.
+ *
+ * Resolves to `null` when the climb genuinely does not exist; rejects when the
+ * read failed.
+ */
+const getClimbCached = cache(
+  async (boardName: BoardName, layoutId: LayoutId, angle: number, climbUuid: string): Promise<Climb | null> =>
+    cachedClimbFetch(boardName, layoutId, angle, climbUuid),
+);
+
+export async function getClimb(params: ParsedBoardRouteParametersWithUuid): Promise<Climb | null> {
+  return getClimbCached(params.board_name, params.layout_id, params.angle, params.climb_uuid);
 }
 
 export type ClimbStatsForAngle = {
@@ -93,10 +138,13 @@ export type ClimbStatsForAngle = {
 };
 
 async function fetchClimbStatsForAllAnglesFromDb(
-  params: ParsedBoardRouteParametersWithUuid,
+  boardName: BoardName,
+  climbUuid: string,
 ): Promise<ClimbStatsForAngle[]> {
   const result = rowsFromResult<ClimbStatsForAngle & { difficulty_id: number | null }>(
-    await sql`
+    await withReadDeadline(
+      'climb-stats-all-angles',
+      sql`
     SELECT
       climb_stats.angle,
       COALESCE(climb_stats.ascensionist_count, 0) as ascensionist_count,
@@ -107,10 +155,11 @@ async function fetchClimbStatsForAllAnglesFromDb(
       climb_stats.fa_at,
       ROUND(climb_stats.display_difficulty::numeric, 0) as difficulty_id
     FROM board_climb_stats climb_stats
-    WHERE climb_stats.board_type = ${params.board_name}
-    AND climb_stats.climb_uuid = ${params.climb_uuid}
+    WHERE climb_stats.board_type = ${boardName}
+    AND climb_stats.climb_uuid = ${climbUuid}
     ORDER BY climb_stats.angle ASC
   `,
+    ),
   );
   return result.map((row) => ({
     ...row,
@@ -126,18 +175,18 @@ async function fetchClimbStatsForAllAnglesFromDb(
  * `revalidateTag` clears both: a page that renders the climb's own facts from a
  * fresh row and its angle table from an hour-old one is worse than either.
  */
+const getClimbStatsForAllAnglesCached = cache(
+  async (boardName: BoardName, climbUuid: string): Promise<ClimbStatsForAngle[]> =>
+    unstable_cache(fetchClimbStatsForAllAnglesFromDb, ['climb-stats-all-angles', boardName, climbUuid], {
+      revalidate: 3600,
+      tags: [`climb-${climbUuid}`],
+    })(boardName, climbUuid),
+);
+
 export async function getClimbStatsForAllAngles(
   params: ParsedBoardRouteParametersWithUuid,
 ): Promise<ClimbStatsForAngle[]> {
-  const cachedFn = unstable_cache(
-    async () => fetchClimbStatsForAllAnglesFromDb(params),
-    ['climb-stats-all-angles', params.board_name, params.climb_uuid],
-    {
-      revalidate: 3600,
-      tags: [`climb-${params.climb_uuid}`],
-    },
-  );
-  return cachedFn();
+  return getClimbStatsForAllAnglesCached(params.board_name, params.climb_uuid);
 }
 
 export type LayoutRow = {

--- a/packages/web/app/lib/db/__tests__/read-deadline-wiring.test.ts
+++ b/packages/web/app/lib/db/__tests__/read-deadline-wiring.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * The caller-side half of the read deadline.
+ *
+ * `read-deadline.test.ts` proves the helper bounds a wait and
+ * `db-pool-exhaustion.test.ts` proves it against a live Postgres — but both
+ * would stay green if a refactor (or a merge that resolved a conflict by keeping
+ * the old `await sql\`…\`` form) dropped the wrapper from the front-door reads.
+ * This pins the four call sites by name.
+ */
+const { recordedReads, mockSqlTag } = vi.hoisted(() => ({
+  recordedReads: [] as { label: string; ms: number | undefined }[],
+  mockSqlTag: vi.fn(async () => []),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/app/lib/db/read-deadline', () => ({
+  FRONT_DOOR_READ_DEADLINE_MS: 6000,
+  DEFAULT_READ_DEADLINE_MS: 6000,
+  parseReadDeadlineMs: () => 6000,
+  DbReadTimeoutError: class DbReadTimeoutError extends Error {},
+  withReadDeadline: async <T>(label: string, pending: PromiseLike<T>, ms?: number) => {
+    recordedReads.push({ label, ms });
+    return pending;
+  },
+}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache:
+    <T extends (...args: unknown[]) => unknown>(fn: T) =>
+    (...args: Parameters<T>) =>
+      fn(...args),
+}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  sql: mockSqlTag,
+  rowsFromResult: <T>(result: unknown): T[] => (Array.isArray(result) ? (result as T[]) : []),
+  getReadDb: vi.fn(() => ({})),
+}));
+
+vi.mock('@boardsesh/db/queries', () => ({
+  getGradeLabel: vi.fn(() => '6c/V5'),
+  searchClimbs: vi.fn(async () => ({ climbs: [], hasMore: false })),
+  mapSearchInputToParams: vi.fn((input: unknown) => input),
+}));
+
+import { getClimb, getClimbStatsForAllAngles } from '@/app/lib/data/queries';
+import { cachedSearchClimbs } from '@/app/lib/db/queries/climbs/search-climbs';
+import type { ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
+
+const params = {
+  board_name: 'kilter' as const,
+  layout_id: 8,
+  size_id: 10,
+  set_ids: [1, 2],
+  angle: 40,
+  climb_uuid: 'climb-uuid-wiring',
+};
+
+const labels = () => recordedReads.map((read) => read.label);
+
+describe('front-door reads run under a deadline', () => {
+  beforeEach(() => {
+    recordedReads.length = 0;
+    mockSqlTag.mockClear();
+  });
+
+  it('bounds the alias lookup and the climb select', async () => {
+    await getClimb(params);
+
+    expect(labels()).toEqual(['climb-alias', 'climb-select']);
+  });
+
+  it('bounds the all-angles stats read', async () => {
+    await getClimbStatsForAllAngles(params);
+
+    expect(labels()).toEqual(['climb-stats-all-angles']);
+  });
+
+  it('bounds the list front door search', async () => {
+    const listParams: ParsedBoardRouteParameters = {
+      board_name: 'kilter',
+      layout_id: 8,
+      size_id: 10,
+      set_ids: [1, 2],
+      angle: 40,
+    };
+
+    await cachedSearchClimbs(listParams, { page: 0, pageSize: 50 } as SearchRequestPagination, true, undefined, {
+      cacheable: true,
+    });
+
+    expect(labels()).toEqual(['climb-search']);
+  });
+
+  it('gives every climb-page read a budget inside the 6 s ceiling', async () => {
+    await getClimb(params);
+    await getClimbStatsForAllAngles(params);
+
+    for (const read of recordedReads) {
+      expect(read.ms).toBeGreaterThan(0);
+      expect(read.ms).toBeLessThanOrEqual(6000);
+    }
+  });
+});

--- a/packages/web/app/lib/db/__tests__/read-deadline.test.ts
+++ b/packages/web/app/lib/db/__tests__/read-deadline.test.ts
@@ -3,7 +3,34 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 
 vi.mock('server-only', () => ({}));
 
-import { DbReadTimeoutError, FRONT_DOOR_READ_DEADLINE_MS, withReadDeadline } from '../read-deadline';
+import {
+  DEFAULT_READ_DEADLINE_MS,
+  DbReadTimeoutError,
+  FRONT_DOOR_READ_DEADLINE_MS,
+  parseReadDeadlineMs,
+  withReadDeadline,
+} from '../read-deadline';
+
+describe('parseReadDeadlineMs', () => {
+  // `FRONT_DOOR_READ_DEADLINE_MS` is captured at module load, so reading it back
+  // can only ever exercise the unset branch — the escape valve the docs
+  // advertise (`DB_READ_DEADLINE_MS`) needs the parser tested directly.
+  it('falls back to the default when unset', () => {
+    expect(parseReadDeadlineMs(undefined)).toBe(DEFAULT_READ_DEADLINE_MS);
+    expect(parseReadDeadlineMs('')).toBe(DEFAULT_READ_DEADLINE_MS);
+  });
+
+  it('honours a valid override', () => {
+    expect(parseReadDeadlineMs('8000')).toBe(8000);
+    expect(parseReadDeadlineMs('1500')).toBe(1500);
+  });
+
+  it('rejects values that would disable or invert the deadline', () => {
+    expect(parseReadDeadlineMs('0')).toBe(DEFAULT_READ_DEADLINE_MS);
+    expect(parseReadDeadlineMs('-1')).toBe(DEFAULT_READ_DEADLINE_MS);
+    expect(parseReadDeadlineMs('abc')).toBe(DEFAULT_READ_DEADLINE_MS);
+  });
+});
 
 describe('withReadDeadline', () => {
   beforeEach(() => {

--- a/packages/web/app/lib/db/__tests__/read-deadline.test.ts
+++ b/packages/web/app/lib/db/__tests__/read-deadline.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+import { DbReadTimeoutError, FRONT_DOOR_READ_DEADLINE_MS, withReadDeadline } from '../read-deadline';
+
+describe('withReadDeadline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('defaults to a 6 second front-door deadline', () => {
+    expect(FRONT_DOOR_READ_DEADLINE_MS).toBe(6000);
+  });
+
+  it('rejects with DbReadTimeoutError once the deadline elapses', async () => {
+    const cancel = vi.fn();
+    const neverSettling = Object.assign(new Promise<string>(() => {}), { cancel });
+
+    const pending = withReadDeadline('climb-select', neverSettling);
+    const assertion = expect(pending).rejects.toBeInstanceOf(DbReadTimeoutError);
+
+    await vi.advanceTimersByTimeAsync(FRONT_DOOR_READ_DEADLINE_MS);
+    await assertion;
+  });
+
+  it('cancels the pending query exactly once when the deadline wins', async () => {
+    const cancel = vi.fn();
+    const neverSettling = Object.assign(new Promise<string>(() => {}), { cancel });
+
+    const pending = withReadDeadline('climb-select', neverSettling, 1000);
+    const assertion = expect(pending).rejects.toThrow(/exceeded 1000ms/);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await assertion;
+
+    // postgres.js queues a query with no timeout of its own, so walking away
+    // would leave a zombie statement that fires when the pool recovers.
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries the label into the error message', async () => {
+    const neverSettling = Object.assign(new Promise<string>(() => {}), { cancel: vi.fn() });
+
+    const pending = withReadDeadline('climb-alias', neverSettling, 500);
+    const assertion = expect(pending).rejects.toThrow(/"climb-alias"/);
+
+    await vi.advanceTimersByTimeAsync(500);
+    await assertion;
+  });
+
+  it('resolves a fast read without cancelling it, and clears the timer', async () => {
+    const cancel = vi.fn();
+    const fast = Object.assign(Promise.resolve('rows'), { cancel });
+
+    await expect(withReadDeadline('climb-select', fast, 1000)).resolves.toBe('rows');
+
+    expect(cancel).not.toHaveBeenCalled();
+    // A leaked timer per read would keep a serverless instance alive past its
+    // response for the length of the deadline.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('propagates the underlying error and clears the timer', async () => {
+    const cancel = vi.fn();
+    const failing = Object.assign(Promise.reject(new Error('relation does not exist')), { cancel });
+
+    await expect(withReadDeadline('climb-select', failing, 1000)).rejects.toThrow('relation does not exist');
+
+    expect(cancel).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('accepts a plain promise with no cancel (drizzle-issued queries)', async () => {
+    await expect(withReadDeadline('climb-search', Promise.resolve(['a']), 1000)).resolves.toEqual(['a']);
+  });
+
+  it('does not blow up cancelling a plain promise on timeout', async () => {
+    const pending = withReadDeadline('climb-search', new Promise<string>(() => {}), 750);
+    const assertion = expect(pending).rejects.toBeInstanceOf(DbReadTimeoutError);
+
+    await vi.advanceTimersByTimeAsync(750);
+    await assertion;
+  });
+});

--- a/packages/web/app/lib/db/__tests__/request-read-budget.test.ts
+++ b/packages/web/app/lib/db/__tests__/request-read-budget.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vite-plus/test';
+
+import { MIN_REMAINING_READ_BUDGET_MS, remainingBudgetMs } from '../request-read-budget';
+
+describe('remainingBudgetMs', () => {
+  it('hands back what is left of the request budget', () => {
+    expect(remainingBudgetMs({ deadlineAt: 10_000 }, 4_000)).toBe(6_000);
+    expect(remainingBudgetMs({ deadlineAt: 10_000 }, 8_000)).toBe(2_000);
+  });
+
+  it('floors an exhausted budget rather than issuing a 0 ms deadline', () => {
+    // A 0 ms deadline can beat an already-resolved promise on a busy event loop,
+    // turning a cache hit into a spurious timeout.
+    expect(remainingBudgetMs({ deadlineAt: 10_000 }, 10_000)).toBe(MIN_REMAINING_READ_BUDGET_MS);
+    expect(remainingBudgetMs({ deadlineAt: 10_000 }, 25_000)).toBe(MIN_REMAINING_READ_BUDGET_MS);
+  });
+});

--- a/packages/web/app/lib/db/queries/climbs/__tests__/search-climbs-moonboard-cache.test.ts
+++ b/packages/web/app/lib/db/queries/climbs/__tests__/search-climbs-moonboard-cache.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * MoonBoard `/list` front doors used to bypass the data cache entirely, so every
+ * crawled page was a live search against the biggest board in the catalogue.
+ * The bypass now only applies when the caller has NOT asked for caching
+ * explicitly — and `fetchFrontDoorListPage` is the only caller that does.
+ *
+ * `unstable_cache` is mocked with a *memoising* recorder rather than the
+ * identity stub used elsewhere: an identity stub cannot tell a cached call from
+ * an uncached one, which is exactly what this test is about.
+ */
+const { searchExecutions, cacheStore } = vi.hoisted(() => ({
+  searchExecutions: { count: 0 },
+  cacheStore: new Map<string, unknown>(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache:
+    <T extends (...args: unknown[]) => Promise<unknown>>(fn: T, keyParts: string[]) =>
+    async (...args: Parameters<T>) => {
+      const key = `${keyParts.join('|')}::${JSON.stringify(args)}`;
+      if (!cacheStore.has(key)) {
+        cacheStore.set(key, await fn(...args));
+      }
+      return cacheStore.get(key);
+    },
+}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  getReadDb: vi.fn(() => ({})),
+}));
+
+vi.mock('@boardsesh/db/queries', () => ({
+  searchClimbs: vi.fn(async () => {
+    searchExecutions.count += 1;
+    return { climbs: [], hasMore: false };
+  }),
+  mapSearchInputToParams: vi.fn((input: unknown) => input),
+}));
+
+import { cachedSearchClimbs } from '../search-climbs';
+import type { ParsedBoardRouteParameters, SearchRequestPagination } from '@/app/lib/types';
+
+const moonboardParams: ParsedBoardRouteParameters = {
+  board_name: 'moonboard',
+  layout_id: 3,
+  size_id: 1,
+  set_ids: [1],
+  angle: 40,
+};
+
+const searchParams = { page: 0, pageSize: 50 } as SearchRequestPagination;
+
+describe('cachedSearchClimbs — MoonBoard front-door caching', () => {
+  beforeEach(() => {
+    searchExecutions.count = 0;
+    cacheStore.clear();
+  });
+
+  it('caches a MoonBoard search the front door asked to cache', async () => {
+    await cachedSearchClimbs(moonboardParams, searchParams, true, undefined, { cacheable: true });
+    await cachedSearchClimbs(moonboardParams, searchParams, true, undefined, { cacheable: true });
+
+    expect(searchExecutions.count).toBe(1);
+  });
+
+  it('still bypasses the cache for MoonBoard when the caller did not ask for it', async () => {
+    await cachedSearchClimbs(moonboardParams, searchParams, true);
+    await cachedSearchClimbs(moonboardParams, searchParams, true);
+
+    expect(searchExecutions.count).toBe(2);
+  });
+
+  it('still bypasses the cache when the caller opts out explicitly', async () => {
+    await cachedSearchClimbs(moonboardParams, searchParams, true, undefined, { cacheable: false });
+    await cachedSearchClimbs(moonboardParams, searchParams, true, undefined, { cacheable: false });
+
+    expect(searchExecutions.count).toBe(2);
+  });
+
+  it('still bypasses the cache for a personalised search', async () => {
+    await cachedSearchClimbs(moonboardParams, searchParams, true, 'user-1');
+    await cachedSearchClimbs(moonboardParams, searchParams, true, 'user-1');
+
+    expect(searchExecutions.count).toBe(2);
+  });
+
+  it('keeps the random-sort bypass even when the front door asks for caching', async () => {
+    const randomParams = { ...searchParams, sortBy: 'random', sortSeed: '12345' } as SearchRequestPagination;
+
+    await cachedSearchClimbs(moonboardParams, randomParams, false, undefined, { cacheable: true });
+    await cachedSearchClimbs(moonboardParams, randomParams, false, undefined, { cacheable: true });
+
+    expect(searchExecutions.count).toBe(2);
+  });
+
+  it('leaves the non-MoonBoard front door caching as it was', async () => {
+    const kilterParams: ParsedBoardRouteParameters = { ...moonboardParams, board_name: 'kilter' };
+
+    await cachedSearchClimbs(kilterParams, searchParams, true, undefined, { cacheable: true });
+    await cachedSearchClimbs(kilterParams, searchParams, true, undefined, { cacheable: true });
+
+    expect(searchExecutions.count).toBe(1);
+  });
+});

--- a/packages/web/app/lib/db/queries/climbs/__tests__/search-climbs-moonboard-cache.test.ts
+++ b/packages/web/app/lib/db/queries/climbs/__tests__/search-climbs-moonboard-cache.test.ts
@@ -11,18 +11,27 @@ import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
  * identity stub used elsewhere: an identity stub cannot tell a cached call from
  * an uncached one, which is exactly what this test is about.
  */
-const { searchExecutions, cacheStore } = vi.hoisted(() => ({
+const { searchExecutions, cacheStore, revalidateByKey } = vi.hoisted(() => ({
   searchExecutions: { count: 0 },
   cacheStore: new Map<string, unknown>(),
+  revalidateByKey: new Map<string, number | undefined>(),
 }));
 
 vi.mock('server-only', () => ({}));
 
 vi.mock('next/cache', () => ({
   unstable_cache:
-    <T extends (...args: unknown[]) => Promise<unknown>>(fn: T, keyParts: string[]) =>
+    <T extends (...args: unknown[]) => Promise<unknown>>(
+      fn: T,
+      keyParts: string[],
+      options?: { revalidate?: number; tags?: string[] },
+    ) =>
     async (...args: Parameters<T>) => {
       const key = `${keyParts.join('|')}::${JSON.stringify(args)}`;
+      // The TTL is the whole freshness argument for caching MoonBoard at all, so
+      // the recorder has to see the options object — an identity stub that drops
+      // it leaves `revalidate` free to be changed to anything.
+      revalidateByKey.set(key, options?.revalidate);
       if (!cacheStore.has(key)) {
         cacheStore.set(key, await fn(...args));
       }
@@ -55,10 +64,22 @@ const moonboardParams: ParsedBoardRouteParameters = {
 
 const searchParams = { page: 0, pageSize: 50 } as SearchRequestPagination;
 
+/** 15 minutes — see `CACHE_DURATION_MOONBOARD_FRONT_DOOR` in the module under test. */
+const MOONBOARD_FRONT_DOOR_TTL_SECONDS = 900;
+/** 24 hours — the default-search TTL every other board keeps. */
+const DEFAULT_SEARCH_TTL_SECONDS = 86400;
+
+function onlyRevalidate(): number | undefined {
+  const values = [...revalidateByKey.values()];
+  expect(values).toHaveLength(1);
+  return values[0];
+}
+
 describe('cachedSearchClimbs — MoonBoard front-door caching', () => {
   beforeEach(() => {
     searchExecutions.count = 0;
     cacheStore.clear();
+    revalidateByKey.clear();
   });
 
   it('caches a MoonBoard search the front door asked to cache', async () => {
@@ -66,6 +87,15 @@ describe('cachedSearchClimbs — MoonBoard front-door caching', () => {
     await cachedSearchClimbs(moonboardParams, searchParams, true, undefined, { cacheable: true });
 
     expect(searchExecutions.count).toBe(1);
+  });
+
+  it('holds a MoonBoard front-door entry for 15 minutes, not the 24-hour default', async () => {
+    // The freshness contract that replaces the blanket bypass: an in-progress
+    // import shows up within a quarter hour. If this becomes the default TTL,
+    // MoonBoard front doors serve day-old import state.
+    await cachedSearchClimbs(moonboardParams, searchParams, true, undefined, { cacheable: true });
+
+    expect(onlyRevalidate()).toBe(MOONBOARD_FRONT_DOOR_TTL_SECONDS);
   });
 
   it('still bypasses the cache for MoonBoard when the caller did not ask for it', async () => {
@@ -105,5 +135,7 @@ describe('cachedSearchClimbs — MoonBoard front-door caching', () => {
     await cachedSearchClimbs(kilterParams, searchParams, true, undefined, { cacheable: true });
 
     expect(searchExecutions.count).toBe(1);
+    // Unchanged by the MoonBoard branch: the default-search TTL still applies.
+    expect(onlyRevalidate()).toBe(DEFAULT_SEARCH_TTL_SECONDS);
   });
 });

--- a/packages/web/app/lib/db/queries/climbs/search-climbs.ts
+++ b/packages/web/app/lib/db/queries/climbs/search-climbs.ts
@@ -6,12 +6,21 @@ import { getBoardClimbSearchTag } from '@/app/lib/climb-search-cache';
 import type { ParsedBoardRouteParameters, SearchRequestPagination, BoardName, Climb } from '@/app/lib/types';
 import { sortObjectKeys } from '@/app/lib/cache-utils';
 import { isNoMatch, isNoMatchClimb } from '@/app/lib/no-match-climb';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 /**
  * Cache durations for climb search queries (in seconds)
  */
 const CACHE_DURATION_DEFAULT_SEARCH = 24 * 60 * 60; // 24 hours for default searches
 const CACHE_DURATION_FILTERED_SEARCH = 60 * 60; // 1 hour for filtered searches
+/**
+ * MoonBoard front doors only. Short enough that an in-progress import shows up
+ * within a quarter hour — the freshness the blanket bypass below was protecting
+ * — but not so short that a crawler pays a live search per page view. MoonBoard
+ * is the largest board in the catalogue, so it is also the biggest single
+ * contributor to the crawl surface.
+ */
+const CACHE_DURATION_MOONBOARD_FRONT_DOOR = 15 * 60;
 
 /**
  * Module-level query function with explicit arguments so unstable_cache holds a
@@ -41,7 +50,14 @@ async function _executeClimbSearch(
   // `mapSearchInputToParams` lives in `@boardsesh/db` so the SSR path and the
   // GraphQL resolver share the same input → params shape. Don't duplicate the
   // falsy-collapse rules here.
-  const result = await sharedSearchClimbs(db, params, mapSearchInputToParams(searchParams), userId);
+  //
+  // The deadline is what stops a saturated pool turning this into an unbounded
+  // wait — postgres.js queues with no acquire timeout. drizzle exposes no
+  // `.cancel()`, so this bounds the caller, not the statement.
+  const result = await withReadDeadline(
+    'climb-search',
+    sharedSearchClimbs(db, params, mapSearchInputToParams(searchParams), userId),
+  );
 
   const climbs: Climb[] = result.climbs.map((row) => ({
     ...row,
@@ -149,12 +165,21 @@ export async function cachedSearchClimbs(
   userId?: string,
   options?: { cacheable?: boolean },
 ): Promise<{ climbs: Climb[]; hasMore: boolean }> {
-  // MoonBoard list data is still being actively imported/curated, so bypass
-  // the server cache there to surface new climbs immediately. Random sort also
-  // bypasses: each shuffle carries a unique ~31-bit seed, so caching per seed is a
-  // 0%-hit-rate entry that only bloats the Next.js data cache.
+  // MoonBoard list data is still being actively imported/curated, so it bypasses
+  // the server cache by default to surface new climbs immediately — except when
+  // a caller asks for caching explicitly. Only the `/list` front door does
+  // (`fetchFrontDoorListPage`), and every one of those renders was a live search
+  // on the biggest board in the catalogue; a 15-minute entry keeps the import
+  // freshness the bypass was protecting, and `revalidateClimbSearchTags` still
+  // clears it on demand via the board-level tag.
+  //
+  // Random sort bypasses unconditionally: each shuffle carries a unique ~31-bit
+  // seed, so caching per seed is a 0%-hit-rate entry that only bloats the
+  // Next.js data cache.
+  const isMoonboard = params.board_name === 'moonboard';
+  const explicitlyCacheable = options?.cacheable === true;
   const cacheable =
-    (options?.cacheable ?? !userId) && params.board_name !== 'moonboard' && searchParams.sortBy !== 'random';
+    (options?.cacheable ?? !userId) && searchParams.sortBy !== 'random' && (explicitlyCacheable || !isMoonboard);
 
   const setIdsStr = [...params.set_ids].sort((a, b) => a - b).join(',');
   const searchParamsJson = buildClimbSearchParamsJson(searchParams);
@@ -171,7 +196,11 @@ export async function cachedSearchClimbs(
     );
   }
 
-  const revalidate = isDefaultSearch ? CACHE_DURATION_DEFAULT_SEARCH : CACHE_DURATION_FILTERED_SEARCH;
+  const revalidate = isMoonboard
+    ? CACHE_DURATION_MOONBOARD_FRONT_DOOR
+    : isDefaultSearch
+      ? CACHE_DURATION_DEFAULT_SEARCH
+      : CACHE_DURATION_FILTERED_SEARCH;
   return _getCachedFn(params.board_name, revalidate)(
     params.board_name,
     params.layout_id,

--- a/packages/web/app/lib/db/queries/climbs/search-climbs.ts
+++ b/packages/web/app/lib/db/queries/climbs/search-climbs.ts
@@ -196,6 +196,9 @@ export async function cachedSearchClimbs(
     );
   }
 
+  // Keyed on the board, not on `explicitlyCacheable`: the front door is the only
+  // cacheable MoonBoard caller today, and if a second one appears it inherits
+  // the *shorter* TTL — erring toward import freshness rather than away from it.
   const revalidate = isMoonboard
     ? CACHE_DURATION_MOONBOARD_FRONT_DOOR
     : isDefaultSearch

--- a/packages/web/app/lib/db/read-deadline.ts
+++ b/packages/web/app/lib/db/read-deadline.ts
@@ -7,6 +7,9 @@
  * only Vitest project in this repo with a live Postgres — exercise it.
  */
 
+/** The deadline when `DB_READ_DEADLINE_MS` is unset or unparseable. */
+export const DEFAULT_READ_DEADLINE_MS = 6000;
+
 /**
  * Wall-clock ceiling for one front-door read: queue wait + connect + execute.
  *
@@ -14,16 +17,26 @@
  * docs/db-connectivity.md). On a brownout we want the front door to shed load,
  * not to spend a second and third connect attempt holding a pool slot while a
  * crawler waits. It is also far inside Vercel's function limit and inside
- * Googlebot's patience, and every front-door URL carries a CDN
- * `stale-while-revalidate` window, so a shed request is usually invisible.
+ * Googlebot's patience.
+ *
+ * It does NOT hide behind the CDN. `stale-while-revalidate` only cushions a URL
+ * whose `age` is already past `s-maxage` — climb views are covered for age 1 h
+ * to 7 h, lists for 24 h to 7 d — and Vercel supports no `stale-if-error`
+ * (https://vercel.com/docs/caching/cdn-cache). A cold-MISS crawl of a long-tail
+ * sitemap URL therefore sees the 500 directly. That is still the right answer:
+ * 5xx is not a cacheable status on Vercel, so it is never pinned, where the 404
+ * this replaces *is* cacheable and could stick for a full `s-maxage`.
  */
-export const FRONT_DOOR_READ_DEADLINE_MS = readDeadlineMs();
+export const FRONT_DOOR_READ_DEADLINE_MS = parseReadDeadlineMs(process.env.DB_READ_DEADLINE_MS);
 
-function readDeadlineMs(): number {
-  const raw = process.env.DB_READ_DEADLINE_MS;
-  if (!raw) return 6000;
+/**
+ * Exported for its own test: the constant above is captured at module load, so
+ * the parse branches are unreachable from a test that only reads it.
+ */
+export function parseReadDeadlineMs(raw: string | undefined): number {
+  if (!raw) return DEFAULT_READ_DEADLINE_MS;
   const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 6000;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_READ_DEADLINE_MS;
 }
 
 export class DbReadTimeoutError extends Error {
@@ -88,15 +101,27 @@ export async function withReadDeadline<T>(
   }
 }
 
+/**
+ * What `.cancel()` actually costs, because the two regimes differ and only one
+ * of them is free:
+ *
+ * - **Still queued** — the saturated-pool case this deadline exists for.
+ *   `postgres/src/index.js:350` removes the query from the queue and rejects it
+ *   locally (`57014`). No connection is opened. The rejection is already handled
+ *   because `settled` above attached to `pending` before the race.
+ * - **Already executing on the server.** postgres.js opens a *brand new*
+ *   connection to send the cancel request. During a brownout that connect can
+ *   itself fail, and postgres.js keeps the promise for it internally —
+ *   `Query.cancel()` returns `null` (a comma expression ending in an
+ *   assignment, `postgres/src/query.js:52`), so there is nothing to attach a
+ *   handler to from out here. Such a failure surfaces as an unhandled rejection
+ *   that Next's process-level handler logs. Accepted: leaving a zombie
+ *   statement to fire against a recovered pool is worse than one log line.
+ */
 function cancelQuietly(pending: Cancellable): void {
   if (typeof pending.cancel !== 'function') return;
   try {
-    // Typed `void`, but postgres.js hands back a promise when the query already
-    // reached the server, so swallow its rejection too.
-    const cancelled: unknown = pending.cancel();
-    if (cancelled && typeof (cancelled as PromiseLike<unknown>).then === 'function') {
-      void Promise.resolve(cancelled).catch(() => {});
-    }
+    pending.cancel();
   } catch {
     // Cancelling is best effort; a failure here must not mask the deadline.
   }

--- a/packages/web/app/lib/db/read-deadline.ts
+++ b/packages/web/app/lib/db/read-deadline.ts
@@ -11,7 +11,9 @@
 export const DEFAULT_READ_DEADLINE_MS = 6000;
 
 /**
- * Wall-clock ceiling for one front-door read: queue wait + connect + execute.
+ * Wall-clock ceiling for one front-door *request's* reads — queue wait +
+ * connect + execute, shared across them by `request-read-budget.ts`. A caller
+ * that passes no explicit `ms` gets the whole thing for a single read.
  *
  * 6 s is deliberately *below* `DB_CONNECT_RETRY_BUDGET_MS` (10 s, see
  * docs/db-connectivity.md). On a brownout we want the front door to shed load,

--- a/packages/web/app/lib/db/read-deadline.ts
+++ b/packages/web/app/lib/db/read-deadline.ts
@@ -1,0 +1,103 @@
+/**
+ * No `server-only` marker, deliberately: this file is a timer race with no
+ * database handle, no secrets and no server-side data, and the modules that DO
+ * hold a pool (`app/lib/data/queries.ts`, `app/lib/db/queries/climbs/…`) carry
+ * the marker themselves. Keeping it importable is what lets the bounded-wait
+ * oracle in `packages/backend/src/__tests__/db-pool-exhaustion.test.ts` — the
+ * only Vitest project in this repo with a live Postgres — exercise it.
+ */
+
+/**
+ * Wall-clock ceiling for one front-door read: queue wait + connect + execute.
+ *
+ * 6 s is deliberately *below* `DB_CONNECT_RETRY_BUDGET_MS` (10 s, see
+ * docs/db-connectivity.md). On a brownout we want the front door to shed load,
+ * not to spend a second and third connect attempt holding a pool slot while a
+ * crawler waits. It is also far inside Vercel's function limit and inside
+ * Googlebot's patience, and every front-door URL carries a CDN
+ * `stale-while-revalidate` window, so a shed request is usually invisible.
+ */
+export const FRONT_DOOR_READ_DEADLINE_MS = readDeadlineMs();
+
+function readDeadlineMs(): number {
+  const raw = process.env.DB_READ_DEADLINE_MS;
+  if (!raw) return 6000;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 6000;
+}
+
+export class DbReadTimeoutError extends Error {
+  readonly code = 'DB_READ_TIMEOUT';
+
+  constructor(label: string, ms: number) {
+    super(`[db] front-door read "${label}" exceeded ${ms}ms`);
+    this.name = 'DbReadTimeoutError';
+  }
+}
+
+/** postgres.js `PendingQuery` shape we care about; a plain Promise satisfies it too. */
+type Cancellable = { cancel?: () => unknown };
+
+/**
+ * Bounds one read client-side.
+ *
+ * postgres.js has no acquire timeout and its internal queue is unbounded and
+ * untimed (`postgres/src/index.js:341`), so a saturated pool turns a cheap
+ * statement into an unbounded wait — which is what makes a crawl burst look
+ * like a hang rather than an error. This races the pending read against a
+ * timer and rejects with `DbReadTimeoutError` when the timer wins.
+ *
+ * When the pending value is a postgres.js query it is also `.cancel()`ed, the
+ * same way `packages/backend/src/services/db-health.ts` does, so a timed-out
+ * statement does not become a zombie that fires when the pool recovers.
+ * drizzle-issued queries expose no `.cancel()`, so for those this is a deadline
+ * without cancellation — the caller still fails fast, the statement still
+ * completes in the background.
+ */
+export async function withReadDeadline<T>(
+  label: string,
+  pending: PromiseLike<T> & Cancellable,
+  ms: number = FRONT_DOOR_READ_DEADLINE_MS,
+): Promise<T> {
+  // Settle inside the race so cancelling below can never surface as an
+  // unhandled rejection.
+  const settled = pending.then(
+    (value) => ({ ok: true as const, value }),
+    (error: unknown) => ({ ok: false as const, error }),
+  );
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), ms);
+    timer.unref?.();
+  });
+
+  try {
+    const outcome = await Promise.race([settled, deadline]);
+
+    if (outcome === 'timeout') {
+      cancelQuietly(pending);
+      throw new DbReadTimeoutError(label, ms);
+    }
+    if (!outcome.ok) {
+      throw outcome.error;
+    }
+    return outcome.value;
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function cancelQuietly(pending: Cancellable): void {
+  if (typeof pending.cancel !== 'function') return;
+  try {
+    // Typed `void`, but postgres.js hands back a promise when the query already
+    // reached the server, so swallow its rejection too.
+    const cancelled: unknown = pending.cancel();
+    if (cancelled && typeof (cancelled as PromiseLike<unknown>).then === 'function') {
+      void Promise.resolve(cancelled).catch(() => {});
+    }
+  } catch {
+    // Cancelling is best effort; a failure here must not mask the deadline.
+  }
+}

--- a/packages/web/app/lib/db/request-read-budget.ts
+++ b/packages/web/app/lib/db/request-read-budget.ts
@@ -5,6 +5,10 @@ import { FRONT_DOOR_READ_DEADLINE_MS } from '@/app/lib/db/read-deadline';
  * A read that gets less than this is not worth issuing, and a floor keeps an
  * exhausted budget from turning into a 0 ms deadline that can beat an already
  * resolved promise on a busy event loop.
+ *
+ * The cost of the floor, stated plainly: a request whose budget is already spent
+ * can still overrun it by up to this much per remaining read, so the climb
+ * page's worst case is ~6 s + 2 × 500 ms rather than exactly 6 s.
  */
 export const MIN_REMAINING_READ_BUDGET_MS = 500;
 

--- a/packages/web/app/lib/db/request-read-budget.ts
+++ b/packages/web/app/lib/db/request-read-budget.ts
@@ -1,0 +1,42 @@
+import { cache } from 'react';
+import { FRONT_DOOR_READ_DEADLINE_MS } from '@/app/lib/db/read-deadline';
+
+/**
+ * A read that gets less than this is not worth issuing, and a floor keeps an
+ * exhausted budget from turning into a 0 ms deadline that can beat an already
+ * resolved promise on a busy event loop.
+ */
+export const MIN_REMAINING_READ_BUDGET_MS = 500;
+
+export type ReadBudget = { deadlineAt: number };
+
+/**
+ * One deadline per server request, not per statement.
+ *
+ * The climb front door issues three reads in sequence — alias, climb select,
+ * then the angle table — so a per-statement ceiling of 6 s is really a ~18 s
+ * request. Every one of those seconds is spent holding a pool slot on a
+ * database that is by construction already saturated, which is the opposite of
+ * shedding load. React's `cache` scopes this object to the render, so the three
+ * reads share one budget and the request as a whole is bounded.
+ *
+ * Outside a render scope — scripts, unit tests — React's `cache` is a
+ * passthrough, so each call starts a fresh budget and the behaviour degrades to
+ * the per-statement deadline. That is the pre-existing behaviour, not a
+ * regression, and no server request goes down that path.
+ */
+export const currentReadBudget = cache(
+  (): ReadBudget => ({
+    deadlineAt: Date.now() + FRONT_DOOR_READ_DEADLINE_MS,
+  }),
+);
+
+/** How much of the request's budget is left, floored. Pure, so it is testable. */
+export function remainingBudgetMs(budget: ReadBudget, now: number = Date.now()): number {
+  return Math.max(MIN_REMAINING_READ_BUDGET_MS, budget.deadlineAt - now);
+}
+
+/** The remaining budget for the current request. */
+export function remainingReadBudgetMs(): number {
+  return remainingBudgetMs(currentReadBudget());
+}

--- a/packages/web/app/lib/graphql/__tests__/server-cached-client-timeout.test.ts
+++ b/packages/web/app/lib/graphql/__tests__/server-cached-client-timeout.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * Both halves of the backend-call deadline: that the signal reaches the client
+ * and aborts on time, and that the climb front door's two sections actually ask
+ * for one. Without this the mechanism could be deleted outright — a wedged
+ * backend would go back to hanging the climb page inside its `Promise.all` — and
+ * nothing would go red.
+ */
+const { constructorOptions, backend } = vi.hoisted(() => ({
+  constructorOptions: [] as ({ signal?: AbortSignal } | undefined)[],
+  /** `wedged` never answers; flip it to model a healthy backend. */
+  backend: { wedged: true },
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('graphql-request', () => ({
+  GraphQLClient: class {
+    constructor(
+      public url: string,
+      options?: { signal?: AbortSignal },
+    ) {
+      constructorOptions.push(options);
+    }
+    request<T>(): Promise<T> {
+      // A wedged backend: the socket is open and nothing ever comes back.
+      return backend.wedged ? new Promise<T>(() => {}) : (Promise.resolve({}) as Promise<T>);
+    }
+  },
+}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache:
+    <T extends (...args: unknown[]) => unknown>(fn: T) =>
+    (...args: Parameters<T>) =>
+      fn(...args),
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({ getGraphQLHttpUrl: () => 'http://backend.test/graphql' }));
+vi.mock('../server-graphql', () => ({
+  executeAuthenticatedGraphQL: vi.fn(),
+  serverMyBoards: vi.fn(),
+  serverUserPlaylists: vi.fn(),
+  serverGroupedNotifications: vi.fn(),
+  serverPlaylist: vi.fn(),
+  serverPlaylistClimbs: vi.fn(),
+}));
+
+import { createCachedGraphQLQuery } from '../server-cached-client';
+
+describe('createCachedGraphQLQuery timeout', () => {
+  beforeEach(() => {
+    constructorOptions.length = 0;
+    backend.wedged = true;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('aborts the request once the timeout elapses', async () => {
+    const query = createCachedGraphQLQuery('query Q { x }', 'similar-climbs', 3600, 3000);
+    void query();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const signal = constructorOptions[0]?.signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it('passes no signal when no timeout is asked for', async () => {
+    const query = createCachedGraphQLQuery('query Q { x }', 'session-grouped-feed-public', 86400);
+    void query();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(constructorOptions[0]?.signal).toBeUndefined();
+    // And no stray timer keeps a serverless instance alive past its response.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('clears the timer when the backend answers in time', async () => {
+    backend.wedged = false;
+
+    const query = createCachedGraphQLQuery('query Q { x }', 'beta-links-x', 3600, 3000);
+    await query();
+
+    // A leaked timer per backend call keeps a serverless instance alive for
+    // three seconds past its response.
+    expect(vi.getTimerCount()).toBe(0);
+    expect(constructorOptions[0]?.signal?.aborted).toBe(false);
+  });
+});

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -66,15 +66,30 @@ function createCacheKeyFromVariables(variables: Variables | undefined): string[]
  * @param variables - Query variables
  * @param cacheTag - Tag for cache invalidation (e.g., 'climb-search')
  * @param revalidate - Cache duration in seconds
+ * @param timeoutMs - Optional wall-clock ceiling. Without one a wedged backend
+ *   hangs the caller indefinitely; `graphql-request` honours the signal, so the
+ *   call rejects with an abort error the caller can degrade on.
  */
 export function createCachedGraphQLQuery<T = unknown, V extends Variables = Variables>(
   document: RequestDocument,
   cacheTag: string,
   revalidate: number,
+  timeoutMs?: number,
 ) {
   return async (variables?: V): Promise<T> => {
     const cachedFn = unstable_cache(
-      async () => executeGraphQLInternal<T, V>(document, variables),
+      async () => {
+        if (!timeoutMs) {
+          return executeGraphQLInternal<T, V>(document, variables);
+        }
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+          return await executeGraphQLInternal<T, V>(document, variables, controller.signal);
+        } finally {
+          clearTimeout(timer);
+        }
+      },
       ['graphql', cacheTag, ...createCacheKeyFromVariables(variables)],
       {
         revalidate,

--- a/packages/web/app/lib/seo/list-page-robots.ts
+++ b/packages/web/app/lib/seo/list-page-robots.ts
@@ -35,8 +35,10 @@ export const FRONT_DOOR_PAGE_SIZE = 50;
  * That gating is the load-bearing half: `noindex, follow` on page 11 is an
  * explicit instruction to keep walking, so a `next` chain that ran past the cap
  * would invite crawlers down a corridor whose per-request `OFFSET` grows without
- * limit (and on MoonBoard, `cachedSearchClimbs` bypasses the server cache, so
- * every hop would be an uncached origin query).
+ * limit. (MoonBoard front doors used to compound that by bypassing the server
+ * cache entirely; they now cache for 15 minutes like every other board — see
+ * `CACHE_DURATION_MOONBOARD_FRONT_DOOR` — so the cap is about `OFFSET` growth
+ * alone.)
  */
 export const FRONT_DOOR_MAX_INDEXABLE_PAGE = 10;
 

--- a/packages/web/app/lib/warm-overlay-cache.ts
+++ b/packages/web/app/lib/warm-overlay-cache.ts
@@ -4,6 +4,19 @@ import type { BoardDetails, Climb } from '@/app/lib/types';
 
 const BASE_URL = process.env.VERCEL_URL ? SITE_URL : 'http://localhost:3000';
 
+/**
+ * How many list rows the `/list` front door warms per SSR render.
+ *
+ * Each warm target is a same-origin `/api/internal/board-render` call — a
+ * CPU-bound WASM render in the same runtime — so the default 20 turned one
+ * crawled list page into 20 extra invocations competing with the request that
+ * spawned them. Six is roughly what a reader sees before scrolling.
+ */
+export const FRONT_DOOR_WARM_LIMIT = 6;
+
+/** Ceiling on a single warm fetch. A never-settling one keeps the instance (and its pool slots) alive. */
+const WARM_FETCH_TIMEOUT_MS = 5000;
+
 type WarmOverlaysOptions = {
   boardDetails: BoardDetails;
   climbs: Pick<Climb, 'frames'>[];
@@ -55,7 +68,7 @@ export async function warmOverlays(options: WarmOverlaysOptions): Promise<void> 
 
     await Promise.allSettled(
       warmTargets.map((url) =>
-        fetch(url)
+        fetch(url, { signal: AbortSignal.timeout(WARM_FETCH_TIMEOUT_MS) })
           .then((response) => response.body?.cancel())
           .catch(() => {}),
       ),

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -18,14 +18,21 @@ export default defineConfig({
   retries: 1,
   /* 1 in CI, deliberately. The suite already fans out as 8 shard jobs, each
    * with its own server + database, so cross-shard parallelism carries the
-   * wall-clock. A second in-shard worker makes front-door page loads (SSR
-   * with direct Postgres reads) compete for the web server's DB pool against
-   * the raw-request specs, and on the 2-core runner's postgres that queue can
-   * exceed any sane request timeout. Which files share a shard reshuffles
-   * whenever specs are added or removed, so the resulting flake jumps between
-   * unrelated files instead of staying put. (Diagnosed on #4448: the embed
-   * header checks hung >60s whenever they shared shard 7 with the rewritten
-   * tab-bar spec's front-door loads.) */
+   * wall-clock. A second in-shard worker makes front-door page loads compete
+   * with the raw-request specs on a 2-core runner; the observed symptom was the
+   * embed header checks hanging >60s whenever they shared shard 7 with the
+   * rewritten tab-bar spec's front-door loads (#4448).
+   *
+   * Attribution corrected in #4461: this is NOT web DB-pool contention, as this
+   * comment used to claim. `/embed/**` issues zero web-side Postgres statements
+   * — it fetches the backend over HTTP (`embed-fetchers.ts`), so it cannot
+   * queue behind the web pool. The likelier mechanism is the event loop: a
+   * `/list` SSR render fires same-origin `/api/internal/board-render` warm
+   * requests, each a CPU-bound WASM render in the same runtime, and unrelated
+   * raw requests queue behind those. #4461 capped that fan-out; whether it is
+   * enough to restore 2 workers is #4463's call, not a change to make here.
+   * Which files share a shard reshuffles whenever specs are added or removed,
+   * so the flake jumps between unrelated files instead of staying put. */
   workers: process.env.CI ? 1 : undefined,
   /* Global per-test timeout — some tests (zoom, login flows) need more than Playwright's 30 s default */
   timeout: 60_000,


### PR DESCRIPTION
## Summary

Closes #4461. Part of #4358 (W-tier-4 tail). Lands **before or with** W-23 (#4436), which submits the climb sitemaps.

The front doors (`/…/view/{climb_uuid}` and `/…/list`, both trees) SSR with direct Postgres reads, and postgres.js has **no acquire timeout** — its internal queue is unbounded and untimed (`postgres/src/index.js:341`). A statement that cannot get a connection waits forever. This PR bounds that wait, gives the deployment knobs to shrink its connection footprint, and — the highest-value part — fixes what those pages emit when the read fails.

### First: the issue's stated mechanism is wrong, and the fix does not depend on it

The issue attributes the CI hang to "the embed pages' single-row lookups queueing behind front-door SSR for the web PG pool". That cannot be it: **`/embed/**` issues zero web-side Postgres statements**. `app/components/kiosk/embed/embed-fetchers.ts:47-56` fetches the backend over HTTP, and there is no `sql` / `dbz` / `getReadDb` import anywhere under `app/embed/` or `app/components/kiosk/embed/`.

The likelier mechanism is the event loop, not the pool: a `/list` SSR render fired up to **20 same-origin `/api/internal/board-render` warm requests**, each a CPU-bound WASM render in the same runtime. Unrelated raw requests queue behind those. That is why the fan-out cap below is in this PR.

`workers: 1` in `playwright.config.ts` is **unchanged** — flipping it back is #4463's call. The misattributing comment there is corrected so the next reader is not misled.

### Also refuted before implementation: the locale CDN scare

The plan's largest claimed amplifier was that the sticky-locale `Set-Cookie` in `middleware.ts` makes the 75% of the crawl surface that is locale-prefixed CDN-uncacheable. **Measured against production 2026-08-15: it does not.** A cold German list front door went MISS → HIT → HIT; a warm French climb view was HIT at `age: 899`; the Spanish list went MISS → HIT within seconds **with `set-cookie: boardsesh-locale=es` present on both**. Locale front doors are CDN-cached, the cookie is benign here (its value matches the URL's own locale), and `middleware.ts` is untouched by this PR.

### What changed

**1. Fail-loud status semantics — the SEO fix.** Today a DB brownout emits a **404** on an indexed climb URL and a **200 with an empty list** on an indexed list URL. At sitemap scale the first is an instruction to deindex and the second is worse: Google reads it as legitimate thin content.

- `fetchClimbFromDb` resolves `null` for a genuinely missing row instead of dereferencing an undefined one.
- `notFound()` now fires only for a genuinely missing climb (it was dead code — the undefined-row throw reached the catch first).
- The catch in both view pages rethrows everything. Next's error boundary turns that into a 500.
- `fetchFrontDoorListPage` rethrows instead of degrading to `{ climbs: [], hasMore: false }`.
- `resolveBoardBySlug` — the **first** read on every `/b/{slug}/…` request, and the one the QA round caught still swallowing failures — now returns `null` only for a clean 200 with no such board. A rejected fetch, a non-2xx, or a 200 carrying GraphQL `errors` throws.

| condition | before | after |
|---|---|---|
| climb row absent | 404 | 404 — unchanged, now for the right reason |
| board slug resolves cleanly to nothing | 404 | 404 — unchanged |
| read fails/deadlines, climb page | hung to the platform limit, then 404 | 500 at ~6 s per request |
| read fails/deadlines, list page | 200 with zero climbs | 500 at ~6 s |
| backend `boardBySlug` fails, `/b/…` | 404 | 500 |
| backend GraphQL wedged | climb page hung indefinitely | similar climbs / beta links render empty at 3 s |

**500 rather than a literal 503 + `Retry-After` is deliberate**, not an oversight: an App Router page cannot emit one without a middleware round trip, and the property that matters — Google retries a 5xx and keeps the URL — holds for both.

**The CDN does not hide the 500, and that is fine.** `stale-while-revalidate` only cushions a URL whose `age` has already passed `s-maxage`: climb views are covered for age 1 h–7 h, lists for 24 h–7 d, and Vercel supports [no `stale-if-error`](https://vercel.com/docs/caching/cdn-cache). A cold-MISS crawl of a long-tail sitemap URL sees the 500 directly. The asymmetry that matters is what happens next: 5xx is **not** a cacheable status on Vercel, so it is never pinned, while the 404 this replaces **is** — one blip used to stick a 404 in the CDN for a full `s-maxage` (24 h on a list front door).

**2. A read deadline** (`app/lib/db/read-deadline.ts`). Races the pending read against a timer and rejects with `DbReadTimeoutError` (`code: 'DB_READ_TIMEOUT'`). Default 6000 ms, `DB_READ_DEADLINE_MS`-overridable — deliberately below `DB_CONNECT_RETRY_BUDGET_MS` (10 s), because during a brownout the front door should shed rather than spend a second and third connect attempt holding a slot.

Wired at four call sites only: the alias lookup, the climb select, the all-angles stats select, and the shared climb search. **Not** inside `withConnectRetry` or `packages/db` — that would change behaviour for the backend, the sync runners and every script, and would miss the raw-`sql` path `getClimb` uses anyway.

**The budget is per request, not per statement** (`app/lib/db/request-read-budget.ts`). The climb page issues three reads in sequence, so three independent 6 s deadlines would have been an ~18 s request ceiling — the opposite of shedding load, and it would have broken the comparison against the 10 s connect-retry budget that justifies 6000 in the first place. One deadline timestamp lives in React's per-render `cache` scope and each read gets what the earlier ones left, floored at 500 ms.

**Cancellation covers three of the four.** On a timeout the helper calls `query.cancel()` the way `db-health.ts` does, so a timed-out statement does not fire later against a recovered pool. The list search is drizzle-issued and exposes no `.cancel()`, so there the deadline sheds the caller while the statement runs on holding its connection — stated in the code, in `docs/db-connectivity.md`, and here, because the first draft of this PR claimed cancellation unconditionally.

**3. Backend-call deadlines.** `createCachedGraphQLQuery` takes an optional `timeoutMs`; the two front-door GraphQL reads pass 3000. Both already degrade to an empty section, so a timeout never 500s the page.

**4. Per-deployment pool knobs.** `DB_POOL_MAX` (default 10, clamped to a floor of 2) and `DB_POOL_IDLE_TIMEOUT_S` (default 30, **no** floor — postgres.js reads a falsy `idle_timeout` as "never close an idle connection", so clamping 0 up to 1 would invert the operator's request into a teardown every second). **Defaults unchanged, so backend, sync and scripts behave identically.** They exist because peak server-side connections scale with instance count × connections held *idle*, not with per-instance `max`.

**5. `DB_STATEMENT_TIMEOUT_MS` — env-gated, ships off.** PgBouncer in transaction pooling rejects startup parameters outside `ignore_startup_parameters`, and `statement_timeout` is not among the defaults, so enabling it against a pooled URL would fail *every connection*. `docs/db-connectivity.md` documents both paths (env var for a direct URL, `ALTER ROLE … SET statement_timeout` for a pooled one). Neither is enabled here.

**6. Stop paying for the crawl path.**
- MoonBoard `/list` front doors were **never** cached (`board_name !== 'moonboard'` overrode the caller's `cacheable: true`), so every crawled page was a live search against the largest board in the catalogue. An explicit `cacheable: true` now wins, at a 15-minute TTL that keeps the import freshness the bypass was protecting. Only `fetchFrontDoorListPage` passes it, so the blast radius is exactly the front door, and `revalidateClimbSearchTags` still clears it via the board-level tag.
- Warm fan-out capped at 6 rows per list render (was 20).
- Each warm fetch carries `AbortSignal.timeout(5000)` — one that never settles keeps a serverless instance, and the pool slots it holds, alive past its response.

**7. Two free wins on the climb page.** `getClimb` / `getClimbStatsForAllAngles` are React-`cache()`d on primitives, so `generateMetadata` and the page body share one read instead of both missing a cold `unstable_cache` key concurrently — 4 statements down to 2 per cold render, in both trees. The `unstable_cache` executors are now stable module-level functions taking explicit primitive arguments (the pattern `search-climbs.ts` documents) rather than a fresh closure per request. The `unstable_cache` *instance* still has to be built per call because its `tags` carry the climb uuid; a uuid-keyed registry would grow without bound on a crawl. That is commented at the call site.

**8. A missing climb is not negatively cached.** Returning `null` from *inside* `unstable_cache` would store it for the full hour, so a climb a crawler reached minutes before its import landed would keep 404-ing until the entry expired. The executor throws a private not-found error instead — `unstable_cache` never stores a rejection — and the caller translates it back to `null`.

**9. Dead code removed.** `fetchListPageData` has had no caller since the climbing UI moved to Expo in W-16, and it still carried both anti-patterns this PR removes: degrade-to-empty on a read failure, and the uncapped 20-image warm fan-out.

### What the QA round changed

Three adversarial lenses (SEO/status, concurrency, test strength) reviewed the first draft and filed 22 findings. Everything real is fixed in this PR:

| finding | fix |
|---|---|
| `/b` tree still 404s a backend failure (`resolveBoardBySlug` swallowed everything into `null`) | fail-loud, item 1 above, + three transport-level tests and a page-level one |
| The 6 s ceiling was per *statement* — the climb page's real worst case was ~16 s, measured | per-request budget, item 2 |
| Deleting the digest early-rethrow made every routine 404 and 308 log at error level | the digest check is back as a **logging** guard; the rethrow stays unconditional |
| A missing row became negatively cached for an hour | item 8 |
| `DB_POOL_IDLE_TIMEOUT_S=0` was clamped to 1, inverting "never close" into "close every second" | no floor on the idle knob, item 4 |
| `cancelQuietly`'s promise-swallow branch was dead code (`Query.cancel()` returns `null`) | removed, and the real cost is documented: a **queued** cancel is free, an **executing** one opens a fresh connection whose failure the runtime logs |
| "a shed request is usually invisible behind the CDN" | false, and replaced with the actual window everywhere it appeared |
| `fetchListPageData` dead code, stale comments in `list-page-robots.ts` and the `/list` `generateMetadata` catch | deleted / corrected |
| Six inert or missing guards (see the test plan) | six new/rewritten tests, each mutation-probed |

### Deliberately out of scope

No front-door refactor. No web `/health/db` (a real observability gap — during a web-pool incident the backend's `/health/db` stays green and tells you nothing — but a separate change). No touching `withConnectRetry`, the backend pool or the sync-runner pools. No batching the alias lookup into the climb select. No `middleware.ts` change.

### Sizing note for #4436

`MAX_ITEMS_PER_SHARD` is 11,250 (`sitemap-xml.ts:14`) and W-22 fans every item out ×4 locales. 128,655 tier-2 climbs is **514,620 `<url>` entries → ~12 shards**, not the 3 in the epic body.

## Asks for @marcodejongh

Four production facts I cannot see from the repo. **None of them block this PR** — every default is unchanged, so the change is safe without the answers — but each one sharpens the numbers:

| # | question | how to answer |
|---|---|---|
| 1 | Railway `max_connections` | `psql "$DB_URL" -c 'show max_connections;'`, or Railway → Postgres → Variables |
| 2 | Is `READ_REPLICA_URL` set on the Vercel project? | Vercel → Settings → Environment Variables. If set, every instance opens **two** pools |
| 3 | Is Vercel's `DATABASE_URL` pooled (PgBouncer) or direct? | `psql "$DATABASE_URL" -c 'show pool_mode;'` — a direct Postgres errors, PgBouncer answers. Decides whether `DB_STATEMENT_TIMEOUT_MS` is usable at all |
| 4 | Is Fluid compute enabled? | Vercel → Settings → Functions. Decides whether one instance can ever reach `max` |

And a request, not a claim: setting **`DB_POOL_MAX=4`** and **`DB_POOL_IDLE_TIMEOUT_S=10`** on the Vercel project only. A front-door render needs at most 3 concurrent statements and the list page needs 1, so 4 leaves headroom without letting an instance claim 10 slots it will never use in parallel; dropping the idle hold 30 → 10 s cuts a bursting fleet's steady-state footprint roughly threefold. Those are **not set by this PR**.

## Test plan

Every guard below was mutation-probed: the mutation is named, it went red, and the file was restored.

- **`db-pool-exhaustion.test.ts` (backend, live Postgres) — the real oracle.** Six concurrent `pg_sleep(30)` through a `max: 2` pool with a 1500 ms deadline: everything settles inside 3 s (a serial drain would take three 30 s rounds), all six reject with `DB_READ_TIMEOUT`, and `pg_stat_activity` shows the cancelled statements gone. *Probe: break the `Promise.race` → the test times out.* It reaches across to `packages/web` for the helper because that is where #4461 rules the helper must live, and the backend project is the only Vitest project here with a live database; the specifier is computed so `tsc --rootDir src` never type-links across the boundary.
- **`read-deadline.test.ts`** — fake timers: rejects at the deadline, `.cancel()` called exactly once, not called on the success or the error path, `vi.getTimerCount() === 0` after both. Plus `parseReadDeadlineMs`, which the constant cannot exercise because it is captured at module load: unset → 6000, `'8000'` → 8000, `'0'` / `'-1'` / `'abc'` → 6000. *Probe: make a valid override fall through to the default → 3 fail.*
- **`read-deadline-wiring.test.ts` (new) — the caller-side half.** The helper being correct proved nothing about the front door using it: the whole web suite stayed green with `withReadDeadline` neutralised at all four sites. This asserts the labels `climb-alias`, `climb-select`, `climb-stats-all-angles`, `climb-search` are actually raised, and that every climb-page read gets a budget inside the ceiling. *Probe: unwrap the all-angles read → red.*
- **`climb-request-dedupe.test.ts` (new)** — substitutes a real memo for React's `cache` (the client build vitest resolves is a passthrough) and pins the two properties that ride the render scope: two calls with equal primitives from *different* params objects cost 2 statements not 4, a full page pass costs 3, a different uuid still costs 4, and the three reads receive `[6000, 5000, 4000]` from one shared budget. *Probes: drop the `cache()` wrapper → red; give each read the full deadline again → red.*
- **`climb-missing-not-cached.test.ts` (new)** — a memoising `unstable_cache` that stores resolved values and nothing for a rejection, i.e. the real semantics: a missing climb re-reads on the next request and recovers the moment the row lands, while a climb that exists is still cached. *Probe: return `null` from inside the cache again → red.*
- **`read-failure-status.test.tsx` × 2 (both trees)** — the mass-deindexing guard. `null` → `notFound()`; `DbReadTimeoutError` and a generic error → the page throws and `notFound` is **not** called; a failed `resolveBoardBySlug` throws rather than 404s; and a 404 does **not** write to `console.error`. *Probes: restore the trailing `notFound()` → 4 of 6 fail; drop the digest logging guard → red.*
- **`board-slug-utils.test.ts`** — a rejecting fetch, a 502, and a 200 carrying `errors` all throw; a clean 200 with `boardBySlug: null` still resolves `null`, and the existing auth/cache-split cases are unchanged. *Probe: swallow failures into `null` again → 3 fail.*
- **`front-door-fanout.test.ts`** — the statement budget: `getClimb` costs exactly 2 and they are strictly sequential (max in flight 1), the stats select costs 1. The old "a full pass costs 3" case was dropped: it was arithmetic on the other two and could not tell a deduped page pass from an un-deduped one. That assertion now lives in the dedupe test, where it can.
- **`search-climbs-moonboard-cache.test.ts`** — a *memoising* `unstable_cache` recorder that now also captures the options object: an explicitly-cacheable MoonBoard search executes once **at `revalidate: 900`**; the Kilter control keeps 86400; without the flag, opted out, personalised, or `sortBy: 'random'` it executes twice. *Probes: revert the `explicitlyCacheable` clause → red; raise the MoonBoard TTL to 24 h → red (it was inert before).*
- **`server-cached-client-timeout.test.ts` (new)** — the backend deadline had no coverage at all: deleting it left all 3426 web tests green. A fake `GraphQLClient` captures the constructor options; with `timeoutMs` the signal aborts at the deadline, without it no signal and no timer is created, and a timely answer clears the timer. *Probe: stop passing the signal → red.*
- **`front-door-data-timeout.test.ts` (new)** — the caller-side half: both front-door queries construct theirs with 3000. *Probe: drop the argument at both sites → red.*
- **Warm fan-out, both halves** — the unit assertion (6 fetches from 50 climbs, each carrying a signal) **and** the caller-side assertion that `maxImages: FRONT_DOOR_WARM_LIMIT` was actually passed. *Probe: drop `maxImages` at the call site → the caller half fails while the unit half stays green.*
- **Pool knobs, now in a project CI runs.** `packages/db` is not a Vitest project and the only db test CI invokes is the migration-journal one, so the knob assertions were inert in CI. They are mirrored into `shutdown.unit.test.ts` (backend project, every PR): defaults 10/30, honours both env vars, clamps `DB_POOL_MAX=1` to 2, falls back on `abc`, `DB_POOL_IDLE_TIMEOUT_S=0` stays 0, and `statement_timeout` is emitted only when asked. All read the resolved options off the constructed client, never the source text. *Probe: clamp the idle knob to a floor of 1 → red.* That file's old assertion grepped `postgres.ts` for the literal `idle_timeout: 30`, which would have gone green-but-meaningless once the value came from env — rewriting it is part of this change, not scope creep.

Gates run:

| command | result |
|---|---|
| `vp check` | formatting clean; 33 repo-wide lint errors, all in `scripts/**` files this diff does not touch (`main` itself reports 36) |
| `vp run typecheck` | green (full graph, `build:web` included) |
| `vp test run --project web` | **315 files, 3454 tests, all pass** |
| `vp test run --project backend` | **257 files, 3542 tests, all pass** (includes the live-Postgres oracle) |
| `vp run test:db` (node:test) | 425 pass / 3 fail — the 3 are the pre-existing `createClimbFilters` zone-mode and MoonBoard hold-search failures, unchanged by this diff; the pool-knob file itself is 14/14 |

`vp run test:e2e` not run: this PR changes no rendered copy. `check:i18n` not applicable — no user-facing strings added (the 500 path uses the existing `error.tsx`).

One correction to the first commit message on this branch: it says the deadline "cancel()s the pending query" without the drizzle carve-out. The code, the docs and this body all state it accurately; the commit message is left as-is rather than force-pushing a rebase over green CI.

## Release Notes

- Climb and board pages now stay up when the database is slow, and stop turning a bad moment into a "page not found".
- MoonBoard board pages load from cache instead of running a fresh search every time.
