### PR TITLE
fix(web): stop double-branding the page title

### DIFF
--- a/packages/web/app/__tests__/page-seo-metadata.test.ts
+++ b/packages/web/app/__tests__/page-seo-metadata.test.ts
@@ -48,7 +48,7 @@ describe('page metadata exports', () => {
     const aboutImages = toOpenGraphImageList(aboutMetadata.openGraph?.images);
     const aboutImageUrl = getOpenGraphImageUrl(aboutImages[0]);
 
-    expect(aboutMetadata.title).toBe('About | Boardsesh');
+    expect(aboutMetadata.title).toEqual({ absolute: 'About | Boardsesh' });
     expect(aboutMetadata.alternates?.canonical).toBe('/about');
     expect(aboutMetadata.alternates?.languages).toEqual({
       'en-US': '/about',
@@ -73,7 +73,7 @@ describe('page metadata exports', () => {
   });
 
   it('keeps the public playlists directory indexable because it exposes discoverable content', () => {
-    expect(playlistsMetadata.title).toBe('Discover Climbing Playlists | Boardsesh');
+    expect(playlistsMetadata.title).toEqual({ absolute: 'Discover Climbing Playlists | Boardsesh' });
     expect(playlistsMetadata.description).toBe(
       'Discover public climbing playlists and manage your own after signing in.',
     );

--- a/packages/web/app/lib/seo/__tests__/metadata.test.ts
+++ b/packages/web/app/lib/seo/__tests__/metadata.test.ts
@@ -29,7 +29,7 @@ describe('SEO metadata helper', () => {
         path: 'docs',
       });
 
-      expect(metadata.title).toBe('API Documentation | Boardsesh');
+      expect(metadata.title).toEqual({ absolute: 'API Documentation | Boardsesh' });
       expect(metadata.description).toBe('REST and WebSocket docs for Boardsesh.');
       expect(metadata.alternates?.canonical).toBe('/docs');
       expect(metadata.openGraph).toEqual({
@@ -96,7 +96,64 @@ describe('SEO metadata helper', () => {
 
       expect(metadata.robots).toEqual({ index: false, follow: true });
       expect(metadata.alternates?.canonical).toBe('/auth/login');
-      expect(metadata.title).toBe('Login | Boardsesh');
+      expect(metadata.title).toEqual({ absolute: 'Login | Boardsesh' });
+    });
+  });
+
+  // #4472. Production shipped `<title>… | Boardsesh | Boardsesh</title>` on every
+  // page outside the board tree, because two independent things brand the title:
+  // `withBrandTitle` here, and the root layout's `title.template = '%s | Boardsesh'`
+  // (app/layout.tsx), which Next applies to any descendant whose title is a plain
+  // string. Returning `{ absolute }` is what stops the second one.
+  describe('brand suffix is applied exactly once (#4472)', () => {
+    const brandOccurrences = (value: string) => value.match(/\|\s*Boardsesh/g)?.length ?? 0;
+
+    it('never returns a bare-string title for the root layout template to re-brand', () => {
+      const metadata = createPageMetadata({
+        title: "Marco's Kilter Sessions",
+        description: 'Sessions and sends.',
+        path: '/profile/123',
+      });
+
+      // The load-bearing assertion. A bare string here is silently re-branded by
+      // the ancestor template, and no assertion on its *value* can see that
+      // happen — the doubling occurs after this function returns.
+      expect(typeof metadata.title).not.toBe('string');
+      expect(metadata.title).toEqual({ absolute: "Marco's Kilter Sessions | Boardsesh" });
+    });
+
+    it('carries the suffix once in the page, Open Graph and Twitter titles alike', () => {
+      const metadata = createPageMetadata({
+        title: 'Kilter climbs at 40°',
+        description: 'Browse climbs.',
+        path: '/kilter/original/12x12-square/screw_bolt/40/list',
+      });
+
+      const pageTitle = (metadata.title as { absolute: string }).absolute;
+      expect(brandOccurrences(pageTitle)).toBe(1);
+      expect(brandOccurrences(String(metadata.openGraph?.title))).toBe(1);
+      expect(brandOccurrences(String(metadata.twitter?.title))).toBe(1);
+    });
+
+    it('does not add a second suffix to a title that already carries one', () => {
+      const metadata = createPageMetadata({
+        title: 'API Documentation | Boardsesh',
+        description: 'Docs.',
+        path: '/docs',
+      });
+
+      expect(metadata.title).toEqual({ absolute: 'API Documentation | Boardsesh' });
+      expect(brandOccurrences((metadata.title as { absolute: string }).absolute)).toBe(1);
+    });
+
+    it('leaves a Boardsesh-prefixed title alone', () => {
+      const metadata = createPageMetadata({
+        title: 'Boardsesh - Train smarter on your climbing board',
+        description: 'Home.',
+        path: '/',
+      });
+
+      expect(metadata.title).toEqual({ absolute: 'Boardsesh - Train smarter on your climbing board' });
     });
   });
 });

--- a/packages/web/app/lib/seo/metadata.ts
+++ b/packages/web/app/lib/seo/metadata.ts
@@ -85,7 +85,23 @@ export function createPageMetadata({
     : undefined;
 
   return {
-    title: fullTitle,
+    // `absolute`, not a bare string. The root layout sets
+    // `title.template = '%s | Boardsesh'` (app/layout.tsx), and Next applies that
+    // template to any descendant whose title is a plain string. `fullTitle`
+    // already carries the suffix, so a plain string here renders
+    // `… | Boardsesh | Boardsesh` — which is exactly what production served on
+    // every page outside the board tree until #4472.
+    //
+    // The board tree escaped only by accident: its
+    // `[board_name]/…/[angle]/layout.tsx` exports its own `generateMetadata`
+    // returning a plain `title` string, which consumes the inherited template
+    // before `/list` and `/view/[climb_uuid]` ever see it. Do not rely on that —
+    // `absolute` makes the outcome the same in both trees.
+    //
+    // `openGraph.title` and `twitter.title` below are already immune: Next never
+    // applies the template to them, which is why they were correct in production
+    // while `<title>` — the one Google renders in the SERP — was not.
+    title: { absolute: fullTitle },
     description,
     alternates,
     robots,

--- a/packages/web/app/preview/[channel]/__tests__/page.test.tsx
+++ b/packages/web/app/preview/[channel]/__tests__/page.test.tsx
@@ -47,7 +47,7 @@ describe('OTA preview page', () => {
   it('names the PR in the title and keeps the page out of the index', async () => {
     const metadata = await pageModule.generateMetadata({ params: Promise.resolve({ channel: 'pr-1234' }) });
 
-    expect(metadata.title).toBe('Try PR #1234 in the app | Boardsesh');
+    expect(metadata.title).toEqual({ absolute: 'Try PR #1234 in the app | Boardsesh' });
     expect(metadata.robots).toEqual({ index: false, follow: true });
   });
 

--- a/packages/web/app/profile/[user_id]/__tests__/page.test.tsx
+++ b/packages/web/app/profile/[user_id]/__tests__/page.test.tsx
@@ -70,7 +70,7 @@ describe('profile page route', () => {
       params: Promise.resolve({ user_id: 'missing-user' }),
     });
 
-    expect(metadata.title).toBe('Profile Not Found | Boardsesh');
+    expect(metadata.title).toEqual({ absolute: 'Profile Not Found | Boardsesh' });
     // `follow: true` is the house default — the page 404s anyway, and there is
     // no reason to stop a crawler following the links it renders.
     expect(metadata.robots).toEqual({ index: false, follow: true });
@@ -104,7 +104,7 @@ describe('profile page route', () => {
 
     // Public profiles are a search surface — indexable, deliberately.
     expect(metadata.robots).toBeUndefined();
-    expect(metadata.title).toBe("Marco's Kilter Sessions | Boardsesh");
+    expect(metadata.title).toEqual({ absolute: "Marco's Kilter Sessions | Boardsesh" });
     expect(metadata.alternates?.canonical).toBe('/profile/user-1');
     expect(metadata.alternates?.languages).toEqual({
       'en-US': '/profile/user-1',
@@ -128,7 +128,7 @@ describe('profile page route', () => {
       params: Promise.resolve({ user_id: 'user-1' }),
     });
 
-    expect(metadata.title).toBe("Marco's Climbing Sessions | Boardsesh");
+    expect(metadata.title).toEqual({ absolute: "Marco's Climbing Sessions | Boardsesh" });
   });
 
   it('calls notFound and skips stats fetch when the user does not exist', async () => {

--- a/packages/web/app/session/[sessionId]/__tests__/page-metadata.test.tsx
+++ b/packages/web/app/session/[sessionId]/__tests__/page-metadata.test.tsx
@@ -85,7 +85,7 @@ describe('session page metadata', () => {
 
     const image = Array.isArray(metadata.openGraph?.images) ? metadata.openGraph.images[0] : metadata.openGraph?.images;
 
-    expect(metadata.title).toBe('Board Session | Boardsesh');
+    expect(metadata.title).toEqual({ absolute: 'Board Session | Boardsesh' });
     expect(metadata.description).toBe('Alex — 3 sends');
     expect(getOpenGraphImageUrl(image)).toBe('/api/og/session?sessionId=session-1&v=abc123');
   });
@@ -110,7 +110,7 @@ describe('session page metadata', () => {
       params: Promise.resolve({ sessionId: 'missing-session' }),
     });
 
-    expect(metadata.title).toBe('Session Not Found | Boardsesh');
+    expect(metadata.title).toEqual({ absolute: 'Session Not Found | Boardsesh' });
   });
 
   it('never leaks the private session recap notes into title/description/OG', async () => {
@@ -141,7 +141,7 @@ describe('session page metadata', () => {
 
     const serialized = JSON.stringify(metadata);
     expect(serialized).not.toContain(secretRecap);
-    expect(metadata.title).not.toContain(secretRecap);
+    expect((metadata.title as { absolute: string }).absolute).not.toContain(secretRecap);
     expect(metadata.description).not.toContain(secretRecap);
     expect(getOpenGraphImageUrl(image) ?? '').not.toContain(secretRecap);
   });


### PR DESCRIPTION
## Summary

Every indexable page outside the board tree was shipping `<title>… | Boardsesh | Boardsesh</title>` in production. One line fixes it. Closes #4472 (the title half — see "Not in this PR" below).

Found while running epic #4358's owed definition-of-done curl matrix against production after W-16 and W-22 deployed.

### Measured in production, 2026-08-15

| URL | `<title>` before |
|---|---|
| `/setter/KilterStudio` | `KilterStudio - Setter \| Boardsesh \| Boardsesh` |
| `/playlists/3e3bb224-…` | `Fresh · Tension Board 2 Spray 12 high x 12 wide @ 40° \| Boardsesh \| Boardsesh` |
| `/playlists` | `Discover Climbing Playlists \| Boardsesh \| Boardsesh` |
| `/kilter/…/40/view/bell-of-the-wall-…` | `Bell of the Wall - 6b/V4 \| Boardsesh` ✅ |
| `/kilter/…/40/list` | `Kilter climbs at 40° \| Boardsesh` ✅ |

`og:title` and `twitter:title` were correct everywhere. Only `<title>` doubled — the one Google renders in the SERP, and the one with a ~60-character budget.

## Root cause

Two independent things brand the title, and they stack:

1. `app/lib/seo/metadata.ts:78` — `createPageMetadata` computes `withBrandTitle(title)` and returned it as a **plain string**.
2. `app/layout.tsx:32` — the root layout returns `title: { default: …, template: '%s | Boardsesh' }`. Next applies that template to any descendant whose title is a plain string.

`withBrandTitle`'s existing guard only stops *itself* re-appending; it cannot see an ancestor template.

**The board tree escaped by accident, not by design.** `app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/layout.tsx:27` exports its own `generateMetadata` returning a plain `title` string, which consumes the inherited template before `/list` and `/view/[climb_uuid]` ever see it. Every route outside that layout — setter, playlists, profile, gym, legal, docs, about, help, auth, preview — doubled.

## The fix

```diff
-    title: fullTitle,
+    title: { absolute: fullTitle },
```

`absolute` tells Next no ancestor template applies. Correct in both trees: the board layout's template-consumption becomes irrelevant, and `openGraph.title` / `twitter.title` are byte-identical to before (Next never templated those, which is exactly why they were already right).

## Test plan

`vp test run --reporter=agent --project web` — **303 files / 3401 tests, all green.**

Four new assertions in `app/lib/seo/__tests__/metadata.test.ts` under `brand suffix is applied exactly once (#4472)`:

- **`never returns a bare-string title for the root layout template to re-brand`** — the load-bearing one. It asserts `typeof metadata.title !== 'string'`, because the doubling happens *after* this function returns: no assertion on the title's *value* here can observe it. That is why the original bug was invisible to a unit test that checked the string.
- the suffix appears exactly once across page, OG and Twitter titles
- an already-branded title does not gain a second suffix
- a `Boardsesh`-prefixed title (the homepage) is left alone

### Mutation probe

Reverted `title: { absolute: fullTitle }` back to `title: fullTitle` and re-ran:

```
× builds canonical, Open Graph, and Twitter metadata with normalized paths
× marks utility pages as noindex while preserving canonical metadata
× never returns a bare-string title for the root layout template to re-brand
× carries the suffix once in the page, Open Graph and Twitter titles alike
× does not add a second suffix to a title that already carries one
× leaves a Boardsesh-prefixed title alone
Tests  6 failed | 4 passed (10)
```

Restored; `git status --porcelain` clean.

### Downstream assertions updated (8 across 4 files)

These asserted `metadata.title` as a plain string and are shape-updates, not behaviour changes: `page-seo-metadata.test.ts` (2), `profile/[user_id]/__tests__/page.test.tsx` (3), `session/[sessionId]/__tests__/page-metadata.test.tsx` (3), `preview/[channel]/__tests__/page.test.tsx` (1).

**One of those needed care rather than a mechanical swap.** `session/[sessionId]/__tests__/page-metadata.test.tsx:143` is a leak guard — `expect(metadata.title).not.toContain(secretRecap)` — and `.not.toContain` against an object passes vacuously. It now asserts on the resolved `.absolute` string, so the guard stays real. (The `JSON.stringify(metadata)` assertion on the line above independently covers the same leak, but an inert assertion left in place is worse than no assertion.)

### Gates

| command | result |
|---|---|
| `vp run typecheck` | ✅ green (full monorepo) |
| `vp test run --reporter=agent --project web` | ✅ 303 files / 3401 tests |

No i18n catalogs are touched — this PR adds no user-facing strings.

## Not in this PR

#4472 also lists two things this does not fix, both still open on that issue:

- **Missing `<h1>`** on `/playlists` (no headings at all in server HTML), `/playlists/[uuid]` (top heading is an `<h2>`) and `/setter/[username]`.
- **`/setter/[username]` serving an indexable empty shell**, and answering 200 for any username — that is #4473, and it is a much larger change.

Splitting them keeps this reviewable as the one-line fix it is.

## Release Notes

none — internal SEO metadata fix. Search results stop showing the site name twice; no product change.

- [x] This change is internal-only and needs no release note.
