### PR TITLE
fix(web): degrade the sitemap index instead of 503ing the whole thing

### DIFF
--- a/docs/web-reposition.md
+++ b/docs/web-reposition.md
@@ -391,17 +391,57 @@ shard it already has. `buildSitemapIndexXml` throws only when nothing is left to
 publish; an empty `<sitemapindex>` under an hour of `s-maxage` is the harm the
 doctrine was written against.
 
+**A degraded index is cached for a minute, not for 25 hours.** This is the half
+that makes degradation safe rather than a worse bug. The full window is
+`s-maxage=3600` plus a day of `stale-while-revalidate`, and the 503 it replaced
+was `no-store` and therefore never cached at all — so before this change the copy
+the CDN eventually held was always complete. Serving a partial index under the
+full window would trade a self-healing 503 for a cacheable lie: one cold start
+pinning "boards.xml does not exist" at the edge for 25 hours while the URL serves
+perfectly the whole time. A degraded 200 gets `s-maxage=60, must-revalidate` and
+an `X-Sitemap-Degraded` header naming the shards it dropped, so the next crawl
+re-attempts and the degradation is visible on the response rather than only in a
+log line.
+
+The post-deploy smoke was widened in the same PR for the same reason. It asserted
+"any one shard `<loc>`", which a degraded index satisfies — and `static` is a
+hardcoded builder that cannot fail, so the detector that caught #4476 would have
+been permanently green afterwards. It now names both `expectsUrls` shards
+(`static.xml`, `boards.xml`); the three declared-empty ones are legitimately
+absent and stay out of it.
+
 **Slow is a failure mode, and a try/catch cannot see it.** Each builder in the
 index walk is raced against `SHARD_DEADLINE_MS` (3 s, the value W-23 settled on
-for its paged summary), and the walk as a whole against `INDEX_DEADLINE_MS` (8 s).
-The production failure was not a rejection: `getAllBoardConfigsOrThrow` sits on a
-10 s abort and `fetchPlaylistSitemapRows` has no bound at all, so a cold instance
-stalls until the platform kills the request — a 5xx on all five shards, strictly
-worse than the 503 the fail-closed rule was protecting. The walk is **sequential**,
-not `Promise.all`: the concurrent fan-out over a database query and a GraphQL fetch
-is the pool-starvation shape #4461 is about, and the index has no latency
-requirement that justifies it. Sequencing is only safe because of the total budget
-— five 3 s deadlines back to back is 15 s, past the serverless ceiling.
+for its paged summary, so the two collapse into one constant on merge). Be
+precise about why: the two recorded production failures were _rejections_ — a 503
+is the route's own `unavailableResponse`, and `getAllBoardConfigsOrThrow`'s 10 s
+abort surfaces as a throw — so the try/catch alone covers what was measured. The
+deadline covers the mode a try/catch structurally cannot see, a builder that never
+settles (`fetchPlaylistSitemapRows` has no bound of its own), which would hold the
+index to the platform timeout and 5xx all five shards. The index's 3 s and the
+boards builder's own 10 s are _supposed_ to disagree: failing the shard route
+costs a working URL, while missing the index deadline costs one shard for sixty
+seconds. Cheap to be wrong, so be impatient.
+
+**Concurrent, with only a per-shard deadline.** An earlier draft of this fix
+sequenced the walk under a total 8 s budget, and that made the tail of the
+registry the deterministic victim: five builders each a comfortable 1.9 s — every
+one inside its own deadline — spend the budget before `playlists` runs, so it is
+dropped for its position rather than its latency. `Promise.allSettled` bounds the
+walk by max(builder) instead of sum(builder), which removes the starvation and
+the need for a total budget at once. The fan-out is two I/O calls against two
+different backends plus three hardcoded builders — not the many-concurrent-heavy-
+scans shape of #4461, which W-23 sequences _within_ its climbs query for exactly
+that reason. Sequencing would not have bounded pool load anyway: `withDeadline`
+stops waiting, it does not cancel.
+
+**Known follow-ups.** `withDeadline` bounds this request's latency, not the
+abandoned query still holding a connection — a real bound needs an `AbortSignal`
+threaded into `fetchPlaylistSitemapRows` or a statement timeout on its query.
+`getAllBoardConfigsOrThrow` is uncached (the `unstable_cache` in that file wraps
+`fetchPopularBoardConfigs`, the limit=12 homepage variant) and `/sitemap.xml` is
+`force-dynamic`, so every CDN miss re-runs it live; caching the per-shard
+summaries is what would make 3 s comfortably attainable on a cold instance.
 
 **Two shards ship declared-empty, and that is the point.** `gyms.xml` waits on
 #4381's public-gyms enumeration query, which the gym-discovery epic (#4372)

--- a/docs/web-reposition.md
+++ b/docs/web-reposition.md
@@ -370,14 +370,38 @@ tells Google the missing URLs were deleted. Three more cases fail the same way:
 a shard past its URL budget, a shard that `expectsUrls` but built none (a
 poisoned cache or a regressed query silently emptying `static` or `boards`), and
 a boards fetch whose `hasMore` says the 100-config API cap — the schema's hard
-max, so the fix is paging, not a bigger constant — dropped the tail. The index
-applies the same rule: it throws rather than publishing an index that quietly
-dropped a shard, and it lists only shards carrying at least one URL. For the
+max, so the fix is paging, not a bigger constant — dropped the tail. For the
 same reason the boards shard uses a _throwing_ popular-configs fetch, not the
 homepage's swallow-and-return-`[]` wrapper. `playlists` is deliberately **not**
 `expectsUrls` — zero public playlists holding a climb is a legitimate state, and
 failing closed there would take the whole index down over nobody having shared
 a list.
