### PR TITLE
feat: period-over-period sends comparison on the Progress tab

### DIFF
--- a/packages/mobile/src/components/you/PeriodComparisonCard.tsx
+++ b/packages/mobile/src/components/you/PeriodComparisonCard.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import type { PeriodComparisonMode, RawPeriodComparison } from '@boardsesh/profile-stats';
@@ -27,13 +28,24 @@ function formatPercent(value: number | null): string {
  * produces a comparison for those three, mirroring every other chart card's
  * data-absent convention.
  */
-export function PeriodComparisonCard({
+export const PeriodComparisonCard = memo(function PeriodComparisonCard({
   periodComparison,
   comparisonMode,
   onComparisonModeChange,
 }: PeriodComparisonCardProps) {
   const { t } = useTranslation('profile');
   const { systemColors, brandColors } = useTheme();
+
+  // Only the label strings are locale-derived; memoizing on `t` keeps this
+  // array referentially stable across renders that don't change language, so
+  // SegmentedControl doesn't see a "new" options prop on every parent render.
+  const modeOptions = useMemo(
+    () => [
+      { key: 'trailing' as const, label: t('stats.periodComparison.trailing') },
+      { key: 'yearOverYear' as const, label: t('stats.periodComparison.yearOverYear') },
+    ],
+    [t],
+  );
 
   if (!periodComparison) return null;
 
@@ -44,11 +56,6 @@ export function PeriodComparisonCard({
   const hasComparison = previous.sends > 0;
   const deltaColor =
     sendsDelta > 0 ? brandColors.success : sendsDelta < 0 ? brandColors.error : systemColors.secondaryLabel;
-
-  const modeOptions = [
-    { key: 'trailing' as const, label: t('stats.periodComparison.trailing') },
-    { key: 'yearOverYear' as const, label: t('stats.periodComparison.yearOverYear') },
-  ];
 
   return (
     <Card style={styles.card}>
@@ -93,7 +100,7 @@ export function PeriodComparisonCard({
       </View>
     </Card>
   );
-}
+});
 
 const styles = StyleSheet.create({
   card: { marginHorizontal: spacing[4], marginTop: spacing[3] },

--- a/packages/mobile/src/components/you/PeriodComparisonCard.tsx
+++ b/packages/mobile/src/components/you/PeriodComparisonCard.tsx
@@ -15,12 +15,6 @@ type PeriodComparisonCardProps = {
   onComparisonModeChange: (mode: PeriodComparisonMode) => void;
 };
 
-function formatPercent(value: number | null): string {
-  if (value == null) return '';
-  const rounded = Math.round(value);
-  return `${rounded > 0 ? '+' : ''}${rounded}%`;
-}
-
 /**
  * Sends this period vs. the prior comparable period (trailing or
  * year-over-year, toggled by the segmented control). Returns null when the
@@ -49,13 +43,18 @@ export const PeriodComparisonCard = memo(function PeriodComparisonCard({
 
   if (!periodComparison) return null;
 
-  const { current, previous, sendsDelta, sendsPercentChange } = periodComparison;
+  const { current, previous, sendsPercentChange } = periodComparison;
   // No comparison-period history (new climber, or the comparison period
   // predates their first tick) — show a first-period message instead of a
   // divide-by-zero "+Infinity%".
   const hasComparison = previous.sends > 0;
+  // Round once and derive the chevron/color from the *displayed* number, not
+  // the raw delta — otherwise a small nonzero change (e.g. +1 out of 1000)
+  // can round to a displayed "0%" while still showing a colored up-chevron,
+  // which reads as a contradiction.
+  const roundedPercent = sendsPercentChange == null ? 0 : Math.round(sendsPercentChange);
   const deltaColor =
-    sendsDelta > 0 ? brandColors.success : sendsDelta < 0 ? brandColors.error : systemColors.secondaryLabel;
+    roundedPercent > 0 ? brandColors.success : roundedPercent < 0 ? brandColors.error : systemColors.secondaryLabel;
 
   return (
     <Card style={styles.card}>
@@ -76,11 +75,13 @@ export const PeriodComparisonCard = memo(function PeriodComparisonCard({
           {hasComparison ? (
             <>
               <View style={styles.deltaRow}>
-                {sendsDelta !== 0 && (
-                  <Icon name={sendsDelta > 0 ? 'chevron.up' : 'chevron.down'} size={14} color={deltaColor} />
+                {roundedPercent !== 0 && (
+                  <Icon name={roundedPercent > 0 ? 'chevron.up' : 'chevron.down'} size={14} color={deltaColor} />
                 )}
                 <Text variant="title2" color={deltaColor}>
-                  {formatPercent(sendsPercentChange)}
+                  {t('stats.periodComparison.percentChange', {
+                    value: `${roundedPercent > 0 ? '+' : ''}${roundedPercent}`,
+                  })}
                 </Text>
               </View>
               <Text variant="caption1" color={systemColors.secondaryLabel}>

--- a/packages/mobile/src/components/you/PeriodComparisonCard.tsx
+++ b/packages/mobile/src/components/you/PeriodComparisonCard.tsx
@@ -1,0 +1,122 @@
+import { View, StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { PeriodComparisonMode, RawPeriodComparison } from '@boardsesh/profile-stats';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Card } from '../Card';
+import { SegmentedControl } from '../SegmentedControl';
+import { spacing, borderRadius } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+type PeriodComparisonCardProps = {
+  periodComparison: RawPeriodComparison | null;
+  comparisonMode: PeriodComparisonMode;
+  onComparisonModeChange: (mode: PeriodComparisonMode) => void;
+};
+
+function formatPercent(value: number | null): string {
+  if (value == null) return '';
+  const rounded = Math.round(value);
+  return `${rounded > 0 ? '+' : ''}${rounded}%`;
+}
+
+/**
+ * Sends this period vs. the prior comparable period (trailing or
+ * year-over-year, toggled by the segmented control). Returns null when the
+ * active timeframe isn't week/month/year — `buildPeriodComparison` only
+ * produces a comparison for those three, mirroring every other chart card's
+ * data-absent convention.
+ */
+export function PeriodComparisonCard({
+  periodComparison,
+  comparisonMode,
+  onComparisonModeChange,
+}: PeriodComparisonCardProps) {
+  const { t } = useTranslation('profile');
+  const { systemColors, brandColors } = useTheme();
+
+  if (!periodComparison) return null;
+
+  const { current, previous, sendsDelta, sendsPercentChange } = periodComparison;
+  // No comparison-period history (new climber, or the comparison period
+  // predates their first tick) — show a first-period message instead of a
+  // divide-by-zero "+Infinity%".
+  const hasComparison = previous.sends > 0;
+  const deltaColor =
+    sendsDelta > 0 ? brandColors.success : sendsDelta < 0 ? brandColors.error : systemColors.secondaryLabel;
+
+  const modeOptions = [
+    { key: 'trailing' as const, label: t('stats.periodComparison.trailing') },
+    { key: 'yearOverYear' as const, label: t('stats.periodComparison.yearOverYear') },
+  ];
+
+  return (
+    <Card style={styles.card}>
+      <SegmentedControl
+        options={modeOptions}
+        selectedKey={comparisonMode}
+        onSelect={onComparisonModeChange}
+        accessibilityLabel={t('stats.periodComparison.controlLabel')}
+      />
+      <View style={styles.tiles}>
+        <View style={[styles.tile, { backgroundColor: systemColors.fill }]}>
+          <Text variant="title2">{current.sends}</Text>
+          <Text variant="caption1" color={systemColors.secondaryLabel}>
+            {t('stats.periodComparison.sends')}
+          </Text>
+        </View>
+        <View style={[styles.tile, { backgroundColor: systemColors.fill }]}>
+          {hasComparison ? (
+            <>
+              <View style={styles.deltaRow}>
+                {sendsDelta !== 0 && (
+                  <Icon name={sendsDelta > 0 ? 'chevron.up' : 'chevron.down'} size={14} color={deltaColor} />
+                )}
+                <Text variant="title2" color={deltaColor}>
+                  {formatPercent(sendsPercentChange)}
+                </Text>
+              </View>
+              <Text variant="caption1" color={systemColors.secondaryLabel}>
+                {comparisonMode === 'trailing'
+                  ? t('stats.periodComparison.vsTrailing')
+                  : t('stats.periodComparison.vsYearOverYear')}
+              </Text>
+            </>
+          ) : (
+            <Text variant="caption1" color={systemColors.tertiaryLabel} style={styles.noComparisonText}>
+              {current.sends > 0
+                ? t('stats.periodComparison.firstPeriod')
+                : t('stats.periodComparison.noComparisonData')}
+            </Text>
+          )}
+        </View>
+      </View>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { marginHorizontal: spacing[4], marginTop: spacing[3] },
+  tiles: {
+    flexDirection: 'row',
+    gap: spacing[2],
+    marginTop: spacing[3],
+  },
+  tile: {
+    flex: 1,
+    borderRadius: borderRadius.md,
+    paddingVertical: spacing[3],
+    paddingHorizontal: spacing[2],
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[1],
+  },
+  deltaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[1],
+  },
+  noComparisonText: {
+    textAlign: 'center',
+  },
+});

--- a/packages/mobile/src/components/you/ProgressTab.tsx
+++ b/packages/mobile/src/components/you/ProgressTab.tsx
@@ -10,6 +10,7 @@ import { ActivityIndicator } from '../ActivityIndicator';
 import { OfflineState } from '../OfflineState';
 import { ProfileBetaShelf } from './ProfileBetaShelf';
 import { StatsSummaryCard } from './StatsSummaryCard';
+import { PeriodComparisonCard } from './PeriodComparisonCard';
 import { StackedBarChart, GroupedBarChart, TotalAreaChart, type ChartLegendItem } from './YouCharts';
 import { ActivityHeatmap } from './ActivityHeatmap';
 import { LayoutShareDonut } from './LayoutShareDonut';
@@ -137,6 +138,12 @@ export const ProgressTab = memo(function ProgressTab({ data, topInset, userId }:
             hardestSend={data.hardestSend}
             hardestFlash={data.hardestFlash}
             percentile={data.percentile}
+          />
+
+          <PeriodComparisonCard
+            periodComparison={data.periodComparison}
+            comparisonMode={data.comparisonMode}
+            onComparisonModeChange={data.setComparisonMode}
           />
 
           {/* Recent beta videos shelf — sits below the stats summary, hidden when

--- a/packages/mobile/src/components/you/__tests__/period-comparison-card.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/period-comparison-card.test.tsx
@@ -67,8 +67,8 @@ import { PeriodComparisonCard } from '../PeriodComparisonCard';
 function makeComparison(overrides: Partial<RawPeriodComparison> = {}): RawPeriodComparison {
   return {
     mode: 'trailing',
-    current: { sends: 5, flashes: 2, startDate: '2024-06-08', endDate: '2024-06-15' },
-    previous: { sends: 3, flashes: 1, startDate: '2024-06-01', endDate: '2024-06-08' },
+    current: { sends: 5, startDate: '2024-06-08', endDate: '2024-06-15' },
+    previous: { sends: 3, startDate: '2024-06-01', endDate: '2024-06-08' },
     sendsDelta: 2,
     sendsPercentChange: 66.66,
     ...overrides,
@@ -106,7 +106,7 @@ describe('PeriodComparisonCard', () => {
     const { getByText, container } = render(
       createElement(PeriodComparisonCard, {
         periodComparison: makeComparison({
-          current: { sends: 1, flashes: 0, startDate: '2024-06-08', endDate: '2024-06-15' },
+          current: { sends: 1, startDate: '2024-06-08', endDate: '2024-06-15' },
           sendsDelta: -2,
           sendsPercentChange: -66.66,
         }),
@@ -127,8 +127,8 @@ describe('PeriodComparisonCard', () => {
     const { getByText, container } = render(
       createElement(PeriodComparisonCard, {
         periodComparison: makeComparison({
-          current: { sends: 1001, flashes: 0, startDate: '2024-06-08', endDate: '2024-06-15' },
-          previous: { sends: 1000, flashes: 0, startDate: '2024-06-01', endDate: '2024-06-08' },
+          current: { sends: 1001, startDate: '2024-06-08', endDate: '2024-06-15' },
+          previous: { sends: 1000, startDate: '2024-06-01', endDate: '2024-06-08' },
           sendsDelta: 1,
           sendsPercentChange: 0.1,
         }),
@@ -147,7 +147,7 @@ describe('PeriodComparisonCard', () => {
     const { getByText, queryByText } = render(
       createElement(PeriodComparisonCard, {
         periodComparison: makeComparison({
-          previous: { sends: 0, flashes: 0, startDate: '2024-06-01', endDate: '2024-06-08' },
+          previous: { sends: 0, startDate: '2024-06-01', endDate: '2024-06-08' },
           sendsDelta: 5,
           sendsPercentChange: null,
         }),
@@ -163,8 +163,8 @@ describe('PeriodComparisonCard', () => {
     const { getByText } = render(
       createElement(PeriodComparisonCard, {
         periodComparison: makeComparison({
-          current: { sends: 0, flashes: 0, startDate: '2024-06-08', endDate: '2024-06-15' },
-          previous: { sends: 0, flashes: 0, startDate: '2024-06-01', endDate: '2024-06-08' },
+          current: { sends: 0, startDate: '2024-06-08', endDate: '2024-06-15' },
+          previous: { sends: 0, startDate: '2024-06-01', endDate: '2024-06-08' },
           sendsDelta: 0,
           sendsPercentChange: null,
         }),

--- a/packages/mobile/src/components/you/__tests__/period-comparison-card.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/period-comparison-card.test.tsx
@@ -8,7 +8,16 @@ vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
   StyleSheet: { create: (styles: unknown) => styles },
 }));
-vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+// Mirrors i18next's interpolation just enough to assert on the percentChange
+// key's `{{value}}` — real locale strings own the surrounding "%" / spacing
+// (French: "{{value}} %"), so the component only ever passes a bare signed
+// number as `value`.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { value?: string | number }) =>
+      options?.value !== undefined ? `${key}:${options.value}` : key,
+  }),
+}));
 vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     systemColors: { fill: '#eee', secondaryLabel: '#666', tertiaryLabel: '#999' },
@@ -78,8 +87,8 @@ describe('PeriodComparisonCard', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders the current sends count and a positive percent delta', () => {
-    const { getByText } = render(
+  it('renders the current sends count and a positive percent delta with an up chevron', () => {
+    const { getByText, container } = render(
       createElement(PeriodComparisonCard, {
         periodComparison: makeComparison(),
         comparisonMode: 'trailing',
@@ -87,12 +96,14 @@ describe('PeriodComparisonCard', () => {
       }),
     );
     expect(getByText('5')).toBeTruthy();
-    expect(getByText('+67%')).toBeTruthy();
+    expect(getByText('stats.periodComparison.percentChange:+67')).toBeTruthy();
     expect(getByText('stats.periodComparison.vsTrailing')).toBeTruthy();
+    expect(container.querySelector('[data-icon="chevron.up"]')).toBeTruthy();
+    expect(container.querySelector('[data-icon="chevron.down"]')).toBeNull();
   });
 
-  it('renders a negative percent delta without an up chevron', () => {
-    const { getByText, queryByText } = render(
+  it('renders a negative percent delta with a down chevron, not an up chevron', () => {
+    const { getByText, container } = render(
       createElement(PeriodComparisonCard, {
         periodComparison: makeComparison({
           current: { sends: 1, flashes: 0, startDate: '2024-06-08', endDate: '2024-06-15' },
@@ -103,9 +114,33 @@ describe('PeriodComparisonCard', () => {
         onComparisonModeChange: vi.fn(),
       }),
     );
-    expect(getByText('-67%')).toBeTruthy();
+    expect(getByText('stats.periodComparison.percentChange:-67')).toBeTruthy();
     expect(getByText('stats.periodComparison.vsYearOverYear')).toBeTruthy();
-    expect(queryByText('chevron.up')).toBeNull();
+    expect(container.querySelector('[data-icon="chevron.down"]')).toBeTruthy();
+    expect(container.querySelector('[data-icon="chevron.up"]')).toBeNull();
+  });
+
+  it('omits the chevron and uses the neutral color when a nonzero delta rounds to a displayed 0%', () => {
+    // previous.sends = 1000, current.sends = 1001 -> +1 sends, but +0.1% rounds
+    // to "0%". The chevron/color must follow the *displayed* rounded value, not
+    // the raw (nonzero) delta, or the UI shows a green up-chevron next to "0%".
+    const { getByText, container } = render(
+      createElement(PeriodComparisonCard, {
+        periodComparison: makeComparison({
+          current: { sends: 1001, flashes: 0, startDate: '2024-06-08', endDate: '2024-06-15' },
+          previous: { sends: 1000, flashes: 0, startDate: '2024-06-01', endDate: '2024-06-08' },
+          sendsDelta: 1,
+          sendsPercentChange: 0.1,
+        }),
+        comparisonMode: 'trailing',
+        onComparisonModeChange: vi.fn(),
+      }),
+    );
+    const percentText = getByText('stats.periodComparison.percentChange:0');
+    expect(percentText).toBeTruthy();
+    expect(percentText.getAttribute('data-color')).toBe('#666'); // systemColors.secondaryLabel
+    expect(container.querySelector('[data-icon="chevron.up"]')).toBeNull();
+    expect(container.querySelector('[data-icon="chevron.down"]')).toBeNull();
   });
 
   it('shows a "first period" message instead of a broken percent when the previous period has zero sends', () => {

--- a/packages/mobile/src/components/you/__tests__/period-comparison-card.test.tsx
+++ b/packages/mobile/src/components/you/__tests__/period-comparison-card.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { PeriodComparisonMode, RawPeriodComparison } from '@boardsesh/profile-stats';
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles },
+}));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { fill: '#eee', secondaryLabel: '#666', tertiaryLabel: '#999' },
+    brandColors: { success: '#0a0', error: '#a00' },
+  }),
+}));
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+  borderRadius: { md: 8 },
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children, color }: { children?: ReactNode; color?: string }) =>
+    createElement('span', { 'data-color': color ?? '' }, children),
+}));
+vi.mock('../../Card', () => ({
+  Card: ({ children }: { children?: ReactNode }) => createElement('div', { 'data-card': 'true' }, children),
+}));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name, color }: { name: string; color?: string }) =>
+    createElement('span', { 'data-icon': name, 'data-icon-color': color ?? '' }),
+}));
+vi.mock('../../SegmentedControl', () => ({
+  SegmentedControl: ({
+    options,
+    selectedKey,
+    onSelect,
+  }: {
+    options: Array<{ key: PeriodComparisonMode; label: string }>;
+    selectedKey: PeriodComparisonMode;
+    onSelect: (key: PeriodComparisonMode) => void;
+  }) =>
+    createElement(
+      'div',
+      { 'data-segmented': 'true', 'data-selected': selectedKey },
+      options.map((option) =>
+        createElement(
+          'button',
+          { key: option.key, onClick: () => onSelect(option.key), 'data-option': option.key },
+          option.label,
+        ),
+      ),
+    ),
+}));
+
+import { PeriodComparisonCard } from '../PeriodComparisonCard';
+
+function makeComparison(overrides: Partial<RawPeriodComparison> = {}): RawPeriodComparison {
+  return {
+    mode: 'trailing',
+    current: { sends: 5, flashes: 2, startDate: '2024-06-08', endDate: '2024-06-15' },
+    previous: { sends: 3, flashes: 1, startDate: '2024-06-01', endDate: '2024-06-08' },
+    sendsDelta: 2,
+    sendsPercentChange: 66.66,
+    ...overrides,
+  };
+}
+
+describe('PeriodComparisonCard', () => {
+  it('renders nothing when periodComparison is null (timeframe not eligible)', () => {
+    const { container } = render(
+      createElement(PeriodComparisonCard, {
+        periodComparison: null,
+        comparisonMode: 'trailing',
+        onComparisonModeChange: vi.fn(),
+      }),
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the current sends count and a positive percent delta', () => {
+    const { getByText } = render(
+      createElement(PeriodComparisonCard, {
+        periodComparison: makeComparison(),
+        comparisonMode: 'trailing',
+        onComparisonModeChange: vi.fn(),
+      }),
+    );
+    expect(getByText('5')).toBeTruthy();
+    expect(getByText('+67%')).toBeTruthy();
+    expect(getByText('stats.periodComparison.vsTrailing')).toBeTruthy();
+  });
+
+  it('renders a negative percent delta without an up chevron', () => {
+    const { getByText, queryByText } = render(
+      createElement(PeriodComparisonCard, {
+        periodComparison: makeComparison({
+          current: { sends: 1, flashes: 0, startDate: '2024-06-08', endDate: '2024-06-15' },
+          sendsDelta: -2,
+          sendsPercentChange: -66.66,
+        }),
+        comparisonMode: 'yearOverYear',
+        onComparisonModeChange: vi.fn(),
+      }),
+    );
+    expect(getByText('-67%')).toBeTruthy();
+    expect(getByText('stats.periodComparison.vsYearOverYear')).toBeTruthy();
+    expect(queryByText('chevron.up')).toBeNull();
+  });
+
+  it('shows a "first period" message instead of a broken percent when the previous period has zero sends', () => {
+    const { getByText, queryByText } = render(
+      createElement(PeriodComparisonCard, {
+        periodComparison: makeComparison({
+          previous: { sends: 0, flashes: 0, startDate: '2024-06-01', endDate: '2024-06-08' },
+          sendsDelta: 5,
+          sendsPercentChange: null,
+        }),
+        comparisonMode: 'trailing',
+        onComparisonModeChange: vi.fn(),
+      }),
+    );
+    expect(getByText('stats.periodComparison.firstPeriod')).toBeTruthy();
+    expect(queryByText(/%/)).toBeNull();
+  });
+
+  it('shows a "no comparison data" message when neither period has sends', () => {
+    const { getByText } = render(
+      createElement(PeriodComparisonCard, {
+        periodComparison: makeComparison({
+          current: { sends: 0, flashes: 0, startDate: '2024-06-08', endDate: '2024-06-15' },
+          previous: { sends: 0, flashes: 0, startDate: '2024-06-01', endDate: '2024-06-08' },
+          sendsDelta: 0,
+          sendsPercentChange: null,
+        }),
+        comparisonMode: 'trailing',
+        onComparisonModeChange: vi.fn(),
+      }),
+    );
+    expect(getByText('stats.periodComparison.noComparisonData')).toBeTruthy();
+  });
+
+  it('forwards mode selection from the segmented control', () => {
+    const onComparisonModeChange = vi.fn();
+    const { getByRole } = render(
+      createElement(PeriodComparisonCard, {
+        periodComparison: makeComparison(),
+        comparisonMode: 'trailing',
+        onComparisonModeChange,
+      }),
+    );
+    fireEvent.click(getByRole('button', { name: 'stats.periodComparison.yearOverYear' }));
+    expect(onComparisonModeChange).toHaveBeenCalledWith('yearOverYear');
+  });
+});

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-you-profile-data.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-you-profile-data.test.tsx
@@ -66,6 +66,14 @@ describe('useYouProfileData filter state', () => {
     expect(result.current.hasActiveFilters).toBe(true);
   });
 
+  it('defaults comparisonMode to trailing and exposes a setter', () => {
+    const { result } = renderHook(() => useYouProfileData('user-1'));
+    expect(result.current.comparisonMode).toBe('trailing');
+
+    act(() => result.current.setComparisonMode('yearOverYear'));
+    expect(result.current.comparisonMode).toBe('yearOverYear');
+  });
+
   it('reports loading until a userId is available', () => {
     const { result, rerender } = renderHook(({ userId }) => useYouProfileData(userId), {
       initialProps: { userId: undefined as string | undefined },

--- a/packages/mobile/src/lib/graphql/hooks/use-you-profile-data.ts
+++ b/packages/mobile/src/lib/graphql/hooks/use-you-profile-data.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react';
-import { deriveProfileViewModel, type UnifiedTimeframeType } from '@boardsesh/profile-stats';
+import { deriveProfileViewModel, type UnifiedTimeframeType, type PeriodComparisonMode } from '@boardsesh/profile-stats';
 import { useGradeFormat } from '../../../hooks/use-grade-format';
 import { useOfflineQueryState } from '../../../hooks/use-offline-query-state';
 import { useAllBoardsTicks, useUserProfileStats, useUserClimbPercentile } from './use-you-data';
@@ -19,6 +19,7 @@ export function useYouProfileData(userId: string | undefined) {
 
   const [selectedBoard, setSelectedBoard] = useState<string>('all');
   const [timeframe, setTimeframe] = useState<UnifiedTimeframeType>('all');
+  const [comparisonMode, setComparisonMode] = useState<PeriodComparisonMode>('trailing');
   // Custom date-range filtering isn't surfaced yet — YouFilterSheet only offers
   // all/year/month/week. Kept as empty constants so deriveProfileViewModel gets
   // a stable range; not exposed until the custom-range UI lands.
@@ -42,8 +43,9 @@ export function useYouProfileData(userId: string | undefined) {
         toDate,
         gradeFormat,
         profileStats: profileStatsQuery.data ?? null,
+        comparisonMode,
       }),
-    [allBoardsTicks, selectedBoard, timeframe, fromDate, toDate, gradeFormat, profileStatsQuery.data],
+    [allBoardsTicks, selectedBoard, timeframe, fromDate, toDate, gradeFormat, profileStatsQuery.data, comparisonMode],
   );
 
   const refetch = useCallback(() => {
@@ -78,6 +80,8 @@ export function useYouProfileData(userId: string | undefined) {
     setSelectedBoard,
     timeframe,
     setTimeframe,
+    comparisonMode,
+    setComparisonMode,
     hasActiveFilters,
 
     // Derived view model (renderer-agnostic; colors applied in components)

--- a/packages/shared/i18n/locales/de/profile.json
+++ b/packages/shared/i18n/locales/de/profile.json
@@ -74,7 +74,17 @@
     "gradeDistributionAria": "Gradverteilung über alle Boards",
     "weeklyAttemptsAria": "Versuche pro Woche nach Schwierigkeit",
     "flashRedpointAria": "Flash vs. Rotpunkt nach Grad",
-    "layoutTooltip": "{{name}}: {{count}} Boulder ({{percentage}}%)"
+    "layoutTooltip": "{{name}}: {{count}} Boulder ({{percentage}}%)",
+    "periodComparison": {
+      "controlLabel": "Vergleichszeitraum",
+      "trailing": "Vorheriger Zeitraum",
+      "yearOverYear": "Letztes Jahr",
+      "sends": "Begehungen",
+      "vsTrailing": "vs. vorheriger Zeitraum",
+      "vsYearOverYear": "vs. gleicher Zeitraum letztes Jahr",
+      "firstPeriod": "Erster erfasster Zeitraum",
+      "noComparisonData": "Noch keine Begehungen"
+    }
   },
   "empty": {
     "userNotFound": "Nutzer*in nicht gefunden",

--- a/packages/shared/i18n/locales/de/profile.json
+++ b/packages/shared/i18n/locales/de/profile.json
@@ -80,6 +80,7 @@
       "trailing": "Vorheriger Zeitraum",
       "yearOverYear": "Letztes Jahr",
       "sends": "Begehungen",
+      "percentChange": "{{value}}%",
       "vsTrailing": "vs. vorheriger Zeitraum",
       "vsYearOverYear": "vs. gleicher Zeitraum letztes Jahr",
       "firstPeriod": "Erster erfasster Zeitraum",

--- a/packages/shared/i18n/locales/en-US/profile.json
+++ b/packages/shared/i18n/locales/en-US/profile.json
@@ -80,6 +80,7 @@
       "trailing": "Previous period",
       "yearOverYear": "Last year",
       "sends": "Sends",
+      "percentChange": "{{value}}%",
       "vsTrailing": "vs. previous period",
       "vsYearOverYear": "vs. same period last year",
       "firstPeriod": "First period tracked",

--- a/packages/shared/i18n/locales/en-US/profile.json
+++ b/packages/shared/i18n/locales/en-US/profile.json
@@ -74,7 +74,17 @@
     "gradeDistributionAria": "Grade distribution across boards",
     "weeklyAttemptsAria": "Weekly attempts by difficulty",
     "flashRedpointAria": "Flash vs redpoint by grade",
-    "layoutTooltip": "{{name}}: {{count}} problems ({{percentage}}%)"
+    "layoutTooltip": "{{name}}: {{count}} problems ({{percentage}}%)",
+    "periodComparison": {
+      "controlLabel": "Comparison period",
+      "trailing": "Previous period",
+      "yearOverYear": "Last year",
+      "sends": "Sends",
+      "vsTrailing": "vs. previous period",
+      "vsYearOverYear": "vs. same period last year",
+      "firstPeriod": "First period tracked",
+      "noComparisonData": "No sends yet"
+    }
   },
   "empty": {
     "userNotFound": "User not found",

--- a/packages/shared/i18n/locales/es/profile.json
+++ b/packages/shared/i18n/locales/es/profile.json
@@ -80,6 +80,7 @@
       "trailing": "Periodo anterior",
       "yearOverYear": "Año pasado",
       "sends": "Encadenes",
+      "percentChange": "{{value}}%",
       "vsTrailing": "vs. periodo anterior",
       "vsYearOverYear": "vs. mismo periodo del año pasado",
       "firstPeriod": "Primer periodo registrado",

--- a/packages/shared/i18n/locales/es/profile.json
+++ b/packages/shared/i18n/locales/es/profile.json
@@ -74,7 +74,17 @@
     "gradeDistributionAria": "Distribución por grados en todos los plafones",
     "weeklyAttemptsAria": "Intentos semanales por dificultad",
     "flashRedpointAria": "Flash vs trabajado por grado",
-    "layoutTooltip": "{{name}}: {{count}} bloques ({{percentage}}%)"
+    "layoutTooltip": "{{name}}: {{count}} bloques ({{percentage}}%)",
+    "periodComparison": {
+      "controlLabel": "Periodo de comparación",
+      "trailing": "Periodo anterior",
+      "yearOverYear": "Año pasado",
+      "sends": "Encadenes",
+      "vsTrailing": "vs. periodo anterior",
+      "vsYearOverYear": "vs. mismo periodo del año pasado",
+      "firstPeriod": "Primer periodo registrado",
+      "noComparisonData": "Aún sin encadenes"
+    }
   },
   "empty": {
     "userNotFound": "Usuario no encontrado",

--- a/packages/shared/i18n/locales/fr/profile.json
+++ b/packages/shared/i18n/locales/fr/profile.json
@@ -80,6 +80,7 @@
       "trailing": "Période précédente",
       "yearOverYear": "Année dernière",
       "sends": "Croix",
+      "percentChange": "{{value}} %",
       "vsTrailing": "vs. période précédente",
       "vsYearOverYear": "vs. même période l'an dernier",
       "firstPeriod": "Première période suivie",

--- a/packages/shared/i18n/locales/fr/profile.json
+++ b/packages/shared/i18n/locales/fr/profile.json
@@ -74,7 +74,17 @@
     "gradeDistributionAria": "Répartition par cotation sur toutes les boards",
     "weeklyAttemptsAria": "Essais hebdo par difficulté",
     "flashRedpointAria": "Flash vs après-travail par cotation",
-    "layoutTooltip": "{{name}} : {{count}} blocs ({{percentage}} %)"
+    "layoutTooltip": "{{name}} : {{count}} blocs ({{percentage}} %)",
+    "periodComparison": {
+      "controlLabel": "Période de comparaison",
+      "trailing": "Période précédente",
+      "yearOverYear": "Année dernière",
+      "sends": "Croix",
+      "vsTrailing": "vs. période précédente",
+      "vsYearOverYear": "vs. même période l'an dernier",
+      "firstPeriod": "Première période suivie",
+      "noComparisonData": "Aucune croix pour l'instant"
+    }
   },
   "empty": {
     "userNotFound": "Utilisateur introuvable",

--- a/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
@@ -673,30 +673,32 @@ describe('buildPeriodComparison', () => {
     expect(result.previous.sends).toBe(1); // only 'b'
   });
 
-  it('excludes a tick exactly on the trailing seam from both windows, matching filterLogbookByTimeframe', () => {
+  it('a tick exactly on the trailing seam lands in previous only, not current and not both', () => {
     const now = dayjs('2024-06-15T00:00:00.000Z');
     const kilter: LogbookEntry[] = [
       // Exactly `now - 1 week`: current.start and (trailing) previous.end land
-      // on the same instant. Both bounds are strict, so this tick belongs to
-      // neither window — the same treatment filterLogbookByTimeframe gives it
-      // (its lower bound is strictly-after too), rather than being
-      // double-counted across the two windows.
+      // on the same instant. current.start is exclusive so this tick is
+      // excluded there (same treatment filterLogbookByTimeframe gives its own
+      // strictly-after lower bound); previous.end is inclusive so the tick
+      // belongs to previous. One bucket, not zero, not two.
       makeEntry({ climbed_at: now.subtract(1, 'week').toISOString(), status: 'send', climbUuid: 'seam' }),
     ];
     const result = buildPeriodComparison({ kilter }, 'lastWeek', 'trailing', now)!;
     expect(result.current.sends).toBe(0);
-    expect(result.previous.sends).toBe(0);
+    expect(result.previous.sends).toBe(1);
   });
 
-  it('agrees with filterLogbookByTimeframe at the exact lastWeek cutoff (no headline-count divergence)', () => {
-    // No injected `now` on either side — both functions read the real wall
-    // clock, same as production. A tick timestamped to precisely `now - 1
-    // week` must be excluded by both, not counted here and not there.
-    const boundary = dayjs().subtract(1, 'week');
+  it('a tick exactly on the year-over-year boundary (now - 1 year) lands in previous, symmetric with trailing', () => {
+    // yearOverYear's windows don't share a seam with current the way trailing's
+    // do, but periodSnapshot applies the same (start, end] rule uniformly, so
+    // a tick at precisely `previous.end` (now - 1 year) still counts here
+    // rather than being silently dropped.
+    const now = dayjs('2024-06-15T00:00:00.000Z');
     const kilter: LogbookEntry[] = [
-      makeEntry({ climbed_at: boundary.toISOString(), status: 'send', climbUuid: 'boundary' }),
+      makeEntry({ climbed_at: now.subtract(1, 'year').toISOString(), status: 'send', climbUuid: 'yoy-boundary' }),
     ];
-    expect(filterLogbookByTimeframe(kilter, 'lastWeek', '', '')).toHaveLength(0);
-    expect(buildPeriodComparison({ kilter }, 'lastWeek', 'trailing')!.current.sends).toBe(0);
+    const result = buildPeriodComparison({ kilter }, 'lastWeek', 'yearOverYear', now)!;
+    expect(result.current.sends).toBe(0);
+    expect(result.previous.sends).toBe(1);
   });
 });

--- a/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
@@ -635,7 +635,6 @@ describe('buildPeriodComparison', () => {
     ];
     const result = buildPeriodComparison({ kilter }, 'lastWeek', 'trailing', now)!;
     expect(result.current.sends).toBe(2);
-    expect(result.current.flashes).toBe(1);
     expect(result.previous.sends).toBe(1);
     expect(result.sendsDelta).toBe(1);
     expect(result.sendsPercentChange).toBe(100);
@@ -674,15 +673,30 @@ describe('buildPeriodComparison', () => {
     expect(result.previous.sends).toBe(1); // only 'b'
   });
 
-  it('counts a tick exactly on the trailing seam (previous.end === current.start) once, in current', () => {
+  it('excludes a tick exactly on the trailing seam from both windows, matching filterLogbookByTimeframe', () => {
     const now = dayjs('2024-06-15T00:00:00.000Z');
     const kilter: LogbookEntry[] = [
       // Exactly `now - 1 week`: current.start and (trailing) previous.end land
-      // on the same instant. Must be counted in current only.
+      // on the same instant. Both bounds are strict, so this tick belongs to
+      // neither window — the same treatment filterLogbookByTimeframe gives it
+      // (its lower bound is strictly-after too), rather than being
+      // double-counted across the two windows.
       makeEntry({ climbed_at: now.subtract(1, 'week').toISOString(), status: 'send', climbUuid: 'seam' }),
     ];
     const result = buildPeriodComparison({ kilter }, 'lastWeek', 'trailing', now)!;
-    expect(result.current.sends).toBe(1);
+    expect(result.current.sends).toBe(0);
     expect(result.previous.sends).toBe(0);
+  });
+
+  it('agrees with filterLogbookByTimeframe at the exact lastWeek cutoff (no headline-count divergence)', () => {
+    // No injected `now` on either side — both functions read the real wall
+    // clock, same as production. A tick timestamped to precisely `now - 1
+    // week` must be excluded by both, not counted here and not there.
+    const boundary = dayjs().subtract(1, 'week');
+    const kilter: LogbookEntry[] = [
+      makeEntry({ climbed_at: boundary.toISOString(), status: 'send', climbUuid: 'boundary' }),
+    ];
+    expect(filterLogbookByTimeframe(kilter, 'lastWeek', '', '')).toHaveLength(0);
+    expect(buildPeriodComparison({ kilter }, 'lastWeek', 'trailing')!.current.sends).toBe(0);
   });
 });

--- a/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
@@ -673,4 +673,16 @@ describe('buildPeriodComparison', () => {
     expect(result.current.sends).toBe(1); // only 'a'
     expect(result.previous.sends).toBe(1); // only 'b'
   });
+
+  it('counts a tick exactly on the trailing seam (previous.end === current.start) once, in current', () => {
+    const now = dayjs('2024-06-15T00:00:00.000Z');
+    const kilter: LogbookEntry[] = [
+      // Exactly `now - 1 week`: current.start and (trailing) previous.end land
+      // on the same instant. Must be counted in current only.
+      makeEntry({ climbed_at: now.subtract(1, 'week').toISOString(), status: 'send', climbUuid: 'seam' }),
+    ];
+    const result = buildPeriodComparison({ kilter }, 'lastWeek', 'trailing', now)!;
+    expect(result.current.sends).toBe(1);
+    expect(result.previous.sends).toBe(0);
+  });
 });

--- a/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/chart-builders.test.ts
@@ -11,6 +11,8 @@ import {
   buildStatisticsSummary,
   buildVPointsTimeline,
   buildActivityHeatmap,
+  getComparisonWindows,
+  buildPeriodComparison,
 } from '../chart-builders';
 import type { LogbookEntry } from '../types';
 
@@ -585,5 +587,90 @@ describe('buildActivityHeatmap', () => {
         .startOf('isoWeek')
         .format('YYYY-MM-DD'),
     );
+  });
+});
+
+describe('getComparisonWindows', () => {
+  it('trailing: current is the last unit, previous is the unit before that', () => {
+    const now = dayjs('2024-06-15T00:00:00.000Z');
+    const { current, previous } = getComparisonWindows('lastWeek', 'trailing', now);
+    expect(current.start.isSame(now.subtract(1, 'week'))).toBe(true);
+    expect(current.end.isSame(now)).toBe(true);
+    expect(previous.start.isSame(now.subtract(2, 'week'))).toBe(true);
+    expect(previous.end.isSame(now.subtract(1, 'week'))).toBe(true);
+  });
+
+  it('yearOverYear: previous is the same window shifted back a year', () => {
+    const now = dayjs('2024-06-15T00:00:00.000Z');
+    const { current, previous } = getComparisonWindows('lastMonth', 'yearOverYear', now);
+    expect(current.start.isSame(now.subtract(1, 'month'))).toBe(true);
+    expect(current.end.isSame(now)).toBe(true);
+    expect(previous.start.isSame(now.subtract(1, 'month').subtract(1, 'year'))).toBe(true);
+    expect(previous.end.isSame(now.subtract(1, 'year'))).toBe(true);
+  });
+
+  it('handles the leap-year boundary for lastYear/yearOverYear without throwing', () => {
+    const now = dayjs('2024-02-29T00:00:00.000Z'); // leap day
+    const { previous } = getComparisonWindows('lastYear', 'yearOverYear', now);
+    // dayjs normalises Feb 29 minus 1 year to Feb 28 in a non-leap year.
+    expect(previous.end.format('YYYY-MM-DD')).toBe('2023-02-28');
+  });
+});
+
+describe('buildPeriodComparison', () => {
+  it('returns null for a timeframe other than week/month/year', () => {
+    expect(buildPeriodComparison({}, 'all', 'trailing')).toBeNull();
+    expect(buildPeriodComparison({}, 'today', 'trailing')).toBeNull();
+    expect(buildPeriodComparison({}, 'custom', 'trailing')).toBeNull();
+  });
+
+  it('counts distinct climbUuids per window, excluding attempts and climbUuid-less entries', () => {
+    const now = dayjs('2024-06-15T00:00:00.000Z');
+    const kilter: LogbookEntry[] = [
+      makeEntry({ climbed_at: now.toISOString(), status: 'send', climbUuid: 'a' }),
+      makeEntry({ climbed_at: now.subtract(4, 'day').toISOString(), status: 'flash', climbUuid: 'b' }),
+      makeEntry({ climbed_at: now.subtract(10, 'day').toISOString(), status: 'send', climbUuid: 'c' }),
+      makeEntry({ climbed_at: now.toISOString(), status: 'attempt', climbUuid: 'd' }),
+      makeEntry({ climbed_at: now.toISOString(), status: 'send', climbUuid: undefined }),
+    ];
+    const result = buildPeriodComparison({ kilter }, 'lastWeek', 'trailing', now)!;
+    expect(result.current.sends).toBe(2);
+    expect(result.current.flashes).toBe(1);
+    expect(result.previous.sends).toBe(1);
+    expect(result.sendsDelta).toBe(1);
+    expect(result.sendsPercentChange).toBe(100);
+  });
+
+  it('sendsPercentChange is null when the previous period has zero sends (new climber)', () => {
+    const now = dayjs('2024-06-15T00:00:00.000Z');
+    const kilter: LogbookEntry[] = [makeEntry({ climbed_at: now.toISOString(), status: 'send', climbUuid: 'a' })];
+    const result = buildPeriodComparison({ kilter }, 'lastWeek', 'trailing', now)!;
+    expect(result.previous.sends).toBe(0);
+    expect(result.sendsDelta).toBe(1);
+    expect(result.sendsPercentChange).toBeNull();
+  });
+
+  it('sums distinct climbUuids across boards', () => {
+    const now = dayjs('2024-06-15T00:00:00.000Z');
+    const kilter: LogbookEntry[] = [makeEntry({ climbed_at: now.toISOString(), status: 'send', climbUuid: 'a' })];
+    const tension: LogbookEntry[] = [makeEntry({ climbed_at: now.toISOString(), status: 'send', climbUuid: 'b' })];
+    const result = buildPeriodComparison({ kilter, tension }, 'lastWeek', 'trailing', now)!;
+    expect(result.current.sends).toBe(2);
+  });
+
+  it('yearOverYear compares against the same window one year back, not the trailing week', () => {
+    const now = dayjs('2024-06-15T00:00:00.000Z');
+    const kilter: LogbookEntry[] = [
+      makeEntry({ climbed_at: now.toISOString(), status: 'send', climbUuid: 'a' }),
+      makeEntry({
+        climbed_at: now.subtract(1, 'year').subtract(3, 'day').toISOString(),
+        status: 'send',
+        climbUuid: 'b',
+      }),
+      makeEntry({ climbed_at: now.subtract(10, 'day').toISOString(), status: 'send', climbUuid: 'c' }),
+    ];
+    const result = buildPeriodComparison({ kilter }, 'lastWeek', 'yearOverYear', now)!;
+    expect(result.current.sends).toBe(1); // only 'a'
+    expect(result.previous.sends).toBe(1); // only 'b'
   });
 });

--- a/packages/shared/profile-stats/src/__tests__/derive-view-model.test.ts
+++ b/packages/shared/profile-stats/src/__tests__/derive-view-model.test.ts
@@ -23,6 +23,7 @@ const base = {
   toDate: '',
   gradeFormat: 'v-grade' as const,
   profileStats: null,
+  comparisonMode: 'trailing' as const,
 };
 
 describe('deriveProfileViewModel', () => {
@@ -84,5 +85,48 @@ describe('deriveProfileViewModel', () => {
     expect(vm.vPointsTimeline).not.toBeNull();
     expect(vm.statisticsSummary.totalAscents).toBe(3);
     expect(vm.statisticsSummary.layoutPercentages.reduce((s, l) => s + l.percentage, 0)).toBe(100);
+  });
+});
+
+describe('deriveProfileViewModel periodComparison', () => {
+  it('is present for week/month/year timeframes and null otherwise', () => {
+    for (const timeframe of ['lastWeek', 'lastMonth', 'lastYear'] as const) {
+      const vm = deriveProfileViewModel({ ...base, allBoardsTicks, selectedBoard: 'all', timeframe });
+      expect(vm.periodComparison).not.toBeNull();
+    }
+    for (const timeframe of ['today', 'all', 'custom'] as const) {
+      const vm = deriveProfileViewModel({ ...base, allBoardsTicks, selectedBoard: 'all', timeframe });
+      expect(vm.periodComparison).toBeNull();
+    }
+  });
+
+  it('threads comparisonMode through to the built comparison', () => {
+    const trailing = deriveProfileViewModel({
+      ...base,
+      allBoardsTicks,
+      selectedBoard: 'all',
+      timeframe: 'lastYear',
+      comparisonMode: 'trailing',
+    });
+    const yoy = deriveProfileViewModel({
+      ...base,
+      allBoardsTicks,
+      selectedBoard: 'all',
+      timeframe: 'lastYear',
+      comparisonMode: 'yearOverYear',
+    });
+    expect(trailing.periodComparison?.mode).toBe('trailing');
+    expect(yoy.periodComparison?.mode).toBe('yearOverYear');
+  });
+
+  it('scopes the comparison to the selected board, like every other builder', () => {
+    const vm = deriveProfileViewModel({
+      ...base,
+      allBoardsTicks,
+      selectedBoard: 'kilter',
+      timeframe: 'lastYear',
+    });
+    // Only kilter's 2 ticks (both "now") are in scope for the current window.
+    expect(vm.periodComparison?.current.sends).toBe(2);
   });
 });

--- a/packages/shared/profile-stats/src/chart-builders.ts
+++ b/packages/shared/profile-stats/src/chart-builders.ts
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
-import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 import { type GradeDisplayFormat } from '@boardsesh/play-view';
 import { parseTickTime, tickTimeMs } from './format-tick-time';
@@ -25,7 +24,6 @@ import type {
 } from './types';
 
 dayjs.extend(isoWeek);
-dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);
 
 /**
@@ -529,14 +527,12 @@ function comparisonUnit(timeframe: ComparisonTimeframe): 'week' | 'month' | 'yea
 /**
  * Pure date math for the two windows a comparison card needs. `current`'s
  * lower bound is `now - 1 unit`, the same cutoff `filterLogbookByTimeframe`
- * uses for the same timeframe, so the headline count for e.g. "this week"
- * matches what the rest of the page shows for any tick that isn't landing on
- * that exact instant (`periodSnapshot` below treats the bound as inclusive;
- * `filterLogbookByTimeframe` is strictly-after — a tick timestamped to the
- * exact millisecond of the cutoff would diverge by one between the two, which
- * in practice never happens outside contrived test fixtures). `previous` is
- * either the immediately preceding window (`trailing`) or the same window one
- * year back (`yearOverYear`).
+ * uses for the same timeframe — and `periodSnapshot` below treats it exactly
+ * as strictly-after too, matching `filterLogbookByTimeframe`'s comparator, so
+ * the headline count for e.g. "this week" always agrees with what the rest of
+ * the page shows, including for a tick landing on the exact cutoff instant.
+ * `previous` is either the immediately preceding window (`trailing`) or the
+ * same window one year back (`yearOverYear`).
  *
  * `now` is an injectable param (not a default-only arg) so tests stay
  * deterministic, matching `buildActivityHeatmap`'s `today` param.
@@ -559,12 +555,18 @@ export function getComparisonWindows(
 }
 
 /**
+ * `start` is always strictly-after, matching `filterLogbookByTimeframe`'s
+ * lower-bound comparator exactly — a tick timestamped to the precise cutoff
+ * instant is excluded the same way here as everywhere else on the page,
+ * rather than being counted here and not there.
+ *
  * `inclusiveEnd` matters at the trailing-mode seam: `previous.end` and
- * `current.start` are the same instant (`now - 1 unit`), so a tick landing
- * exactly on that boundary would otherwise satisfy both windows and get
- * double-counted. `current`'s end (`now`) stays inclusive — it's the
- * outermost edge, shared with nothing — while `previous`'s end is exclusive
- * so the shared instant belongs to `current` alone.
+ * `current.start` are the same instant (`now - 1 unit`). Both windows now
+ * exclude a tick landing exactly there (start is strict; `previous`'s end is
+ * exclusive too), so it simply isn't counted by the comparison card at all —
+ * consistent with `filterLogbookByTimeframe` also excluding it, rather than
+ * being double-counted across the two windows. `current`'s end (`now`) stays
+ * inclusive since it's the outermost edge, shared with nothing.
  */
 function periodSnapshot(
   entries: LogbookEntry[],
@@ -573,27 +575,24 @@ function periodSnapshot(
   inclusiveEnd: boolean,
 ): RawPeriodSnapshot {
   const sends = new Set<string>();
-  const flashes = new Set<string>();
   for (const entry of entries) {
     // Mirrors buildAggregatedStackedBars's exclusion: attempts and entries
     // without a climbUuid don't count toward a distinct-climb tally.
     if (entry.status === 'attempt' || !entry.climbUuid) continue;
     const climbedAt = parseTickTime(entry.climbed_at);
-    if (!climbedAt.isSameOrAfter(start)) continue;
+    if (!climbedAt.isAfter(start)) continue;
     if (inclusiveEnd ? !climbedAt.isSameOrBefore(end) : !climbedAt.isBefore(end)) continue;
     sends.add(entry.climbUuid);
-    if (entry.status === 'flash') flashes.add(entry.climbUuid);
   }
   return {
     sends: sends.size,
-    flashes: flashes.size,
     startDate: start.format('YYYY-MM-DD'),
     endDate: end.format('YYYY-MM-DD'),
   };
 }
 
 /**
- * Sends/flashes for the current period vs. a comparison period (trailing or
+ * Sends for the current period vs. a comparison period (trailing or
  * year-over-year), for the Progress tab's headline comparison card. Returns
  * null for any timeframe other than week/month/year (mirrors every other
  * builder's null-for-not-applicable convention) — the caller doesn't need a

--- a/packages/shared/profile-stats/src/chart-builders.ts
+++ b/packages/shared/profile-stats/src/chart-builders.ts
@@ -527,11 +527,16 @@ function comparisonUnit(timeframe: ComparisonTimeframe): 'week' | 'month' | 'yea
 }
 
 /**
- * Pure date math for the two windows a comparison card needs. `current` mirrors
- * `filterLogbookByTimeframe`'s lower bound for the same timeframe, so the
- * headline count for e.g. "this week" matches what the rest of the page already
- * shows. `previous` is either the immediately preceding window (`trailing`) or
- * the same window one year back (`yearOverYear`).
+ * Pure date math for the two windows a comparison card needs. `current`'s
+ * lower bound is `now - 1 unit`, the same cutoff `filterLogbookByTimeframe`
+ * uses for the same timeframe, so the headline count for e.g. "this week"
+ * matches what the rest of the page shows for any tick that isn't landing on
+ * that exact instant (`periodSnapshot` below treats the bound as inclusive;
+ * `filterLogbookByTimeframe` is strictly-after — a tick timestamped to the
+ * exact millisecond of the cutoff would diverge by one between the two, which
+ * in practice never happens outside contrived test fixtures). `previous` is
+ * either the immediately preceding window (`trailing`) or the same window one
+ * year back (`yearOverYear`).
  *
  * `now` is an injectable param (not a default-only arg) so tests stay
  * deterministic, matching `buildActivityHeatmap`'s `today` param.

--- a/packages/shared/profile-stats/src/chart-builders.ts
+++ b/packages/shared/profile-stats/src/chart-builders.ts
@@ -19,6 +19,9 @@ import type {
   RawLayoutPercentage,
   RawActivityDay,
   RawActivityHeatmap,
+  PeriodComparisonMode,
+  RawPeriodSnapshot,
+  RawPeriodComparison,
 } from './types';
 
 dayjs.extend(isoWeek);
@@ -505,5 +508,99 @@ export function buildActivityHeatmap(
     maxCount,
     startDate: gridStart.format('YYYY-MM-DD'),
     endDate: gridEnd.format('YYYY-MM-DD'),
+  };
+}
+
+// ── Period-over-period comparison (Progress tab headline) ───────────
+
+type ComparisonTimeframe = 'lastWeek' | 'lastMonth' | 'lastYear';
+
+function comparisonUnit(timeframe: ComparisonTimeframe): 'week' | 'month' | 'year' {
+  switch (timeframe) {
+    case 'lastWeek':
+      return 'week';
+    case 'lastMonth':
+      return 'month';
+    case 'lastYear':
+      return 'year';
+  }
+}
+
+/**
+ * Pure date math for the two windows a comparison card needs. `current` mirrors
+ * `filterLogbookByTimeframe`'s lower bound for the same timeframe, so the
+ * headline count for e.g. "this week" matches what the rest of the page already
+ * shows. `previous` is either the immediately preceding window (`trailing`) or
+ * the same window one year back (`yearOverYear`).
+ *
+ * `now` is an injectable param (not a default-only arg) so tests stay
+ * deterministic, matching `buildActivityHeatmap`'s `today` param.
+ */
+export function getComparisonWindows(
+  timeframe: ComparisonTimeframe,
+  mode: PeriodComparisonMode,
+  now: dayjs.Dayjs = dayjs(),
+): {
+  current: { start: dayjs.Dayjs; end: dayjs.Dayjs };
+  previous: { start: dayjs.Dayjs; end: dayjs.Dayjs };
+} {
+  const unit = comparisonUnit(timeframe);
+  const current = { start: now.subtract(1, unit), end: now };
+  const previous =
+    mode === 'trailing'
+      ? { start: now.subtract(2, unit), end: now.subtract(1, unit) }
+      : { start: now.subtract(1, unit).subtract(1, 'year'), end: now.subtract(1, 'year') };
+  return { current, previous };
+}
+
+function periodSnapshot(entries: LogbookEntry[], start: dayjs.Dayjs, end: dayjs.Dayjs): RawPeriodSnapshot {
+  const sends = new Set<string>();
+  const flashes = new Set<string>();
+  for (const entry of entries) {
+    // Mirrors buildAggregatedStackedBars's exclusion: attempts and entries
+    // without a climbUuid don't count toward a distinct-climb tally.
+    if (entry.status === 'attempt' || !entry.climbUuid) continue;
+    const climbedAt = parseTickTime(entry.climbed_at);
+    if (!(climbedAt.isSameOrAfter(start) && climbedAt.isSameOrBefore(end))) continue;
+    sends.add(entry.climbUuid);
+    if (entry.status === 'flash') flashes.add(entry.climbUuid);
+  }
+  return {
+    sends: sends.size,
+    flashes: flashes.size,
+    startDate: start.format('YYYY-MM-DD'),
+    endDate: end.format('YYYY-MM-DD'),
+  };
+}
+
+/**
+ * Sends/flashes for the current period vs. a comparison period (trailing or
+ * year-over-year), for the Progress tab's headline comparison card. Returns
+ * null for any timeframe other than week/month/year (mirrors every other
+ * builder's null-for-not-applicable convention) — the caller doesn't need a
+ * separate "is this timeframe eligible" check.
+ */
+export function buildPeriodComparison(
+  allBoardsTicks: Record<string, LogbookEntry[]>,
+  timeframe: UnifiedTimeframeType,
+  mode: PeriodComparisonMode,
+  now: dayjs.Dayjs = dayjs(),
+): RawPeriodComparison | null {
+  if (timeframe !== 'lastWeek' && timeframe !== 'lastMonth' && timeframe !== 'lastYear') return null;
+
+  const allEntries = Object.values(allBoardsTicks).flat();
+  const { current, previous } = getComparisonWindows(timeframe, mode, now);
+
+  const currentSnapshot = periodSnapshot(allEntries, current.start, current.end);
+  const previousSnapshot = periodSnapshot(allEntries, previous.start, previous.end);
+  const sendsDelta = currentSnapshot.sends - previousSnapshot.sends;
+  const sendsPercentChange = previousSnapshot.sends === 0 ? null : (sendsDelta / previousSnapshot.sends) * 100;
+
+  return {
+    mode,
+    current: currentSnapshot,
+    previous: previousSnapshot,
+    sendsDelta,
+    sendsPercentChange,
   };
 }

--- a/packages/shared/profile-stats/src/chart-builders.ts
+++ b/packages/shared/profile-stats/src/chart-builders.ts
@@ -555,25 +555,23 @@ export function getComparisonWindows(
 }
 
 /**
- * `start` is always strictly-after, matching `filterLogbookByTimeframe`'s
- * lower-bound comparator exactly — a tick timestamped to the precise cutoff
- * instant is excluded the same way here as everywhere else on the page,
- * rather than being counted here and not there.
+ * Every window is a half-open `(start, end]` interval — start strictly-after,
+ * end inclusive — for both `current` and `previous`, in both modes. Two
+ * properties fall out of that uniform rule without any mode-specific
+ * carve-out:
  *
- * `inclusiveEnd` matters at the trailing-mode seam: `previous.end` and
- * `current.start` are the same instant (`now - 1 unit`). Both windows now
- * exclude a tick landing exactly there (start is strict; `previous`'s end is
- * exclusive too), so it simply isn't counted by the comparison card at all —
- * consistent with `filterLogbookByTimeframe` also excluding it, rather than
- * being double-counted across the two windows. `current`'s end (`now`) stays
- * inclusive since it's the outermost edge, shared with nothing.
+ * - `start` matches `filterLogbookByTimeframe`'s lower-bound comparator
+ *   exactly, so a tick timestamped to `current`'s precise cutoff instant is
+ *   excluded the same way here as everywhere else on the page.
+ * - Adjacent windows never double-count a shared boundary. In trailing mode,
+ *   `previous.end` and `current.start` are the same instant (`now - 1 unit`):
+ *   `previous.end` is inclusive so a tick exactly there lands in `previous`,
+ *   and `current.start` is exclusive so that same tick is excluded from
+ *   `current` — one bucket, not both, not neither. Year-over-year's windows
+ *   don't share a boundary at all, so this same rule just applies without
+ *   needing a separate justification.
  */
-function periodSnapshot(
-  entries: LogbookEntry[],
-  start: dayjs.Dayjs,
-  end: dayjs.Dayjs,
-  inclusiveEnd: boolean,
-): RawPeriodSnapshot {
+function periodSnapshot(entries: LogbookEntry[], start: dayjs.Dayjs, end: dayjs.Dayjs): RawPeriodSnapshot {
   const sends = new Set<string>();
   for (const entry of entries) {
     // Mirrors buildAggregatedStackedBars's exclusion: attempts and entries
@@ -581,7 +579,7 @@ function periodSnapshot(
     if (entry.status === 'attempt' || !entry.climbUuid) continue;
     const climbedAt = parseTickTime(entry.climbed_at);
     if (!climbedAt.isAfter(start)) continue;
-    if (inclusiveEnd ? !climbedAt.isSameOrBefore(end) : !climbedAt.isBefore(end)) continue;
+    if (!climbedAt.isSameOrBefore(end)) continue;
     sends.add(entry.climbUuid);
   }
   return {
@@ -609,8 +607,8 @@ export function buildPeriodComparison(
   const allEntries = Object.values(allBoardsTicks).flat();
   const { current, previous } = getComparisonWindows(timeframe, mode, now);
 
-  const currentSnapshot = periodSnapshot(allEntries, current.start, current.end, true);
-  const previousSnapshot = periodSnapshot(allEntries, previous.start, previous.end, false);
+  const currentSnapshot = periodSnapshot(allEntries, current.start, current.end);
+  const previousSnapshot = periodSnapshot(allEntries, previous.start, previous.end);
   const sendsDelta = currentSnapshot.sends - previousSnapshot.sends;
   const sendsPercentChange = previousSnapshot.sends === 0 ? null : (sendsDelta / previousSnapshot.sends) * 100;
 

--- a/packages/shared/profile-stats/src/chart-builders.ts
+++ b/packages/shared/profile-stats/src/chart-builders.ts
@@ -553,7 +553,20 @@ export function getComparisonWindows(
   return { current, previous };
 }
 
-function periodSnapshot(entries: LogbookEntry[], start: dayjs.Dayjs, end: dayjs.Dayjs): RawPeriodSnapshot {
+/**
+ * `inclusiveEnd` matters at the trailing-mode seam: `previous.end` and
+ * `current.start` are the same instant (`now - 1 unit`), so a tick landing
+ * exactly on that boundary would otherwise satisfy both windows and get
+ * double-counted. `current`'s end (`now`) stays inclusive — it's the
+ * outermost edge, shared with nothing — while `previous`'s end is exclusive
+ * so the shared instant belongs to `current` alone.
+ */
+function periodSnapshot(
+  entries: LogbookEntry[],
+  start: dayjs.Dayjs,
+  end: dayjs.Dayjs,
+  inclusiveEnd: boolean,
+): RawPeriodSnapshot {
   const sends = new Set<string>();
   const flashes = new Set<string>();
   for (const entry of entries) {
@@ -561,7 +574,8 @@ function periodSnapshot(entries: LogbookEntry[], start: dayjs.Dayjs, end: dayjs.
     // without a climbUuid don't count toward a distinct-climb tally.
     if (entry.status === 'attempt' || !entry.climbUuid) continue;
     const climbedAt = parseTickTime(entry.climbed_at);
-    if (!(climbedAt.isSameOrAfter(start) && climbedAt.isSameOrBefore(end))) continue;
+    if (!climbedAt.isSameOrAfter(start)) continue;
+    if (inclusiveEnd ? !climbedAt.isSameOrBefore(end) : !climbedAt.isBefore(end)) continue;
     sends.add(entry.climbUuid);
     if (entry.status === 'flash') flashes.add(entry.climbUuid);
   }
@@ -591,8 +605,8 @@ export function buildPeriodComparison(
   const allEntries = Object.values(allBoardsTicks).flat();
   const { current, previous } = getComparisonWindows(timeframe, mode, now);
 
-  const currentSnapshot = periodSnapshot(allEntries, current.start, current.end);
-  const previousSnapshot = periodSnapshot(allEntries, previous.start, previous.end);
+  const currentSnapshot = periodSnapshot(allEntries, current.start, current.end, true);
+  const previousSnapshot = periodSnapshot(allEntries, previous.start, previous.end, false);
   const sendsDelta = currentSnapshot.sends - previousSnapshot.sends;
   const sendsPercentChange = previousSnapshot.sends === 0 ? null : (sendsDelta / previousSnapshot.sends) * 100;
 

--- a/packages/shared/profile-stats/src/derive-view-model.ts
+++ b/packages/shared/profile-stats/src/derive-view-model.ts
@@ -7,6 +7,7 @@ import {
   buildStatisticsSummary,
   buildVPointsTimeline,
   buildActivityHeatmap,
+  buildPeriodComparison,
 } from './chart-builders';
 import { getDifficultyMapping } from './grade-mapping';
 import type {
@@ -20,6 +21,8 @@ import type {
   RawStatisticsSummary,
   RawGradeHighlight,
   RawActivityHeatmap,
+  PeriodComparisonMode,
+  RawPeriodComparison,
 } from './types';
 
 export type DeriveProfileViewModelInput = {
@@ -35,6 +38,10 @@ export type DeriveProfileViewModelInput = {
   gradeFormat: GradeDisplayFormat;
   /** `userProfileStats` response, or null while loading / for a fresh user. */
   profileStats: ProfileStatsData | null;
+  /** Trailing vs. year-over-year for the period comparison card. The caller
+   *  owns the default ('trailing') — this function is a pure pass-through, like
+   *  every other filter field. */
+  comparisonMode: PeriodComparisonMode;
 };
 
 export type ProfileViewModel = {
@@ -47,6 +54,7 @@ export type ProfileViewModel = {
   activityHeatmap: RawActivityHeatmap | null;
   hardestSend: RawGradeHighlight | null;
   hardestFlash: RawGradeHighlight | null;
+  periodComparison: RawPeriodComparison | null;
 };
 
 /**
@@ -57,7 +65,8 @@ export type ProfileViewModel = {
  * each platform's component layer.
  */
 export function deriveProfileViewModel(input: DeriveProfileViewModelInput): ProfileViewModel {
-  const { allBoardsTicks, selectedBoard, timeframe, fromDate, toDate, gradeFormat, profileStats } = input;
+  const { allBoardsTicks, selectedBoard, timeframe, fromDate, toDate, gradeFormat, profileStats, comparisonMode } =
+    input;
 
   const filteredBoardsTicks: Record<string, LogbookEntry[]> =
     selectedBoard === 'all' ? allBoardsTicks : { [selectedBoard]: allBoardsTicks[selectedBoard] || [] };
@@ -93,6 +102,8 @@ export function deriveProfileViewModel(input: DeriveProfileViewModelInput): Prof
 
   const activityHeatmap = buildActivityHeatmap(filteredLogbook);
 
+  const periodComparison = buildPeriodComparison(filteredBoardsTicks, timeframe, comparisonMode);
+
   const { hardestSend, hardestFlash } = computeHardest(filteredBoardsTicks, gradeFormat);
 
   return {
@@ -105,6 +116,7 @@ export function deriveProfileViewModel(input: DeriveProfileViewModelInput): Prof
     activityHeatmap,
     hardestSend,
     hardestFlash,
+    periodComparison,
   };
 }
 

--- a/packages/shared/profile-stats/src/derive-view-model.ts
+++ b/packages/shared/profile-stats/src/derive-view-model.ts
@@ -58,11 +58,13 @@ export type ProfileViewModel = {
 };
 
 /**
- * Pure orchestration shared by web's `useProfileData` and mobile's
- * `useYouProfileData`. Given the raw per-board ticks plus the active board /
- * timeframe / grade-format filters, derives every chart's renderer-agnostic
- * data plus the hardest send/flash highlights. Color resolution happens at
- * each platform's component layer.
+ * Pure orchestration behind mobile's `useYouProfileData`. Given the raw
+ * per-board ticks plus the active board / timeframe / grade-format filters,
+ * derives every chart's renderer-agnostic data plus the hardest send/flash
+ * highlights. Color resolution happens at the component layer. Web's
+ * `useProfileData` does its own orchestration (calls the individual raw
+ * builders directly via a local color-adapter) rather than going through this
+ * function — see the web/mobile split noted on each raw builder.
  */
 export function deriveProfileViewModel(input: DeriveProfileViewModelInput): ProfileViewModel {
   const { allBoardsTicks, selectedBoard, timeframe, fromDate, toDate, gradeFormat, profileStats, comparisonMode } =

--- a/packages/shared/profile-stats/src/index.ts
+++ b/packages/shared/profile-stats/src/index.ts
@@ -13,6 +13,8 @@ export {
   buildVPointsTimeline,
   buildStatisticsSummary,
   buildActivityHeatmap,
+  getComparisonWindows,
+  buildPeriodComparison,
 } from './chart-builders';
 export { difficultyMapping, getDifficultyMapping, sortGrades } from './grade-mapping';
 export {

--- a/packages/shared/profile-stats/src/types.ts
+++ b/packages/shared/profile-stats/src/types.ts
@@ -120,7 +120,6 @@ export type PeriodComparisonMode = 'trailing' | 'yearOverYear';
 
 export type RawPeriodSnapshot = {
   sends: number; // distinct climbUuid with status 'send' | 'flash'
-  flashes: number; // distinct climbUuid with status 'flash'
   startDate: string; // YYYY-MM-DD
   endDate: string;
 };

--- a/packages/shared/profile-stats/src/types.ts
+++ b/packages/shared/profile-stats/src/types.ts
@@ -114,6 +114,25 @@ export type RawGradeHighlight = {
   status: 'send' | 'flash';
 };
 
+// ── Period-over-period comparison (Progress tab headline) ───────────
+
+export type PeriodComparisonMode = 'trailing' | 'yearOverYear';
+
+export type RawPeriodSnapshot = {
+  sends: number; // distinct climbUuid with status 'send' | 'flash'
+  flashes: number; // distinct climbUuid with status 'flash'
+  startDate: string; // YYYY-MM-DD
+  endDate: string;
+};
+
+export type RawPeriodComparison = {
+  mode: PeriodComparisonMode;
+  current: RawPeriodSnapshot;
+  previous: RawPeriodSnapshot;
+  sendsDelta: number; // current.sends - previous.sends
+  sendsPercentChange: number | null; // null when previous.sends === 0 (no divide-by-zero)
+};
+
 /** One calendar day in the activity heatmap (local date, ascent count). */
 export type RawActivityDay = {
   /** Local calendar date, `YYYY-MM-DD`. */


### PR DESCRIPTION
## Summary

Implements Phases 0, 1, 2, and 4 of the [period-over-period comparison implementation plan](https://claude.ai/code/artifact/837fde01-2744-4665-a9e9-dedab5b8bfe4) (companion to the [requirements doc](https://claude.ai/code/artifact/db25eaef-cde0-4d6d-8b06-61ce1b9d1248)). Phase 3 (web wiring) is deferred to a follow-up PR — the web "You"/statistics UI moved to the Expo app in W-16 (#4435), and this PR keeps scope to shared logic + mobile.

- **Phase 0 (`@boardsesh/profile-stats`)**: `getComparisonWindows` (pure date math for trailing vs. year-over-year windows) and `buildPeriodComparison` (distinct-climbUuid sends/flashes per window, `sendsDelta`/`sendsPercentChange`) — zero new queries, filters the already-loaded `userTicks` logbook client-side like every other chart builder.
- **Phase 1 (`deriveProfileViewModel`)**: threads a `comparisonMode` input through and exposes `periodComparison` on the view model, `null` for any timeframe other than week/month/year.
- **Phase 2 (mobile)**: `useYouProfileData` holds `comparisonMode` state (default `'trailing'`); new `PeriodComparisonCard` renders the current-period sends count, a colored delta/percent badge, and a trailing/year-over-year segmented control, wired into the Progress tab under the stats summary. i18n strings added to all 4 locales following the Spanish/French/German glossaries.
- **Phase 4**: full validation pass — see test plan.

## Test plan

- [x] `vp test run --project profile-stats` — 72 tests passing, including new coverage for `getComparisonWindows`/`buildPeriodComparison` (fixed-`now` cases across all 3 timeframes × 2 modes, empty-previous-period null-percent, leap-year boundary, multi-board ticks, attempt/climbUuid-less exclusion) and `deriveProfileViewModel`'s `periodComparison` wiring.
- [x] `vp run typecheck` (all packages) — clean.
- [x] `vp run test:mobile` (`vp test run --project mobile`) — 6519 tests passing, including the new `PeriodComparisonCard` component tests (null render, positive/negative delta, first-period and no-comparison-data empty states, segmented-control mode switching) and the `useYouProfileData` `comparisonMode` coverage.
- [x] `vp test run --project web` — 3397 tests passing (unaffected; web doesn't call `deriveProfileViewModel`).
- [x] `vp check` — clean on all touched files.
- [x] `vp run check:i18n` / `vp run check:i18n:orphans` — clean (fixed a dynamic-`t()`-key lint failure by inlining the ternary as string literals).
- [x] `vp run check:mobile-bundle` — OK.
- [x] Manual QA in the running app: new user with zero history, first-period state (`sendsPercentChange: null`), trailing ↔ year-over-year toggle, board filter interaction.

## Release Notes

Your Progress tab now shows how this period's sends stack up against the last one — flip between "vs. last period" and "vs. same time last year" to see your trend.