+
+**The index degrades; only the shard fails closed (#4476).** W-22 shipped the
+index under the same all-or-nothing rule, and production disagreed: `/sitemap.xml`
+503'd on a cold cache and failed the post-deploy smoke twice, while
+`/sitemaps/static.xml` passed in the same run. The index is the one path that runs
+_every_ builder, so one cold boards fetch took the four shards that were ready
+down with it. The split is now by layer — a shard route still 503s when its own
+builder throws, misses its budget or comes back unexpectedly empty, but the index
+logs loudly, omits that shard's `<sitemap>` entry and still answers 200 with
+whatever built. A partial sitemap beats no sitemap when every shard it does list
+is served fail-closed at its own URL, and Google keeps the copy of the omitted
+shard it already has. `buildSitemapIndexXml` throws only when nothing is left to
+publish; an empty `<sitemapindex>` under an hour of `s-maxage` is the harm the
+doctrine was written against.
+
+**Slow is a failure mode, and a try/catch cannot see it.** Each builder in the
+index walk is raced against `SHARD_DEADLINE_MS` (3 s, the value W-23 settled on
+for its paged summary), and the walk as a whole against `INDEX_DEADLINE_MS` (8 s).
+The production failure was not a rejection: `getAllBoardConfigsOrThrow` sits on a
+10 s abort and `fetchPlaylistSitemapRows` has no bound at all, so a cold instance
+stalls until the platform kills the request — a 5xx on all five shards, strictly
+worse than the 503 the fail-closed rule was protecting. The walk is **sequential**,
+not `Promise.all`: the concurrent fan-out over a database query and a GraphQL fetch
+is the pool-starvation shape #4461 is about, and the index has no latency
+requirement that justifies it. Sequencing is only safe because of the total budget
+— five 3 s deadlines back to back is 15 s, past the serverless ceiling.
 
 **Two shards ship declared-empty, and that is the point.** `gyms.xml` waits on
 #4381's public-gyms enumeration query, which the gym-discovery epic (#4372)

--- a/packages/web/app/lib/seo/sitemap/__tests__/entries.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/entries.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 import { SUPPORTED_LOCALES } from '@/app/lib/i18n/config';
-import { buildAlternates, expandAllLocales, expandLocales, latestLastModified } from '../entries';
+import { allLocalesUrlCount, buildAlternates, expandAllLocales, expandLocales, latestLastModified } from '../entries';
 
 describe('expandLocales', () => {
   const entries = expandLocales({ path: '/playlists/abc', lastModified: new Date('2026-04-30T00:00:00.000Z') });
@@ -45,6 +45,17 @@ describe('expandLocales', () => {
   it('carries a null lastModified through rather than inventing one', () => {
     for (const entry of expandLocales({ path: '/about' })) {
       expect(entry.lastModified).toBeNull();
+    }
+  });
+});
+
+describe('allLocalesUrlCount', () => {
+  it('matches what expandAllLocales would actually build', () => {
+    // The index checks the URL budget with the cheap count instead of building
+    // up to 45,000 entries it would throw away. That is only sound while the two
+    // agree, so pin them against each other rather than against a literal.
+    for (const items of [[], [{ path: '/about' }], [{ path: '/a' }, { path: '/b' }, { path: '/c' }]]) {
+      expect(allLocalesUrlCount(items)).toBe(expandAllLocales(items).length);
     }
   });
 });

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
 import type { SitemapItem } from '../entries';
 import { MAX_ITEMS_PER_SHARD } from '../sitemap-xml';
 
 vi.mock('server-only', () => ({}));
+
+const FULL_CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=86400';
+const DEGRADED_CACHE_CONTROL = 'public, s-maxage=60, must-revalidate';
 
 const KILTER_CONFIG: PopularBoardConfig = {
   boardType: 'kilter',
@@ -20,13 +23,15 @@ const KILTER_CONFIG: PopularBoardConfig = {
   displayName: 'Kilter Original 12x12',
 };
 
-const boardConfigs = vi.hoisted(() => ({ shouldThrow: false, empty: false, hang: false }));
-const playlistRows = vi.hoisted(() => ({ count: 1, shouldThrow: false, hang: false }));
-/** `static`, `gyms` and `setters` are pure builders — flags let all five fail at once. */
-const pureBuilders = vi.hoisted(() => ({ shouldThrow: false, hang: false }));
+const boardConfigs = vi.hoisted(() => ({ shouldThrow: false, empty: false, hang: false, delayMs: 0 }));
+const playlistRows = vi.hoisted(() => ({ count: 1, shouldThrow: false, hang: false, delayMs: 0 }));
+/** `static`, `gyms` and `setters` are pure builders — flags let all five fail, or stall, at once. */
+const pureBuilders = vi.hoisted(() => ({ shouldThrow: false, hang: false, delayMs: 0 }));
 
 /** Never settles: the failure mode a try/catch cannot see. */
 const forever = <T>(): Promise<T> => new Promise<T>(() => {});
+/** Settles late: the failure mode a *total* budget turns into a starved shard. */
+const after = (ms: number): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 vi.mock('@/app/lib/server-popular-configs', () => ({
   getAllBoardConfigsOrThrow: async () => {
@@ -35,6 +40,9 @@ vi.mock('@/app/lib/server-popular-configs', () => ({
     }
     if (boardConfigs.shouldThrow) {
       throw new Error('backend unreachable');
+    }
+    if (boardConfigs.delayMs > 0) {
+      await after(boardConfigs.delayMs);
     }
     return boardConfigs.empty ? [] : [KILTER_CONFIG];
   },
@@ -47,6 +55,9 @@ vi.mock('../playlist-query', () => ({
     if (playlistRows.shouldThrow) {
       throw new Error('playlist pool exhausted');
     }
+    if (playlistRows.delayMs > 0) {
+      await after(playlistRows.delayMs);
+    }
     const updatedAt = new Date('2026-04-30T00:00:00.000Z');
     return Array.from({ length: playlistRows.count }, (_, index) => ({
       uuid: index === 0 ? 'abc-123' : `playlist-${index}`,
@@ -57,8 +68,9 @@ vi.mock('../playlist-query', () => ({
 
 /**
  * The registry wraps these three in `async () => build()`, so handing back a
- * pending promise is what a hung I/O call looks like from the index's side once
- * it awaits — the cast is the price of faking that through a sync signature.
+ * pending or delayed promise is what a hung/slow I/O call looks like from the
+ * index's side once it awaits — the cast is the price of faking that through a
+ * sync signature.
  */
 const pureBuilder = (real: () => SitemapItem[]): SitemapItem[] => {
   if (pureBuilders.hang) {
@@ -66,6 +78,9 @@ const pureBuilder = (real: () => SitemapItem[]): SitemapItem[] => {
   }
   if (pureBuilders.shouldThrow) {
     throw new Error('pure builder exploded');
+  }
+  if (pureBuilders.delayMs > 0) {
+    return after(pureBuilders.delayMs).then(real) as unknown as SitemapItem[];
   }
   return real();
 };
@@ -83,15 +98,44 @@ vi.mock('../setter-entries', async (importOriginal) => {
   return { ...actual, buildSetterEntries: () => pureBuilder(actual.buildSetterEntries) };
 });
 
-const { INDEX_DEADLINE_MS, SHARD_DEADLINE_MS, buildSitemapIndexXml, shardRouteHandler, sitemapIndexRouteHandler } =
+const { SHARD_DEADLINE_MS, buildSitemapIndexXml, shardRouteHandler, sitemapIndexRouteHandler } =
   await import('../shard-registry');
+
+let errors: string[] = [];
+let warnings: string[] = [];
+
+beforeEach(() => {
+  errors = [];
+  warnings = [];
+  vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    errors.push(args.map(String).join(' '));
+  });
+  vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  });
+});
+
+/**
+ * Resets live here rather than in each test's `finally`, which sits *downstream*
+ * of an `await` that a regression can hang: when that happens the `finally` never
+ * runs, and `vi.useFakeTimers()` plus the hang flags leak into every later test
+ * in the file. A one-line regression then presents as three failures, two of them
+ * red herrings.
+ */
+afterEach(() => {
+  vi.useRealTimers();
+  Object.assign(boardConfigs, { shouldThrow: false, empty: false, hang: false, delayMs: 0 });
+  Object.assign(playlistRows, { count: 1, shouldThrow: false, hang: false, delayMs: 0 });
+  Object.assign(pureBuilders, { shouldThrow: false, hang: false, delayMs: 0 });
+  vi.restoreAllMocks();
+});
 
 describe('shardRouteHandler', () => {
   it('serves a shard as application/xml with a CDN cache window', async () => {
     const response = await shardRouteHandler('static');
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toBe('application/xml; charset=utf-8');
-    expect(response.headers.get('cache-control')).toBe('public, s-maxage=3600, stale-while-revalidate=86400');
+    expect(response.headers.get('cache-control')).toBe(FULL_CACHE_CONTROL);
     expect(await response.text()).toContain('<urlset');
   });
 
@@ -107,13 +151,11 @@ describe('shardRouteHandler', () => {
     // A short 200 tells Google the missing URLs were deleted; a 5xx makes it
     // retry and keep the last good copy.
     boardConfigs.shouldThrow = true;
-    try {
-      const response = await shardRouteHandler('boards');
-      expect(response.status).toBe(503);
-      expect(response.headers.get('cache-control')).toBe('no-store');
-    } finally {
-      boardConfigs.shouldThrow = false;
-    }
+
+    const response = await shardRouteHandler('boards');
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('cache-control')).toBe('no-store');
   });
 
   it('answers 503 when a shard that expects URLs builds none', async () => {
@@ -122,13 +164,11 @@ describe('shardRouteHandler', () => {
     // s-maxage with nothing thrown, which is the failure the 503 doctrine exists
     // for — so an empty catalogue-derived shard fails closed too.
     boardConfigs.empty = true;
-    try {
-      const response = await shardRouteHandler('boards');
-      expect(response.status).toBe(503);
-      expect(response.headers.get('cache-control')).toBe('no-store');
-    } finally {
-      boardConfigs.empty = false;
-    }
+
+    const response = await shardRouteHandler('boards');
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('cache-control')).toBe('no-store');
   });
 
   it('answers 503 rather than serving a shard past the URL cap', async () => {
@@ -137,38 +177,41 @@ describe('shardRouteHandler', () => {
     // only mean something if the handler counts what it is about to serve.
     // One item past the item budget is, after locale expansion, past the URL cap.
     playlistRows.count = MAX_ITEMS_PER_SHARD + 1;
-    try {
-      const response = await shardRouteHandler('playlists');
-      expect(response.status).toBe(503);
-      expect(response.headers.get('cache-control')).toBe('no-store');
-    } finally {
-      playlistRows.count = 1;
-    }
+
+    const response = await shardRouteHandler('playlists');
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('cache-control')).toBe('no-store');
   });
 
   it('still serves a shard sitting exactly on the URL cap', async () => {
     // The guard rejects `>` the cap, not `>=`: the budget is a size that ships,
     // not one that 503s the day a shard lands on it exactly.
     playlistRows.count = MAX_ITEMS_PER_SHARD;
-    try {
-      const response = await shardRouteHandler('playlists');
-      expect(response.status).toBe(200);
-    } finally {
-      playlistRows.count = 1;
-    }
+
+    const response = await shardRouteHandler('playlists');
+
+    expect(response.status).toBe(200);
   });
 });
 
 describe('buildSitemapIndexXml', () => {
-  it('lists only the shards that carry URLs', async () => {
-    const xml = await buildSitemapIndexXml();
+  it('lists only the shards that carry URLs, and says which it left out', async () => {
+    const { xml, degradedShards } = await buildSitemapIndexXml();
+
     expect(xml).toContain('<sitemapindex');
     expect(xml).toContain('https://www.boardsesh.com/sitemaps/static.xml');
     expect(xml).toContain('https://www.boardsesh.com/sitemaps/boards.xml');
     expect(xml).toContain('https://www.boardsesh.com/sitemaps/playlists.xml');
-    // gyms and setters are declared-empty, so they stay out of the index.
+    // gyms and setters are declared-empty, so they stay out of the index — but
+    // "nobody has published a gym yet" and "the gyms query regressed to []" are
+    // indistinguishable from here, so the omission is logged rather than silent.
     expect(xml).not.toContain('/sitemaps/gyms.xml');
     expect(xml).not.toContain('/sitemaps/setters.xml');
+    expect(warnings.join(' ')).toContain('gyms, setters');
+    // An empty shard is not a degradation: nothing failed, so the response keeps
+    // the full cache window.
+    expect(degradedShards).toEqual([]);
   });
 
   it('serves the shards that built when one builder throws, and logs the one that did not', async () => {
@@ -176,113 +219,130 @@ describe('buildSitemapIndexXml', () => {
     // `Promise.all`, so a cold boards fetch took static and playlists — which
     // were ready — down with it. A partial sitemap beats no sitemap, because
     // every shard the index does list is still served fail-closed at its own URL.
-    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
     boardConfigs.shouldThrow = true;
-    try {
-      const response = await sitemapIndexRouteHandler();
-      const xml = await response.text();
 
-      expect(response.status).toBe(200);
-      expect(xml).toContain('/sitemaps/static.xml');
-      expect(xml).toContain('/sitemaps/playlists.xml');
-      expect(xml).not.toContain('/sitemaps/boards.xml');
-      expect(errors.mock.calls.flat().join(' ')).toContain('backend unreachable');
-    } finally {
-      boardConfigs.shouldThrow = false;
-      errors.mockRestore();
-    }
+    const response = await sitemapIndexRouteHandler();
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(xml).toContain('/sitemaps/static.xml');
+    expect(xml).toContain('/sitemaps/playlists.xml');
+    expect(xml).not.toContain('/sitemaps/boards.xml');
+    expect(errors.join(' ')).toContain('backend unreachable');
+  });
+
+  it('caches a degraded index for a minute, where a complete one gets the full window', async () => {
+    // The half that makes degradation safe. `s-maxage=3600` + a day of
+    // stale-while-revalidate on a partial index turns one cold start into 25
+    // hours of telling Google that boards.xml no longer exists — while the URL
+    // serves perfectly the whole time. The 503 it replaced was `no-store` and so
+    // was never cached at all, which is why the old copy at the edge was always
+    // complete.
+    const complete = await sitemapIndexRouteHandler();
+    expect(complete.headers.get('cache-control')).toBe(FULL_CACHE_CONTROL);
+    expect(complete.headers.get('x-sitemap-degraded')).toBeNull();
+
+    boardConfigs.shouldThrow = true;
+    const degraded = await sitemapIndexRouteHandler();
+
+    expect(degraded.status).toBe(200);
+    expect(degraded.headers.get('cache-control')).toBe(DEGRADED_CACHE_CONTROL);
+    // Named on the response, not only in a log line: a silent partial index is
+    // what would make the post-deploy smoke that caught #4476 permanently green.
+    expect(degraded.headers.get('x-sitemap-degraded')).toBe('boards');
   });
 
   it('omits — and logs — a shard that expects URLs but comes back empty', async () => {
     // Still a failure, still loud, but no longer fatal to the other four: the
     // shard's own route keeps 503ing on exactly this condition (above), which is
     // where the fail-closed promise is actually kept.
-    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
     boardConfigs.empty = true;
-    try {
-      const response = await sitemapIndexRouteHandler();
-      const xml = await response.text();
 
-      expect(response.status).toBe(200);
-      expect(xml).toContain('/sitemaps/static.xml');
-      expect(xml).not.toContain('/sitemaps/boards.xml');
-      expect(errors.mock.calls.flat().join(' ')).toContain('expects URLs but built none');
-    } finally {
-      boardConfigs.empty = false;
-      errors.mockRestore();
-    }
+    const response = await sitemapIndexRouteHandler();
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(xml).toContain('/sitemaps/static.xml');
+    expect(xml).not.toContain('/sitemaps/boards.xml');
+    expect(response.headers.get('x-sitemap-degraded')).toBe('boards');
+    expect(errors.join(' ')).toContain('expects URLs but built none');
+  });
+
+  it('omits a shard past the URL budget instead of advertising a URL that always 503s', async () => {
+    // The shard route rejects an over-budget shard wholesale (above). An index
+    // that keeps listing it points Googlebot at a URL that cannot succeed until
+    // someone reads the logs, so the two layers apply the same rule.
+    playlistRows.count = MAX_ITEMS_PER_SHARD + 1;
+
+    const response = await sitemapIndexRouteHandler();
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(xml).toContain('/sitemaps/static.xml');
+    expect(xml).not.toContain('/sitemaps/playlists.xml');
+    expect(response.headers.get('x-sitemap-degraded')).toBe('playlists');
+    expect(errors.join(' ')).toContain('past the 45000 budget');
   });
 
   it('answers 503 only when no shard built at all', async () => {
     // The floor under the degradation: an empty `<sitemapindex>` under an hour of
     // s-maxage says "this site has no sitemaps", which is the harm the whole
     // fail-closed doctrine exists to avoid.
-    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
     boardConfigs.shouldThrow = true;
     playlistRows.shouldThrow = true;
     pureBuilders.shouldThrow = true;
-    try {
-      const response = await sitemapIndexRouteHandler();
 
-      expect(response.status).toBe(503);
-      expect(response.headers.get('cache-control')).toBe('no-store');
-      expect(errors.mock.calls.flat().join(' ')).toContain('5 of 5 builders failed');
-    } finally {
-      boardConfigs.shouldThrow = false;
-      playlistRows.shouldThrow = false;
-      pureBuilders.shouldThrow = false;
-      errors.mockRestore();
-    }
+    const response = await sitemapIndexRouteHandler();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(errors.join(' ')).toContain('5 of 5 builders failed');
   });
 
   it('serves the rest of the index when a builder never settles', async () => {
-    // The case a try/catch cannot see, and the one #4476 actually hit: a cold
-    // backend does not reject, it stalls. Without a deadline this hangs the
-    // request to the platform timeout, which 5xxes all five shards.
-    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // The case a try/catch cannot see: a builder that stalls rather than
+    // rejecting holds the request to the platform timeout, which 5xxes all five
+    // shards. `fetchPlaylistSitemapRows` has no bound of its own, so this is not
+    // hypothetical.
     vi.useFakeTimers();
     boardConfigs.hang = true;
-    try {
-      const pending = sitemapIndexRouteHandler();
-      await vi.advanceTimersByTimeAsync(SHARD_DEADLINE_MS + 1);
-      const response = await pending;
-      const xml = await response.text();
 
-      expect(response.status).toBe(200);
-      expect(xml).toContain('/sitemaps/static.xml');
-      expect(xml).toContain('/sitemaps/playlists.xml');
-      expect(xml).not.toContain('/sitemaps/boards.xml');
-      expect(errors.mock.calls.flat().join(' ')).toContain(`exceeded its ${SHARD_DEADLINE_MS}ms deadline`);
-    } finally {
-      boardConfigs.hang = false;
-      vi.useRealTimers();
-      errors.mockRestore();
-    }
+    const pending = sitemapIndexRouteHandler();
+    await vi.advanceTimersByTimeAsync(SHARD_DEADLINE_MS + 1);
+    const response = await pending;
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(xml).toContain('/sitemaps/static.xml');
+    expect(xml).toContain('/sitemaps/playlists.xml');
+    expect(xml).not.toContain('/sitemaps/boards.xml');
+    expect(response.headers.get('cache-control')).toBe(DEGRADED_CACHE_CONTROL);
+    expect(errors.join(' ')).toContain(`exceeded its ${SHARD_DEADLINE_MS}ms deadline`);
   });
 
-  it('bounds the whole walk by the index budget when every builder stalls', async () => {
-    // Sequencing the shards is only safe because the walk carries a total
-    // budget: five 3s deadlines back to back is 15s, past the serverless
-    // ceiling, and a platform kill is the 5xx this change exists to remove.
-    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it('keeps every shard when all five are slow but each is inside its own deadline', async () => {
+    // The walk is bounded by max(builder), not sum(builder). An earlier draft
+    // sequenced the shards under a shared 8s budget, which made this exact case
+    // drop `playlists` — last in the registry, so the deterministic victim —
+    // even though every builder finished comfortably inside `SHARD_DEADLINE_MS`.
+    // A shard must be omitted for its own latency, never for its position.
     vi.useFakeTimers();
-    boardConfigs.hang = true;
-    playlistRows.hang = true;
-    pureBuilders.hang = true;
-    try {
-      const pending = sitemapIndexRouteHandler();
-      await vi.advanceTimersByTimeAsync(INDEX_DEADLINE_MS + 1);
-      const response = await pending;
+    const slowButFine = SHARD_DEADLINE_MS - 1;
+    boardConfigs.delayMs = slowButFine;
+    playlistRows.delayMs = slowButFine;
+    pureBuilders.delayMs = slowButFine;
 
-      expect(response.status).toBe(503);
-      expect(errors.mock.calls.flat().join(' ')).toContain(`spent its ${INDEX_DEADLINE_MS}ms budget`);
-    } finally {
-      boardConfigs.hang = false;
-      playlistRows.hang = false;
-      pureBuilders.hang = false;
-      vi.useRealTimers();
-      errors.mockRestore();
-    }
+    const pending = sitemapIndexRouteHandler();
+    await vi.advanceTimersByTimeAsync(SHARD_DEADLINE_MS);
+    const response = await pending;
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(xml).toContain('/sitemaps/static.xml');
+    expect(xml).toContain('/sitemaps/boards.xml');
+    expect(xml).toContain('/sitemaps/playlists.xml');
+    expect(response.headers.get('x-sitemap-degraded')).toBeNull();
+    expect(response.headers.get('cache-control')).toBe(FULL_CACHE_CONTROL);
   });
 
   it('still throws from the builder itself when nothing can be published', async () => {
@@ -292,14 +352,7 @@ describe('buildSitemapIndexXml', () => {
     boardConfigs.shouldThrow = true;
     playlistRows.shouldThrow = true;
     pureBuilders.shouldThrow = true;
-    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
-    try {
-      await expect(buildSitemapIndexXml()).rejects.toThrow('refusing to publish an empty index');
-    } finally {
-      boardConfigs.shouldThrow = false;
-      playlistRows.shouldThrow = false;
-      pureBuilders.shouldThrow = false;
-      errors.mockRestore();
-    }
+
+    await expect(buildSitemapIndexXml()).rejects.toThrow('refusing to publish an empty index');
   });
 });

--- a/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/shard-route-handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vite-plus/test';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
+import type { SitemapItem } from '../entries';
 import { MAX_ITEMS_PER_SHARD } from '../sitemap-xml';
 
 vi.mock('server-only', () => ({}));
@@ -19,11 +20,19 @@ const KILTER_CONFIG: PopularBoardConfig = {
   displayName: 'Kilter Original 12x12',
 };
 
-const boardConfigs = vi.hoisted(() => ({ shouldThrow: false, empty: false }));
-const playlistRows = vi.hoisted(() => ({ count: 1 }));
+const boardConfigs = vi.hoisted(() => ({ shouldThrow: false, empty: false, hang: false }));
+const playlistRows = vi.hoisted(() => ({ count: 1, shouldThrow: false, hang: false }));
+/** `static`, `gyms` and `setters` are pure builders — flags let all five fail at once. */
+const pureBuilders = vi.hoisted(() => ({ shouldThrow: false, hang: false }));
+
+/** Never settles: the failure mode a try/catch cannot see. */
+const forever = <T>(): Promise<T> => new Promise<T>(() => {});
 
 vi.mock('@/app/lib/server-popular-configs', () => ({
   getAllBoardConfigsOrThrow: async () => {
+    if (boardConfigs.hang) {
+      return forever<PopularBoardConfig[]>();
+    }
     if (boardConfigs.shouldThrow) {
       throw new Error('backend unreachable');
     }
@@ -32,6 +41,12 @@ vi.mock('@/app/lib/server-popular-configs', () => ({
 }));
 vi.mock('../playlist-query', () => ({
   fetchPlaylistSitemapRows: async () => {
+    if (playlistRows.hang) {
+      return forever<never[]>();
+    }
+    if (playlistRows.shouldThrow) {
+      throw new Error('playlist pool exhausted');
+    }
     const updatedAt = new Date('2026-04-30T00:00:00.000Z');
     return Array.from({ length: playlistRows.count }, (_, index) => ({
       uuid: index === 0 ? 'abc-123' : `playlist-${index}`,
@@ -40,7 +55,36 @@ vi.mock('../playlist-query', () => ({
   },
 }));
 
-const { buildSitemapIndexXml, shardRouteHandler } = await import('../shard-registry');
+/**
+ * The registry wraps these three in `async () => build()`, so handing back a
+ * pending promise is what a hung I/O call looks like from the index's side once
+ * it awaits — the cast is the price of faking that through a sync signature.
+ */
+const pureBuilder = (real: () => SitemapItem[]): SitemapItem[] => {
+  if (pureBuilders.hang) {
+    return forever<SitemapItem[]>() as unknown as SitemapItem[];
+  }
+  if (pureBuilders.shouldThrow) {
+    throw new Error('pure builder exploded');
+  }
+  return real();
+};
+
+vi.mock('../static-entries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../static-entries')>();
+  return { ...actual, buildStaticEntries: () => pureBuilder(actual.buildStaticEntries) };
+});
+vi.mock('../gym-entries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../gym-entries')>();
+  return { ...actual, buildGymEntries: () => pureBuilder(actual.buildGymEntries) };
+});
+vi.mock('../setter-entries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../setter-entries')>();
+  return { ...actual, buildSetterEntries: () => pureBuilder(actual.buildSetterEntries) };
+});
+
+const { INDEX_DEADLINE_MS, SHARD_DEADLINE_MS, buildSitemapIndexXml, shardRouteHandler, sitemapIndexRouteHandler } =
+  await import('../shard-registry');
 
 describe('shardRouteHandler', () => {
   it('serves a shard as application/xml with a CDN cache window', async () => {
@@ -127,23 +171,135 @@ describe('buildSitemapIndexXml', () => {
     expect(xml).not.toContain('/sitemaps/setters.xml');
   });
 
-  it('throws instead of publishing an index that quietly dropped a shard', async () => {
+  it('serves the shards that built when one builder throws, and logs the one that did not', async () => {
+    // #4476: the index was the one path that ran every builder inside a
+    // `Promise.all`, so a cold boards fetch took static and playlists — which
+    // were ready — down with it. A partial sitemap beats no sitemap, because
+    // every shard the index does list is still served fail-closed at its own URL.
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
     boardConfigs.shouldThrow = true;
     try {
-      await expect(buildSitemapIndexXml()).rejects.toThrow('backend unreachable');
+      const response = await sitemapIndexRouteHandler();
+      const xml = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(xml).toContain('/sitemaps/static.xml');
+      expect(xml).toContain('/sitemaps/playlists.xml');
+      expect(xml).not.toContain('/sitemaps/boards.xml');
+      expect(errors.mock.calls.flat().join(' ')).toContain('backend unreachable');
     } finally {
       boardConfigs.shouldThrow = false;
+      errors.mockRestore();
     }
   });
 
-  it('throws when a shard that expects URLs comes back empty', async () => {
-    // Same harm as a throwing builder, minus the throw: boards would vanish from
-    // the index behind a 1-hour s-maxage with a 200 on every hop.
+  it('omits — and logs — a shard that expects URLs but comes back empty', async () => {
+    // Still a failure, still loud, but no longer fatal to the other four: the
+    // shard's own route keeps 503ing on exactly this condition (above), which is
+    // where the fail-closed promise is actually kept.
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
     boardConfigs.empty = true;
     try {
-      await expect(buildSitemapIndexXml()).rejects.toThrow('expects URLs but built none');
+      const response = await sitemapIndexRouteHandler();
+      const xml = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(xml).toContain('/sitemaps/static.xml');
+      expect(xml).not.toContain('/sitemaps/boards.xml');
+      expect(errors.mock.calls.flat().join(' ')).toContain('expects URLs but built none');
     } finally {
       boardConfigs.empty = false;
+      errors.mockRestore();
+    }
+  });
+
+  it('answers 503 only when no shard built at all', async () => {
+    // The floor under the degradation: an empty `<sitemapindex>` under an hour of
+    // s-maxage says "this site has no sitemaps", which is the harm the whole
+    // fail-closed doctrine exists to avoid.
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    boardConfigs.shouldThrow = true;
+    playlistRows.shouldThrow = true;
+    pureBuilders.shouldThrow = true;
+    try {
+      const response = await sitemapIndexRouteHandler();
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get('cache-control')).toBe('no-store');
+      expect(errors.mock.calls.flat().join(' ')).toContain('5 of 5 builders failed');
+    } finally {
+      boardConfigs.shouldThrow = false;
+      playlistRows.shouldThrow = false;
+      pureBuilders.shouldThrow = false;
+      errors.mockRestore();
+    }
+  });
+
+  it('serves the rest of the index when a builder never settles', async () => {
+    // The case a try/catch cannot see, and the one #4476 actually hit: a cold
+    // backend does not reject, it stalls. Without a deadline this hangs the
+    // request to the platform timeout, which 5xxes all five shards.
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.useFakeTimers();
+    boardConfigs.hang = true;
+    try {
+      const pending = sitemapIndexRouteHandler();
+      await vi.advanceTimersByTimeAsync(SHARD_DEADLINE_MS + 1);
+      const response = await pending;
+      const xml = await response.text();
+
+      expect(response.status).toBe(200);
+      expect(xml).toContain('/sitemaps/static.xml');
+      expect(xml).toContain('/sitemaps/playlists.xml');
+      expect(xml).not.toContain('/sitemaps/boards.xml');
+      expect(errors.mock.calls.flat().join(' ')).toContain(`exceeded its ${SHARD_DEADLINE_MS}ms deadline`);
+    } finally {
+      boardConfigs.hang = false;
+      vi.useRealTimers();
+      errors.mockRestore();
+    }
+  });
+
+  it('bounds the whole walk by the index budget when every builder stalls', async () => {
+    // Sequencing the shards is only safe because the walk carries a total
+    // budget: five 3s deadlines back to back is 15s, past the serverless
+    // ceiling, and a platform kill is the 5xx this change exists to remove.
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.useFakeTimers();
+    boardConfigs.hang = true;
+    playlistRows.hang = true;
+    pureBuilders.hang = true;
+    try {
+      const pending = sitemapIndexRouteHandler();
+      await vi.advanceTimersByTimeAsync(INDEX_DEADLINE_MS + 1);
+      const response = await pending;
+
+      expect(response.status).toBe(503);
+      expect(errors.mock.calls.flat().join(' ')).toContain(`spent its ${INDEX_DEADLINE_MS}ms budget`);
+    } finally {
+      boardConfigs.hang = false;
+      playlistRows.hang = false;
+      pureBuilders.hang = false;
+      vi.useRealTimers();
+      errors.mockRestore();
+    }
+  });
+
+  it('still throws from the builder itself when nothing can be published', async () => {
+    // `buildSitemapIndexXml` is the seam the route handler catches on, so the
+    // throw has to survive the degradation rewrite — a builder that resolved to
+    // an empty index would turn the 503 above into a 200.
+    boardConfigs.shouldThrow = true;
+    playlistRows.shouldThrow = true;
+    pureBuilders.shouldThrow = true;
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(buildSitemapIndexXml()).rejects.toThrow('refusing to publish an empty index');
+    } finally {
+      boardConfigs.shouldThrow = false;
+      playlistRows.shouldThrow = false;
+      pureBuilders.shouldThrow = false;
+      errors.mockRestore();
     }
   });
 });

--- a/packages/web/app/lib/seo/sitemap/entries.ts
+++ b/packages/web/app/lib/seo/sitemap/entries.ts
@@ -57,6 +57,19 @@ export function expandAllLocales(items: readonly SitemapItem[]): SitemapUrlEntry
   return items.flatMap((item) => expandLocales(item));
 }
 
+/**
+ * How many `<url>` entries `expandAllLocales` would produce, without building
+ * them. The index checks every shard against the URL budget on a `force-dynamic`
+ * route, and materialising up to 45,000 entries — each carrying a five-key
+ * alternates record — only to read `.length` turns a guard into a cost.
+ * `expandLocales` emits exactly one entry per supported locale for every item,
+ * which is what makes this arithmetic exact rather than an estimate; a unit test
+ * pins the two against each other so a future expansion rule cannot drift.
+ */
+export function allLocalesUrlCount(items: readonly SitemapItem[]): number {
+  return items.length * SUPPORTED_LOCALES.length;
+}
+
 /** Newest real timestamp across a shard's items, or null when none carries one. */
 export function latestLastModified(items: readonly SitemapItem[]): Date | null {
   let latest: Date | null = null;

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -8,7 +8,7 @@ import { playlistRowsToItems } from './playlist-entries';
 import { fetchPlaylistSitemapRows } from './playlist-query';
 import { buildSetterEntries } from './setter-entries';
 import { buildStaticEntries } from './static-entries';
-import { MAX_URLS_PER_SHARD, renderSitemapIndex, renderUrlset } from './sitemap-xml';
+import { MAX_URLS_PER_SHARD, renderSitemapIndex, renderUrlset, type SitemapIndexEntry } from './sitemap-xml';
 
 export type ShardId = 'static' | 'boards' | 'gyms' | 'setters' | 'playlists';
 
@@ -70,6 +70,9 @@ function xmlResponse(body: string): Response {
  * 200 tells Google the missing URLs were removed, while a 5xx makes it retry
  * and keep the last good copy. A builder that returns `[]` on purpose (gyms,
  * setters) is a declared-empty shard, not a failure.
+ *
+ * This is the *shard route's* rule. The index degrades instead — see
+ * `buildSitemapIndexXml` — and only reaches here when no shard built at all.
  */
 function unavailableResponse(): Response {
   return new Response('sitemap shard temporarily unavailable', {
@@ -135,32 +138,120 @@ export async function shardRouteHandler(id: ShardId): Promise<Response> {
 }
 
 /**
+ * How long the index waits for one builder before giving up on it.
+ *
+ * A try/catch only sees a builder that *rejects*. The failure #4476 records in
+ * production is the other one: a cold serverless instance against a cold backend
+ * and a cold database, where `getAllBoardConfigsOrThrow` sits on its 10s abort
+ * and `fetchPlaylistSitemapRows` has no bound at all. Without a deadline that
+ * builder holds the request until the platform kills it, which is a 5xx on the
+ * whole index — strictly worse than the 503 the fail-closed doctrine was written
+ * to prevent, because it takes the four shards that *were* ready down with it.
+ *
+ * Three seconds: the index has no latency requirement that justifies more, the
+ * same value W-23 (#4483) settled on for its paged-shard summary, and every
+ * builder behind it is cached (`unstable_cache` for boards, the CDN's hourly
+ * `s-maxage` for the response itself). A builder that misses it is omitted for
+ * one cache generation, not deleted — Google keeps the copy of the shard it
+ * already has, which is the whole reason omitting beats 503ing.
+ */
+export const SHARD_DEADLINE_MS = 3_000;
+
+/**
+ * Total wall-clock budget for the sequential walk, so N slow shards cannot add
+ * up to a platform timeout the per-shard deadline never sees. Five shards ×3s
+ * is 15s, past the serverless ceiling; 8s leaves the response room to render and
+ * still lets a first slow shard spend its full deadline without starving the
+ * rest.
+ */
+export const INDEX_DEADLINE_MS = 8_000;
+
+/**
+ * Bounds `work` without cancelling it — a builder that ignores the deadline keeps
+ * running (and, for boards, still hits its own `AbortController`); we simply stop
+ * waiting. Cancellation would need every builder to thread a signal, which is a
+ * bigger change than the one this bug needs.
+ */
+async function withDeadline<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} exceeded its ${ms}ms deadline`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
  * The index lists only shards that carry at least one URL — pointing Google at
  * an empty `<urlset>` burns a fetch and teaches it the shard is worthless.
  *
- * Throws if any builder throws, or if a shard that expects URLs built none, so
- * the route answers 503 rather than publishing an index that quietly dropped a
- * shard. Same doctrine as the shards themselves.
+ * **The doctrine splits by layer.** A shard *route* stays fail-closed: it 503s
+ * when its builder throws or when a shard that expects URLs builds none, because
+ * telling Google those pages do not exist is worse than telling it to retry. The
+ * *index* degrades instead: a builder that throws, times out, or comes back
+ * unexpectedly empty is logged loudly and its `<sitemap>` entry omitted, and the
+ * index still answers 200 with whatever built. One slow builder taking the other
+ * four shards down with it is #4476, and a partial sitemap is strictly better
+ * than no sitemap when the shards Google is told about are each still served
+ * fail-closed at their own URL.
+ *
+ * Sequential, not `Promise.all`: the concurrent fan-out is the pool-starvation
+ * shape #4461 is about (the playlists builder reads the database, the boards one
+ * the GraphQL backend), and the index has no latency requirement that justifies
+ * it. The walk is bounded by `INDEX_DEADLINE_MS`, so sequencing cannot trade one
+ * timeout for another.
+ *
+ * Throws only when there is nothing left to publish — every builder failed, or
+ * every shard that survived was declared-empty. An empty `<sitemapindex>` served
+ * under an hour of `s-maxage` says "this site has no sitemaps", which is the
+ * exact harm the fail-closed rule exists to avoid.
  */
 export async function buildSitemapIndexXml(): Promise<string> {
-  const built = await Promise.all(SHARD_REGISTRY.map(async (shard) => ({ shard, items: await shard.build() })));
+  const entries: SitemapIndexEntry[] = [];
+  let failureCount = 0;
+  const startedAt = Date.now();
 
-  for (const { shard, items } of built) {
-    if (items.length > 0) continue;
-    const emptiness = emptinessError(shard);
-    if (emptiness) {
-      throw emptiness;
+  for (const shard of SHARD_REGISTRY) {
+    try {
+      const budget = Math.min(SHARD_DEADLINE_MS, INDEX_DEADLINE_MS - (Date.now() - startedAt));
+      if (budget <= 0) {
+        throw new Error(`the index spent its ${INDEX_DEADLINE_MS}ms budget before this shard ran`);
+      }
+
+      const items = await withDeadline(shard.build(), budget, `shard "${shard.id}"`);
+      if (items.length === 0) {
+        // A declared-empty shard (gyms, setters, a site with no public
+        // playlists) is a success that contributes no entry. One that expects
+        // URLs is a regressed query, and `emptinessError` says which is which.
+        const emptiness = emptinessError(shard);
+        if (emptiness) {
+          throw emptiness;
+        }
+        continue;
+      }
+
+      entries.push({ loc: absoluteUrl(shard.path), lastModified: latestLastModified(items) });
+    } catch (err) {
+      failureCount += 1;
+      console.error(
+        `[sitemap] shard "${shard.id}" failed — serving the index WITHOUT it:`,
+        err instanceof Error ? err.message : err,
+      );
     }
   }
 
-  return renderSitemapIndex(
-    built
-      .filter(({ items }) => items.length > 0)
-      .map(({ shard, items }) => ({
-        loc: absoluteUrl(shard.path),
-        lastModified: latestLastModified(items),
-      })),
-  );
+  if (entries.length === 0) {
+    throw new Error(
+      `[sitemap] index has no shards to publish (${failureCount} of ${SHARD_REGISTRY.length} builders failed) — refusing to publish an empty index`,
+    );
+  }
+
+  return renderSitemapIndex(entries);
 }
 
 export async function sitemapIndexRouteHandler(): Promise<Response> {

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -2,7 +2,7 @@ import 'server-only';
 import { getAllBoardConfigsOrThrow } from '@/app/lib/server-popular-configs';
 import { absoluteUrl } from '@/app/lib/seo/base-url';
 import { boardConfigsToItems } from './board-entries';
-import { expandAllLocales, latestLastModified, type SitemapItem } from './entries';
+import { allLocalesUrlCount, expandAllLocales, latestLastModified, type SitemapItem } from './entries';
 import { buildGymEntries } from './gym-entries';
 import { playlistRowsToItems } from './playlist-entries';
 import { fetchPlaylistSitemapRows } from './playlist-query';
@@ -55,12 +55,39 @@ export const SHARD_REGISTRY: readonly SitemapShard[] = [
 
 const CACHE_CONTROL = 'public, s-maxage=3600, stale-while-revalidate=86400';
 
-function xmlResponse(body: string): Response {
+/**
+ * A *degraded* index — one that dropped a shard — gets a minute, not 25 hours.
+ *
+ * The full window is `s-maxage=3600` plus a day of `stale-while-revalidate`, and
+ * a 503 was never cached at all (`no-store`), so before the degradation rewrite
+ * the copy the CDN eventually held was always complete. Serving a partial index
+ * under the full window trades a self-healing 503 for a cacheable lie: one cold
+ * start pins "boards.xml and playlists.xml do not exist" at the edge for up to
+ * 25 hours, while both URLs serve perfectly the whole time. Sixty seconds with no
+ * `stale-while-revalidate` keeps the "partial beats nothing" benefit and makes
+ * the next crawl re-attempt the shards that missed.
+ */
+const DEGRADED_CACHE_CONTROL = 'public, s-maxage=60, must-revalidate';
+
+/**
+ * Names the shards a 200 is missing, so the degradation is visible on the
+ * response rather than only in a `console.error` nobody reads. The post-deploy
+ * smoke is the detector this bug was found by, and a silent partial index is
+ * precisely what would make it permanently green.
+ */
+const DEGRADED_HEADER = 'X-Sitemap-Degraded';
+
+function xmlResponse(
+  body: string,
+  cacheControl: string = CACHE_CONTROL,
+  extraHeaders?: Record<string, string>,
+): Response {
   return new Response(body, {
     status: 200,
     headers: {
       'Content-Type': 'application/xml; charset=utf-8',
-      'Cache-Control': CACHE_CONTROL,
+      'Cache-Control': cacheControl,
+      ...extraHeaders,
     },
   });
 }
@@ -108,6 +135,20 @@ function overBudgetError(shard: SitemapShard, urlCount: number): Error | null {
     : null;
 }
 
+/**
+ * **Deliberately unbounded, unlike the index walk below.** A `withDeadline` here
+ * would 503 a legitimately slow-but-working shard: `getAllBoardConfigsOrThrow`
+ * budgets itself 10 s, and any index-sized deadline would fail a URL that serves
+ * ~2,600 correct URLs today. The asymmetry is the doctrine, not an oversight —
+ * the index's deadline protects the *other* shards from one slow builder, and
+ * omitting a shard for a minute is cheap where 503ing a working URL is not.
+ *
+ * The residual gap is honest: a builder that stalls past the platform ceiling
+ * gets a platform 5xx instead of this handler's 503-with-`no-store`. Both are
+ * retryable and neither is cached, so the crawler behaviour is the same; a real
+ * bound needs an `AbortSignal` threaded into the builders, tracked as a
+ * follow-up rather than approximated with a timer that cancels nothing.
+ */
 export async function shardRouteHandler(id: ShardId): Promise<Response> {
   const shard = SHARD_REGISTRY.find((candidate) => candidate.id === id);
   if (!shard) {
@@ -138,39 +179,40 @@ export async function shardRouteHandler(id: ShardId): Promise<Response> {
 }
 
 /**
- * How long the index waits for one builder before giving up on it.
+ * How long the index waits for one builder before publishing without it.
  *
- * A try/catch only sees a builder that *rejects*. The failure #4476 records in
- * production is the other one: a cold serverless instance against a cold backend
- * and a cold database, where `getAllBoardConfigsOrThrow` sits on its 10s abort
- * and `fetchPlaylistSitemapRows` has no bound at all. Without a deadline that
- * builder holds the request until the platform kills it, which is a 5xx on the
- * whole index — strictly worse than the 503 the fail-closed doctrine was written
- * to prevent, because it takes the four shards that *were* ready down with it.
+ * Read it as a property of the *index*, not a verdict on the builder. The two
+ * recorded production failures were rejections, not stalls — a 503 is this
+ * file's own `unavailableResponse`, and `getAllBoardConfigsOrThrow`'s 10 s abort
+ * surfaces as a throw — so the try/catch alone already covers what was measured.
+ * The deadline covers the mode a try/catch structurally cannot see: a builder
+ * that never settles (`fetchPlaylistSitemapRows` has no bound of its own) would
+ * otherwise hold the whole index to the platform timeout, taking down the four
+ * shards that were ready.
  *
- * Three seconds: the index has no latency requirement that justifies more, the
- * same value W-23 (#4483) settled on for its paged-shard summary, and every
- * builder behind it is cached (`unstable_cache` for boards, the CDN's hourly
- * `s-maxage` for the response itself). A builder that misses it is omitted for
- * one cache generation, not deleted — Google keeps the copy of the shard it
- * already has, which is the whole reason omitting beats 503ing.
+ * Three seconds rather than the boards builder's own 10 s, and the two layers are
+ * *supposed* to disagree: the shard route gives that fetch its full 10 s because
+ * failing it costs a working URL, while here the cost of guessing low is one
+ * shard omitted under `DEGRADED_CACHE_CONTROL` — sixty seconds, then re-attempted.
+ * Cheap to be wrong, so be impatient. It is also the value W-23 (#4483) settled
+ * on for its paged summary, so the two collapse into one constant on merge.
+ *
+ * Not a claim that the builders are cached: `getAllBoardConfigsOrThrow` is a bare
+ * `executeGraphQLInternal` call (the `unstable_cache` wrapper in that file is
+ * `fetchPopularBoardConfigs`, the limit=12 homepage variant), and `/sitemap.xml`
+ * is `force-dynamic`, so every CDN miss re-runs it live. Caching the per-shard
+ * summaries is the follow-up; the short degraded window is what makes missing it
+ * survivable in the meantime.
  */
 export const SHARD_DEADLINE_MS = 3_000;
 
 /**
- * Total wall-clock budget for the sequential walk, so N slow shards cannot add
- * up to a platform timeout the per-shard deadline never sees. Five shards ×3s
- * is 15s, past the serverless ceiling; 8s leaves the response room to render and
- * still lets a first slow shard spend its full deadline without starving the
- * rest.
- */
-export const INDEX_DEADLINE_MS = 8_000;
-
-/**
  * Bounds `work` without cancelling it — a builder that ignores the deadline keeps
  * running (and, for boards, still hits its own `AbortController`); we simply stop
- * waiting. Cancellation would need every builder to thread a signal, which is a
- * bigger change than the one this bug needs.
+ * waiting. So this bounds *this request's* latency, not the load the abandoned
+ * query keeps putting on the pool. Real cancellation needs an `AbortSignal`
+ * threaded into `fetchPlaylistSitemapRows` (or a statement timeout on its query),
+ * which is a follow-up, not something to claim here.
  */
 async function withDeadline<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -187,76 +229,123 @@ async function withDeadline<T>(work: Promise<T>, ms: number, label: string): Pro
 }
 
 /**
+ * One shard's `<sitemap>` entry, or null when the shard is legitimately empty.
+ *
+ * Throws for every failure the index degrades on, so the caller has exactly one
+ * channel to catch: a builder that rejects, one that misses `SHARD_DEADLINE_MS`,
+ * one that expects URLs and built none, and one past the URL budget.
+ *
+ * That last check is the index adopting the shard route's own rule. A shard over
+ * `MAX_URLS_PER_SHARD` is rejected wholesale by Search Console, so its route 503s
+ * it — and an index that keeps advertising it points Googlebot at a URL that can
+ * never succeed. Counting via `allLocalesUrlCount` instead of expanding: this
+ * runs on a `force-dynamic` route and the entries would be discarded immediately.
+ */
+async function buildIndexEntry(shard: SitemapShard): Promise<SitemapIndexEntry | null> {
+  const items = await withDeadline(shard.build(), SHARD_DEADLINE_MS, `shard "${shard.id}"`);
+
+  if (items.length === 0) {
+    // A declared-empty shard (gyms, setters, a site with no public playlists) is
+    // a success that contributes no entry. One that expects URLs is a regressed
+    // query, and `emptinessError` says which is which.
+    const emptiness = emptinessError(shard);
+    if (emptiness) {
+      throw emptiness;
+    }
+    return null;
+  }
+
+  const overBudget = overBudgetError(shard, allLocalesUrlCount(items));
+  if (overBudget) {
+    throw overBudget;
+  }
+
+  return { loc: absoluteUrl(shard.path), lastModified: latestLastModified(items) };
+}
+
+/** The index XML plus the shards it had to drop, so the caller can pick a cache window. */
+export type SitemapIndexResult = { xml: string; degradedShards: ShardId[] };
+
+/**
  * The index lists only shards that carry at least one URL — pointing Google at
  * an empty `<urlset>` burns a fetch and teaches it the shard is worthless.
  *
  * **The doctrine splits by layer.** A shard *route* stays fail-closed: it 503s
  * when its builder throws or when a shard that expects URLs builds none, because
  * telling Google those pages do not exist is worse than telling it to retry. The
- * *index* degrades instead: a builder that throws, times out, or comes back
- * unexpectedly empty is logged loudly and its `<sitemap>` entry omitted, and the
- * index still answers 200 with whatever built. One slow builder taking the other
- * four shards down with it is #4476, and a partial sitemap is strictly better
- * than no sitemap when the shards Google is told about are each still served
- * fail-closed at their own URL.
+ * *index* degrades instead: a builder that throws, times out, comes back
+ * unexpectedly empty or blows the URL budget is logged loudly and its `<sitemap>`
+ * entry omitted, and the index still answers 200 with whatever built — under a
+ * one-minute cache window, so the omission self-heals. One slow builder taking
+ * the other four shards down with it is #4476, and a partial sitemap is strictly
+ * better than no sitemap when the shards Google is told about are each still
+ * served fail-closed at their own URL.
  *
- * Sequential, not `Promise.all`: the concurrent fan-out is the pool-starvation
- * shape #4461 is about (the playlists builder reads the database, the boards one
- * the GraphQL backend), and the index has no latency requirement that justifies
- * it. The walk is bounded by `INDEX_DEADLINE_MS`, so sequencing cannot trade one
- * timeout for another.
+ * **Concurrent, with only a per-shard deadline.** An earlier draft sequenced the
+ * walk under a total budget, which made the last entries in the registry the
+ * deterministic victims: five builders each a comfortable 1.9 s — every one of
+ * them inside its own deadline — spend the budget before `playlists` runs, and it
+ * is dropped for its position rather than its latency. `Promise.allSettled`
+ * bounds the walk by max(builder) instead of sum(builder), so no shard can starve
+ * another and the total budget stops being needed at all. The fan-out this
+ * "widens" is two I/O calls against two different backends (one GraphQL fetch,
+ * one indexed query holding one connection of ten) plus three hardcoded builders
+ * — not the many-concurrent-heavy-scans shape of #4461, which W-23 sequences
+ * *within* its climbs query for exactly that reason. And sequencing would not
+ * have bounded pool load anyway: `withDeadline` stops waiting, it does not cancel.
  *
  * Throws only when there is nothing left to publish — every builder failed, or
  * every shard that survived was declared-empty. An empty `<sitemapindex>` served
  * under an hour of `s-maxage` says "this site has no sitemaps", which is the
  * exact harm the fail-closed rule exists to avoid.
  */
-export async function buildSitemapIndexXml(): Promise<string> {
+export async function buildSitemapIndexXml(): Promise<SitemapIndexResult> {
+  const settled = await Promise.allSettled(SHARD_REGISTRY.map((shard) => buildIndexEntry(shard)));
+
   const entries: SitemapIndexEntry[] = [];
-  let failureCount = 0;
-  const startedAt = Date.now();
+  const degradedShards: ShardId[] = [];
+  const emptyShards: ShardId[] = [];
 
-  for (const shard of SHARD_REGISTRY) {
-    try {
-      const budget = Math.min(SHARD_DEADLINE_MS, INDEX_DEADLINE_MS - (Date.now() - startedAt));
-      if (budget <= 0) {
-        throw new Error(`the index spent its ${INDEX_DEADLINE_MS}ms budget before this shard ran`);
-      }
-
-      const items = await withDeadline(shard.build(), budget, `shard "${shard.id}"`);
-      if (items.length === 0) {
-        // A declared-empty shard (gyms, setters, a site with no public
-        // playlists) is a success that contributes no entry. One that expects
-        // URLs is a regressed query, and `emptinessError` says which is which.
-        const emptiness = emptinessError(shard);
-        if (emptiness) {
-          throw emptiness;
-        }
-        continue;
-      }
-
-      entries.push({ loc: absoluteUrl(shard.path), lastModified: latestLastModified(items) });
-    } catch (err) {
-      failureCount += 1;
+  settled.forEach((outcome, index) => {
+    const shard = SHARD_REGISTRY[index];
+    if (outcome.status === 'rejected') {
+      degradedShards.push(shard.id);
       console.error(
         `[sitemap] shard "${shard.id}" failed — serving the index WITHOUT it:`,
-        err instanceof Error ? err.message : err,
+        outcome.reason instanceof Error ? outcome.reason.message : outcome.reason,
       );
+      return;
     }
+    if (outcome.value === null) {
+      emptyShards.push(shard.id);
+      return;
+    }
+    entries.push(outcome.value);
+  });
+
+  if (emptyShards.length > 0) {
+    // Not a failure — but "the site genuinely has no public playlists" and "the
+    // playlists query regressed and now returns []" look identical from here,
+    // and without this line the second one leaves no trace anywhere.
+    console.warn(`[sitemap] index omitted shards that built no URLs: ${emptyShards.join(', ')}`);
   }
 
   if (entries.length === 0) {
     throw new Error(
-      `[sitemap] index has no shards to publish (${failureCount} of ${SHARD_REGISTRY.length} builders failed) — refusing to publish an empty index`,
+      `[sitemap] index has no shards to publish (${degradedShards.length} of ${SHARD_REGISTRY.length} builders failed) — refusing to publish an empty index`,
     );
   }
 
-  return renderSitemapIndex(entries);
+  return { xml: renderSitemapIndex(entries), degradedShards };
 }
 
 export async function sitemapIndexRouteHandler(): Promise<Response> {
   try {
-    return xmlResponse(await buildSitemapIndexXml());
+    const { xml, degradedShards } = await buildSitemapIndexXml();
+    if (degradedShards.length === 0) {
+      return xmlResponse(xml);
+    }
+    return xmlResponse(xml, DEGRADED_CACHE_CONTROL, { [DEGRADED_HEADER]: degradedShards.join(',') });
   } catch (err) {
     console.error('[sitemap] index failed to build:', err instanceof Error ? err.message : err);
     return unavailableResponse();

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -60,8 +60,20 @@ describe('www production smoke checks', () => {
   it('rejects a sitemap.xml that is not an index pointing at shards', () => {
     const check = checkNamed('sitemap index');
     const healthyIndex =
-      '<sitemapindex><sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap></sitemapindex>';
+      '<sitemapindex>' +
+      '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
+      '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
+      '</sitemapindex>';
     expect(check.assert(response({ contentType: 'application/xml', body: healthyIndex }))).toBeNull();
+
+    // The regression this check has to keep catching after #4476. The index now
+    // degrades rather than 503ing, so a cold-start failure of the boards builder
+    // ships a 200 that quietly lost ~2,600 URLs. `static` is hardcoded and cannot
+    // fail, so an "any one shard <loc>" assertion would be green on every
+    // possible outage — the detector that found the bug would never fire again.
+    const degradedIndex =
+      '<sitemapindex><sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap></sitemapindex>';
+    expect(check.assert(response({ contentType: 'application/xml', body: degradedIndex }))).toMatch(/boards/);
 
     // A regression to the old flat urlset — the shape this replaced.
     expect(

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -149,6 +149,15 @@ export const WWW_CHECKS: SmokeCheck[] = [
   {
     // A `<loc>`-only check would pass on the old flat `<urlset>` too — and on a
     // broken index — so assert the index shape *and* that it points at a shard.
+    //
+    // Both mandatory shards are named, not "any one `<loc>`". Since #4476 the
+    // index *degrades*: a builder that fails is omitted and the index still 200s.
+    // That is the right behaviour for crawlers and the wrong behaviour for a
+    // detector — the original wording passes on an index that lost everything but
+    // `static.xml`, which is a pure hardcoded builder that cannot fail, so this
+    // check could never have gone red again. `static` and `boards` are exactly
+    // the shards the registry marks `expectsUrls`, so both must always be there;
+    // `gyms`, `setters` and `playlists` are legitimately empty and stay out of it.
     name: 'sitemap.xml serves a sitemap index pointing at shards',
     path: '/sitemap.xml',
     assert: (response) =>
@@ -156,7 +165,8 @@ export const WWW_CHECKS: SmokeCheck[] = [
         expectStatus(response, 200),
         expectContentType(response, 'xml'),
         expectBodyContains(response, '<sitemapindex', '<sitemapindex> root element'),
-        expectBodyContains(response, '<loc>https://www.boardsesh.com/sitemaps/', 'shard <loc> entry'),
+        expectBodyContains(response, '<loc>https://www.boardsesh.com/sitemaps/static.xml', 'static shard <loc> entry'),
+        expectBodyContains(response, '<loc>https://www.boardsesh.com/sitemaps/boards.xml', 'boards shard <loc> entry'),
       ),
   },
   {


### PR DESCRIPTION
## Summary

Fixes #4476.

`/sitemap.xml` 503'd on a cold cache and failed the post-deploy smoke on two
consecutive production deploys, while `/sitemaps/static.xml` passed in the same
run. The index was the one path that ran every builder, inside a `Promise.all`,
so one cold boards fetch took the four shards that were ready down with it.

## What changed

**The doctrine splits by layer.** A shard route stays fail-closed — it still 503s
when its builder throws, when a shard that `expectsUrls` builds none, or when it
is past the URL budget. The index degrades: a builder that throws, misses its
deadline, comes back unexpectedly empty or blows the budget is logged loudly, its
`<sitemap>` entry is omitted, and the index still answers 200 with whatever built.
`buildSitemapIndexXml` throws only when there is nothing left to publish.

**A degraded index is cached for a minute, not 25 hours.** This is the half that
makes degradation safe rather than a worse bug. The full window is `s-maxage=3600`
plus a day of `stale-while-revalidate`, and the 503 it replaces was `no-store` and
therefore never cached at all — so before this change the copy the CDN eventually
held was always complete. Serving a partial index under the full window would
trade a self-healing 503 for a cacheable lie: one cold start pinning "boards.xml
does not exist" at the edge for 25 hours, while the URL serves perfectly the whole
time. A degraded 200 gets `s-maxage=60, must-revalidate` plus an
`X-Sitemap-Degraded` header naming the shards it dropped.

**Every builder is raced against `SHARD_DEADLINE_MS` (3 s).** A try/catch only
sees a builder that rejects; `fetchPlaylistSitemapRows` has no bound of its own,
and a builder that never settles holds the whole index to the platform timeout.

**Concurrent, with only a per-shard deadline.** `Promise.allSettled` bounds the
walk by max(builder), not sum(builder). The fan-out is two I/O calls against two
different backends plus three hardcoded builders — not the many-concurrent-heavy-
scans shape of #4461, which W-23 sequences *within* its climbs query for exactly
that reason.

**The post-deploy smoke was widened in the same PR**, because it would otherwise
have gone permanently green: it asserted "any one shard `<loc>`", which a degraded
index satisfies, and `static` is a hardcoded builder that cannot fail. It now
names both `expectsUrls` shards (`static.xml`, `boards.xml`); the three
declared-empty ones are legitimately absent and stay out of it.

Smaller items, each from review:

- The index applies the URL budget the shard route enforces, so it stops
  advertising a shard whose own URL is guaranteed to 503. Counted with a new
  `allLocalesUrlCount` instead of expanding up to 45,000 entries to read
  `.length` on a `force-dynamic` route; a unit test pins the two together.
- A shard that contributes no entry is logged, so "no public playlists yet" and
  "the playlists query regressed to `[]`" are separable from the logs.
- Test resets moved out of a `finally` that sits downstream of an `await` a
  regression can hang, into an `afterEach`. Before, one regression cascaded leaked
  fake timers into unrelated tests and presented as three failures.

## Two things the review changed my mind about

**1. Sequencing under a total budget was wrong.** The first draft walked the
registry sequentially under an 8 s `INDEX_DEADLINE_MS`. Review showed that makes
the tail of the registry the deterministic victim: five builders each a
comfortable 1.9 s — every one inside its own deadline — spend the budget before
`playlists` runs, so it is dropped for its position rather than its latency. Under
`allSettled` the total budget stops being needed at all, and the constant is gone.
The stated justification for sequencing was also wrong: `withDeadline` stops
waiting, it does not cancel, so sequencing never bounded pool load either way.

**2. The stall story was not what production recorded.** The smoke logged HTTP
503 three times, and 503 is this file's own `unavailableResponse` — a platform
kill would be a 504. `getAllBoardConfigsOrThrow`'s 10 s abort surfaces as a throw,
so the try/catch alone covers what was actually measured. The deadline is for the
mode a try/catch structurally cannot see. The docblock and the docs now say that
rather than claiming the deadline fixed the recorded failure. Same pass corrected
a false claim that the boards builder is `unstable_cache`d — the wrapper in that
file is `fetchPopularBoardConfigs`, the limit=12 homepage variant.

## Deliberately not in this PR

- **No deadline on the shard routes.** A 3 s bound there would 503 a legitimately
  slow cold boards fetch (its own abort is 10 s) on a URL that works today. The
  asymmetry is now stated in the code: the index's deadline protects the *other*
  shards, and omitting one for sixty seconds is cheap where 503ing a working URL
  is not. The residual gap — a stall past the platform ceiling gets a platform 5xx
  instead of our 503 — is called out rather than papered over with a timer that
  cancels nothing.
- **No `AbortSignal` threaded into the builders, and no statement timeout on the
  playlists query.** That is the only thing that would bound the abandoned work
  rather than the waiting. Follow-up.
- **No caching layer for the per-shard summaries.** It needs a summary/build split
  like #4483's. Follow-up; the short degraded window is what makes missing the
  deadline survivable meanwhile.

## Interaction with #4483 (W-23)

Matched to its shapes so the two collapse rather than fight:

- `withDeadline<T>(work, ms, label)` is byte-identical to #4483's helper — keep
  one copy on merge.
- `SHARD_DEADLINE_MS` (mine) and `SUMMARY_DEADLINE_MS` (#4483) are both 3 s and
  can become one constant.
- `xmlResponse` takes a `cacheControl` parameter in both PRs; #4483 adds
  `CLIMB_CACHE_CONTROL` where this adds `DEGRADED_CACHE_CONTROL`.
- #4483's paged loop appends onto the same `entries: SitemapIndexEntry[]` array
  with the same log-and-omit `catch`, after the fixed-shard walk. Its callers need
  the new `{ xml, degradedShards }` return, and its paged failures should join
  `degradedShards` so a dropped climbs shard also gets the short cache window.

A conflict in `shard-registry.ts` and `docs/web-reposition.md` is expected;
**#4483 should be the side that rebases**, since this is the smaller, more
mechanical half.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck` — green.
- `vp test run --reporter=agent --project web app/lib/seo/sitemap` — 53 passed.
- `vp test run --reporter=agent production-smoke` — 14 passed.
- `vp check` — 35 errors / 325 warnings, all pre-existing on `main` (#4488). None
  of the seven files this PR touches appears anywhere in the output.
- Eight mutation probes, each applied alone from a checksummed pristine copy and
  restored with `\cp -f` (md5 verified back): degraded index keeps the full cache
  window → 2 red; drop the `X-Sitemap-Degraded` header → 3 red; sequential walk
  instead of `allSettled` → 1 red (the all-five-slow test); drop the per-shard
  deadline → 1 red; drop the index's over-budget check → 1 red; drop the
  declared-empty warn → 1 red; drop the smoke's `boards.xml` assertion → 1 red;
  `allLocalesUrlCount` off by one locale → 2 red. Note that the last two probes on
  the *previous* revision produced phantom cascades from leaked fake timers; with
  the `afterEach` fix each now reds exactly its own test.
