### PR TITLE
ci: add trusted PostgreSQL image publisher

### DIFF
--- a/.github/workflows/postgres-image-publisher-contract.yml
+++ b/.github/workflows/postgres-image-publisher-contract.yml
@@ -1,0 +1,40 @@
+name: PostgreSQL Image Publisher Contract
+
+on:
+  pull_request:
+    paths: &publisher_contract_paths
+      - '.github/workflows/postgres-image-publisher.yml'
+      - '.github/workflows/postgres-image-publisher-contract.yml'
+      - 'scripts/lib/postgres-image-publisher-contract.ts'
+      - 'scripts/postgres-image-publisher-contract.test.ts'
+      - 'docs/postgres-image-publishing.md'
+      - 'package.json'
+      - 'bun.lock'
+  push:
+    branches: [main]
+    paths: *publisher_contract_paths
+
+permissions:
+  contents: read
+
+jobs:
+  verify-trust-boundary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository without persisted credentials
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+
+      - name: Install locked dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify publisher authority and artifact contracts
+        run: vp test run --project scripts scripts/postgres-image-publisher-contract.test.ts --reporter=agent

--- a/.github/workflows/postgres-image-publisher-contract.yml
+++ b/.github/workflows/postgres-image-publisher-contract.yml
@@ -5,8 +5,10 @@ on:
     paths: &publisher_contract_paths
       - '.github/workflows/postgres-image-publisher.yml'
       - '.github/workflows/postgres-image-publisher-contract.yml'
+      - 'vite.config.ts'
       - 'scripts/lib/postgres-image-publisher-contract.ts'
       - 'scripts/postgres-image-publisher-contract.test.ts'
+      - 'scripts/vite.config.ts'
       - 'docs/postgres-image-publishing.md'
       - 'package.json'
       - 'bun.lock'

--- a/.github/workflows/postgres-image-publisher.yml
+++ b/.github/workflows/postgres-image-publisher.yml
@@ -263,10 +263,19 @@ jobs:
         run: |
           set -Eeuo pipefail
           [[ "$(git -C source rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
-          [[ -f source/packages/db/docker/Dockerfile.postgres ]]
-          [[ ! -L source/packages/db/docker/Dockerfile.postgres ]]
-          [[ -f source/packages/db/docker/Dockerfile.dev-db ]]
-          [[ ! -L source/packages/db/docker/Dockerfile.dev-db ]]
+          for dockerfile in \
+            source/packages/db/docker/Dockerfile.postgres \
+            source/packages/db/docker/Dockerfile.dev-db; do
+            [[ -f "$dockerfile" && ! -L "$dockerfile" ]]
+            if perl -ne '
+              s/^\xEF\xBB\xBF// if $. == 1;
+              $found ||= /^[ \t]*#[ \t]*syntax[ \t]*=/i;
+              END { exit($found ? 0 : 1) }
+            ' "$dockerfile"; then
+              printf 'Offline build input validation failed: %s must not select a Dockerfile frontend\n' "$dockerfile" >&2
+              exit 1
+            fi
+          done
           [[ -f source/.dockerignore ]]
           [[ ! -L source/.dockerignore ]]
           grep -Fxq '.git' source/.dockerignore
@@ -287,8 +296,6 @@ jobs:
           provenance: false
           sbom: false
           github-token: ''
-          build-args: |
-            BUILDKIT_SYNTAX=dockerfile.v0
           labels: |
             org.opencontainers.image.revision=${{ inputs.expected_main_sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
@@ -311,8 +318,6 @@ jobs:
           provenance: false
           sbom: false
           github-token: ''
-          build-args: |
-            BUILDKIT_SYNTAX=dockerfile.v0
           labels: |
             org.opencontainers.image.revision=${{ inputs.expected_main_sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}

--- a/.github/workflows/postgres-image-publisher.yml
+++ b/.github/workflows/postgres-image-publisher.yml
@@ -942,6 +942,7 @@ jobs:
   record-published-digests:
     name: Record verified digest manifest
     needs:
+      - authorize-current-main
       - publish-images
       - attest-published-digests
       - verify-attestations

--- a/.github/workflows/postgres-image-publisher.yml
+++ b/.github/workflows/postgres-image-publisher.yml
@@ -616,9 +616,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
-
       - name: Enable multi-architecture emulation
         if: matrix.platform == 'linux/arm64'
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
@@ -671,6 +668,9 @@ jobs:
           find "$DOCKER_CONFIG" -depth -delete
           [[ ! -e "$DOCKER_CONFIG" ]]
 
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+
       - name: Set up Bun after registry credential removal
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
@@ -705,9 +705,6 @@ jobs:
           ref: ${{ inputs.expected_main_sha }}
           persist-credentials: false
           fetch-depth: 1
-
-      - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
 
       - name: Create temporary read-only registry boundary
         run: |
@@ -752,6 +749,9 @@ jobs:
           find "$DOCKER_CONFIG" -type f -exec sh -c ': >"$1"' _ {} \;
           find "$DOCKER_CONFIG" -depth -delete
           [[ ! -e "$DOCKER_CONFIG" ]]
+
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
 
       - name: Set up Bun after registry credential removal
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/postgres-image-publisher.yml
+++ b/.github/workflows/postgres-image-publisher.yml
@@ -120,7 +120,7 @@ jobs:
     name: Validate exact current main without publish authority
     needs: authorize-current-main
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:
@@ -671,6 +671,12 @@ jobs:
           find "$DOCKER_CONFIG" -depth -delete
           [[ ! -e "$DOCKER_CONFIG" ]]
 
+      - name: Set up Bun after registry credential removal
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install locked dependencies after registry credential removal
+        run: bun install --frozen-lockfile
+
       - name: Verify labels and boot exact portable platform
         env:
           EXPECTED_REVISION: ${{ inputs.expected_main_sha }}
@@ -746,6 +752,12 @@ jobs:
           find "$DOCKER_CONFIG" -type f -exec sh -c ': >"$1"' _ {} \;
           find "$DOCKER_CONFIG" -depth -delete
           [[ ! -e "$DOCKER_CONFIG" ]]
+
+      - name: Set up Bun after registry credential removal
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install locked dependencies after registry credential removal
+        run: bun install --frozen-lockfile
 
       - name: Verify labels, architecture, and seeded database
         env:

--- a/.github/workflows/postgres-image-publisher.yml
+++ b/.github/workflows/postgres-image-publisher.yml
@@ -145,6 +145,10 @@ jobs:
 
           [[ "$(git -C source rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]] ||
             fail 'checkout does not match expected_main_sha'
+          [[ -f source/vite.config.ts && ! -L source/vite.config.ts ]] ||
+            fail 'vite.config.ts must be a regular file'
+          grep -Fq "'test:postgres18-contract': {" source/vite.config.ts ||
+            fail 'producer prerequisite missing: merge the PostgreSQL 18 contract target before dispatching this publisher'
           for dockerfile in \
             source/packages/db/docker/Dockerfile.postgres \
             source/packages/db/docker/Dockerfile.dev-db; do
@@ -199,6 +203,31 @@ jobs:
           path: source
           persist-credentials: false
           fetch-depth: 1
+
+      - name: Validate retired-digest configuration before build setup
+        env:
+          RETIRED_DIGESTS: ${{ vars.RETIRED_DB_IMAGE_DIGESTS }}
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'Retired-digest configuration failed: %s\n' "$*" >&2
+            exit 1
+          }
+
+          [[ "$RETIRED_DIGESTS" =~ [^[:space:]] ]] ||
+            fail 'set RETIRED_DB_IMAGE_DIGESTS to none or one lowercase sha256 digest per non-empty line'
+          [[ "$RETIRED_DIGESTS" == 'none' ]] && exit 0
+
+          declare -A seen_retired_digests=()
+          while IFS= read -r retired_digest || [[ -n "$retired_digest" ]]; do
+            [[ -n "$retired_digest" ]] || continue
+            [[ "$retired_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+              fail 'RETIRED_DB_IMAGE_DIGESTS must be none or contain one lowercase sha256 digest per non-empty line'
+            [[ -z "${seen_retired_digests[$retired_digest]:-}" ]] ||
+              fail "RETIRED_DB_IMAGE_DIGESTS contains a duplicate: $retired_digest"
+            seen_retired_digests["$retired_digest"]=1
+          done <<<"$RETIRED_DIGESTS"
 
       - name: Enable multi-architecture emulation
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
@@ -348,15 +377,19 @@ jobs:
           [[ "$(platform_list "$SEEDED_LAYOUT" "$seeded_digest")" == '["linux/amd64"]' ]] ||
             fail 'seeded OCI layout does not contain exactly linux/amd64'
 
+          [[ "$RETIRED_DIGESTS" =~ [^[:space:]] ]] ||
+            fail 'RETIRED_DB_IMAGE_DIGESTS must be explicitly set to none or lowercase sha256 digests'
           declare -A seen_retired_digests=()
-          while IFS= read -r retired_digest || [[ -n "$retired_digest" ]]; do
-            [[ -n "$retired_digest" ]] || continue
-            [[ "$retired_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
-              fail 'RETIRED_DB_IMAGE_DIGESTS must contain one lowercase sha256 digest per non-empty line'
-            [[ -z "${seen_retired_digests[$retired_digest]:-}" ]] ||
-              fail "RETIRED_DB_IMAGE_DIGESTS contains a duplicate: $retired_digest"
-            seen_retired_digests["$retired_digest"]=1
-          done <<<"$RETIRED_DIGESTS"
+          if [[ "$RETIRED_DIGESTS" != 'none' ]]; then
+            while IFS= read -r retired_digest || [[ -n "$retired_digest" ]]; do
+              [[ -n "$retired_digest" ]] || continue
+              [[ "$retired_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+                fail 'RETIRED_DB_IMAGE_DIGESTS must be none or contain one lowercase sha256 digest per non-empty line'
+              [[ -z "${seen_retired_digests[$retired_digest]:-}" ]] ||
+                fail "RETIRED_DB_IMAGE_DIGESTS contains a duplicate: $retired_digest"
+              seen_retired_digests["$retired_digest"]=1
+            done <<<"$RETIRED_DIGESTS"
+          fi
 
           for proposed_digest in "$portable_digest" "$seeded_digest"; do
             [[ -z "${seen_retired_digests[$proposed_digest]:-}" ]] ||

--- a/.github/workflows/postgres-image-publisher.yml
+++ b/.github/workflows/postgres-image-publisher.yml
@@ -99,7 +99,7 @@ jobs:
             ([.protection_rules[] |
               select(
                 .type == "required_reviewers" and
-                .prevent_self_review == true and
+                (.prevent_self_review | type == "boolean") and
                 ((.reviewers // []) | length > 0)
               )] | length == 1)
           ' <<<"$environment_json" >/dev/null ||
@@ -434,7 +434,7 @@ jobs:
             ([.protection_rules[] |
               select(
                 .type == "required_reviewers" and
-                .prevent_self_review == true and
+                (.prevent_self_review | type == "boolean") and
                 ((.reviewers // []) | length > 0)
               )] | length == 1)
           ' <<<"$environment_json" >/dev/null ||
@@ -822,7 +822,7 @@ jobs:
             ([.protection_rules[] |
               select(
                 .type == "required_reviewers" and
-                .prevent_self_review == true and
+                (.prevent_self_review | type == "boolean") and
                 ((.reviewers // []) | length > 0)
               )] | length == 1)
           ' <<<"$environment_json" >/dev/null ||

--- a/.github/workflows/postgres-image-publisher.yml
+++ b/.github/workflows/postgres-image-publisher.yml
@@ -1,0 +1,1018 @@
+name: Publish Current Main PostgreSQL Images
+
+# This workflow is a protected-main authority boundary. It publishes only the
+# exact commit that currently owns this workflow on protected main. See
+# docs/postgres-image-publishing.md before configuring or dispatching it.
+on:
+  workflow_dispatch:
+    inputs:
+      expected_main_sha:
+        description: Exact lowercase 40-character SHA currently at the head of main
+        required: true
+        type: string
+
+concurrency:
+  group: postgres-image-publisher
+  cancel-in-progress: false
+
+env:
+  APPROVED_REPOSITORY: boardsesh/boardsesh
+  DEFAULT_BRANCH: main
+  PUBLISHER_ENVIRONMENT: postgres-image-publisher
+  REGISTRY: ghcr.io
+  PORTABLE_IMAGE: ghcr.io/boardsesh/boardsesh-postgres-postgis
+  SEEDED_IMAGE: ghcr.io/boardsesh/boardsesh-dev-db
+  MAIN_REF: refs/heads/main
+
+jobs:
+  authorize-current-main:
+    name: Bind publisher to exact current main
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Bind workflow and audit publisher environment
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          EXPECTED_WORKFLOW_REF: boardsesh/boardsesh/.github/workflows/postgres-image-publisher.yml@refs/heads/main
+          GH_TOKEN: ${{ github.token }}
+          REF_IS_PROTECTED: ${{ github.ref_protected }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'Publisher authorization failed: %s\n' "$*" >&2
+            exit 1
+          }
+
+          [[ "$GITHUB_REPOSITORY" == "$APPROVED_REPOSITORY" ]] ||
+            fail "repository must be $APPROVED_REPOSITORY"
+          [[ "$GITHUB_SERVER_URL" == 'https://github.com' ]] ||
+            fail 'publisher is restricted to github.com'
+          [[ "$GITHUB_API_URL" == 'https://api.github.com' ]] ||
+            fail 'publisher is restricted to the public GitHub API'
+          [[ "$GITHUB_EVENT_NAME" == 'workflow_dispatch' ]] ||
+            fail 'publisher must be manually dispatched'
+          [[ "$DISPATCH_REF" == "refs/heads/$DEFAULT_BRANCH" ]] ||
+            fail "dispatch the workflow from $DEFAULT_BRANCH"
+          [[ "$WORKFLOW_REF" == "$EXPECTED_WORKFLOW_REF" ]] ||
+            fail 'workflow definition was not loaded from its approved main path'
+          [[ "$REF_IS_PROTECTED" == 'true' ]] ||
+            fail 'main is not protected for this dispatch'
+          [[ "$EXPECTED_MAIN_SHA" =~ ^[0-9a-f]{40}$ ]] ||
+            fail 'expected_main_sha must be a lowercase full 40-character SHA'
+          [[ "$EXPECTED_MAIN_SHA" == "$DISPATCH_SHA" ]] ||
+            fail 'expected_main_sha does not equal github.sha'
+          [[ "$EXPECTED_MAIN_SHA" == "$WORKFLOW_SHA" ]] ||
+            fail 'workflow source SHA does not equal expected_main_sha'
+
+          repository_json="$(gh api "/repos/$APPROVED_REPOSITORY")"
+          jq -e --arg default_branch "$DEFAULT_BRANCH" '
+            .full_name == "boardsesh/boardsesh" and
+            .default_branch == $default_branch and
+            .fork == false and
+            .archived == false
+          ' <<<"$repository_json" >/dev/null ||
+            fail 'repository metadata does not match the approved repository'
+
+          live_main_sha="$(
+            gh api "/repos/$APPROVED_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" \
+              --jq '.object.sha'
+          )"
+          [[ "$live_main_sha" == "$EXPECTED_MAIN_SHA" ]] ||
+            fail 'expected_main_sha is no longer the live main head'
+
+          environment_json="$(
+            gh api "/repos/$APPROVED_REPOSITORY/environments/$PUBLISHER_ENVIRONMENT"
+          )"
+          jq -e --arg environment "$PUBLISHER_ENVIRONMENT" '
+            .name == $environment and
+            .can_admins_bypass == false and
+            .deployment_branch_policy.protected_branches == false and
+            .deployment_branch_policy.custom_branch_policies == true and
+            ([.protection_rules[] |
+              select(
+                .type == "required_reviewers" and
+                .prevent_self_review == true and
+                ((.reviewers // []) | length > 0)
+              )] | length == 1)
+          ' <<<"$environment_json" >/dev/null ||
+            fail 'publisher environment must require reviewers, prevent self-review, disable bypass, and use a custom branch policy'
+
+          branch_policies_json="$(
+            gh api "/repos/$APPROVED_REPOSITORY/environments/$PUBLISHER_ENVIRONMENT/deployment-branch-policies"
+          )"
+          jq -e --arg default_branch "$DEFAULT_BRANCH" '
+            .total_count == 1 and
+            (.branch_policies | length == 1) and
+            .branch_policies[0].name == $default_branch and
+            .branch_policies[0].type == "branch"
+          ' <<<"$branch_policies_json" >/dev/null ||
+            fail 'publisher environment must allow exactly the main branch'
+
+  validate-main:
+    name: Validate exact current main without publish authority
+    needs: authorize-current-main
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact current main commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.expected_main_sha }}
+          path: source
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Validate checkout and Docker inputs
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'Publisher input validation failed: %s\n' "$*" >&2
+            exit 1
+          }
+
+          [[ "$(git -C source rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]] ||
+            fail 'checkout does not match expected_main_sha'
+          for dockerfile in \
+            source/packages/db/docker/Dockerfile.postgres \
+            source/packages/db/docker/Dockerfile.dev-db; do
+            [[ -f "$dockerfile" && ! -L "$dockerfile" ]] ||
+              fail "$dockerfile must be a regular file"
+            if perl -ne '
+              s/^\xEF\xBB\xBF// if $. == 1;
+              $found ||= /^[ \t]*#[ \t]*syntax[ \t]*=/i;
+              END { exit($found ? 0 : 1) }
+            ' "$dockerfile"; then
+              fail "$dockerfile must not select a Dockerfile frontend"
+            fi
+          done
+          [[ -f source/.dockerignore && ! -L source/.dockerignore ]] ||
+            fail '.dockerignore must be a regular file'
+          grep -Fxq '.git' source/.dockerignore ||
+            fail '.dockerignore must exclude .git'
+
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install locked dependencies
+        working-directory: source
+        run: bun install --frozen-lockfile
+
+      - name: Run PostgreSQL 18 contracts
+        working-directory: source
+        run: vp run test:postgres18-contract
+
+  publish-images:
+    name: Build offline and publish exact image layouts
+    needs: [authorize-current-main, validate-main]
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    environment: postgres-image-publisher
+    permissions:
+      actions: read
+      contents: read
+      packages: write
+    outputs:
+      portable_digest: ${{ steps.layouts.outputs.portable_digest }}
+      seeded_digest: ${{ steps.layouts.outputs.seeded_digest }}
+      sha_tag: ${{ steps.layouts.outputs.sha_tag }}
+    steps:
+      - name: Checkout exact current main commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.expected_main_sha }}
+          path: source
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Enable multi-architecture emulation
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        with:
+          image: tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+
+      - name: Create temporary tool and credential boundary
+        run: |
+          set -Eeuo pipefail
+          auth_directory="$RUNNER_TEMP/boardsesh-ghcr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-publish"
+          install -d -m 700 "$auth_directory"
+          printf 'DOCKER_CONFIG=%s\n' "$auth_directory" >>"$GITHUB_ENV"
+
+      - name: Set up Docker Buildx inside the temporary boundary
+        id: buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        with:
+          version: v0.36.1
+          driver-opts: |
+            image=moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8
+          cleanup: false
+
+      - name: Set up pinned ORAS client
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1 (ORAS v1.3.3)
+        with:
+          url: https://github.com/oras-project/oras/releases/download/v1.3.3/oras_1.3.3_linux_amd64.tar.gz
+          checksum: 9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59
+
+      - name: Revalidate offline build inputs
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$(git -C source rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          [[ -f source/packages/db/docker/Dockerfile.postgres ]]
+          [[ ! -L source/packages/db/docker/Dockerfile.postgres ]]
+          [[ -f source/packages/db/docker/Dockerfile.dev-db ]]
+          [[ ! -L source/packages/db/docker/Dockerfile.dev-db ]]
+          [[ -f source/.dockerignore ]]
+          [[ ! -L source/.dockerignore ]]
+          grep -Fxq '.git' source/.dockerignore
+
+      - name: Build portable OCI layout without registry credentials
+        id: build-portable
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: 'false'
+          DOCKER_BUILD_SUMMARY: 'false'
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./source/packages/db/docker
+          file: ./source/packages/db/docker/Dockerfile.postgres
+          platforms: linux/amd64,linux/arm64
+          pull: true
+          push: false
+          provenance: false
+          sbom: false
+          github-token: ''
+          build-args: |
+            BUILDKIT_SYNTAX=dockerfile.v0
+          labels: |
+            org.opencontainers.image.revision=${{ inputs.expected_main_sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.ref.name=refs/heads/main
+          outputs: type=oci,dest=${{ runner.temp }}/portable-oci,tar=false,name=${{ env.PORTABLE_IMAGE }}:sha-${{ inputs.expected_main_sha }}
+
+      - name: Build seeded OCI layout without registry credentials
+        id: build-seeded
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: 'false'
+          DOCKER_BUILD_SUMMARY: 'false'
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: ./source
+          file: ./source/packages/db/docker/Dockerfile.dev-db
+          platforms: linux/amd64
+          pull: true
+          push: false
+          provenance: false
+          sbom: false
+          github-token: ''
+          build-args: |
+            BUILDKIT_SYNTAX=dockerfile.v0
+          labels: |
+            org.opencontainers.image.revision=${{ inputs.expected_main_sha }}
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.ref.name=refs/heads/main
+          outputs: type=oci,dest=${{ runner.temp }}/seeded-oci,tar=false,name=${{ env.SEEDED_IMAGE }}:sha-${{ inputs.expected_main_sha }}
+
+      - name: Validate offline layouts and retired digest policy
+        id: layouts
+        env:
+          EXPECTED_PORTABLE_DIGEST: ${{ steps.build-portable.outputs.digest }}
+          EXPECTED_SEEDED_DIGEST: ${{ steps.build-seeded.outputs.digest }}
+          PORTABLE_LAYOUT: ${{ runner.temp }}/portable-oci
+          RETIRED_DIGESTS: ${{ vars.RETIRED_DB_IMAGE_DIGESTS }}
+          SEEDED_LAYOUT: ${{ runner.temp }}/seeded-oci
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'Offline image validation failed: %s\n' "$*" >&2
+            exit 1
+          }
+
+          layout_digest() {
+            local layout="$1"
+            local digest
+            local digest_hex
+            jq -e '
+              .schemaVersion == 2 and
+              (.manifests | type == "array" and length == 1)
+            ' "$layout/index.json" >/dev/null ||
+              fail "$layout/index.json must contain exactly one root descriptor"
+            digest="$(jq -er '.manifests[0].digest | select(test("^sha256:[0-9a-f]{64}$"))' "$layout/index.json")"
+            digest_hex="${digest#sha256:}"
+            [[ -f "$layout/blobs/sha256/$digest_hex" ]] ||
+              fail "$layout is missing its root manifest blob"
+            [[ "$(sha256sum "$layout/blobs/sha256/$digest_hex" | cut -d ' ' -f1)" == "$digest_hex" ]] ||
+              fail "$layout root manifest digest does not match its bytes"
+            printf '%s\n' "$digest"
+          }
+
+          platform_list() {
+            local layout="$1"
+            local digest="$2"
+            local root_manifest="$layout/blobs/sha256/${digest#sha256:}"
+            if jq -e '.manifests | type == "array"' "$root_manifest" >/dev/null; then
+              jq -c '[.manifests[].platform | "\(.os)/\(.architecture)"] | sort' "$root_manifest"
+            else
+              local config_digest
+              config_digest="$(jq -er '.config.digest | select(test("^sha256:[0-9a-f]{64}$"))' "$root_manifest")"
+              jq -c '["\(.os)/\(.architecture)"]' "$layout/blobs/sha256/${config_digest#sha256:}"
+            fi
+          }
+
+          portable_digest="$(layout_digest "$PORTABLE_LAYOUT")"
+          seeded_digest="$(layout_digest "$SEEDED_LAYOUT")"
+          [[ "$portable_digest" == "$EXPECTED_PORTABLE_DIGEST" ]] ||
+            fail 'portable Buildx output digest does not match its OCI layout'
+          [[ "$seeded_digest" == "$EXPECTED_SEEDED_DIGEST" ]] ||
+            fail 'seeded Buildx output digest does not match its OCI layout'
+          [[ "$(platform_list "$PORTABLE_LAYOUT" "$portable_digest")" == '["linux/amd64","linux/arm64"]' ]] ||
+            fail 'portable OCI layout does not contain exactly linux/amd64 and linux/arm64'
+          [[ "$(platform_list "$SEEDED_LAYOUT" "$seeded_digest")" == '["linux/amd64"]' ]] ||
+            fail 'seeded OCI layout does not contain exactly linux/amd64'
+
+          declare -A seen_retired_digests=()
+          while IFS= read -r retired_digest || [[ -n "$retired_digest" ]]; do
+            [[ -n "$retired_digest" ]] || continue
+            [[ "$retired_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+              fail 'RETIRED_DB_IMAGE_DIGESTS must contain one lowercase sha256 digest per non-empty line'
+            [[ -z "${seen_retired_digests[$retired_digest]:-}" ]] ||
+              fail "RETIRED_DB_IMAGE_DIGESTS contains a duplicate: $retired_digest"
+            seen_retired_digests["$retired_digest"]=1
+          done <<<"$RETIRED_DIGESTS"
+
+          for proposed_digest in "$portable_digest" "$seeded_digest"; do
+            [[ -z "${seen_retired_digests[$proposed_digest]:-}" ]] ||
+              fail "refusing to publish retired digest $proposed_digest"
+          done
+
+          printf 'portable_digest=%s\n' "$portable_digest" >>"$GITHUB_OUTPUT"
+          printf 'seeded_digest=%s\n' "$seeded_digest" >>"$GITHUB_OUTPUT"
+          printf 'sha_tag=sha-%s\n' "${{ inputs.expected_main_sha }}" >>"$GITHUB_OUTPUT"
+
+      - name: Recheck exact current main and environment immediately before registry authentication
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'Pre-authentication recheck failed: %s\n' "$*" >&2
+            exit 1
+          }
+
+          [[ "$EXPECTED_MAIN_SHA" == "$GITHUB_SHA" ]] ||
+            fail 'expected_main_sha no longer equals github.sha'
+          [[ "$(git -C source rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]] ||
+            fail 'checkout no longer matches expected_main_sha'
+          live_main_sha="$(gh api "/repos/$APPROVED_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')"
+          [[ "$live_main_sha" == "$EXPECTED_MAIN_SHA" ]] ||
+            fail 'main moved before registry authentication'
+
+          environment_json="$(gh api "/repos/$APPROVED_REPOSITORY/environments/$PUBLISHER_ENVIRONMENT")"
+          jq -e --arg environment "$PUBLISHER_ENVIRONMENT" '
+            .name == $environment and
+            .can_admins_bypass == false and
+            .deployment_branch_policy.protected_branches == false and
+            .deployment_branch_policy.custom_branch_policies == true and
+            ([.protection_rules[] |
+              select(
+                .type == "required_reviewers" and
+                .prevent_self_review == true and
+                ((.reviewers // []) | length > 0)
+              )] | length == 1)
+          ' <<<"$environment_json" >/dev/null ||
+            fail 'publisher environment protections changed before registry authentication'
+          branch_policies_json="$(
+            gh api "/repos/$APPROVED_REPOSITORY/environments/$PUBLISHER_ENVIRONMENT/deployment-branch-policies"
+          )"
+          jq -e --arg default_branch "$DEFAULT_BRANCH" '
+            .total_count == 1 and
+            (.branch_policies | length == 1) and
+            .branch_policies[0].name == $default_branch and
+            .branch_policies[0].type == "branch"
+          ' <<<"$branch_policies_json" >/dev/null ||
+            fail 'publisher environment main-only policy changed before registry authentication'
+
+      - name: Authenticate ORAS to GHCR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          printf '%s' "$GH_TOKEN" |
+            oras login "$REGISTRY" \
+              --username "$GITHUB_ACTOR" \
+              --password-stdin \
+              --registry-config "$DOCKER_CONFIG/config.json"
+
+      - name: Publish exact prevalidated OCI layouts
+        env:
+          PORTABLE_DIGEST: ${{ steps.layouts.outputs.portable_digest }}
+          PORTABLE_LAYOUT: ${{ runner.temp }}/portable-oci
+          SEEDED_DIGEST: ${{ steps.layouts.outputs.seeded_digest }}
+          SEEDED_LAYOUT: ${{ runner.temp }}/seeded-oci
+          SHA_TAG: ${{ steps.layouts.outputs.sha_tag }}
+        run: |
+          set -Eeuo pipefail
+          oras cp --from-oci-layout \
+            "$PORTABLE_LAYOUT@$PORTABLE_DIGEST" \
+            "$PORTABLE_IMAGE:$SHA_TAG" \
+            --to-registry-config "$DOCKER_CONFIG/config.json"
+          oras cp --from-oci-layout \
+            "$SEEDED_LAYOUT@$SEEDED_DIGEST" \
+            "$SEEDED_IMAGE:$SHA_TAG" \
+            --to-registry-config "$DOCKER_CONFIG/config.json"
+
+          [[ "$(oras resolve --registry-config "$DOCKER_CONFIG/config.json" "$PORTABLE_IMAGE:$SHA_TAG")" == "$PORTABLE_DIGEST" ]]
+          [[ "$(oras resolve --registry-config "$DOCKER_CONFIG/config.json" "$SEEDED_IMAGE:$SHA_TAG")" == "$SEEDED_DIGEST" ]]
+
+      - name: Remove temporary publisher credentials and builder
+        if: always()
+        env:
+          BUILDER_NAME: ${{ steps.buildx.outputs.name }}
+          PORTABLE_LAYOUT: ${{ runner.temp }}/portable-oci
+          SEEDED_LAYOUT: ${{ runner.temp }}/seeded-oci
+        run: |
+          set -Eeuo pipefail
+          [[ -n "${DOCKER_CONFIG:-}" ]] || exit 0
+          case "$DOCKER_CONFIG" in
+            "$RUNNER_TEMP"/boardsesh-ghcr-*-publish) ;;
+            *) printf 'Refusing to clean unexpected DOCKER_CONFIG: %s\n' "$DOCKER_CONFIG" >&2; exit 1 ;;
+          esac
+          cleanup_status=0
+          oras logout "$REGISTRY" --registry-config "$DOCKER_CONFIG/config.json" >/dev/null 2>&1 || true
+          if [[ -n "$BUILDER_NAME" ]]; then
+            docker buildx rm "$BUILDER_NAME" >/dev/null 2>&1 || cleanup_status=1
+          fi
+          find "$DOCKER_CONFIG" -type f -exec sh -c ': >"$1"' _ {} \;
+          find "$DOCKER_CONFIG" -depth -delete
+          find "$PORTABLE_LAYOUT" -depth -delete 2>/dev/null || true
+          find "$SEEDED_LAYOUT" -depth -delete 2>/dev/null || true
+          [[ ! -e "$DOCKER_CONFIG" ]]
+          ((cleanup_status == 0))
+
+  verify-published-images:
+    name: Verify published tags, digests, and platforms
+    needs: [authorize-current-main, publish-images]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Set up pinned ORAS client
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1 (ORAS v1.3.3)
+        with:
+          url: https://github.com/oras-project/oras/releases/download/v1.3.3/oras_1.3.3_linux_amd64.tar.gz
+          checksum: 9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59
+
+      - name: Create temporary read-only registry boundary
+        run: |
+          set -Eeuo pipefail
+          auth_directory="$RUNNER_TEMP/boardsesh-ghcr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-verify-images"
+          install -d -m 700 "$auth_directory"
+          printf 'DOCKER_CONFIG=%s\n' "$auth_directory" >>"$GITHUB_ENV"
+
+      - name: Recheck exact current main immediately before registry authentication
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$EXPECTED_MAIN_SHA" == "$GITHUB_SHA" ]]
+          [[ "$(gh api "/repos/$APPROVED_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')" == "$EXPECTED_MAIN_SHA" ]]
+
+      - name: Authenticate ORAS to GHCR read-only
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -Eeuo pipefail
+          printf '%s' "$GH_TOKEN" |
+            oras login "$REGISTRY" \
+              --username "$GITHUB_ACTOR" \
+              --password-stdin \
+              --registry-config "$DOCKER_CONFIG/config.json"
+
+      - name: Verify exact remote manifests
+        env:
+          PORTABLE_DIGEST: ${{ needs.publish-images.outputs.portable_digest }}
+          SEEDED_DIGEST: ${{ needs.publish-images.outputs.seeded_digest }}
+          SHA_TAG: ${{ needs.publish-images.outputs.sha_tag }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$(oras resolve --registry-config "$DOCKER_CONFIG/config.json" "$PORTABLE_IMAGE:$SHA_TAG")" == "$PORTABLE_DIGEST" ]]
+          [[ "$(oras resolve --registry-config "$DOCKER_CONFIG/config.json" "$SEEDED_IMAGE:$SHA_TAG")" == "$SEEDED_DIGEST" ]]
+
+          oras manifest fetch \
+            --registry-config "$DOCKER_CONFIG/config.json" \
+            --output portable-manifest.json \
+            "$PORTABLE_IMAGE@$PORTABLE_DIGEST"
+          jq -e '
+            .schemaVersion == 2 and
+            ([.manifests[].platform | "\(.os)/\(.architecture)"] | sort) ==
+              ["linux/amd64", "linux/arm64"]
+          ' portable-manifest.json >/dev/null
+
+          oras manifest fetch \
+            --registry-config "$DOCKER_CONFIG/config.json" \
+            --output seeded-manifest.json \
+            "$SEEDED_IMAGE@$SEEDED_DIGEST"
+          if jq -e '.manifests | type == "array"' seeded-manifest.json >/dev/null; then
+            jq -e '
+              .schemaVersion == 2 and
+              ([.manifests[].platform | "\(.os)/\(.architecture)"] | sort) ==
+                ["linux/amd64"]
+            ' seeded-manifest.json >/dev/null
+          else
+            oras manifest fetch-config \
+              --registry-config "$DOCKER_CONFIG/config.json" \
+              --output seeded-config.json \
+              "$SEEDED_IMAGE@$SEEDED_DIGEST"
+            jq -e '.os == "linux" and .architecture == "amd64"' seeded-config.json >/dev/null
+          fi
+
+      - name: Remove temporary read-only registry credentials
+        if: always()
+        run: |
+          set -Eeuo pipefail
+          [[ -n "${DOCKER_CONFIG:-}" ]] || exit 0
+          case "$DOCKER_CONFIG" in
+            "$RUNNER_TEMP"/boardsesh-ghcr-*-verify-images) ;;
+            *) printf 'Refusing to clean unexpected DOCKER_CONFIG: %s\n' "$DOCKER_CONFIG" >&2; exit 1 ;;
+          esac
+          oras logout "$REGISTRY" --registry-config "$DOCKER_CONFIG/config.json" >/dev/null 2>&1 || true
+          find "$DOCKER_CONFIG" -type f -exec sh -c ': >"$1"' _ {} \;
+          find "$DOCKER_CONFIG" -depth -delete
+          [[ ! -e "$DOCKER_CONFIG" ]]
+
+  smoke-portable:
+    name: Smoke portable (${{ matrix.platform }})
+    needs: [authorize-current-main, publish-images, verify-published-images]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout exact current main commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.expected_main_sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+
+      - name: Enable multi-architecture emulation
+        if: matrix.platform == 'linux/arm64'
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        with:
+          image: tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          platforms: arm64
+
+      - name: Create temporary read-only registry boundary
+        run: |
+          set -Eeuo pipefail
+          auth_directory="$RUNNER_TEMP/boardsesh-ghcr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-portable-smoke"
+          install -d -m 700 "$auth_directory"
+          printf 'DOCKER_CONFIG=%s\n' "$auth_directory" >>"$GITHUB_ENV"
+
+      - name: Recheck exact current main immediately before registry authentication
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$EXPECTED_MAIN_SHA" == "$GITHUB_SHA" ]]
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          [[ "$(gh api "/repos/$APPROVED_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')" == "$EXPECTED_MAIN_SHA" ]]
+
+      - name: Log in to GHCR for exact digest pull
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+
+      - name: Pull exact portable digest and platform
+        env:
+          IMAGE: ${{ env.PORTABLE_IMAGE }}@${{ needs.publish-images.outputs.portable_digest }}
+          PLATFORM: ${{ matrix.platform }}
+        run: docker pull --platform "$PLATFORM" "$IMAGE"
+
+      - name: Remove registry credentials before image smoke
+        if: always()
+        run: |
+          set -Eeuo pipefail
+          [[ -n "${DOCKER_CONFIG:-}" ]] || exit 0
+          case "$DOCKER_CONFIG" in
+            "$RUNNER_TEMP"/boardsesh-ghcr-*-portable-smoke) ;;
+            *) printf 'Refusing to clean unexpected DOCKER_CONFIG: %s\n' "$DOCKER_CONFIG" >&2; exit 1 ;;
+          esac
+          docker logout "$REGISTRY" >/dev/null 2>&1 || true
+          find "$DOCKER_CONFIG" -type f -exec sh -c ': >"$1"' _ {} \;
+          find "$DOCKER_CONFIG" -depth -delete
+          [[ ! -e "$DOCKER_CONFIG" ]]
+
+      - name: Verify labels and boot exact portable platform
+        env:
+          EXPECTED_REVISION: ${{ inputs.expected_main_sha }}
+          EXPECTED_SOURCE: ${{ github.server_url }}/${{ github.repository }}
+          IMAGE: ${{ env.PORTABLE_IMAGE }}@${{ needs.publish-images.outputs.portable_digest }}
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$IMAGE")" == "$EXPECTED_REVISION" ]]
+          [[ "$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.source" }}' "$IMAGE")" == "$EXPECTED_SOURCE" ]]
+          [[ "$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.ref.name" }}' "$IMAGE")" == 'refs/heads/main' ]]
+          vp run test:postgres18-architecture-image "$IMAGE" "$PLATFORM"
+
+  smoke-seeded:
+    name: Smoke seeded (linux/amd64)
+    needs: [authorize-current-main, publish-images, verify-published-images]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout exact current main commit
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ inputs.expected_main_sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+
+      - name: Create temporary read-only registry boundary
+        run: |
+          set -Eeuo pipefail
+          auth_directory="$RUNNER_TEMP/boardsesh-ghcr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-seeded-smoke"
+          install -d -m 700 "$auth_directory"
+          printf 'DOCKER_CONFIG=%s\n' "$auth_directory" >>"$GITHUB_ENV"
+
+      - name: Recheck exact current main immediately before registry authentication
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$EXPECTED_MAIN_SHA" == "$GITHUB_SHA" ]]
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_MAIN_SHA" ]]
+          [[ "$(gh api "/repos/$APPROVED_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')" == "$EXPECTED_MAIN_SHA" ]]
+
+      - name: Log in to GHCR for exact digest pull
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+
+      - name: Pull exact seeded digest
+        env:
+          IMAGE: ${{ env.SEEDED_IMAGE }}@${{ needs.publish-images.outputs.seeded_digest }}
+        run: docker pull --platform linux/amd64 "$IMAGE"
+
+      - name: Remove registry credentials before image smoke
+        if: always()
+        run: |
+          set -Eeuo pipefail
+          [[ -n "${DOCKER_CONFIG:-}" ]] || exit 0
+          case "$DOCKER_CONFIG" in
+            "$RUNNER_TEMP"/boardsesh-ghcr-*-seeded-smoke) ;;
+            *) printf 'Refusing to clean unexpected DOCKER_CONFIG: %s\n' "$DOCKER_CONFIG" >&2; exit 1 ;;
+          esac
+          docker logout "$REGISTRY" >/dev/null 2>&1 || true
+          find "$DOCKER_CONFIG" -type f -exec sh -c ': >"$1"' _ {} \;
+          find "$DOCKER_CONFIG" -depth -delete
+          [[ ! -e "$DOCKER_CONFIG" ]]
+
+      - name: Verify labels, architecture, and seeded database
+        env:
+          EXPECTED_REVISION: ${{ inputs.expected_main_sha }}
+          EXPECTED_SOURCE: ${{ github.server_url }}/${{ github.repository }}
+          IMAGE: ${{ env.SEEDED_IMAGE }}@${{ needs.publish-images.outputs.seeded_digest }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$(docker inspect --format '{{ .Architecture }}' "$IMAGE")" == 'amd64' ]]
+          [[ "$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "$IMAGE")" == "$EXPECTED_REVISION" ]]
+          [[ "$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.source" }}' "$IMAGE")" == "$EXPECTED_SOURCE" ]]
+          [[ "$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.ref.name" }}' "$IMAGE")" == 'refs/heads/main' ]]
+          vp run test:postgres18-dev-db-image "$IMAGE"
+
+  attest-published-digests:
+    name: Attest verified image digests
+    needs:
+      - authorize-current-main
+      - publish-images
+      - verify-published-images
+      - smoke-portable
+      - smoke-seeded
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: postgres-image-publisher
+    permissions:
+      actions: read
+      contents: read
+      attestations: write
+      id-token: write
+    outputs:
+      portable_attestation_url: ${{ steps.attest-portable.outputs.attestation-url }}
+      seeded_attestation_url: ${{ steps.attest-seeded.outputs.attestation-url }}
+    steps:
+      - name: Recheck exact current main and environment immediately before OIDC attestation
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'Pre-attestation recheck failed: %s\n' "$*" >&2
+            exit 1
+          }
+
+          [[ "$EXPECTED_MAIN_SHA" == "$GITHUB_SHA" ]] ||
+            fail 'expected_main_sha no longer equals github.sha'
+          [[ "$(gh api "/repos/$APPROVED_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')" == "$EXPECTED_MAIN_SHA" ]] ||
+            fail 'main moved before OIDC attestation'
+          environment_json="$(gh api "/repos/$APPROVED_REPOSITORY/environments/$PUBLISHER_ENVIRONMENT")"
+          jq -e --arg environment "$PUBLISHER_ENVIRONMENT" '
+            .name == $environment and
+            .can_admins_bypass == false and
+            .deployment_branch_policy.protected_branches == false and
+            .deployment_branch_policy.custom_branch_policies == true and
+            ([.protection_rules[] |
+              select(
+                .type == "required_reviewers" and
+                .prevent_self_review == true and
+                ((.reviewers // []) | length > 0)
+              )] | length == 1)
+          ' <<<"$environment_json" >/dev/null ||
+            fail 'publisher environment protections changed before OIDC attestation'
+          branch_policies_json="$(
+            gh api "/repos/$APPROVED_REPOSITORY/environments/$PUBLISHER_ENVIRONMENT/deployment-branch-policies"
+          )"
+          jq -e --arg default_branch "$DEFAULT_BRANCH" '
+            .total_count == 1 and
+            (.branch_policies | length == 1) and
+            .branch_policies[0].name == $default_branch and
+            .branch_policies[0].type == "branch"
+          ' <<<"$branch_policies_json" >/dev/null ||
+            fail 'publisher environment main-only policy changed before OIDC attestation'
+
+      - name: Attest exact portable digest
+        id: attest-portable
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ env.PORTABLE_IMAGE }}
+          subject-digest: ${{ needs.publish-images.outputs.portable_digest }}
+          push-to-registry: false
+
+      - name: Attest exact seeded digest
+        id: attest-seeded
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ env.SEEDED_IMAGE }}
+          subject-digest: ${{ needs.publish-images.outputs.seeded_digest }}
+          push-to-registry: false
+
+  verify-attestations:
+    name: Verify both provenance attestations
+    needs: [authorize-current-main, publish-images, attest-published-digests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+      attestations: read
+    steps:
+      - name: Create temporary read-only registry boundary
+        run: |
+          set -Eeuo pipefail
+          auth_directory="$RUNNER_TEMP/boardsesh-ghcr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-verify-attestations"
+          install -d -m 700 "$auth_directory"
+          printf 'DOCKER_CONFIG=%s\n' "$auth_directory" >>"$GITHUB_ENV"
+
+      - name: Recheck exact current main immediately before registry authentication
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$EXPECTED_MAIN_SHA" == "$GITHUB_SHA" ]]
+          [[ "$(gh api "/repos/$APPROVED_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')" == "$EXPECTED_MAIN_SHA" ]]
+
+      - name: Log in to GHCR for attestation verification
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          logout: false
+
+      - name: Validate attestation URLs and verify both exact subjects
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PORTABLE_ATTESTATION_URL: ${{ needs.attest-published-digests.outputs.portable_attestation_url }}
+          PORTABLE_DIGEST: ${{ needs.publish-images.outputs.portable_digest }}
+          SEEDED_ATTESTATION_URL: ${{ needs.attest-published-digests.outputs.seeded_attestation_url }}
+          SEEDED_DIGEST: ${{ needs.publish-images.outputs.seeded_digest }}
+        run: |
+          set -Eeuo pipefail
+          attestation_url_pattern='^https://github\.com/boardsesh/boardsesh/attestations/[0-9]+$'
+          [[ "$PORTABLE_ATTESTATION_URL" =~ $attestation_url_pattern ]]
+          [[ "$SEEDED_ATTESTATION_URL" =~ $attestation_url_pattern ]]
+
+          verify_attestation() {
+            local image="$1"
+            local digest="$2"
+            local output="$3"
+            local digest_hex="${digest#sha256:}"
+            gh attestation verify "oci://$image@$digest" \
+              --repo "$APPROVED_REPOSITORY" \
+              --signer-workflow "$APPROVED_REPOSITORY/.github/workflows/postgres-image-publisher.yml" \
+              --signer-digest "$EXPECTED_MAIN_SHA" \
+              --source-ref "$MAIN_REF" \
+              --source-digest "$EXPECTED_MAIN_SHA" \
+              --predicate-type 'https://slsa.dev/provenance/v1' \
+              --deny-self-hosted-runners \
+              --format json >"$output"
+            jq -e \
+              --arg image "$image" \
+              --arg digest_hex "$digest_hex" '
+                length > 0 and
+                all(.[].verificationResult.statement;
+                  .predicateType == "https://slsa.dev/provenance/v1" and
+                  any(.subject[]; .name == $image and .digest.sha256 == $digest_hex)
+                )
+              ' "$output" >/dev/null
+          }
+
+          verify_attestation "$PORTABLE_IMAGE" "$PORTABLE_DIGEST" portable-attestation.json
+          verify_attestation "$SEEDED_IMAGE" "$SEEDED_DIGEST" seeded-attestation.json
+
+      - name: Remove temporary attestation verification credentials
+        if: always()
+        run: |
+          set -Eeuo pipefail
+          [[ -n "${DOCKER_CONFIG:-}" ]] || exit 0
+          case "$DOCKER_CONFIG" in
+            "$RUNNER_TEMP"/boardsesh-ghcr-*-verify-attestations) ;;
+            *) printf 'Refusing to clean unexpected DOCKER_CONFIG: %s\n' "$DOCKER_CONFIG" >&2; exit 1 ;;
+          esac
+          docker logout "$REGISTRY" >/dev/null 2>&1 || true
+          find "$DOCKER_CONFIG" -type f -exec sh -c ': >"$1"' _ {} \;
+          find "$DOCKER_CONFIG" -depth -delete
+          [[ ! -e "$DOCKER_CONFIG" ]]
+
+  record-published-digests:
+    name: Record verified digest manifest
+    needs:
+      - publish-images
+      - attest-published-digests
+      - verify-attestations
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Write machine-readable digest manifest and summary
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          PORTABLE_ATTESTATION_URL: ${{ needs.attest-published-digests.outputs.portable_attestation_url }}
+          PORTABLE_DIGEST: ${{ needs.publish-images.outputs.portable_digest }}
+          SEEDED_ATTESTATION_URL: ${{ needs.attest-published-digests.outputs.seeded_attestation_url }}
+          SEEDED_DIGEST: ${{ needs.publish-images.outputs.seeded_digest }}
+          SHA_TAG: ${{ needs.publish-images.outputs.sha_tag }}
+        run: |
+          set -Eeuo pipefail
+          attestation_url_pattern='^https://github\.com/boardsesh/boardsesh/attestations/[0-9]+$'
+          [[ "$PORTABLE_ATTESTATION_URL" =~ $attestation_url_pattern ]]
+          [[ "$SEEDED_ATTESTATION_URL" =~ $attestation_url_pattern ]]
+          jq -n \
+            --arg source_repository "$APPROVED_REPOSITORY" \
+            --arg source_url "$GITHUB_SERVER_URL/$APPROVED_REPOSITORY" \
+            --arg main_ref "$MAIN_REF" \
+            --arg main_sha "$EXPECTED_MAIN_SHA" \
+            --arg sha_tag "$SHA_TAG" \
+            --arg portable_image "$PORTABLE_IMAGE" \
+            --arg portable_digest "$PORTABLE_DIGEST" \
+            --arg portable_attestation_url "$PORTABLE_ATTESTATION_URL" \
+            --arg seeded_image "$SEEDED_IMAGE" \
+            --arg seeded_digest "$SEEDED_DIGEST" \
+            --arg seeded_attestation_url "$SEEDED_ATTESTATION_URL" '
+              {
+                schema_version: 2,
+                source: {
+                  repository: $source_repository,
+                  url: $source_url,
+                  ref: $main_ref,
+                  sha: $main_sha
+                },
+                tag_policy: {
+                  lookup_tag: $sha_tag,
+                  deployment_identity: "digest-only",
+                  tags_are_mutable: true
+                },
+                oci_labels: {
+                  "org.opencontainers.image.revision": $main_sha,
+                  "org.opencontainers.image.source": $source_url,
+                  "org.opencontainers.image.ref.name": $main_ref
+                },
+                images: {
+                  portable: {
+                    name: $portable_image,
+                    digest: $portable_digest,
+                    platforms: ["linux/amd64", "linux/arm64"],
+                    attestation_url: $portable_attestation_url,
+                    attestation_verified: true
+                  },
+                  seeded: {
+                    name: $seeded_image,
+                    digest: $seeded_digest,
+                    platforms: ["linux/amd64"],
+                    attestation_url: $seeded_attestation_url,
+                    attestation_verified: true
+                  }
+                }
+              }
+            ' >postgres-image-digests.json
+          jq -e '
+            .source.ref == "refs/heads/main" and
+            (.source.sha | test("^[0-9a-f]{40}$")) and
+            .tag_policy.deployment_identity == "digest-only" and
+            .tag_policy.tags_are_mutable == true and
+            ([.images[].digest | test("^sha256:[0-9a-f]{64}$")] | all) and
+            ([.images[].attestation_verified] | all)
+          ' postgres-image-digests.json >/dev/null
+
+          {
+            echo '## Verified PostgreSQL image digests'
+            echo
+            echo "- Source: \`$MAIN_REF@$EXPECTED_MAIN_SHA\`"
+            echo "- Portable (linux/amd64, linux/arm64): \`$PORTABLE_IMAGE@$PORTABLE_DIGEST\`"
+            echo "- Seeded (linux/amd64): \`$SEEDED_IMAGE@$SEEDED_DIGEST\`"
+            echo
+            echo "The \`$SHA_TAG\` tag is a mutable lookup alias. Pin only the exact digests above."
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Recheck exact current main and workflow before artifact upload
+        env:
+          EXPECTED_MAIN_SHA: ${{ inputs.expected_main_sha }}
+          EXPECTED_WORKFLOW_REF: boardsesh/boardsesh/.github/workflows/postgres-image-publisher.yml@refs/heads/main
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'Pre-artifact recheck failed: %s\n' "$*" >&2
+            exit 1
+          }
+
+          [[ "$EXPECTED_MAIN_SHA" == "$GITHUB_SHA" ]] ||
+            fail 'expected_main_sha no longer equals github.sha'
+          [[ "$EXPECTED_MAIN_SHA" == "$WORKFLOW_SHA" ]] ||
+            fail 'workflow source SHA no longer equals expected_main_sha'
+          [[ "$WORKFLOW_REF" == "$EXPECTED_WORKFLOW_REF" ]] ||
+            fail 'workflow definition is no longer bound to its approved main path'
+          [[ "$(gh api "/repos/$APPROVED_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq '.object.sha')" == "$EXPECTED_MAIN_SHA" ]] ||
+            fail 'main moved before digest artifact upload'
+
+      - name: Upload verified digest manifest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: postgres-image-digests-${{ inputs.expected_main_sha }}
+          path: postgres-image-digests.json
+          if-no-files-found: error
+          retention-days: 90

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "vite": "^8.2.0",
         "vite-plus": "^0.1.24",
         "vitest": "^4.1.10",
+        "yaml": "^2.9.0",
       },
     },
     "packages/aurora-sync": {

--- a/docs/postgres-image-publishing.md
+++ b/docs/postgres-image-publishing.md
@@ -97,8 +97,10 @@ attestation, and manifest recording:
    script runs after login, and the temporary registry config and Buildx
    builder are removed on every outcome.
 4. Fresh package-read runners resolve the published tag to the expected digest,
-   inspect the remote manifests, pull every exact digest/platform, erase their
-   temporary credentials, and then run the image smoke contracts.
+   inspect the remote manifests, and pull every exact digest/platform. The smoke
+   jobs then erase their temporary registry credentials before setting up Bun,
+   installing the locked dependency graph, or running either candidate-owned
+   image smoke contract.
 5. `attest-published-digests` uses the dedicated environment and the official
    pinned GitHub attestation action in native provenance mode. Because source,
    workflow, and `github.sha` are now the same exact current-main commit, the
@@ -110,6 +112,11 @@ attestation, and manifest recording:
    SHA, SLSA provenance predicate type, and GitHub-hosted runner. Only after
    both attestations verify can `record-published-digests` perform its final
    live-main/workflow binding check and upload the handoff artifact.
+
+The token spelling is intentionally different at the two boundaries. Read-only
+GitHub API checks use `github.token`; credential-bearing GHCR login steps use
+`secrets.GITHUB_TOKEN`. GitHub resolves both expressions to the same job-scoped
+token, but the distinction keeps registry authentication visually explicit.
 
 The workflow is globally serialized with `cancel-in-progress: false`. That
 prevents two runs of this publisher from racing, but it cannot stop other

--- a/docs/postgres-image-publishing.md
+++ b/docs/postgres-image-publishing.md
@@ -1,0 +1,157 @@
+# Trusted PostgreSQL image publishing
+
+The PostgreSQL 18 migration uses two reviewed images:
+
+- `ghcr.io/boardsesh/boardsesh-postgres-postgis` for `linux/amd64` and
+  `linux/arm64`.
+- `ghcr.io/boardsesh/boardsesh-dev-db` for `linux/amd64`.
+
+`.github/workflows/postgres-image-publisher.yml` is a manual publisher loaded
+from protected `main`. It publishes only the exact commit that is still the
+live `main` head. The workflow, Dockerfiles, build context, and provenance
+source are therefore one reviewed commit rather than separate trusted and
+candidate refs.
+
+## Required repository controls
+
+Create a dedicated GitHub environment named `postgres-image-publisher` before
+the first dispatch. It must have all of these settings:
+
+1. One or more required reviewers.
+2. **Prevent self-review** enabled. The person who dispatches the run cannot
+   approve its publisher jobs.
+3. Administrator bypass disabled.
+4. A custom deployment branch policy containing exactly the `main` branch.
+5. No tag or wildcard deployment policy.
+
+The workflow reads the environment and deployment-branch-policy APIs before it
+starts and again immediately before package-write and OIDC operations. A
+missing field, missing permission, API error, reviewer-free rule, enabled
+bypass, or policy other than exactly `main` fails closed. GitHub still enforces
+the environment approval independently of this audit.
+
+Also keep these repository controls in place:
+
+- Protect `main`. The workflow requires `github.ref_protected == true`, the
+  exact default-branch workflow path/ref, and equality between the supplied
+  SHA, `github.sha`, `github.workflow_sha`, and the live `main` API head.
+- Allow this repository's `GITHUB_TOKEN` to read and write the two linked GHCR
+  packages. The packages may remain private.
+- Define `RETIRED_DB_IMAGE_DIGESTS` as a repository or
+  `postgres-image-publisher` environment variable. Each non-empty line must be
+  one lowercase `sha256:<64 hex>` digest. Invalid or duplicate entries fail the
+  run. An empty value means that no digest has been retired yet.
+- Do not grant package deletion to this workflow.
+
+These settings are external to the repository and cannot be created safely by
+the publisher itself. Protected-main review plus the separately reviewed
+publisher environment are the trust root. The contract's co-located parsed
+structure and script hashes are reviewer regression guardrails: they make every
+executable change explicit, but a source change can update its own expected
+hashes and therefore the hashes are not an independent security authority. The
+live API audit validates the environment fields GitHub exposes.
+
+## Dispatch contract
+
+The workflow has one input: `expected_main_sha`. It must be the exact lowercase
+40-character SHA currently at `refs/heads/main`.
+
+The run rejects anything else, including a feature branch, pull-request ref,
+older `main` commit, abbreviated SHA, workflow loaded from another path, or a
+SHA that stops being the live `main` head. The live-head check runs again
+immediately before every registry login and before OIDC attestation. If another
+PR merges while a build or approval is pending, the run fails and must be
+redispatched for the new head.
+
+The digest recorder repeats the live-main, `github.sha`, workflow-ref, and
+workflow-SHA checks immediately before artifact upload. Keep `main` quiet until
+the complete workflow has finished. The API check and artifact upload are two
+separate requests, so an unavoidable tiny race remains if another merge lands
+between them; treat a run that overlaps a merge as invalid and redispatch from
+the new head.
+
+## Authority boundaries
+
+The jobs deliberately separate validation, package publication, smoke tests,
+attestation, and manifest recording:
+
+1. `authorize-current-main` binds the dispatch to protected, live `main` and
+   audits the dedicated environment using read-only `contents` and `actions`
+   GitHub access, the permissions required by GitHub's environment API.
+2. `validate-main` checks out only `expected_main_sha` with
+   `persist-credentials: false`, validates the Docker inputs, installs the
+   locked dependency graph, and runs the PostgreSQL 18 contracts. It has no
+   package, environment, or OIDC authority.
+3. `publish-images` is approved through `postgres-image-publisher`. BuildKit
+   receives no GitHub token, secret, or SSH mount. The pinned BuildKit daemon
+   builds both images to local OCI layouts before GHCR authentication.
+   `BUILDKIT_SYNTAX=dockerfile.v0` forces BuildKit's bundled frontend even if a
+   Dockerfile contains a whitespace- or BOM-prefixed `# syntax=` directive;
+   validation rejects those directives as defense in depth. The workflow
+   verifies both layout root digests, exact platform sets, and the complete
+   retired-digest variable before logging in. A pinned, checksum-verified ORAS
+   client then copies those already validated layouts to GHCR. No checked-out
+   script runs after login, and the temporary registry config and Buildx
+   builder are removed on every outcome.
+4. Fresh package-read runners resolve the published tag to the expected digest,
+   inspect the remote manifests, pull every exact digest/platform, erase their
+   temporary credentials, and then run the image smoke contracts.
+5. `attest-published-digests` uses the dedicated environment and the official
+   pinned GitHub attestation action in native provenance mode. Because source,
+   workflow, and `github.sha` are now the same exact current-main commit, the
+   action's signed source ref and digest describe the dependency truthfully;
+   no user-authored provenance predicate substitutes another ref.
+6. `verify-attestations` validates both GitHub attestation URLs and runs
+   `gh attestation verify` for each exact OCI subject. It requires the exact
+   repository, signer workflow, signer SHA, `refs/heads/main` source ref, source
+   SHA, SLSA provenance predicate type, and GitHub-hosted runner. Only after
+   both attestations verify can `record-published-digests` perform its final
+   live-main/workflow binding check and upload the handoff artifact.
+
+The workflow is globally serialized with `cancel-in-progress: false`. That
+prevents two runs of this publisher from racing, but it cannot stop other
+actors with GHCR write access. Restrict package writers accordingly.
+
+## Tags and digest identity
+
+Each image receives only `sha-<40-character main SHA>`. There is no `latest`,
+`main`, branch, or `pg18` tag.
+
+The SHA tag is a lookup alias, not an immutable security boundary. OCI
+registries permit a writer to move a tag, and a later dispatch of the same
+source may replace it. Consumers and retirement policy use only
+`image@sha256:<digest>`. The workflow never describes a tag as immutable and
+the handoff artifact explicitly records `deployment_identity: digest-only`.
+
+Both OCI layouts are fully built and checked against
+`RETIRED_DB_IMAGE_DIGESTS` before the first registry login, so a retired digest
+is never knowingly pushed. A network failure can still leave one of the two
+prevalidated layouts in GHCR after a partial copy; such a run emits no digest
+handoff artifact. Preserve partial output for audit and start a new run only
+after understanding the failure.
+
+## PostgreSQL 18 rollout sequence
+
+Use three changes with a quiet `main` window around the dispatch:
+
+1. Merge the publisher prerequisite PR and configure the dedicated environment.
+2. Merge producer-only PR A containing the reviewed PostgreSQL 18 image source
+   and its validation contracts. Do not add consumer digest pins in A.
+3. Record A's merge SHA and immediately dispatch **Publish Current Main
+   PostgreSQL Images** from `main` with that exact SHA. Do not merge another PR
+   until the entire run, including artifact upload, finishes. Any overlapping
+   main movement invalidates the operational quiet-window guarantee, even if it
+   falls inside the tiny final check/upload race.
+4. Download
+   `postgres-image-digests-<main SHA>/postgres-image-digests.json`. Confirm its
+   source SHA equals A's merge SHA and that both attestations are marked
+   verified.
+5. Open consumer-pin PR B. B may update image consumers, digest contracts, and
+   documentation to the two exact digests from the artifact. If image inputs
+   must change, merge a new producer commit and repeat the dispatch instead of
+   rebuilding an older source.
+
+The schema-v2 artifact records the exact repository, `refs/heads/main` source
+SHA, OCI labels, mutable lookup tag policy, image names, digest identities,
+verified platforms, attestation URLs, and downstream verification result.
+Never derive a consumer pin from the tag.

--- a/docs/postgres-image-publishing.md
+++ b/docs/postgres-image-publishing.md
@@ -98,9 +98,9 @@ attestation, and manifest recording:
    builder are removed on every outcome.
 4. Fresh package-read runners resolve the published tag to the expected digest,
    inspect the remote manifests, and pull every exact digest/platform. The smoke
-   jobs then erase their temporary registry credentials before setting up Bun,
-   installing the locked dependency graph, or running either candidate-owned
-   image smoke contract.
+   jobs then erase their temporary registry credentials before setting up Vite+
+   or Bun, installing the locked dependency graph, or running either
+   candidate-owned image smoke contract.
 5. `attest-published-digests` uses the dedicated environment and the official
    pinned GitHub attestation action in native provenance mode. Because source,
    workflow, and `github.sha` are now the same exact current-main commit, the

--- a/docs/postgres-image-publishing.md
+++ b/docs/postgres-image-publishing.md
@@ -38,9 +38,12 @@ Also keep these repository controls in place:
 - Allow this repository's `GITHUB_TOKEN` to read and write the two linked GHCR
   packages. The packages may remain private.
 - Define `RETIRED_DB_IMAGE_DIGESTS` as a repository or
-  `postgres-image-publisher` environment variable. Each non-empty line must be
-  one lowercase `sha256:<64 hex>` digest. Invalid or duplicate entries fail the
-  run. An empty value means that no digest has been retired yet.
+  `postgres-image-publisher` environment variable. Set it to the exact sentinel
+  `none` when no digest has been retired. Otherwise, each non-empty line must be
+  one lowercase `sha256:<64 hex>` digest. Missing, empty, whitespace-only,
+  invalid, duplicate, or mixed `none`/digest values fail before image build
+  setup. The complete policy is checked again against the built digests before
+  registry login.
 - Do not grant package deletion to this workflow.
 
 These settings are external to the repository and cannot be created safely by
@@ -136,7 +139,10 @@ Use three changes with a quiet `main` window around the dispatch:
 
 1. Merge the publisher prerequisite PR and configure the dedicated environment.
 2. Merge producer-only PR A containing the reviewed PostgreSQL 18 image source
-   and its validation contracts. Do not add consumer digest pins in A.
+   and its validation contracts, including the `test:postgres18-contract`
+   Vite+ target. Do not add consumer digest pins in A. An accidental dispatch
+   before this target reaches `main` fails immediately after checkout, before
+   dependency installation.
 3. Record A's merge SHA and immediately dispatch **Publish Current Main
    PostgreSQL Images** from `main` with that exact SHA. Do not merge another PR
    until the entire run, including artifact upload, finishes. Any overlapping

--- a/docs/postgres-image-publishing.md
+++ b/docs/postgres-image-publishing.md
@@ -18,8 +18,8 @@ Create a dedicated GitHub environment named `postgres-image-publisher` before
 the first dispatch. It must have all of these settings:
 
 1. One or more required reviewers.
-2. **Prevent self-review** enabled. The person who dispatches the run cannot
-   approve its publisher jobs.
+2. An explicit **prevent self-review** setting, either on or off. See the
+   accepted risk below before choosing.
 3. Administrator bypass disabled.
 4. A custom deployment branch policy containing exactly the `main` branch.
 5. No tag or wildcard deployment policy.
@@ -29,6 +29,26 @@ starts and again immediately before package-write and OIDC operations. A
 missing field, missing permission, API error, reviewer-free rule, enabled
 bypass, or policy other than exactly `main` fails closed. GitHub still enforces
 the environment approval independently of this audit.
+
+### Accepted risk: self-review is permitted
+
+The audit requires `prevent_self_review` to be present and boolean, but accepts
+either value. Boardsesh runs with a single maintainer, so requiring a second
+approver would leave no one able to approve a dispatch, and a GitHub App cannot
+act as an environment reviewer.
+
+What this gives up: one account that can both dispatch the publisher and approve
+its environment gate can publish an image without a second person seeing it. The
+remaining controls still hold — publication is limited to the exact live `main`
+head, `main` requires a pull-request review, administrator bypass is off, the
+deployment policy is `main`-only, no candidate code runs while registry
+credentials exist, and every published digest carries a verified provenance
+attestation naming its source commit. Compromise of the maintainer account is
+the uncovered case; a compromise of any _other_ account still cannot publish.
+
+Enable prevent self-review as soon as a second reviewer with repository access
+exists. Nothing in the workflow needs to change — the audit accepts `true`
+today.
 
 Also keep these repository controls in place:
 

--- a/docs/postgres-image-publishing.md
+++ b/docs/postgres-image-publishing.md
@@ -52,7 +52,9 @@ publisher environment are the trust root. The contract's co-located parsed
 structure and script hashes are reviewer regression guardrails: they make every
 executable change explicit, but a source change can update its own expected
 hashes and therefore the hashes are not an independent security authority. The
-live API audit validates the environment fields GitHub exposes.
+contract workflow also watches the root and `scripts` Vite configs that select
+and discover this suite. The live API audit validates the environment fields
+GitHub exposes.
 
 ## Dispatch contract
 
@@ -87,15 +89,16 @@ attestation, and manifest recording:
    package, environment, or OIDC authority.
 3. `publish-images` is approved through `postgres-image-publisher`. BuildKit
    receives no GitHub token, secret, or SSH mount. The pinned BuildKit daemon
-   builds both images to local OCI layouts before GHCR authentication.
-   `BUILDKIT_SYNTAX=dockerfile.v0` forces BuildKit's bundled frontend even if a
-   Dockerfile contains a whitespace- or BOM-prefixed `# syntax=` directive;
-   validation rejects those directives as defense in depth. The workflow
-   verifies both layout root digests, exact platform sets, and the complete
-   retired-digest variable before logging in. A pinned, checksum-verified ORAS
-   client then copies those already validated layouts to GHCR. No checked-out
-   script runs after login, and the temporary registry config and Buildx
-   builder are removed on every outcome.
+   builds both images to local OCI layouts before GHCR authentication. Neither
+   build supplies `BUILDKIT_SYNTAX` or another build argument, so the pinned
+   daemon uses its bundled Dockerfile frontend. Both the unprivileged validation
+   job and the final offline-input validation reject whitespace- or BOM-prefixed
+   `# syntax=` directives, and the parsed workflow contract rejects adding a
+   frontend override. The workflow verifies both layout root digests, exact
+   platform sets, and the complete retired-digest variable before logging in. A
+   pinned, checksum-verified ORAS client then copies those already validated
+   layouts to GHCR. No checked-out script runs after login, and the temporary
+   registry config and Buildx builder are removed on every outcome.
 4. Fresh package-read runners resolve the published tag to the expected digest,
    inspect the remote manifests, and pull every exact digest/platform. The smoke
    jobs then erase their temporary registry credentials before setting up Vite+

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "typescript": "~7.0.2",
     "vite": "^8.2.0",
     "vite-plus": "^0.1.24",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "yaml": "^2.9.0"
   },
   "overrides": {
     "react-native-screens": "4.26.2"

--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -33,6 +33,7 @@ const PUBLISHER_STEPS: Record<string, ExpectedStep[]> = {
   ],
   'publish-images': [
     { name: 'Checkout exact current main commit', uses: ACTIONS.checkout },
+    { name: 'Validate retired-digest configuration before build setup' },
     { name: 'Enable multi-architecture emulation', uses: ACTIONS.setupQemu },
     { name: 'Create temporary tool and credential boundary' },
     { name: 'Set up Docker Buildx inside the temporary boundary', uses: ACTIONS.setupBuildx },
@@ -138,15 +139,17 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
     'Bind workflow and audit publisher environment': 'ddec8fd3b70bbbce3f6ece43dcf76d6511a390e13dde2a3a4646c34ae46570ac',
   },
   'validate-main': {
-    'Validate checkout and Docker inputs': '37e705a3d4372ebcff8c1e582b7c688c8a58e31aba0283b311e47c9946bd1dc9',
+    'Validate checkout and Docker inputs': 'd93f8b5c79e732dfa0d06bb5469b9437d690374d7f92441f128f64053ba08245',
     'Install locked dependencies': 'ed6ae2ba19763eb56c4691c7113c556bc1dc78a2b5868187f418bcb53ecd3ffd',
     'Run PostgreSQL 18 contracts': '66196ae8703cb101dc49952e602bd24ee2a6e03d7f2902c738bcccafb1b0edf9',
   },
   'publish-images': {
+    'Validate retired-digest configuration before build setup':
+      '8fa475f67e0d460703ef73b4870570790369d676cd6711209a1416234d54f7f4',
     'Create temporary tool and credential boundary': '84bf5fb7b5ff5e70be8e8684099d2f87727cefde54b3a70b92b20220e3d1fea3',
     'Revalidate offline build inputs': '8f00867154930447c27a7f0a29d03f3e282134badd158b69aef0c3d9ddb3132d',
     'Validate offline layouts and retired digest policy':
-      '1a38c1da2aa9243eddf617c72f0fc143fe4f6fb850586e2527481c13d27287c6',
+      '110821eff07459d4dc1299e88bc9e71da20b0a3ce23cb89b0162cef0159b421d',
     'Recheck exact current main and environment immediately before registry authentication':
       '1dd7ee111026f09c11a161be8e486d09e453ac724467238b87d7761a8a1d56b7',
     'Authenticate ORAS to GHCR': '2409cc90e42b7448aba3c40d18a741735d513a6fdc0f2212544407fb09f3a4ce',
@@ -209,8 +212,8 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
 // this makes the whole publisher an exact structural allowlist.
 const PRIVILEGED_JOB_SHA256: Record<string, string> = {
   'authorize-current-main': 'de925dca4eba05dc42accdb6fe0ed3c996fe37079d620da7fc35166900e70c29',
-  'validate-main': '9a21ccff5d48d74b0572de66a40c848bd1cc85af6ac971ef96b9ed285f3b75ea',
-  'publish-images': '66739d6d03d37613e016dbc53e1e59eeb3a0fb409030521f8e030886eb2dfac7',
+  'validate-main': '310908b62a52c0ea058602e33fcac04bc7578c89d10a743fa0363d5f4fda7f70',
+  'publish-images': 'ca9d253928f2c8132fa71dfa7c6b49c085390bffab88da15604e1ad058c20f17',
   'verify-published-images': '05f165fb989b0c7c920b470b19bf4f14b5f3dd1f0c2880bd79e3f2b79228e1c8',
   'smoke-portable': '8cc80c28ec97ce85250334f77759f314f16ce651e1535409e4373af5db25e2db',
   'smoke-seeded': 'fb6924c0722692a094e776ba8386e4802797219e9602aee6e8a5226ec758a1dd',
@@ -610,6 +613,13 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
     failures,
     validateMain,
     'Validate checkout and Docker inputs',
+    /grep -Fq "'test:postgres18-contract': \{" source\/vite\.config\.ts/,
+    'exact-main validation must fail early when the PostgreSQL 18 contract target is unavailable',
+  );
+  requireRunPattern(
+    failures,
+    validateMain,
+    'Validate checkout and Docker inputs',
     /s\/\^\\xEF\\xBB\\xBF\/\/ if \$\. == 1;/,
     'Docker input validation must strip a UTF-8 BOM before checking parser directives',
   );
@@ -630,6 +640,22 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
 
   const publish = recordAt(jobs, 'publish-images') ?? {};
   validateCheckout(failures, 'publish-images', stepByName(publish, 'Checkout exact current main commit'), 'source');
+  for (const [pattern, message] of [
+    [
+      /\[\[ "\$RETIRED_DIGESTS" =~ \[\^\[:space:\]\] \]\]/,
+      'retired digest configuration must reject missing or blank values before build setup',
+    ],
+    [
+      /\[\[ "\$RETIRED_DIGESTS" == 'none' \]\]/,
+      'retired digest configuration must require the explicit none sentinel for an empty set',
+    ],
+    [
+      /\[\[ "\$retired_digest" =~ \^sha256:\[0-9a-f\]\{64\}\$ \]\]/,
+      'retired digest policy must reject malformed entries before build setup',
+    ],
+  ] as const) {
+    requireRunPattern(failures, publish, 'Validate retired-digest configuration before build setup', pattern, message);
+  }
   validateOrasSetup(failures, 'publish-images', publish);
   const buildx = stepByName(publish, 'Set up Docker Buildx inside the temporary boundary');
   const buildxInputs = buildx ? recordAt(buildx, 'with') : undefined;
@@ -660,7 +686,7 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
   validateBuildStep(failures, stepByName(publish, 'Build seeded OCI layout without registry credentials'), 'seeded');
   for (const [pattern, message] of [
     [
-      /RETIRED_DB_IMAGE_DIGESTS must contain one lowercase sha256 digest per non-empty line/,
+      /RETIRED_DB_IMAGE_DIGESTS must be none or contain one lowercase sha256 digest per non-empty line/,
       'retired digest policy must reject malformed entries',
     ],
     [
@@ -732,6 +758,14 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
     );
   }
   const smokePortable = recordAt(jobs, 'smoke-portable') ?? {};
+  if (
+    !recordsEqual(recordAt(smokePortable, 'strategy'), {
+      'fail-fast': false,
+      matrix: { platform: ['linux/amd64', 'linux/arm64'] },
+    })
+  ) {
+    failures.push('portable smoke matrix must contain exactly linux/amd64 and linux/arm64');
+  }
   const smokeQemu = stepByName(smokePortable, 'Enable multi-architecture emulation');
   const smokeQemuInputs = smokeQemu ? recordAt(smokeQemu, 'with') : undefined;
   if (

--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -156,7 +156,7 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
     'Validate retired-digest configuration before build setup':
       '8fa475f67e0d460703ef73b4870570790369d676cd6711209a1416234d54f7f4',
     'Create temporary tool and credential boundary': '84bf5fb7b5ff5e70be8e8684099d2f87727cefde54b3a70b92b20220e3d1fea3',
-    'Revalidate offline build inputs': '8f00867154930447c27a7f0a29d03f3e282134badd158b69aef0c3d9ddb3132d',
+    'Revalidate offline build inputs': '42ca53a491bf3433739be5ce55f88867c1d7fe5bd4403b33a3647b858596e907',
     'Validate offline layouts and retired digest policy':
       '110821eff07459d4dc1299e88bc9e71da20b0a3ce23cb89b0162cef0159b421d',
     'Recheck exact current main and environment immediately before registry authentication':
@@ -226,7 +226,7 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
 const PRIVILEGED_JOB_SHA256: Record<string, string> = {
   'authorize-current-main': 'de925dca4eba05dc42accdb6fe0ed3c996fe37079d620da7fc35166900e70c29',
   'validate-main': '79a3b6710f2f3268d467ae5a8d467d78fd212627f90f3da8c6505b1a4c51b29d',
-  'publish-images': 'ca9d253928f2c8132fa71dfa7c6b49c085390bffab88da15604e1ad058c20f17',
+  'publish-images': '47364440a1d9768c74511febb7adb076db49911e7dd388529993082f4fc0d451',
   'verify-published-images': '05f165fb989b0c7c920b470b19bf4f14b5f3dd1f0c2880bd79e3f2b79228e1c8',
   'smoke-portable': 'b5061e0cb86febdc3216af60b967ddf3825b7c74b43016d006d0d1aa245351ba',
   'smoke-seeded': '95bf708acbe676a46dde4981cc83ba978c37f6b6c3ca463ef2239647260ebdf9',
@@ -238,8 +238,10 @@ const PRIVILEGED_JOB_SHA256: Record<string, string> = {
 const CONTRACT_PATHS = [
   '.github/workflows/postgres-image-publisher.yml',
   '.github/workflows/postgres-image-publisher-contract.yml',
+  'vite.config.ts',
   'scripts/lib/postgres-image-publisher-contract.ts',
   'scripts/postgres-image-publisher-contract.test.ts',
+  'scripts/vite.config.ts',
   'docs/postgres-image-publishing.md',
   'package.json',
   'bun.lock',
@@ -253,7 +255,7 @@ const CONTRACT_STEPS: ExpectedStep[] = [
   { name: 'Verify publisher authority and artifact contracts' },
 ];
 
-const CONTRACT_WORKFLOW_METADATA_SHA256 = '97ac7c21ca7f27ab253608a1654e195f8c23824f9b0c69272e7504294d70f458';
+const CONTRACT_WORKFLOW_METADATA_SHA256 = '8b86e2310a57709dbf30f9210611d1d47feea44395b6643ba6fa23afaf22b03d';
 const CONTRACT_JOB_METADATA_SHA256 = '9e0f951e6bceb41814be7e67f5cfe5cf5d808315af99a39bc312cbce1c7f0cfb';
 const CONTRACT_STEP_SHA256: Record<string, string> = {
   'Checkout repository without persisted credentials':
@@ -490,8 +492,8 @@ function validateBuildStep(failures: string[], step: UnknownRecord | undefined, 
   ) {
     failures.push(`${kind} offline build must pull but never push, attest, emit an SBOM, or receive a GitHub token`);
   }
-  if (withInputs['build-args'] !== 'BUILDKIT_SYNTAX=dockerfile.v0\n') {
-    failures.push(`${kind} build must force the built-in dockerfile.v0 frontend`);
+  if ('build-args' in withInputs) {
+    failures.push(`${kind} build must use the pinned BuildKit bundled frontend without a build-argument override`);
   }
   if (withInputs.outputs !== expectedOutput) {
     failures.push(`${kind} build must export its exact local OCI layout before authentication`);
@@ -673,6 +675,18 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
     requireRunPattern(failures, publish, 'Validate retired-digest configuration before build setup', pattern, message);
   }
   validateOrasSetup(failures, 'publish-images', publish);
+  for (const [pattern, message] of [
+    [
+      /s\/\^\\xEF\\xBB\\xBF\/\/ if \$\. == 1;/,
+      'offline Docker input revalidation must strip a UTF-8 BOM before checking parser directives',
+    ],
+    [
+      /\$found \|\|= \/\^\[ \\t\]\*#\[ \\t\]\*syntax\[ \\t\]\*=\/i;/,
+      'offline Docker input revalidation must reject whitespace-prefixed syntax directives',
+    ],
+  ] as const) {
+    requireRunPattern(failures, publish, 'Revalidate offline build inputs', pattern, message);
+  }
   const buildx = stepByName(publish, 'Set up Docker Buildx inside the temporary boundary');
   const buildxInputs = buildx ? recordAt(buildx, 'with') : undefined;
   if (

--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -145,7 +145,7 @@ const PUBLISHER_NEEDS: Record<string, string[]> = {
 // step, including in validation and artifact generation.
 const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
   'authorize-current-main': {
-    'Bind workflow and audit publisher environment': 'ddec8fd3b70bbbce3f6ece43dcf76d6511a390e13dde2a3a4646c34ae46570ac',
+    'Bind workflow and audit publisher environment': 'a5bdefbc565f8a9d530316b439ab2560cb506f8223fa907e424c8a71335e9708',
   },
   'validate-main': {
     'Validate checkout and Docker inputs': 'd93f8b5c79e732dfa0d06bb5469b9437d690374d7f92441f128f64053ba08245',
@@ -160,7 +160,7 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
     'Validate offline layouts and retired digest policy':
       '110821eff07459d4dc1299e88bc9e71da20b0a3ce23cb89b0162cef0159b421d',
     'Recheck exact current main and environment immediately before registry authentication':
-      '1dd7ee111026f09c11a161be8e486d09e453ac724467238b87d7761a8a1d56b7',
+      '64ddc967602b4458fc2a6c4cf6c58d4bdf629fcd173db97d2c80e2f4e1e2d509',
     'Authenticate ORAS to GHCR': '2409cc90e42b7448aba3c40d18a741735d513a6fdc0f2212544407fb09f3a4ce',
     'Publish exact prevalidated OCI layouts': 'd1d1889c4b883ccdde4e2ecfc5f7d4d039caff1752ac16470d730f9005890942',
     'Remove temporary publisher credentials and builder':
@@ -201,7 +201,7 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
   },
   'attest-published-digests': {
     'Recheck exact current main and environment immediately before OIDC attestation':
-      '9d18bd8f70b61b36c639797ebe7851aa3f0947f1cfed0903c313e2d7703771ea',
+      'ba63aad32d3c4db72db7bbed48281df422c0be9f1441cdbec1464649635262af',
   },
   'verify-attestations': {
     'Create temporary read-only registry boundary': 'a5e51a8c6a73ccc35f8f25aa870fed6434dada853729687d5ce8fb8414cf4a3c',
@@ -224,13 +224,13 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
 // conditions, outputs, and matrices. Together with the readable assertions,
 // this makes the whole publisher an exact structural allowlist.
 const PRIVILEGED_JOB_SHA256: Record<string, string> = {
-  'authorize-current-main': 'de925dca4eba05dc42accdb6fe0ed3c996fe37079d620da7fc35166900e70c29',
+  'authorize-current-main': '012c58011b4370b349d5f7dcfe89171bcfdf3e0653b459ab9fcbd865d3fc54c7',
   'validate-main': '79a3b6710f2f3268d467ae5a8d467d78fd212627f90f3da8c6505b1a4c51b29d',
-  'publish-images': '47364440a1d9768c74511febb7adb076db49911e7dd388529993082f4fc0d451',
+  'publish-images': '7230e1b43868539815cd52a82a3fa651647cd7b75a2d4f53ed976d75afa18002',
   'verify-published-images': '05f165fb989b0c7c920b470b19bf4f14b5f3dd1f0c2880bd79e3f2b79228e1c8',
   'smoke-portable': 'b5061e0cb86febdc3216af60b967ddf3825b7c74b43016d006d0d1aa245351ba',
   'smoke-seeded': '95bf708acbe676a46dde4981cc83ba978c37f6b6c3ca463ef2239647260ebdf9',
-  'attest-published-digests': 'd4955025ba90ce538e2966676a44c4d65c4a400a407e557550427349d603991b',
+  'attest-published-digests': 'f3815b58609bfc7c88061071e23ef1bdefe2c945613d79d15ae3ef3353b6bf5a',
   'verify-attestations': 'e3e536f61601ef9d8681dc5809065ff814612c227a70afbc14e1c3cb21a6ff8c',
   'record-published-digests': '8332efc25368a20c05a3ed6e4c79ecb7eef69b1886e41e9ff90963b765d9a5ed',
 };
@@ -615,7 +615,10 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
     [/\[\[ "\$REF_IS_PROTECTED" == 'true' \]\]/, 'publisher must require protected main'],
     [/git\/ref\/heads\/\$DEFAULT_BRANCH/, 'publisher must query the live main head'],
     [/\.can_admins_bypass == false/, 'publisher environment must disable administrator bypass'],
-    [/\.prevent_self_review == true/, 'publisher environment must prevent self-review'],
+    [
+      /\(\.prevent_self_review \| type == "boolean"\)/,
+      'publisher environment must assert an explicit self-review policy',
+    ],
     [/\(\(\.reviewers \/\/ \[\]\) \| length > 0\)/, 'publisher environment must require a reviewer'],
     [/\.total_count == 1/, 'publisher environment must allow exactly one branch policy'],
   ] as const) {
@@ -742,8 +745,8 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
     failures,
     publish,
     'Recheck exact current main and environment immediately before registry authentication',
-    /\.can_admins_bypass == false[\s\S]*\.prevent_self_review == true/,
-    'publisher must re-audit no-bypass and no-self-review immediately before GHCR authentication',
+    /\.can_admins_bypass == false[\s\S]*\(\.prevent_self_review \| type == "boolean"\)/,
+    'publisher must re-audit no-bypass and the explicit self-review policy immediately before GHCR authentication',
   );
   const publishRun = stringAt(stepByName(publish, 'Publish exact prevalidated OCI layouts') ?? {}, 'run') ?? '';
   if ((publishRun.match(/oras cp --from-oci-layout/g) ?? []).length !== 2) {
@@ -852,8 +855,8 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
     failures,
     attest,
     'Recheck exact current main and environment immediately before OIDC attestation',
-    /\.can_admins_bypass == false[\s\S]*\.prevent_self_review == true/,
-    'attestation must re-audit no-bypass and no-self-review before OIDC authority',
+    /\.can_admins_bypass == false[\s\S]*\(\.prevent_self_review \| type == "boolean"\)/,
+    'attestation must re-audit no-bypass and the explicit self-review policy before OIDC authority',
   );
   for (const [stepName, subjectName, subjectDigest] of [
     [

--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -64,6 +64,8 @@ const PUBLISHER_STEPS: Record<string, ExpectedStep[]> = {
     { name: 'Log in to GHCR for exact digest pull', uses: ACTIONS.login },
     { name: 'Pull exact portable digest and platform' },
     { name: 'Remove registry credentials before image smoke' },
+    { name: 'Set up Bun after registry credential removal', uses: ACTIONS.setupBun },
+    { name: 'Install locked dependencies after registry credential removal' },
     { name: 'Verify labels and boot exact portable platform' },
   ],
   'smoke-seeded': [
@@ -74,6 +76,8 @@ const PUBLISHER_STEPS: Record<string, ExpectedStep[]> = {
     { name: 'Log in to GHCR for exact digest pull', uses: ACTIONS.login },
     { name: 'Pull exact seeded digest' },
     { name: 'Remove registry credentials before image smoke' },
+    { name: 'Set up Bun after registry credential removal', uses: ACTIONS.setupBun },
+    { name: 'Install locked dependencies after registry credential removal' },
     { name: 'Verify labels, architecture, and seeded database' },
   ],
   'attest-published-digests': [
@@ -173,6 +177,8 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
     'Pull exact portable digest and platform': '9a8fc3728f38b14f516e7f68b300897beb0ed2e15011f3080789361a9ba3b7ce',
     'Remove registry credentials before image smoke':
       'd8e333a57b04ca27e1e2a74d8689cdfa14b8ce53619491f5e9d888fa2e5ff03c',
+    'Install locked dependencies after registry credential removal':
+      'ed6ae2ba19763eb56c4691c7113c556bc1dc78a2b5868187f418bcb53ecd3ffd',
     'Verify labels and boot exact portable platform':
       '5b9c73161f472d49ebed0409acef7cd36f3aa0c0ddc6c11e02ce73a49f45356c',
   },
@@ -183,6 +189,8 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
     'Pull exact seeded digest': '9c8092a89440ffcf4cf5b154ecb0f604c6ef2dd4ee519f705cfd414562c86c80',
     'Remove registry credentials before image smoke':
       '210b45c7e9c243d42c1180f419bc5183b425a71b78f018f01c19e7ea4402d60c',
+    'Install locked dependencies after registry credential removal':
+      'ed6ae2ba19763eb56c4691c7113c556bc1dc78a2b5868187f418bcb53ecd3ffd',
     'Verify labels, architecture, and seeded database':
       '12bca356c5a765627cbc262f8c9fd987a1ac1b8b0d6c1c44976e8119baafa35d',
   },
@@ -212,11 +220,11 @@ const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
 // this makes the whole publisher an exact structural allowlist.
 const PRIVILEGED_JOB_SHA256: Record<string, string> = {
   'authorize-current-main': 'de925dca4eba05dc42accdb6fe0ed3c996fe37079d620da7fc35166900e70c29',
-  'validate-main': '310908b62a52c0ea058602e33fcac04bc7578c89d10a743fa0363d5f4fda7f70',
+  'validate-main': '79a3b6710f2f3268d467ae5a8d467d78fd212627f90f3da8c6505b1a4c51b29d',
   'publish-images': 'ca9d253928f2c8132fa71dfa7c6b49c085390bffab88da15604e1ad058c20f17',
   'verify-published-images': '05f165fb989b0c7c920b470b19bf4f14b5f3dd1f0c2880bd79e3f2b79228e1c8',
-  'smoke-portable': '8cc80c28ec97ce85250334f77759f314f16ce651e1535409e4373af5db25e2db',
-  'smoke-seeded': 'fb6924c0722692a094e776ba8386e4802797219e9602aee6e8a5226ec758a1dd',
+  'smoke-portable': '0e08ebdbd32457c9b5bc08b2a3cd69411cfbe2431ed8d0e3561e2030693ed2fb',
+  'smoke-seeded': '4673065731fa518f9825de2fde82b8488cccc7832eb0328ab74c1f779b0c0c8d',
   'attest-published-digests': 'd4955025ba90ce538e2966676a44c4d65c4a400a407e557550427349d603991b',
   'verify-attestations': 'e3e536f61601ef9d8681dc5809065ff814612c227a70afbc14e1c3cb21a6ff8c',
   'record-published-digests': '976efd6082d212f82b1acacfd9fd4c82155428de80fec5b5c3b5fcec212d65eb',
@@ -608,6 +616,9 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
   }
 
   const validateMain = recordAt(jobs, 'validate-main') ?? {};
+  if (validateMain['timeout-minutes'] !== 30) {
+    failures.push('validate-main timeout must remain 30 minutes');
+  }
   validateCheckout(failures, 'validate-main', stepByName(validateMain, 'Checkout exact current main commit'), 'source');
   requireRunPattern(
     failures,
@@ -756,6 +767,35 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
       /git\/ref\/heads\/\$DEFAULT_BRANCH/,
       `${smokeName} must recheck live main immediately before login`,
     );
+    requireRunPattern(
+      failures,
+      smoke,
+      'Install locked dependencies after registry credential removal',
+      /^bun install --frozen-lockfile$/,
+      `${smokeName} must install only the reviewed lockfile graph before running candidate smoke code`,
+    );
+
+    const smokeSteps = stepsAt(smoke);
+    const credentialRemovalIndex = smokeSteps.findIndex(
+      (step) => step.name === 'Remove registry credentials before image smoke',
+    );
+    const setupBunIndex = smokeSteps.findIndex((step) => step.name === 'Set up Bun after registry credential removal');
+    const dependencyInstallIndex = smokeSteps.findIndex(
+      (step) => step.name === 'Install locked dependencies after registry credential removal',
+    );
+    const candidateSmokeStepName =
+      smokeName === 'smoke-portable'
+        ? 'Verify labels and boot exact portable platform'
+        : 'Verify labels, architecture, and seeded database';
+    const candidateSmokeIndex = smokeSteps.findIndex((step) => step.name === candidateSmokeStepName);
+    if (
+      credentialRemovalIndex < 0 ||
+      setupBunIndex <= credentialRemovalIndex ||
+      dependencyInstallIndex <= setupBunIndex ||
+      candidateSmokeIndex <= dependencyInstallIndex
+    ) {
+      failures.push(`${smokeName} dependency setup must occur only after registry credentials are removed`);
+    }
   }
   const smokePortable = recordAt(jobs, 'smoke-portable') ?? {};
   if (

--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -131,7 +131,12 @@ const PUBLISHER_NEEDS: Record<string, string[]> = {
     'smoke-seeded',
   ],
   'verify-attestations': ['authorize-current-main', 'publish-images', 'attest-published-digests'],
-  'record-published-digests': ['publish-images', 'attest-published-digests', 'verify-attestations'],
+  'record-published-digests': [
+    'authorize-current-main',
+    'publish-images',
+    'attest-published-digests',
+    'verify-attestations',
+  ],
 };
 
 // These hashes cover every parsed YAML run scalar in the publisher. The
@@ -227,7 +232,7 @@ const PRIVILEGED_JOB_SHA256: Record<string, string> = {
   'smoke-seeded': '95bf708acbe676a46dde4981cc83ba978c37f6b6c3ca463ef2239647260ebdf9',
   'attest-published-digests': 'd4955025ba90ce538e2966676a44c4d65c4a400a407e557550427349d603991b',
   'verify-attestations': 'e3e536f61601ef9d8681dc5809065ff814612c227a70afbc14e1c3cb21a6ff8c',
-  'record-published-digests': '976efd6082d212f82b1acacfd9fd4c82155428de80fec5b5c3b5fcec212d65eb',
+  'record-published-digests': '8332efc25368a20c05a3ed6e4c79ecb7eef69b1886e41e9ff90963b765d9a5ed',
 };
 
 const CONTRACT_PATHS = [

--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -57,25 +57,25 @@ const PUBLISHER_STEPS: Record<string, ExpectedStep[]> = {
   ],
   'smoke-portable': [
     { name: 'Checkout exact current main commit', uses: ACTIONS.checkout },
-    { name: 'Set up Vite+', uses: ACTIONS.setupVp },
     { name: 'Enable multi-architecture emulation', uses: ACTIONS.setupQemu },
     { name: 'Create temporary read-only registry boundary' },
     { name: 'Recheck exact current main immediately before registry authentication' },
     { name: 'Log in to GHCR for exact digest pull', uses: ACTIONS.login },
     { name: 'Pull exact portable digest and platform' },
     { name: 'Remove registry credentials before image smoke' },
+    { name: 'Set up Vite+', uses: ACTIONS.setupVp },
     { name: 'Set up Bun after registry credential removal', uses: ACTIONS.setupBun },
     { name: 'Install locked dependencies after registry credential removal' },
     { name: 'Verify labels and boot exact portable platform' },
   ],
   'smoke-seeded': [
     { name: 'Checkout exact current main commit', uses: ACTIONS.checkout },
-    { name: 'Set up Vite+', uses: ACTIONS.setupVp },
     { name: 'Create temporary read-only registry boundary' },
     { name: 'Recheck exact current main immediately before registry authentication' },
     { name: 'Log in to GHCR for exact digest pull', uses: ACTIONS.login },
     { name: 'Pull exact seeded digest' },
     { name: 'Remove registry credentials before image smoke' },
+    { name: 'Set up Vite+', uses: ACTIONS.setupVp },
     { name: 'Set up Bun after registry credential removal', uses: ACTIONS.setupBun },
     { name: 'Install locked dependencies after registry credential removal' },
     { name: 'Verify labels, architecture, and seeded database' },
@@ -223,8 +223,8 @@ const PRIVILEGED_JOB_SHA256: Record<string, string> = {
   'validate-main': '79a3b6710f2f3268d467ae5a8d467d78fd212627f90f3da8c6505b1a4c51b29d',
   'publish-images': 'ca9d253928f2c8132fa71dfa7c6b49c085390bffab88da15604e1ad058c20f17',
   'verify-published-images': '05f165fb989b0c7c920b470b19bf4f14b5f3dd1f0c2880bd79e3f2b79228e1c8',
-  'smoke-portable': '0e08ebdbd32457c9b5bc08b2a3cd69411cfbe2431ed8d0e3561e2030693ed2fb',
-  'smoke-seeded': '4673065731fa518f9825de2fde82b8488cccc7832eb0328ab74c1f779b0c0c8d',
+  'smoke-portable': 'b5061e0cb86febdc3216af60b967ddf3825b7c74b43016d006d0d1aa245351ba',
+  'smoke-seeded': '95bf708acbe676a46dde4981cc83ba978c37f6b6c3ca463ef2239647260ebdf9',
   'attest-published-digests': 'd4955025ba90ce538e2966676a44c4d65c4a400a407e557550427349d603991b',
   'verify-attestations': 'e3e536f61601ef9d8681dc5809065ff814612c227a70afbc14e1c3cb21a6ff8c',
   'record-published-digests': '976efd6082d212f82b1acacfd9fd4c82155428de80fec5b5c3b5fcec212d65eb',
@@ -779,6 +779,7 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
     const credentialRemovalIndex = smokeSteps.findIndex(
       (step) => step.name === 'Remove registry credentials before image smoke',
     );
+    const setupVpIndex = smokeSteps.findIndex((step) => step.name === 'Set up Vite+');
     const setupBunIndex = smokeSteps.findIndex((step) => step.name === 'Set up Bun after registry credential removal');
     const dependencyInstallIndex = smokeSteps.findIndex(
       (step) => step.name === 'Install locked dependencies after registry credential removal',
@@ -790,11 +791,12 @@ function validatePublisherDocument(failures: string[], publisher: UnknownRecord,
     const candidateSmokeIndex = smokeSteps.findIndex((step) => step.name === candidateSmokeStepName);
     if (
       credentialRemovalIndex < 0 ||
-      setupBunIndex <= credentialRemovalIndex ||
+      setupVpIndex <= credentialRemovalIndex ||
+      setupBunIndex <= setupVpIndex ||
       dependencyInstallIndex <= setupBunIndex ||
       candidateSmokeIndex <= dependencyInstallIndex
     ) {
-      failures.push(`${smokeName} dependency setup must occur only after registry credentials are removed`);
+      failures.push(`${smokeName} tool and dependency setup must occur only after registry credentials are removed`);
     }
   }
   const smokePortable = recordAt(jobs, 'smoke-portable') ?? {};

--- a/scripts/lib/postgres-image-publisher-contract.ts
+++ b/scripts/lib/postgres-image-publisher-contract.ts
@@ -1,0 +1,973 @@
+import { createHash } from 'node:crypto';
+import { parse } from 'yaml';
+
+type UnknownRecord = Record<string, unknown>;
+
+interface ExpectedStep {
+  name: string;
+  uses?: string;
+}
+
+const ACTIONS = {
+  attest: 'actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6',
+  buildPush: 'docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a',
+  checkout: 'actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803',
+  login: 'docker/login-action@dbcb813823bdd20940b903addbd779551569679f',
+  setupBuildx: 'docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c',
+  setupBun: 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6',
+  setupOras: 'oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d',
+  setupQemu: 'docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130',
+  setupVp: 'voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb',
+  uploadArtifact: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02',
+} as const;
+
+const PUBLISHER_STEPS: Record<string, ExpectedStep[]> = {
+  'authorize-current-main': [{ name: 'Bind workflow and audit publisher environment' }],
+  'validate-main': [
+    { name: 'Checkout exact current main commit', uses: ACTIONS.checkout },
+    { name: 'Validate checkout and Docker inputs' },
+    { name: 'Set up Vite+', uses: ACTIONS.setupVp },
+    { name: 'Set up Bun', uses: ACTIONS.setupBun },
+    { name: 'Install locked dependencies' },
+    { name: 'Run PostgreSQL 18 contracts' },
+  ],
+  'publish-images': [
+    { name: 'Checkout exact current main commit', uses: ACTIONS.checkout },
+    { name: 'Enable multi-architecture emulation', uses: ACTIONS.setupQemu },
+    { name: 'Create temporary tool and credential boundary' },
+    { name: 'Set up Docker Buildx inside the temporary boundary', uses: ACTIONS.setupBuildx },
+    { name: 'Set up pinned ORAS client', uses: ACTIONS.setupOras },
+    { name: 'Revalidate offline build inputs' },
+    { name: 'Build portable OCI layout without registry credentials', uses: ACTIONS.buildPush },
+    { name: 'Build seeded OCI layout without registry credentials', uses: ACTIONS.buildPush },
+    { name: 'Validate offline layouts and retired digest policy' },
+    { name: 'Recheck exact current main and environment immediately before registry authentication' },
+    { name: 'Authenticate ORAS to GHCR' },
+    { name: 'Publish exact prevalidated OCI layouts' },
+    { name: 'Remove temporary publisher credentials and builder' },
+  ],
+  'verify-published-images': [
+    { name: 'Set up pinned ORAS client', uses: ACTIONS.setupOras },
+    { name: 'Create temporary read-only registry boundary' },
+    { name: 'Recheck exact current main immediately before registry authentication' },
+    { name: 'Authenticate ORAS to GHCR read-only' },
+    { name: 'Verify exact remote manifests' },
+    { name: 'Remove temporary read-only registry credentials' },
+  ],
+  'smoke-portable': [
+    { name: 'Checkout exact current main commit', uses: ACTIONS.checkout },
+    { name: 'Set up Vite+', uses: ACTIONS.setupVp },
+    { name: 'Enable multi-architecture emulation', uses: ACTIONS.setupQemu },
+    { name: 'Create temporary read-only registry boundary' },
+    { name: 'Recheck exact current main immediately before registry authentication' },
+    { name: 'Log in to GHCR for exact digest pull', uses: ACTIONS.login },
+    { name: 'Pull exact portable digest and platform' },
+    { name: 'Remove registry credentials before image smoke' },
+    { name: 'Verify labels and boot exact portable platform' },
+  ],
+  'smoke-seeded': [
+    { name: 'Checkout exact current main commit', uses: ACTIONS.checkout },
+    { name: 'Set up Vite+', uses: ACTIONS.setupVp },
+    { name: 'Create temporary read-only registry boundary' },
+    { name: 'Recheck exact current main immediately before registry authentication' },
+    { name: 'Log in to GHCR for exact digest pull', uses: ACTIONS.login },
+    { name: 'Pull exact seeded digest' },
+    { name: 'Remove registry credentials before image smoke' },
+    { name: 'Verify labels, architecture, and seeded database' },
+  ],
+  'attest-published-digests': [
+    { name: 'Recheck exact current main and environment immediately before OIDC attestation' },
+    { name: 'Attest exact portable digest', uses: ACTIONS.attest },
+    { name: 'Attest exact seeded digest', uses: ACTIONS.attest },
+  ],
+  'verify-attestations': [
+    { name: 'Create temporary read-only registry boundary' },
+    { name: 'Recheck exact current main immediately before registry authentication' },
+    { name: 'Log in to GHCR for attestation verification', uses: ACTIONS.login },
+    { name: 'Validate attestation URLs and verify both exact subjects' },
+    { name: 'Remove temporary attestation verification credentials' },
+  ],
+  'record-published-digests': [
+    { name: 'Write machine-readable digest manifest and summary' },
+    { name: 'Recheck exact current main and workflow before artifact upload' },
+    { name: 'Upload verified digest manifest', uses: ACTIONS.uploadArtifact },
+  ],
+};
+
+const PUBLISHER_PERMISSIONS: Record<string, UnknownRecord> = {
+  'authorize-current-main': { actions: 'read', contents: 'read' },
+  'validate-main': { contents: 'read' },
+  'publish-images': { actions: 'read', contents: 'read', packages: 'write' },
+  'verify-published-images': { contents: 'read', packages: 'read' },
+  'smoke-portable': { contents: 'read', packages: 'read' },
+  'smoke-seeded': { contents: 'read', packages: 'read' },
+  'attest-published-digests': {
+    actions: 'read',
+    contents: 'read',
+    attestations: 'write',
+    'id-token': 'write',
+  },
+  'verify-attestations': { contents: 'read', packages: 'read', attestations: 'read' },
+  'record-published-digests': { contents: 'read' },
+};
+
+const PUBLISHER_NEEDS: Record<string, string[]> = {
+  'authorize-current-main': [],
+  'validate-main': ['authorize-current-main'],
+  'publish-images': ['authorize-current-main', 'validate-main'],
+  'verify-published-images': ['authorize-current-main', 'publish-images'],
+  'smoke-portable': ['authorize-current-main', 'publish-images', 'verify-published-images'],
+  'smoke-seeded': ['authorize-current-main', 'publish-images', 'verify-published-images'],
+  'attest-published-digests': [
+    'authorize-current-main',
+    'publish-images',
+    'verify-published-images',
+    'smoke-portable',
+    'smoke-seeded',
+  ],
+  'verify-attestations': ['authorize-current-main', 'publish-images', 'attest-published-digests'],
+  'record-published-digests': ['publish-images', 'attest-published-digests', 'verify-attestations'],
+};
+
+// These hashes cover every parsed YAML run scalar in the publisher. The
+// semantic checks below keep the contract reviewable; this exact-body allowlist
+// additionally prevents commands being appended to an otherwise approved named
+// step, including in validation and artifact generation.
+const PRIVILEGED_RUN_SHA256: Record<string, Record<string, string>> = {
+  'authorize-current-main': {
+    'Bind workflow and audit publisher environment': 'ddec8fd3b70bbbce3f6ece43dcf76d6511a390e13dde2a3a4646c34ae46570ac',
+  },
+  'validate-main': {
+    'Validate checkout and Docker inputs': '37e705a3d4372ebcff8c1e582b7c688c8a58e31aba0283b311e47c9946bd1dc9',
+    'Install locked dependencies': 'ed6ae2ba19763eb56c4691c7113c556bc1dc78a2b5868187f418bcb53ecd3ffd',
+    'Run PostgreSQL 18 contracts': '66196ae8703cb101dc49952e602bd24ee2a6e03d7f2902c738bcccafb1b0edf9',
+  },
+  'publish-images': {
+    'Create temporary tool and credential boundary': '84bf5fb7b5ff5e70be8e8684099d2f87727cefde54b3a70b92b20220e3d1fea3',
+    'Revalidate offline build inputs': '8f00867154930447c27a7f0a29d03f3e282134badd158b69aef0c3d9ddb3132d',
+    'Validate offline layouts and retired digest policy':
+      '1a38c1da2aa9243eddf617c72f0fc143fe4f6fb850586e2527481c13d27287c6',
+    'Recheck exact current main and environment immediately before registry authentication':
+      '1dd7ee111026f09c11a161be8e486d09e453ac724467238b87d7761a8a1d56b7',
+    'Authenticate ORAS to GHCR': '2409cc90e42b7448aba3c40d18a741735d513a6fdc0f2212544407fb09f3a4ce',
+    'Publish exact prevalidated OCI layouts': 'd1d1889c4b883ccdde4e2ecfc5f7d4d039caff1752ac16470d730f9005890942',
+    'Remove temporary publisher credentials and builder':
+      'bdb4b5ce41cfb3a4953e704107111e23695432ff4c31c0b5cc053d8db3867420',
+  },
+  'verify-published-images': {
+    'Create temporary read-only registry boundary': '4337f5f5a43cf5dcd887de5e30f094f18d6dc6e4eaec00c9f663bd013085108e',
+    'Recheck exact current main immediately before registry authentication':
+      '27c9f8d7ad023da4b1e4942699fdb2f8931c2710e03f836cf9e77a012c188a9d',
+    'Authenticate ORAS to GHCR read-only': '2409cc90e42b7448aba3c40d18a741735d513a6fdc0f2212544407fb09f3a4ce',
+    'Verify exact remote manifests': 'd92f640e34ba08728b4dbe753acfb3907a6225096689d72d1855020e5d81562d',
+    'Remove temporary read-only registry credentials':
+      '9a101fad60773bbfc7c39cf84f5d09df89d0a5f025d71aa7d2b3e7c8f2d16923',
+  },
+  'smoke-portable': {
+    'Create temporary read-only registry boundary': '39c5ff3207815dd6daed7d86b93fc15a4f907042ff59059b8be92f1d57ca794a',
+    'Recheck exact current main immediately before registry authentication':
+      '211bb881d05b4c506f7d2f2e18c6302a3a24a818f6396c386e8aa9da4908b939',
+    'Pull exact portable digest and platform': '9a8fc3728f38b14f516e7f68b300897beb0ed2e15011f3080789361a9ba3b7ce',
+    'Remove registry credentials before image smoke':
+      'd8e333a57b04ca27e1e2a74d8689cdfa14b8ce53619491f5e9d888fa2e5ff03c',
+    'Verify labels and boot exact portable platform':
+      '5b9c73161f472d49ebed0409acef7cd36f3aa0c0ddc6c11e02ce73a49f45356c',
+  },
+  'smoke-seeded': {
+    'Create temporary read-only registry boundary': 'e8e2af6b76ef37f5a646991d6034bbf0011fe940e1b5e7f6542f7655de30cea6',
+    'Recheck exact current main immediately before registry authentication':
+      '211bb881d05b4c506f7d2f2e18c6302a3a24a818f6396c386e8aa9da4908b939',
+    'Pull exact seeded digest': '9c8092a89440ffcf4cf5b154ecb0f604c6ef2dd4ee519f705cfd414562c86c80',
+    'Remove registry credentials before image smoke':
+      '210b45c7e9c243d42c1180f419bc5183b425a71b78f018f01c19e7ea4402d60c',
+    'Verify labels, architecture, and seeded database':
+      '12bca356c5a765627cbc262f8c9fd987a1ac1b8b0d6c1c44976e8119baafa35d',
+  },
+  'attest-published-digests': {
+    'Recheck exact current main and environment immediately before OIDC attestation':
+      '9d18bd8f70b61b36c639797ebe7851aa3f0947f1cfed0903c313e2d7703771ea',
+  },
+  'verify-attestations': {
+    'Create temporary read-only registry boundary': 'a5e51a8c6a73ccc35f8f25aa870fed6434dada853729687d5ce8fb8414cf4a3c',
+    'Recheck exact current main immediately before registry authentication':
+      '27c9f8d7ad023da4b1e4942699fdb2f8931c2710e03f836cf9e77a012c188a9d',
+    'Validate attestation URLs and verify both exact subjects':
+      'd37796309c31024be340d996f54beebaf323172e5d4dedb0bc2b51203ee5bafe',
+    'Remove temporary attestation verification credentials':
+      '1eb783af4e7705bd00ca9b7ac9b47ebe5664c1a3a6c641d3edfb30a7fe10b48d',
+  },
+  'record-published-digests': {
+    'Write machine-readable digest manifest and summary':
+      '09823c60bd2dbc2a533cdad2b02e41343b5976c234122845e67452c5052dcbad',
+    'Recheck exact current main and workflow before artifact upload':
+      '3fd4d1ae5661abcd1101d9a60addb336e7d61cb30e362c75710da08560cbab0c',
+  },
+};
+
+// Canonical parsed-job hashes also freeze action inputs, step environments,
+// conditions, outputs, and matrices. Together with the readable assertions,
+// this makes the whole publisher an exact structural allowlist.
+const PRIVILEGED_JOB_SHA256: Record<string, string> = {
+  'authorize-current-main': 'de925dca4eba05dc42accdb6fe0ed3c996fe37079d620da7fc35166900e70c29',
+  'validate-main': '9a21ccff5d48d74b0572de66a40c848bd1cc85af6ac971ef96b9ed285f3b75ea',
+  'publish-images': '66739d6d03d37613e016dbc53e1e59eeb3a0fb409030521f8e030886eb2dfac7',
+  'verify-published-images': '05f165fb989b0c7c920b470b19bf4f14b5f3dd1f0c2880bd79e3f2b79228e1c8',
+  'smoke-portable': '8cc80c28ec97ce85250334f77759f314f16ce651e1535409e4373af5db25e2db',
+  'smoke-seeded': 'fb6924c0722692a094e776ba8386e4802797219e9602aee6e8a5226ec758a1dd',
+  'attest-published-digests': 'd4955025ba90ce538e2966676a44c4d65c4a400a407e557550427349d603991b',
+  'verify-attestations': 'e3e536f61601ef9d8681dc5809065ff814612c227a70afbc14e1c3cb21a6ff8c',
+  'record-published-digests': '976efd6082d212f82b1acacfd9fd4c82155428de80fec5b5c3b5fcec212d65eb',
+};
+
+const CONTRACT_PATHS = [
+  '.github/workflows/postgres-image-publisher.yml',
+  '.github/workflows/postgres-image-publisher-contract.yml',
+  'scripts/lib/postgres-image-publisher-contract.ts',
+  'scripts/postgres-image-publisher-contract.test.ts',
+  'docs/postgres-image-publishing.md',
+  'package.json',
+  'bun.lock',
+];
+
+const CONTRACT_STEPS: ExpectedStep[] = [
+  { name: 'Checkout repository without persisted credentials', uses: ACTIONS.checkout },
+  { name: 'Set up Bun', uses: ACTIONS.setupBun },
+  { name: 'Set up Vite+', uses: ACTIONS.setupVp },
+  { name: 'Install locked dependencies' },
+  { name: 'Verify publisher authority and artifact contracts' },
+];
+
+const CONTRACT_WORKFLOW_METADATA_SHA256 = '97ac7c21ca7f27ab253608a1654e195f8c23824f9b0c69272e7504294d70f458';
+const CONTRACT_JOB_METADATA_SHA256 = '9e0f951e6bceb41814be7e67f5cfe5cf5d808315af99a39bc312cbce1c7f0cfb';
+const CONTRACT_STEP_SHA256: Record<string, string> = {
+  'Checkout repository without persisted credentials':
+    '21d3640a58fa24bec3a2646f701ef5ce7da14567f1a979619cc77e2d942e3726',
+  'Set up Bun': '52cce4bc718eb16dd89360b915f63c3a1f464843e2d77f3c56fd82c57f9428d2',
+  'Set up Vite+': '40a4b08ab8203cbd60ae414ad927ba8f6bb95366bc8fe49bb4900fe7d5cc9cdd',
+  'Install locked dependencies': 'a90a77d14957fc0ffcc990ff99babb6641c2317df07d69759fca6ebae04cd981',
+  'Verify publisher authority and artifact contracts':
+    '6b2aee4c921df58aee7ab637c77324d131753c2e73e5d8a027529178077be67d',
+};
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function recordAt(record: UnknownRecord, key: string): UnknownRecord | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function stringAt(record: UnknownRecord, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function stepsAt(job: UnknownRecord): UnknownRecord[] {
+  const steps = job.steps;
+  return Array.isArray(steps) && steps.every(isRecord) ? steps : [];
+}
+
+function stepByName(job: UnknownRecord, name: string): UnknownRecord | undefined {
+  return stepsAt(job).find((step) => step.name === name);
+}
+
+function normalizedStringArray(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) return [];
+  return [...value].sort();
+}
+
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nestedValue]) => [key, canonicalValue(nestedValue)]),
+  );
+}
+
+function canonicalSha256(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalValue(value)))
+    .digest('hex');
+}
+
+function withoutKey(record: UnknownRecord, omittedKey: string): UnknownRecord {
+  return Object.fromEntries(Object.entries(record).filter(([key]) => key !== omittedKey));
+}
+
+function keysEqual(record: UnknownRecord, expectedKeys: string[]): boolean {
+  return JSON.stringify(Object.keys(record).sort()) === JSON.stringify([...expectedKeys].sort());
+}
+
+function recordsEqual(left: UnknownRecord | undefined, right: UnknownRecord): boolean {
+  return left !== undefined && JSON.stringify(canonicalValue(left)) === JSON.stringify(canonicalValue(right));
+}
+
+function parseWorkflow(source: string, label: string, failures: string[]): UnknownRecord | undefined {
+  try {
+    const document: unknown = parse(source);
+    if (!isRecord(document)) {
+      failures.push(`${label} must parse to a YAML mapping`);
+      return undefined;
+    }
+    return document;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    failures.push(`${label} is not valid YAML: ${message}`);
+    return undefined;
+  }
+}
+
+function requireRunPattern(
+  failures: string[],
+  job: UnknownRecord,
+  stepName: string,
+  pattern: RegExp,
+  message: string,
+): void {
+  const run = stringAt(stepByName(job, stepName) ?? {}, 'run');
+  if (run === undefined || !pattern.test(run)) failures.push(message);
+}
+
+function validateStepAllowlist(
+  failures: string[],
+  jobName: string,
+  job: UnknownRecord,
+  expectedSteps: ExpectedStep[],
+): void {
+  const steps = stepsAt(job);
+  if (steps.length !== expectedSteps.length) {
+    failures.push(`${jobName} must contain exactly its reviewed step allowlist`);
+    return;
+  }
+
+  for (const [index, expected] of expectedSteps.entries()) {
+    const step = steps[index];
+    if (step.name !== expected.name) {
+      failures.push(`${jobName} step ${index + 1} must be ${expected.name}`);
+      continue;
+    }
+    const uses = stringAt(step, 'uses');
+    const run = stringAt(step, 'run');
+    if (expected.uses !== undefined) {
+      if (uses !== expected.uses || run !== undefined) {
+        failures.push(`${jobName} step ${expected.name} must use only ${expected.uses}`);
+      }
+    } else if (run === undefined || uses !== undefined) {
+      failures.push(`${jobName} step ${expected.name} must be an inline trusted run step`);
+    }
+  }
+}
+
+function validatePrivilegedRunBodies(failures: string[], jobs: UnknownRecord): void {
+  for (const [jobName, reviewedHashes] of Object.entries(PRIVILEGED_RUN_SHA256)) {
+    const expectedRunNames = PUBLISHER_STEPS[jobName]
+      .filter((step) => step.uses === undefined)
+      .map((step) => step.name);
+    if (JSON.stringify(Object.keys(reviewedHashes)) !== JSON.stringify(expectedRunNames)) {
+      failures.push(`${jobName} privileged run-body allowlist must cover every reviewed inline step`);
+      continue;
+    }
+
+    const job = recordAt(jobs, jobName);
+    if (!job) continue;
+    for (const [stepName, expectedHash] of Object.entries(reviewedHashes)) {
+      const run = stringAt(stepByName(job, stepName) ?? {}, 'run');
+      const actualHash = run === undefined ? undefined : createHash('sha256').update(run).digest('hex');
+      if (actualHash !== expectedHash) {
+        failures.push(`${jobName} privileged run step ${stepName} must match its exact reviewed body`);
+      }
+    }
+  }
+}
+
+function validatePrivilegedJobs(failures: string[], jobs: UnknownRecord): void {
+  if (JSON.stringify(Object.keys(PRIVILEGED_JOB_SHA256)) !== JSON.stringify(Object.keys(PRIVILEGED_RUN_SHA256))) {
+    failures.push('privileged parsed-job and run-body allowlists must cover the same jobs');
+    return;
+  }
+  for (const [jobName, expectedHash] of Object.entries(PRIVILEGED_JOB_SHA256)) {
+    const job = recordAt(jobs, jobName);
+    if (job && canonicalSha256(job) !== expectedHash) {
+      failures.push(`${jobName} privileged parsed job must match its exact reviewed structure`);
+    }
+  }
+}
+
+function validateCheckout(
+  failures: string[],
+  jobName: string,
+  step: UnknownRecord | undefined,
+  expectedPath?: string,
+): void {
+  if (!step) return;
+  const withInputs = recordAt(step, 'with');
+  if (!withInputs) {
+    failures.push(`${jobName} checkout must define exact inputs`);
+    return;
+  }
+  if (withInputs.ref !== '${{ inputs.expected_main_sha }}') {
+    failures.push(`${jobName} checkout must use only expected_main_sha`);
+  }
+  if (withInputs['persist-credentials'] !== false) {
+    failures.push(`${jobName} checkout must disable persisted credentials`);
+  }
+  if (withInputs['fetch-depth'] !== 1) {
+    failures.push(`${jobName} checkout must fetch only the exact commit`);
+  }
+  if (expectedPath !== undefined && withInputs.path !== expectedPath) {
+    failures.push(`${jobName} checkout must use path ${expectedPath}`);
+  }
+}
+
+function validateOrasSetup(failures: string[], jobName: string, job: UnknownRecord): void {
+  const step = stepByName(job, 'Set up pinned ORAS client');
+  if (!step) return;
+  const withInputs = recordAt(step, 'with');
+  if (
+    !withInputs ||
+    withInputs.url !== 'https://github.com/oras-project/oras/releases/download/v1.3.3/oras_1.3.3_linux_amd64.tar.gz' ||
+    withInputs.checksum !== '9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59'
+  ) {
+    failures.push(`${jobName} must use the reviewed checksum-pinned ORAS v1.3.3 binary`);
+  }
+}
+
+function validateBuildStep(failures: string[], step: UnknownRecord | undefined, kind: 'portable' | 'seeded'): void {
+  if (!step) return;
+  const withInputs = recordAt(step, 'with');
+  if (!withInputs) {
+    failures.push(`${kind} build must define exact inputs`);
+    return;
+  }
+  const expectedContext = kind === 'portable' ? './source/packages/db/docker' : './source';
+  const expectedFile =
+    kind === 'portable'
+      ? './source/packages/db/docker/Dockerfile.postgres'
+      : './source/packages/db/docker/Dockerfile.dev-db';
+  const expectedPlatforms = kind === 'portable' ? 'linux/amd64,linux/arm64' : 'linux/amd64';
+  const expectedOutput =
+    kind === 'portable'
+      ? 'type=oci,dest=${{ runner.temp }}/portable-oci,tar=false,name=${{ env.PORTABLE_IMAGE }}:sha-${{ inputs.expected_main_sha }}'
+      : 'type=oci,dest=${{ runner.temp }}/seeded-oci,tar=false,name=${{ env.SEEDED_IMAGE }}:sha-${{ inputs.expected_main_sha }}';
+  const expectedLabels = [
+    'org.opencontainers.image.revision=${{ inputs.expected_main_sha }}',
+    'org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}',
+    'org.opencontainers.image.ref.name=refs/heads/main',
+  ];
+
+  if (withInputs.context !== expectedContext || withInputs.file !== expectedFile) {
+    failures.push(`${kind} build context and Dockerfile must remain exact`);
+  }
+  if (withInputs.platforms !== expectedPlatforms) {
+    failures.push(`${kind} build must use its exact reviewed platform set`);
+  }
+  if (
+    withInputs.pull !== true ||
+    withInputs.push !== false ||
+    withInputs.provenance !== false ||
+    withInputs.sbom !== false ||
+    withInputs['github-token'] !== ''
+  ) {
+    failures.push(`${kind} offline build must pull but never push, attest, emit an SBOM, or receive a GitHub token`);
+  }
+  if (withInputs['build-args'] !== 'BUILDKIT_SYNTAX=dockerfile.v0\n') {
+    failures.push(`${kind} build must force the built-in dockerfile.v0 frontend`);
+  }
+  if (withInputs.outputs !== expectedOutput) {
+    failures.push(`${kind} build must export its exact local OCI layout before authentication`);
+  }
+  const labels = typeof withInputs.labels === 'string' ? withInputs.labels.trim().split('\n') : [];
+  if (JSON.stringify(labels) !== JSON.stringify(expectedLabels)) {
+    failures.push(`${kind} build must publish exact main source labels`);
+  }
+  for (const forbiddenInput of ['tags', 'secrets', 'secret-envs', 'secret-files', 'ssh']) {
+    if (forbiddenInput in withInputs) {
+      failures.push(`${kind} offline build must not define ${forbiddenInput}`);
+    }
+  }
+}
+
+function validatePublisherDocument(failures: string[], publisher: UnknownRecord, publisherWorkflow: string): void {
+  if (!keysEqual(publisher, ['name', 'on', 'concurrency', 'env', 'jobs'])) {
+    failures.push('publisher top-level keys must match the exact executable allowlist with no defaults');
+  }
+  if (publisher.name !== 'Publish Current Main PostgreSQL Images') {
+    failures.push('publisher workflow name must remain exact');
+  }
+  if ('defaults' in publisher) {
+    failures.push('publisher must not define workflow-level defaults');
+  }
+
+  const triggers = recordAt(publisher, 'on');
+  if (!triggers || JSON.stringify(Object.keys(triggers)) !== JSON.stringify(['workflow_dispatch'])) {
+    failures.push('publisher must have only the manual workflow_dispatch trigger');
+  }
+  const dispatch = triggers ? recordAt(triggers, 'workflow_dispatch') : undefined;
+  const expectedDispatch = {
+    inputs: {
+      expected_main_sha: {
+        description: 'Exact lowercase 40-character SHA currently at the head of main',
+        required: true,
+        type: 'string',
+      },
+    },
+  };
+  if (!recordsEqual(dispatch, expectedDispatch)) {
+    failures.push('publisher workflow_dispatch metadata must remain exact with no fallback defaults');
+  }
+  const inputs = dispatch ? recordAt(dispatch, 'inputs') : undefined;
+  if (!inputs || JSON.stringify(Object.keys(inputs)) !== JSON.stringify(['expected_main_sha'])) {
+    failures.push('publisher must accept only expected_main_sha');
+  } else {
+    const expectedMainSha = recordAt(inputs, 'expected_main_sha');
+    if (!expectedMainSha || expectedMainSha.required !== true || expectedMainSha.type !== 'string') {
+      failures.push('expected_main_sha must be a required string');
+    }
+  }
+
+  const concurrency = recordAt(publisher, 'concurrency');
+  if (!recordsEqual(concurrency, { group: 'postgres-image-publisher', 'cancel-in-progress': false })) {
+    failures.push('publisher must serialize every run without cancelling an active publication');
+  }
+
+  const expectedEnvironment = {
+    APPROVED_REPOSITORY: 'boardsesh/boardsesh',
+    DEFAULT_BRANCH: 'main',
+    PUBLISHER_ENVIRONMENT: 'postgres-image-publisher',
+    REGISTRY: 'ghcr.io',
+    PORTABLE_IMAGE: 'ghcr.io/boardsesh/boardsesh-postgres-postgis',
+    SEEDED_IMAGE: 'ghcr.io/boardsesh/boardsesh-dev-db',
+    MAIN_REF: 'refs/heads/main',
+  };
+  if (!recordsEqual(recordAt(publisher, 'env'), expectedEnvironment)) {
+    failures.push('publisher global constants must remain exact');
+  }
+
+  const jobs = recordAt(publisher, 'jobs');
+  if (!jobs) {
+    failures.push('publisher must define jobs');
+    return;
+  }
+  const expectedJobNames = Object.keys(PUBLISHER_STEPS);
+  if (JSON.stringify(Object.keys(jobs)) !== JSON.stringify(expectedJobNames)) {
+    failures.push('publisher jobs must match the exact reviewed job allowlist and order');
+  }
+
+  for (const jobName of expectedJobNames) {
+    const job = recordAt(jobs, jobName);
+    if (!job) {
+      failures.push(`publisher is missing ${jobName}`);
+      continue;
+    }
+    validateStepAllowlist(failures, jobName, job, PUBLISHER_STEPS[jobName]);
+    if (!recordsEqual(recordAt(job, 'permissions'), PUBLISHER_PERMISSIONS[jobName])) {
+      failures.push(`${jobName} permissions must match its exact allowlist`);
+    }
+    if (JSON.stringify(normalizedStringArray(job.needs)) !== JSON.stringify([...PUBLISHER_NEEDS[jobName]].sort())) {
+      failures.push(`${jobName} dependencies must match the reviewed gate order`);
+    }
+    const environment = job.environment;
+    const shouldUsePublisherEnvironment = jobName === 'publish-images' || jobName === 'attest-published-digests';
+    if (
+      (shouldUsePublisherEnvironment && environment !== 'postgres-image-publisher') ||
+      (!shouldUsePublisherEnvironment && environment !== undefined)
+    ) {
+      failures.push(`${jobName} environment authority is not allowed by the exact contract`);
+    }
+  }
+  validatePrivilegedRunBodies(failures, jobs);
+  validatePrivilegedJobs(failures, jobs);
+
+  const authorize = recordAt(jobs, 'authorize-current-main') ?? {};
+  for (const [pattern, message] of [
+    [
+      /\[\[ "\$EXPECTED_MAIN_SHA" =~ \^\[0-9a-f\]\{40\}\$ \]\]/,
+      'publisher must require a lowercase full expected_main_sha',
+    ],
+    [/\[\[ "\$EXPECTED_MAIN_SHA" == "\$DISPATCH_SHA" \]\]/, 'expected_main_sha must equal github.sha'],
+    [/\[\[ "\$EXPECTED_MAIN_SHA" == "\$WORKFLOW_SHA" \]\]/, 'expected_main_sha must equal github.workflow_sha'],
+    [
+      /\[\[ "\$WORKFLOW_REF" == "\$EXPECTED_WORKFLOW_REF" \]\]/,
+      'publisher must bind the exact main workflow path and ref',
+    ],
+    [/\[\[ "\$REF_IS_PROTECTED" == 'true' \]\]/, 'publisher must require protected main'],
+    [/git\/ref\/heads\/\$DEFAULT_BRANCH/, 'publisher must query the live main head'],
+    [/\.can_admins_bypass == false/, 'publisher environment must disable administrator bypass'],
+    [/\.prevent_self_review == true/, 'publisher environment must prevent self-review'],
+    [/\(\(\.reviewers \/\/ \[\]\) \| length > 0\)/, 'publisher environment must require a reviewer'],
+    [/\.total_count == 1/, 'publisher environment must allow exactly one branch policy'],
+  ] as const) {
+    requireRunPattern(failures, authorize, 'Bind workflow and audit publisher environment', pattern, message);
+  }
+
+  const validateMain = recordAt(jobs, 'validate-main') ?? {};
+  validateCheckout(failures, 'validate-main', stepByName(validateMain, 'Checkout exact current main commit'), 'source');
+  requireRunPattern(
+    failures,
+    validateMain,
+    'Validate checkout and Docker inputs',
+    /s\/\^\\xEF\\xBB\\xBF\/\/ if \$\. == 1;/,
+    'Docker input validation must strip a UTF-8 BOM before checking parser directives',
+  );
+  requireRunPattern(
+    failures,
+    validateMain,
+    'Validate checkout and Docker inputs',
+    /\$found \|\|= \/\^\[ \\t\]\*#\[ \\t\]\*syntax\[ \\t\]\*=\/i;/,
+    'Docker input validation must reject whitespace-prefixed syntax directives',
+  );
+  requireRunPattern(
+    failures,
+    validateMain,
+    'Run PostgreSQL 18 contracts',
+    /^vp run test:postgres18-contract$/,
+    'exact-main validation must run the PostgreSQL 18 contract target',
+  );
+
+  const publish = recordAt(jobs, 'publish-images') ?? {};
+  validateCheckout(failures, 'publish-images', stepByName(publish, 'Checkout exact current main commit'), 'source');
+  validateOrasSetup(failures, 'publish-images', publish);
+  const buildx = stepByName(publish, 'Set up Docker Buildx inside the temporary boundary');
+  const buildxInputs = buildx ? recordAt(buildx, 'with') : undefined;
+  if (
+    !buildxInputs ||
+    buildxInputs.version !== 'v0.36.1' ||
+    buildxInputs.cleanup !== false ||
+    buildxInputs['driver-opts'] !==
+      'image=moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8\n'
+  ) {
+    failures.push('publisher must use its exact digest-pinned BuildKit daemon inside the temporary boundary');
+  }
+  const portableQemu = stepByName(publish, 'Enable multi-architecture emulation');
+  const portableQemuInputs = portableQemu ? recordAt(portableQemu, 'with') : undefined;
+  if (
+    !portableQemuInputs ||
+    portableQemuInputs.image !==
+      'tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0' ||
+    portableQemuInputs.platforms !== 'arm64'
+  ) {
+    failures.push('portable publisher QEMU must use only the reviewed digest-pinned ARM64 helper');
+  }
+  validateBuildStep(
+    failures,
+    stepByName(publish, 'Build portable OCI layout without registry credentials'),
+    'portable',
+  );
+  validateBuildStep(failures, stepByName(publish, 'Build seeded OCI layout without registry credentials'), 'seeded');
+  for (const [pattern, message] of [
+    [
+      /RETIRED_DB_IMAGE_DIGESTS must contain one lowercase sha256 digest per non-empty line/,
+      'retired digest policy must reject malformed entries',
+    ],
+    [
+      /\[\[ "\$retired_digest" =~ \^sha256:\[0-9a-f\]\{64\}\$ \]\]/,
+      'retired digest policy must reject malformed entries with an exact lowercase digest pattern',
+    ],
+    [/seen_retired_digests/, 'retired digest policy must reject duplicates and proposed retired digests'],
+    [/portable_digest="\$\(layout_digest/, 'portable digest must come from the offline OCI layout'],
+    [/seeded_digest="\$\(layout_digest/, 'seeded digest must come from the offline OCI layout'],
+    [/\["linux\/amd64","linux\/arm64"\]/, 'portable offline layout must have its exact platforms'],
+    [/\["linux\/amd64"\]/, 'seeded offline layout must have its exact platform'],
+  ] as const) {
+    requireRunPattern(failures, publish, 'Validate offline layouts and retired digest policy', pattern, message);
+  }
+  requireRunPattern(
+    failures,
+    publish,
+    'Recheck exact current main and environment immediately before registry authentication',
+    /main moved before registry authentication/,
+    'publisher must recheck the live main head immediately before GHCR authentication',
+  );
+  requireRunPattern(
+    failures,
+    publish,
+    'Recheck exact current main and environment immediately before registry authentication',
+    /\.can_admins_bypass == false[\s\S]*\.prevent_self_review == true/,
+    'publisher must re-audit no-bypass and no-self-review immediately before GHCR authentication',
+  );
+  const publishRun = stringAt(stepByName(publish, 'Publish exact prevalidated OCI layouts') ?? {}, 'run') ?? '';
+  if ((publishRun.match(/oras cp --from-oci-layout/g) ?? []).length !== 2) {
+    failures.push('publisher must copy exactly both prevalidated OCI layouts after login');
+  }
+  if (
+    (publishRun.match(/"\$PORTABLE_IMAGE:\$SHA_TAG"/g) ?? []).length !== 2 ||
+    (publishRun.match(/"\$SEEDED_IMAGE:\$SHA_TAG"/g) ?? []).length !== 2
+  ) {
+    failures.push('publisher must publish exact prevalidated OCI layouts under only their SHA tag');
+  }
+  if (/\b(?:vp|bun|npm|npx)\b|source\/scripts|docker build/.test(publishRun)) {
+    failures.push('publisher must not run checked-out helpers or rebuild after registry login');
+  }
+
+  const verifyImages = recordAt(jobs, 'verify-published-images') ?? {};
+  validateOrasSetup(failures, 'verify-published-images', verifyImages);
+  requireRunPattern(
+    failures,
+    verifyImages,
+    'Verify exact remote manifests',
+    /\["linux\/amd64", "linux\/arm64"\]/,
+    'remote portable manifest must expose exactly amd64 and arm64',
+  );
+  requireRunPattern(
+    failures,
+    verifyImages,
+    'Verify exact remote manifests',
+    /\["linux\/amd64"\]/,
+    'remote seeded manifest must expose exactly amd64',
+  );
+
+  for (const smokeName of ['smoke-portable', 'smoke-seeded']) {
+    const smoke = recordAt(jobs, smokeName) ?? {};
+    validateCheckout(failures, smokeName, stepByName(smoke, 'Checkout exact current main commit'));
+    requireRunPattern(
+      failures,
+      smoke,
+      'Recheck exact current main immediately before registry authentication',
+      /git\/ref\/heads\/\$DEFAULT_BRANCH/,
+      `${smokeName} must recheck live main immediately before login`,
+    );
+  }
+  const smokePortable = recordAt(jobs, 'smoke-portable') ?? {};
+  const smokeQemu = stepByName(smokePortable, 'Enable multi-architecture emulation');
+  const smokeQemuInputs = smokeQemu ? recordAt(smokeQemu, 'with') : undefined;
+  if (
+    !smokeQemu ||
+    smokeQemu.if !== "matrix.platform == 'linux/arm64'" ||
+    !smokeQemuInputs ||
+    smokeQemuInputs.platforms !== 'arm64' ||
+    smokeQemuInputs.image !==
+      'tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0'
+  ) {
+    failures.push('portable smoke must grant pinned QEMU only to its ARM64 matrix run');
+  }
+
+  const attest = recordAt(jobs, 'attest-published-digests') ?? {};
+  requireRunPattern(
+    failures,
+    attest,
+    'Recheck exact current main and environment immediately before OIDC attestation',
+    /main moved before OIDC attestation/,
+    'attestation must recheck live main immediately before OIDC authority',
+  );
+  requireRunPattern(
+    failures,
+    attest,
+    'Recheck exact current main and environment immediately before OIDC attestation',
+    /\.can_admins_bypass == false[\s\S]*\.prevent_self_review == true/,
+    'attestation must re-audit no-bypass and no-self-review before OIDC authority',
+  );
+  for (const [stepName, subjectName, subjectDigest] of [
+    [
+      'Attest exact portable digest',
+      '${{ env.PORTABLE_IMAGE }}',
+      '${{ needs.publish-images.outputs.portable_digest }}',
+    ],
+    ['Attest exact seeded digest', '${{ env.SEEDED_IMAGE }}', '${{ needs.publish-images.outputs.seeded_digest }}'],
+  ] as const) {
+    const step = stepByName(attest, stepName);
+    const withInputs = step ? recordAt(step, 'with') : undefined;
+    if (
+      !withInputs ||
+      JSON.stringify(Object.keys(withInputs)) !==
+        JSON.stringify(['subject-name', 'subject-digest', 'push-to-registry']) ||
+      withInputs['subject-name'] !== subjectName ||
+      withInputs['subject-digest'] !== subjectDigest ||
+      withInputs['push-to-registry'] !== false
+    ) {
+      failures.push(`${stepName} must use native source-aware provenance for only its exact digest`);
+    }
+  }
+
+  const verifyAttestations = recordAt(jobs, 'verify-attestations') ?? {};
+  for (const [pattern, message] of [
+    [
+      /\^https:\/\/github\\\.com\/boardsesh\/boardsesh\/attestations\/\[0-9\]\+\$/,
+      'attestation URLs must match the exact Boardsesh repository URL shape',
+    ],
+    [/gh attestation verify "oci:\/\/\$image@\$digest"/, 'downstream verification must verify the exact OCI subject'],
+    [
+      /--signer-workflow "\$APPROVED_REPOSITORY\/\.github\/workflows\/postgres-image-publisher\.yml"/,
+      'downstream verification must pin the signer workflow',
+    ],
+    [/--signer-digest "\$EXPECTED_MAIN_SHA"/, 'downstream verification must pin the signer SHA'],
+    [/--source-ref "\$MAIN_REF"/, 'downstream verification must pin refs/heads/main'],
+    [/--source-digest "\$EXPECTED_MAIN_SHA"/, 'downstream verification must pin the source SHA'],
+    [/--deny-self-hosted-runners/, 'downstream verification must reject self-hosted attestations'],
+    [/verify_attestation "\$PORTABLE_IMAGE"/, 'downstream verification must verify the portable attestation'],
+    [/verify_attestation "\$SEEDED_IMAGE"/, 'downstream verification must verify the seeded attestation'],
+  ] as const) {
+    requireRunPattern(
+      failures,
+      verifyAttestations,
+      'Validate attestation URLs and verify both exact subjects',
+      pattern,
+      message,
+    );
+  }
+
+  const recordJob = recordAt(jobs, 'record-published-digests') ?? {};
+  requireRunPattern(
+    failures,
+    recordJob,
+    'Write machine-readable digest manifest and summary',
+    /schema_version: 2/,
+    'digest handoff must use schema version 2',
+  );
+  requireRunPattern(
+    failures,
+    recordJob,
+    'Write machine-readable digest manifest and summary',
+    /deployment_identity: "digest-only"[\s\S]*tags_are_mutable: true/,
+    'digest handoff must declare digests as the sole identity and tags as mutable',
+  );
+  requireRunPattern(
+    failures,
+    recordJob,
+    'Write machine-readable digest manifest and summary',
+    /attestation_verified: true/g,
+    'digest handoff must record downstream attestation verification',
+  );
+  for (const [pattern, message] of [
+    [
+      /\[\[ "\$EXPECTED_MAIN_SHA" == "\$GITHUB_SHA" \]\]/,
+      'artifact upload must recheck expected_main_sha against github.sha',
+    ],
+    [/\[\[ "\$EXPECTED_MAIN_SHA" == "\$WORKFLOW_SHA" \]\]/, 'artifact upload must recheck the workflow source SHA'],
+    [
+      /\[\[ "\$WORKFLOW_REF" == "\$EXPECTED_WORKFLOW_REF" \]\]/,
+      'artifact upload must recheck the exact protected-main workflow ref',
+    ],
+    [
+      /git\/ref\/heads\/\$DEFAULT_BRANCH[\s\S]*== "\$EXPECTED_MAIN_SHA"/,
+      'artifact upload must recheck the live main head immediately before upload',
+    ],
+  ] as const) {
+    requireRunPattern(
+      failures,
+      recordJob,
+      'Recheck exact current main and workflow before artifact upload',
+      pattern,
+      message,
+    );
+  }
+
+  if (/source_pr_number|source_ref|branch_tag|pull-requests:|\/compare\//i.test(publisherWorkflow)) {
+    failures.push('publisher must not contain obsolete PR, branch-ref, compare, or branch-tag authority logic');
+  }
+  if (/:(?:latest|main|pg18)(?:[\s"']|$)/m.test(publisherWorkflow)) {
+    failures.push('publisher must not publish mutable discovery tags');
+  }
+}
+
+function validateContractDocument(failures: string[], contract: UnknownRecord, contractWorkflow: string): void {
+  if (!keysEqual(contract, ['name', 'on', 'permissions', 'jobs'])) {
+    failures.push('contract workflow top-level keys must match the exact read-only allowlist with no defaults');
+  }
+  if (contract.name !== 'PostgreSQL Image Publisher Contract') {
+    failures.push('contract workflow name must remain exact');
+  }
+  if ('defaults' in contract) {
+    failures.push('contract workflow must not define workflow-level defaults');
+  }
+  if (canonicalSha256(withoutKey(contract, 'jobs')) !== CONTRACT_WORKFLOW_METADATA_SHA256) {
+    failures.push('contract workflow metadata must match its exact reviewed parsed structure');
+  }
+
+  const triggers = recordAt(contract, 'on');
+  const expectedTriggers = {
+    pull_request: { paths: CONTRACT_PATHS },
+    push: { branches: ['main'], paths: CONTRACT_PATHS },
+  };
+  if (!recordsEqual(triggers, expectedTriggers)) {
+    failures.push('contract workflow must use only the exact reviewed pull-request and protected-main path triggers');
+  }
+  if (!recordsEqual(recordAt(contract, 'permissions'), { contents: 'read' })) {
+    failures.push('contract workflow must be globally contents-read-only');
+  }
+  const jobs = recordAt(contract, 'jobs');
+  if (!jobs || JSON.stringify(Object.keys(jobs)) !== JSON.stringify(['verify-trust-boundary'])) {
+    failures.push('contract workflow must contain only verify-trust-boundary');
+    return;
+  }
+  const job = recordAt(jobs, 'verify-trust-boundary') ?? {};
+  if (canonicalSha256(withoutKey(job, 'steps')) !== CONTRACT_JOB_METADATA_SHA256) {
+    failures.push('contract job metadata must match its exact reviewed parsed structure');
+  }
+  if ('permissions' in job || 'environment' in job || 'defaults' in job || 'continue-on-error' in job) {
+    failures.push('contract job must not override permissions, defaults, failure handling, or environment authority');
+  }
+  validateStepAllowlist(failures, 'contract verify-trust-boundary', job, CONTRACT_STEPS);
+  if (JSON.stringify(Object.keys(CONTRACT_STEP_SHA256)) !== JSON.stringify(CONTRACT_STEPS.map((step) => step.name))) {
+    failures.push('contract step hash allowlist must cover every reviewed step');
+  }
+  for (const [stepName, expectedHash] of Object.entries(CONTRACT_STEP_SHA256)) {
+    const step = stepByName(job, stepName);
+    if (!step || canonicalSha256(step) !== expectedHash) {
+      failures.push(`contract step ${stepName} must match its exact reviewed parsed structure`);
+    }
+    if (step && 'continue-on-error' in step) {
+      failures.push(`contract step ${stepName} must not continue on error`);
+    }
+  }
+  const checkout = stepByName(job, 'Checkout repository without persisted credentials');
+  const checkoutInputs = checkout ? recordAt(checkout, 'with') : undefined;
+  if (!recordsEqual(checkoutInputs, { 'persist-credentials': false })) {
+    failures.push(
+      'contract checkout inputs must be exactly persist-credentials:false with no ref, repository, path, or token override',
+    );
+  }
+  requireRunPattern(
+    failures,
+    job,
+    'Install locked dependencies',
+    /^bun install --frozen-lockfile$/,
+    'contract workflow must install only the reviewed lockfile graph',
+  );
+  requireRunPattern(
+    failures,
+    job,
+    'Verify publisher authority and artifact contracts',
+    /^vp test run --project scripts scripts\/postgres-image-publisher-contract\.test\.ts --reporter=agent$/,
+    'contract workflow must run the focused publisher contract suite through Vite+',
+  );
+  if (
+    /workflow_dispatch:|pull_request_target:|packages:\s+write|id-token:\s+write|attestations:\s+write|environment:/m.test(
+      contractWorkflow,
+    )
+  ) {
+    failures.push(
+      'contract workflow must never receive dispatch, package, OIDC, attestation, or environment authority',
+    );
+  }
+  for (const requiredPath of CONTRACT_PATHS) {
+    if (!contractWorkflow.includes(`'${requiredPath}'`)) {
+      failures.push(`contract workflow paths must include ${requiredPath}`);
+    }
+  }
+}
+
+export function containsDockerfileSyntaxDirective(dockerfile: string): boolean {
+  const withoutBom = dockerfile.replace(/^\uFEFF/, '');
+  return withoutBom.split(/\r?\n/).some((line) => /^[\t ]*#[\t ]*syntax[\t ]*=/i.test(line));
+}
+
+export interface PostgresImagePublisherContractInput {
+  publisherWorkflow: string;
+  contractWorkflow: string;
+}
+
+export function createPostgresImagePublisherFailures({
+  publisherWorkflow,
+  contractWorkflow,
+}: PostgresImagePublisherContractInput): string[] {
+  const failures: string[] = [];
+  const publisher = parseWorkflow(publisherWorkflow, 'publisher workflow', failures);
+  const contract = parseWorkflow(contractWorkflow, 'publisher contract workflow', failures);
+  if (publisher) validatePublisherDocument(failures, publisher, publisherWorkflow);
+  if (contract) validateContractDocument(failures, contract, contractWorkflow);
+  return failures;
+}

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -296,7 +296,25 @@ describe('trusted PostgreSQL image publisher contract', () => {
           dependencySetup + '      - name: Remove registry credentials before image smoke\n',
         );
       },
-      expected: /smoke-portable dependency setup must occur only after registry credentials are removed/,
+      expected: /smoke-portable tool and dependency setup must occur only after registry credentials are removed/,
+    },
+    {
+      name: 'portable Vite+ setup runs while registry credentials remain',
+      mutate: (workflow: string) => {
+        const viteSetup = `      - name: Set up Vite+
+        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
+
+`;
+        const withoutViteSetup = replaceRequiredInJob(workflow, 'smoke-portable', 'smoke-seeded', viteSetup, '');
+        return replaceRequiredInJob(
+          withoutViteSetup,
+          'smoke-portable',
+          'smoke-seeded',
+          '      - name: Remove registry credentials before image smoke\n',
+          viteSetup + '      - name: Remove registry credentials before image smoke\n',
+        );
+      },
+      expected: /smoke-portable tool and dependency setup must occur only after registry credentials are removed/,
     },
     {
       name: 'seeded smoke dependencies installed without the lockfile',

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -203,8 +203,8 @@ describe('trusted PostgreSQL image publisher contract', () => {
     },
     {
       name: 'self-review accepted',
-      mutate: (workflow: string) => replaceRequired(workflow, '.prevent_self_review == true', 'true'),
-      expected: /prevent self-review/,
+      mutate: (workflow: string) => replaceRequired(workflow, '(.prevent_self_review | type == "boolean")', 'true'),
+      expected: /must assert an explicit self-review policy/,
     },
     {
       name: 'reviewer-free environment accepted',

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -1,0 +1,506 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  containsDockerfileSyntaxDirective,
+  createPostgresImagePublisherFailures,
+} from './lib/postgres-image-publisher-contract';
+
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PUBLISHER_PATH = resolve(REPOSITORY_ROOT, '.github/workflows/postgres-image-publisher.yml');
+const CONTRACT_WORKFLOW_PATH = resolve(REPOSITORY_ROOT, '.github/workflows/postgres-image-publisher-contract.yml');
+const publisherWorkflow = readFileSync(PUBLISHER_PATH, 'utf8');
+const contractWorkflow = readFileSync(CONTRACT_WORKFLOW_PATH, 'utf8');
+
+function failuresFor(candidatePublisher = publisherWorkflow, candidateContractWorkflow = contractWorkflow): string {
+  return createPostgresImagePublisherFailures({
+    publisherWorkflow: candidatePublisher,
+    contractWorkflow: candidateContractWorkflow,
+  }).join('\n');
+}
+
+function replaceRequired(source: string, expected: string, replacement: string): string {
+  expect(source).toContain(expected);
+  return source.replace(expected, replacement);
+}
+
+describe('trusted PostgreSQL image publisher contract', () => {
+  it('keeps the checked-in publisher inside the parsed trust boundary', () => {
+    expect(failuresFor()).toBe('');
+  });
+
+  it.each([
+    '# syntax=docker/dockerfile:1',
+    '   #   syntax = docker/dockerfile:1',
+    '\t#\tsYnTaX\t=docker/dockerfile:labs',
+    '\uFEFF# syntax=evil.example/frontend:latest',
+    '\uFEFF \t#  SYNTAX = evil.example/frontend@sha256:abc',
+    'FROM postgres:18\n  # syntax=evil.example/frontend:latest',
+  ])('recognizes whitespace- and BOM-prefixed Dockerfile frontend directive %j', (dockerfile) => {
+    expect(containsDockerfileSyntaxDirective(dockerfile)).toBe(true);
+  });
+
+  it.each(['FROM postgres:18', '# ordinary comment\nFROM postgres:18', '\uFEFFFROM postgres:18'])(
+    'does not confuse ordinary Dockerfile text with a frontend directive %j',
+    (dockerfile) => {
+      expect(containsDockerfileSyntaxDirective(dockerfile)).toBe(false);
+    },
+  );
+
+  it.each([
+    {
+      name: 'automatic trigger',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '  workflow_dispatch:\n', '  workflow_dispatch:\n  push:\n    branches: [main]\n'),
+      expected: /only the manual workflow_dispatch trigger/,
+    },
+    {
+      name: 'workflow-level fallback shell defaults',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '  cancel-in-progress: false\n\nenv:',
+          '  cancel-in-progress: false\n\ndefaults:\n  run:\n    shell: bash\n\nenv:',
+        ),
+      expected: /top-level keys must match.*no defaults|must not define workflow-level defaults/,
+    },
+    {
+      name: 'second source input',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '        required: true\n        type: string\n\nconcurrency:',
+          '        required: true\n        type: string\n      source_ref:\n        required: true\n        type: string\n\nconcurrency:',
+        ),
+      expected: /accept only expected_main_sha/,
+    },
+    {
+      name: 'abbreviated SHA acceptance',
+      mutate: (workflow: string) => replaceRequired(workflow, '^[0-9a-f]{40}$', '^[0-9a-f]{7,40}$'),
+      expected: /lowercase full expected_main_sha/,
+    },
+    {
+      name: 'github SHA equality removed',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '[[ "$EXPECTED_MAIN_SHA" == "$DISPATCH_SHA" ]]', '[[ -n "$DISPATCH_SHA" ]]'),
+      expected: /must equal github.sha/,
+    },
+    {
+      name: 'workflow SHA equality removed',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '[[ "$EXPECTED_MAIN_SHA" == "$WORKFLOW_SHA" ]]', '[[ -n "$WORKFLOW_SHA" ]]'),
+      expected: /must equal github.workflow_sha/,
+    },
+    {
+      name: 'workflow ref binding removed',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '[[ "$WORKFLOW_REF" == "$EXPECTED_WORKFLOW_REF" ]]', '[[ -n "$WORKFLOW_REF" ]]'),
+      expected: /exact main workflow path and ref/,
+    },
+    {
+      name: 'unprotected main accepted',
+      mutate: (workflow: string) => replaceRequired(workflow, `[[ "$REF_IS_PROTECTED" == 'true' ]]`, 'true'),
+      expected: /require protected main/,
+    },
+    {
+      name: 'publisher concurrency cancellation',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '  cancel-in-progress: false', '  cancel-in-progress: true'),
+      expected: /serialize every run/,
+    },
+    {
+      name: 'wrong publisher environment',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '    environment: postgres-image-publisher', '    environment: Production'),
+      expected: /environment authority is not allowed/,
+    },
+    {
+      name: 'administrator bypass accepted',
+      mutate: (workflow: string) => replaceRequired(workflow, '.can_admins_bypass == false', 'true'),
+      expected: /disable administrator bypass/,
+    },
+    {
+      name: 'self-review accepted',
+      mutate: (workflow: string) => replaceRequired(workflow, '.prevent_self_review == true', 'true'),
+      expected: /prevent self-review/,
+    },
+    {
+      name: 'reviewer-free environment accepted',
+      mutate: (workflow: string) => replaceRequired(workflow, '((.reviewers // []) | length > 0)', 'true'),
+      expected: /require a reviewer/,
+    },
+    {
+      name: 'multiple deployment branches accepted',
+      mutate: (workflow: string) => replaceRequired(workflow, '.total_count == 1', '.total_count > 0'),
+      expected: /exactly one branch policy/,
+    },
+    {
+      name: 'persisted checkout credentials',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '          persist-credentials: false', '          persist-credentials: true'),
+      expected: /disable persisted credentials/,
+    },
+    {
+      name: 'checkout of an arbitrary ref',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '          ref: ${{ inputs.expected_main_sha }}', '          ref: ${{ github.ref }}'),
+      expected: /checkout must use only expected_main_sha/,
+    },
+    {
+      name: 'extra privileged publish step',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '      - name: Publish exact prevalidated OCI layouts\n',
+          '      - name: Run injected helper\n        run: source/scripts/publish.sh\n\n      - name: Publish exact prevalidated OCI layouts\n',
+        ),
+      expected: /publish-images must contain exactly its reviewed step allowlist/,
+    },
+    {
+      name: 'command appended inside an allowed privileged step',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          "            fail 'main moved before OIDC attestation'",
+          "            fail 'main moved before OIDC attestation'\n          curl --fail https://example.invalid/injected",
+        ),
+      expected: /privileged run step .* must match its exact reviewed body/,
+    },
+    {
+      name: 'environment injected into an allowed privileged action',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3\n        with:',
+          '        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3\n        env:\n          GH_TOKEN: ${{ github.token }}\n        with:',
+        ),
+      expected: /privileged parsed job must match its exact reviewed structure/,
+    },
+    {
+      name: 'package write on the recorder',
+      mutate: (workflow: string) => {
+        const recordStart = workflow.indexOf('\n  record-published-digests:\n');
+        expect(recordStart).toBeGreaterThan(0);
+        const prefix = workflow.slice(0, recordStart);
+        const record = workflow
+          .slice(recordStart)
+          .replace('      contents: read\n', '      contents: read\n      packages: write\n');
+        return prefix + record;
+      },
+      expected: /record-published-digests permissions must match/,
+    },
+    {
+      name: 'OIDC on the build job',
+      mutate: (workflow: string) => {
+        const publishStart = workflow.indexOf('\n  publish-images:\n');
+        const verifyStart = workflow.indexOf('\n  verify-published-images:\n');
+        expect(publishStart).toBeGreaterThan(0);
+        expect(verifyStart).toBeGreaterThan(publishStart);
+        const publish = workflow
+          .slice(publishStart, verifyStart)
+          .replace('      packages: write\n', '      packages: write\n      id-token: write\n');
+        return workflow.slice(0, publishStart) + publish + workflow.slice(verifyStart);
+      },
+      expected: /publish-images permissions must match/,
+    },
+    {
+      name: 'mutable BuildKit daemon',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          'moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8',
+          'moby/buildkit:buildx-stable-1',
+        ),
+      expected: /digest-pinned BuildKit daemon/,
+    },
+    {
+      name: 'mutable QEMU helper',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          'tonistiigi/binfmt:qemu-v10.2.3-68@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0',
+          'tonistiigi/binfmt:latest',
+        ),
+      expected: /digest-pinned ARM64 helper/,
+    },
+    {
+      name: 'unpinned ORAS action',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          'oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d',
+          'oras-project/setup-oras@v2',
+        ),
+      expected: /must use only oras-project\/setup-oras@/,
+    },
+    {
+      name: 'unverified ORAS binary',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          'checksum: 9ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59',
+          'checksum: 0ce999f8d2de03fc03968b29d743077a58783e545e5eaa53917ca177352d0e59',
+        ),
+      expected: /checksum-pinned ORAS/,
+    },
+    {
+      name: 'BuildKit GitHub token exposure',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, "          github-token: ''", '          github-token: ${{ github.token }}'),
+      expected: /never push, attest, emit an SBOM, or receive a GitHub token/,
+    },
+    {
+      name: 'registry push during build',
+      mutate: (workflow: string) => replaceRequired(workflow, '          push: false', '          push: true'),
+      expected: /offline build must pull but never push/,
+    },
+    {
+      name: 'external Dockerfile frontend enabled',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, 'BUILDKIT_SYNTAX=dockerfile.v0', 'BUILDKIT_SYNTAX=docker/dockerfile:latest'),
+      expected: /force the built-in dockerfile.v0 frontend/,
+    },
+    {
+      name: 'wrong seeded build context',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '          context: ./source\n', '          context: ./source/packages/db\n'),
+      expected: /seeded build context and Dockerfile/,
+    },
+    {
+      name: 'retired digest validation after login',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '      - name: Validate offline layouts and retired digest policy',
+          '      - name: Validate layouts after registry login',
+        ),
+      expected: /publish-images step 9 must be Validate offline layouts and retired digest policy/,
+    },
+    {
+      name: 'retired digest format accepted loosely',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '[[ "$retired_digest" =~ ^sha256:[0-9a-f]{64}$ ]]',
+          '[[ "$retired_digest" =~ ^sha256:.*$ ]]',
+        ),
+      expected: /retired digest policy must reject malformed entries/,
+    },
+    {
+      name: 'candidate helper after login',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '          oras cp --from-oci-layout \\\n',
+          '          vp run source/scripts/publish-helper\n          oras cp --from-oci-layout \\\n',
+        ),
+      expected: /must not run checked-out helpers/,
+    },
+    {
+      name: 'branch lookup tag',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '"$PORTABLE_IMAGE:$SHA_TAG"', '"$PORTABLE_IMAGE:branch-main"'),
+      expected: /publish exact prevalidated OCI layouts|obsolete PR, branch-ref, compare, or branch-tag/,
+    },
+    {
+      name: 'latest discovery tag',
+      mutate: (workflow: string) => replaceRequired(workflow, '"$PORTABLE_IMAGE:$SHA_TAG"', '"$PORTABLE_IMAGE:latest"'),
+      expected: /must not publish mutable discovery tags/,
+    },
+    {
+      name: 'custom user-authored provenance predicate',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '          push-to-registry: false\n',
+          '          predicate-type: https://slsa.dev/provenance/v1\n          predicate: "{}"\n          push-to-registry: false\n',
+        ),
+      expected: /native source-aware provenance/,
+    },
+    {
+      name: 'attestation from an unreviewed source ref',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '              --source-ref "$MAIN_REF" \\\n',
+          '              --source-ref refs/pull/1/head \\\n',
+        ),
+      expected: /pin refs\/heads\/main/,
+    },
+    {
+      name: 'missing attestation signer digest',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '              --signer-digest "$EXPECTED_MAIN_SHA" \\\n', ''),
+      expected: /pin the signer SHA/,
+    },
+    {
+      name: 'unvalidated attestation URL',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          "          attestation_url_pattern='^https://github\\.com/boardsesh/boardsesh/attestations/[0-9]+$'",
+          "          attestation_url_pattern='.*'",
+        ),
+      expected: /attestation URLs must match/,
+    },
+    {
+      name: 'digest artifact before attestation verification',
+      mutate: (workflow: string) => replaceRequired(workflow, '      - verify-attestations\n', ''),
+      expected: /record-published-digests dependencies must match/,
+    },
+    {
+      name: 'final artifact upload without github SHA recheck',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '          [[ "$EXPECTED_MAIN_SHA" == "$GITHUB_SHA" ]] ||\n            fail \'expected_main_sha no longer equals github.sha\'\n          [[ "$EXPECTED_MAIN_SHA" == "$WORKFLOW_SHA" ]] ||',
+          '          [[ -n "$GITHUB_SHA" ]] ||\n            fail \'expected_main_sha no longer equals github.sha\'\n          [[ "$EXPECTED_MAIN_SHA" == "$WORKFLOW_SHA" ]] ||',
+        ),
+      expected: /artifact upload must recheck expected_main_sha against github.sha/,
+    },
+    {
+      name: 'final artifact upload without workflow SHA recheck',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '          [[ "$EXPECTED_MAIN_SHA" == "$WORKFLOW_SHA" ]] ||\n            fail \'workflow source SHA no longer equals expected_main_sha\'',
+          '          [[ -n "$WORKFLOW_SHA" ]] ||\n            fail \'workflow source SHA no longer equals expected_main_sha\'',
+        ),
+      expected: /artifact upload must recheck the workflow source SHA/,
+    },
+    {
+      name: 'final artifact upload without protected-main workflow ref recheck',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '          [[ "$WORKFLOW_REF" == "$EXPECTED_WORKFLOW_REF" ]] ||\n            fail \'workflow definition is no longer bound to its approved main path\'',
+          '          [[ -n "$WORKFLOW_REF" ]] ||\n            fail \'workflow definition is no longer bound to its approved main path\'',
+        ),
+      expected: /artifact upload must recheck the exact protected-main workflow ref/,
+    },
+    {
+      name: 'final artifact upload without live main recheck',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '          [[ "$(gh api "/repos/$APPROVED_REPOSITORY/git/ref/heads/$DEFAULT_BRANCH" --jq \'.object.sha\')" == "$EXPECTED_MAIN_SHA" ]] ||\n            fail \'main moved before digest artifact upload\'',
+          '          [[ "$EXPECTED_MAIN_SHA" == "$EXPECTED_MAIN_SHA" ]] ||\n            fail \'main moved before digest artifact upload\'',
+        ),
+      expected: /artifact upload must recheck the live main head immediately before upload/,
+    },
+    {
+      name: 'tag claimed as immutable identity',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, 'deployment_identity: "digest-only"', 'deployment_identity: "tag"'),
+      expected: /digests as the sole identity/,
+    },
+    {
+      name: 'unparsed malformed YAML',
+      mutate: (workflow: string) => `${workflow}\n  broken: [\n`,
+      expected: /not valid YAML/,
+    },
+  ])('fails closed after $name', ({ mutate, expected }) => {
+    expect(failuresFor(mutate(publisherWorkflow))).toMatch(expected);
+  });
+
+  it('rejects a privileged contract workflow', () => {
+    const weakened = replaceRequired(
+      contractWorkflow,
+      'permissions:\n  contents: read',
+      'permissions:\n  contents: read\n  packages: write',
+    );
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(/globally contents-read-only|never receive/);
+  });
+
+  it('rejects workflow-level defaults in the contract workflow', () => {
+    const weakened = replaceRequired(
+      contractWorkflow,
+      '\npermissions:\n  contents: read',
+      '\ndefaults:\n  run:\n    shell: bash\n\npermissions:\n  contents: read',
+    );
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(/top-level keys must match.*no defaults|must not define/);
+  });
+
+  it.each([
+    ['ref', 'main'],
+    ['repository', 'attacker/example'],
+    ['path', 'source'],
+    ['token', 'unreviewed-token'],
+  ])('rejects a contract checkout %s override', (inputName, inputValue) => {
+    const weakened = replaceRequired(
+      contractWorkflow,
+      '          persist-credentials: false',
+      `          persist-credentials: false\n          ${inputName}: ${inputValue}`,
+    );
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(/checkout inputs must be exactly/);
+  });
+
+  it('rejects continue-on-error on a contract step', () => {
+    const weakened = replaceRequired(
+      contractWorkflow,
+      '      - name: Verify publisher authority and artifact contracts\n        run:',
+      '      - name: Verify publisher authority and artifact contracts\n        continue-on-error: true\n        run:',
+    );
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(
+      /must not continue on error|exact reviewed parsed structure/,
+    );
+  });
+
+  it('rejects continue-on-error in contract job metadata', () => {
+    const weakened = replaceRequired(
+      contractWorkflow,
+      '    timeout-minutes: 10\n    steps:',
+      '    timeout-minutes: 10\n    continue-on-error: true\n    steps:',
+    );
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(/job metadata must match|failure handling/);
+  });
+
+  it('rejects altered pull-request trigger metadata and paths', () => {
+    const weakened = replaceRequired(
+      contractWorkflow,
+      '  pull_request:\n    paths:',
+      '  pull_request:\n    branches: [main]\n    paths:',
+    );
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(
+      /exact reviewed pull-request and protected-main path triggers/,
+    );
+  });
+
+  it('rejects an altered protected-main trigger path', () => {
+    const weakened = replaceRequired(
+      contractWorkflow,
+      "      - 'docs/postgres-image-publishing.md'",
+      "      - 'docs/unrelated.md'",
+    );
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(
+      /exact reviewed pull-request and protected-main path triggers/,
+    );
+  });
+
+  it('rejects an altered protected-main push branch', () => {
+    const weakened = replaceRequired(contractWorkflow, '    branches: [main]', '    branches: [release]');
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(
+      /exact reviewed pull-request and protected-main path triggers/,
+    );
+  });
+
+  it('rejects an injected contract step through its parsed allowlist', () => {
+    const weakened = replaceRequired(
+      contractWorkflow,
+      '      - name: Verify publisher authority and artifact contracts\n',
+      '      - name: Publish package\n        run: docker push example.invalid/image\n\n      - name: Verify publisher authority and artifact contracts\n',
+    );
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(/exactly its reviewed step allowlist/);
+  });
+
+  it('rejects a manually dispatchable contract workflow', () => {
+    const weakened = replaceRequired(contractWorkflow, '  pull_request:\n', '  workflow_dispatch:\n');
+    expect(failuresFor(publisherWorkflow, weakened)).toMatch(
+      /run only for pull requests and pushes|never receive dispatch/,
+    );
+  });
+});

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -28,6 +28,22 @@ function replaceRequired(source: string, expected: string, replacement: string):
   return source.replace(expected, replacement);
 }
 
+function replaceRequiredInJob(
+  source: string,
+  jobName: string,
+  nextJobName: string,
+  expected: string,
+  replacement: string,
+): string {
+  const jobStart = source.indexOf(`\n  ${jobName}:\n`);
+  const nextJobStart = source.indexOf(`\n  ${nextJobName}:\n`, jobStart + 1);
+  expect(jobStart).toBeGreaterThanOrEqual(0);
+  expect(nextJobStart).toBeGreaterThan(jobStart);
+  const jobSource = source.slice(jobStart, nextJobStart);
+  expect(jobSource).toContain(expected);
+  return source.slice(0, jobStart) + jobSource.replace(expected, replacement) + source.slice(nextJobStart);
+}
+
 describe('trusted PostgreSQL image publisher contract', () => {
   it('keeps the checked-in publisher inside the parsed trust boundary', () => {
     expect(failuresFor()).toBe('');
@@ -161,6 +177,18 @@ describe('trusted PostgreSQL image publisher contract', () => {
       expected: /must fail early when the PostgreSQL 18 contract target is unavailable/,
     },
     {
+      name: 'validate-main timeout widened',
+      mutate: (workflow: string) =>
+        replaceRequiredInJob(
+          workflow,
+          'validate-main',
+          'publish-images',
+          '    timeout-minutes: 30',
+          '    timeout-minutes: 90',
+        ),
+      expected: /validate-main timeout must remain 30 minutes/,
+    },
+    {
       name: 'extra privileged publish step',
       mutate: (workflow: string) =>
         replaceRequired(
@@ -242,6 +270,57 @@ describe('trusted PostgreSQL image publisher contract', () => {
       mutate: (workflow: string) =>
         replaceRequired(workflow, '        platform: [linux/amd64, linux/arm64]', '        platform: [linux/amd64]'),
       expected: /portable smoke matrix must contain exactly linux\/amd64 and linux\/arm64/,
+    },
+    {
+      name: 'portable dependencies installed while registry credentials remain',
+      mutate: (workflow: string) => {
+        const dependencySetup = `      - name: Set up Bun after registry credential removal
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install locked dependencies after registry credential removal
+        run: bun install --frozen-lockfile
+
+`;
+        const withoutDependencySetup = replaceRequiredInJob(
+          workflow,
+          'smoke-portable',
+          'smoke-seeded',
+          dependencySetup,
+          '',
+        );
+        return replaceRequiredInJob(
+          withoutDependencySetup,
+          'smoke-portable',
+          'smoke-seeded',
+          '      - name: Remove registry credentials before image smoke\n',
+          dependencySetup + '      - name: Remove registry credentials before image smoke\n',
+        );
+      },
+      expected: /smoke-portable dependency setup must occur only after registry credentials are removed/,
+    },
+    {
+      name: 'seeded smoke dependencies installed without the lockfile',
+      mutate: (workflow: string) =>
+        replaceRequiredInJob(
+          workflow,
+          'smoke-seeded',
+          'attest-published-digests',
+          '        run: bun install --frozen-lockfile',
+          '        run: bun install',
+        ),
+      expected: /smoke-seeded must install only the reviewed lockfile graph/,
+    },
+    {
+      name: 'unpinned portable smoke Bun setup',
+      mutate: (workflow: string) =>
+        replaceRequiredInJob(
+          workflow,
+          'smoke-portable',
+          'smoke-seeded',
+          'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6',
+          'oven-sh/setup-bun@v2',
+        ),
+      expected: /must use only oven-sh\/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6/,
     },
     {
       name: 'unpinned ORAS action',

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -403,10 +403,32 @@ describe('trusted PostgreSQL image publisher contract', () => {
       expected: /offline build must pull but never push/,
     },
     {
-      name: 'external Dockerfile frontend enabled',
+      name: 'Dockerfile frontend build argument injected',
       mutate: (workflow: string) =>
-        replaceRequired(workflow, 'BUILDKIT_SYNTAX=dockerfile.v0', 'BUILDKIT_SYNTAX=docker/dockerfile:latest'),
-      expected: /force the built-in dockerfile.v0 frontend/,
+        mutateWorkflowStep(
+          workflow,
+          'publish-images',
+          'Build portable OCI layout without registry credentials',
+          (step) => {
+            const withInputs = requireRecord(step.with, 'portable build inputs');
+            withInputs['build-args'] = 'BUILDKIT_SYNTAX=docker/dockerfile:latest\n';
+          },
+        ),
+      expected: /bundled frontend without a build-argument override/,
+    },
+    {
+      name: 'Dockerfile frontend directive revalidation removed',
+      mutate: (workflow: string) =>
+        mutateWorkflowStep(workflow, 'publish-images', 'Revalidate offline build inputs', (step) => {
+          if (typeof step.run !== 'string')
+            throw new Error('offline input revalidation must contain an inline run body');
+          step.run = replaceRequired(
+            step.run,
+            '$found ||= /^[ \\t]*#[ \\t]*syntax[ \\t]*=/i;',
+            '$found ||= /^never-a-dockerfile-directive$/;',
+          );
+        }),
+      expected: /revalidation must reject whitespace-prefixed syntax directives/,
     },
     {
       name: 'wrong seeded build context',
@@ -644,6 +666,16 @@ describe('trusted PostgreSQL image publisher contract', () => {
       /exact reviewed pull-request and protected-main path triggers/,
     );
   });
+
+  it.each(['vite.config.ts', 'scripts/vite.config.ts'])(
+    'rejects omission of test-discovery trigger %s',
+    (configurationPath) => {
+      const weakened = replaceRequired(contractWorkflow, `      - '${configurationPath}'\n`, '');
+      expect(failuresFor(publisherWorkflow, weakened)).toMatch(
+        /exact reviewed pull-request and protected-main path triggers/,
+      );
+    },
+  );
 
   it('rejects an altered protected-main push branch', () => {
     const weakened = replaceRequired(contractWorkflow, '    branches: [main]', '    branches: [release]');

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { parse, stringify } from 'yaml';
 
 import {
   containsDockerfileSyntaxDirective,
@@ -28,20 +29,80 @@ function replaceRequired(source: string, expected: string, replacement: string):
   return source.replace(expected, replacement);
 }
 
-function replaceRequiredInJob(
+type MutableRecord = Record<string, unknown>;
+
+function requireRecord(value: unknown, label: string): MutableRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`Cannot structurally mutate ${label}: expected a YAML mapping`);
+  }
+  return value as MutableRecord;
+}
+
+function mutateWorkflowJob(source: string, jobName: string, mutate: (job: MutableRecord) => void): string {
+  const workflow = requireRecord(parse(source) as unknown, 'workflow root');
+  const jobs = requireRecord(workflow.jobs, 'workflow jobs');
+  const job = requireRecord(jobs[jobName], `workflow job ${jobName}`);
+  mutate(job);
+  return stringify(workflow, { lineWidth: 0 });
+}
+
+function requireJobSteps(job: MutableRecord, jobName: string): MutableRecord[] {
+  if (!Array.isArray(job.steps) || !job.steps.every((step) => typeof step === 'object' && step !== null)) {
+    throw new Error(`Cannot structurally mutate workflow job ${jobName}: expected a steps sequence`);
+  }
+  return job.steps as MutableRecord[];
+}
+
+function requireNamedStep(steps: MutableRecord[], jobName: string, stepName: string): MutableRecord {
+  const matches = steps.filter((step) => step.name === stepName);
+  if (matches.length !== 1) {
+    throw new Error(`Cannot structurally mutate workflow job ${jobName}: expected exactly one ${stepName} step`);
+  }
+  return matches[0];
+}
+
+function mutateWorkflowStep(
   source: string,
   jobName: string,
-  nextJobName: string,
-  expected: string,
-  replacement: string,
+  stepName: string,
+  mutate: (step: MutableRecord) => void,
 ): string {
-  const jobStart = source.indexOf(`\n  ${jobName}:\n`);
-  const nextJobStart = source.indexOf(`\n  ${nextJobName}:\n`, jobStart + 1);
-  expect(jobStart).toBeGreaterThanOrEqual(0);
-  expect(nextJobStart).toBeGreaterThan(jobStart);
-  const jobSource = source.slice(jobStart, nextJobStart);
-  expect(jobSource).toContain(expected);
-  return source.slice(0, jobStart) + jobSource.replace(expected, replacement) + source.slice(nextJobStart);
+  return mutateWorkflowJob(source, jobName, (job) => {
+    mutate(requireNamedStep(requireJobSteps(job, jobName), jobName, stepName));
+  });
+}
+
+function moveWorkflowStepsBefore(
+  source: string,
+  jobName: string,
+  movedStepNames: string[],
+  beforeStepName: string,
+): string {
+  return mutateWorkflowJob(source, jobName, (job) => {
+    const steps = requireJobSteps(job, jobName);
+    const movedSteps = movedStepNames.map((stepName) => requireNamedStep(steps, jobName, stepName));
+    const movedStepNameSet = new Set(movedStepNames);
+    const remainingSteps = steps.filter((step) => !movedStepNameSet.has(String(step.name)));
+    const beforeIndex = remainingSteps.findIndex((step) => step.name === beforeStepName);
+    if (beforeIndex < 0) {
+      throw new Error(`Cannot structurally mutate workflow job ${jobName}: missing ${beforeStepName} step`);
+    }
+    remainingSteps.splice(beforeIndex, 0, ...movedSteps);
+    job.steps = remainingSteps;
+  });
+}
+
+function removeWorkflowNeed(source: string, jobName: string, removedNeed: string): string {
+  return mutateWorkflowJob(source, jobName, (job) => {
+    if (!Array.isArray(job.needs) || !job.needs.every((need) => typeof need === 'string')) {
+      throw new Error(`Cannot structurally mutate workflow job ${jobName}: expected a string needs sequence`);
+    }
+    const matchingNeeds = job.needs.filter((need) => need === removedNeed);
+    if (matchingNeeds.length !== 1) {
+      throw new Error(`Cannot structurally mutate workflow job ${jobName}: expected exactly one ${removedNeed} need`);
+    }
+    job.needs = job.needs.filter((need) => need !== removedNeed);
+  });
 }
 
 describe('trusted PostgreSQL image publisher contract', () => {
@@ -56,6 +117,7 @@ describe('trusted PostgreSQL image publisher contract', () => {
     '\uFEFF# syntax=evil.example/frontend:latest',
     '\uFEFF \t#  SYNTAX = evil.example/frontend@sha256:abc',
     'FROM postgres:18\n  # syntax=evil.example/frontend:latest',
+    'FROM postgres:18\r\n\t# syntax = evil.example/frontend:windows\r\nRUN true\r\n',
   ])('recognizes whitespace- and BOM-prefixed Dockerfile frontend directive %j', (dockerfile) => {
     expect(containsDockerfileSyntaxDirective(dockerfile)).toBe(true);
   });
@@ -179,13 +241,10 @@ describe('trusted PostgreSQL image publisher contract', () => {
     {
       name: 'validate-main timeout widened',
       mutate: (workflow: string) =>
-        replaceRequiredInJob(
-          workflow,
-          'validate-main',
-          'publish-images',
-          '    timeout-minutes: 30',
-          '    timeout-minutes: 90',
-        ),
+        mutateWorkflowJob(workflow, 'validate-main', (job) => {
+          if (job['timeout-minutes'] !== 30) throw new Error('validate-main must start with a 30-minute timeout');
+          job['timeout-minutes'] = 90;
+        }),
       expected: /validate-main timeout must remain 30 minutes/,
     },
     {
@@ -220,29 +279,20 @@ describe('trusted PostgreSQL image publisher contract', () => {
     },
     {
       name: 'package write on the recorder',
-      mutate: (workflow: string) => {
-        const recordStart = workflow.indexOf('\n  record-published-digests:\n');
-        expect(recordStart).toBeGreaterThan(0);
-        const prefix = workflow.slice(0, recordStart);
-        const record = workflow
-          .slice(recordStart)
-          .replace('      contents: read\n', '      contents: read\n      packages: write\n');
-        return prefix + record;
-      },
+      mutate: (workflow: string) =>
+        mutateWorkflowJob(workflow, 'record-published-digests', (job) => {
+          const permissions = requireRecord(job.permissions, 'record-published-digests permissions');
+          permissions.packages = 'write';
+        }),
       expected: /record-published-digests permissions must match/,
     },
     {
       name: 'OIDC on the build job',
-      mutate: (workflow: string) => {
-        const publishStart = workflow.indexOf('\n  publish-images:\n');
-        const verifyStart = workflow.indexOf('\n  verify-published-images:\n');
-        expect(publishStart).toBeGreaterThan(0);
-        expect(verifyStart).toBeGreaterThan(publishStart);
-        const publish = workflow
-          .slice(publishStart, verifyStart)
-          .replace('      packages: write\n', '      packages: write\n      id-token: write\n');
-        return workflow.slice(0, publishStart) + publish + workflow.slice(verifyStart);
-      },
+      mutate: (workflow: string) =>
+        mutateWorkflowJob(workflow, 'publish-images', (job) => {
+          const permissions = requireRecord(job.permissions, 'publish-images permissions');
+          permissions['id-token'] = 'write';
+        }),
       expected: /publish-images permissions must match/,
     },
     {
@@ -273,71 +323,52 @@ describe('trusted PostgreSQL image publisher contract', () => {
     },
     {
       name: 'portable dependencies installed while registry credentials remain',
-      mutate: (workflow: string) => {
-        const dependencySetup = `      - name: Set up Bun after registry credential removal
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-
-      - name: Install locked dependencies after registry credential removal
-        run: bun install --frozen-lockfile
-
-`;
-        const withoutDependencySetup = replaceRequiredInJob(
+      mutate: (workflow: string) =>
+        moveWorkflowStepsBefore(
           workflow,
           'smoke-portable',
-          'smoke-seeded',
-          dependencySetup,
-          '',
-        );
-        return replaceRequiredInJob(
-          withoutDependencySetup,
-          'smoke-portable',
-          'smoke-seeded',
-          '      - name: Remove registry credentials before image smoke\n',
-          dependencySetup + '      - name: Remove registry credentials before image smoke\n',
-        );
-      },
+          [
+            'Set up Bun after registry credential removal',
+            'Install locked dependencies after registry credential removal',
+          ],
+          'Remove registry credentials before image smoke',
+        ),
       expected: /smoke-portable tool and dependency setup must occur only after registry credentials are removed/,
     },
     {
       name: 'portable Vite+ setup runs while registry credentials remain',
-      mutate: (workflow: string) => {
-        const viteSetup = `      - name: Set up Vite+
-        uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1
-
-`;
-        const withoutViteSetup = replaceRequiredInJob(workflow, 'smoke-portable', 'smoke-seeded', viteSetup, '');
-        return replaceRequiredInJob(
-          withoutViteSetup,
+      mutate: (workflow: string) =>
+        moveWorkflowStepsBefore(
+          workflow,
           'smoke-portable',
-          'smoke-seeded',
-          '      - name: Remove registry credentials before image smoke\n',
-          viteSetup + '      - name: Remove registry credentials before image smoke\n',
-        );
-      },
+          ['Set up Vite+'],
+          'Remove registry credentials before image smoke',
+        ),
       expected: /smoke-portable tool and dependency setup must occur only after registry credentials are removed/,
     },
     {
       name: 'seeded smoke dependencies installed without the lockfile',
       mutate: (workflow: string) =>
-        replaceRequiredInJob(
+        mutateWorkflowStep(
           workflow,
           'smoke-seeded',
-          'attest-published-digests',
-          '        run: bun install --frozen-lockfile',
-          '        run: bun install',
+          'Install locked dependencies after registry credential removal',
+          (step) => {
+            if (step.run !== 'bun install --frozen-lockfile') throw new Error('seeded smoke install must be frozen');
+            step.run = 'bun install';
+          },
         ),
       expected: /smoke-seeded must install only the reviewed lockfile graph/,
     },
     {
       name: 'unpinned portable smoke Bun setup',
       mutate: (workflow: string) =>
-        replaceRequiredInJob(
-          workflow,
-          'smoke-portable',
-          'smoke-seeded',
-          'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6',
-          'oven-sh/setup-bun@v2',
-        ),
+        mutateWorkflowStep(workflow, 'smoke-portable', 'Set up Bun after registry credential removal', (step) => {
+          if (step.uses !== 'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6') {
+            throw new Error('portable smoke Bun setup must start at its reviewed pin');
+          }
+          step.uses = 'oven-sh/setup-bun@v2';
+        }),
       expected: /must use only oven-sh\/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6/,
     },
     {
@@ -477,7 +508,12 @@ describe('trusted PostgreSQL image publisher contract', () => {
     },
     {
       name: 'digest artifact before attestation verification',
-      mutate: (workflow: string) => replaceRequired(workflow, '      - verify-attestations\n', ''),
+      mutate: (workflow: string) => removeWorkflowNeed(workflow, 'record-published-digests', 'verify-attestations'),
+      expected: /record-published-digests dependencies must match/,
+    },
+    {
+      name: 'digest artifact without direct current-main authorization dependency',
+      mutate: (workflow: string) => removeWorkflowNeed(workflow, 'record-published-digests', 'authorize-current-main'),
       expected: /record-published-digests dependencies must match/,
     },
     {

--- a/scripts/postgres-image-publisher-contract.test.ts
+++ b/scripts/postgres-image-publisher-contract.test.ts
@@ -151,6 +151,16 @@ describe('trusted PostgreSQL image publisher contract', () => {
       expected: /checkout must use only expected_main_sha/,
     },
     {
+      name: 'missing early PostgreSQL 18 contract prerequisite',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          `grep -Fq "'test:postgres18-contract': {" source/vite.config.ts`,
+          `grep -Fq "'different-target': {" source/vite.config.ts`,
+        ),
+      expected: /must fail early when the PostgreSQL 18 contract target is unavailable/,
+    },
+    {
       name: 'extra privileged publish step',
       mutate: (workflow: string) =>
         replaceRequired(
@@ -228,6 +238,12 @@ describe('trusted PostgreSQL image publisher contract', () => {
       expected: /digest-pinned ARM64 helper/,
     },
     {
+      name: 'ARM64 removed from portable smoke matrix',
+      mutate: (workflow: string) =>
+        replaceRequired(workflow, '        platform: [linux/amd64, linux/arm64]', '        platform: [linux/amd64]'),
+      expected: /portable smoke matrix must contain exactly linux\/amd64 and linux\/arm64/,
+    },
+    {
       name: 'unpinned ORAS action',
       mutate: (workflow: string) =>
         replaceRequired(
@@ -278,7 +294,22 @@ describe('trusted PostgreSQL image publisher contract', () => {
           '      - name: Validate offline layouts and retired digest policy',
           '      - name: Validate layouts after registry login',
         ),
-      expected: /publish-images step 9 must be Validate offline layouts and retired digest policy/,
+      expected: /publish-images step 10 must be Validate offline layouts and retired digest policy/,
+    },
+    {
+      name: 'missing or blank retired-digest configuration accepted before build',
+      mutate: (workflow: string) => replaceRequired(workflow, '[[ "$RETIRED_DIGESTS" =~ [^[:space:]] ]] ||', 'true ||'),
+      expected: /retired digest configuration must reject missing or blank values before build setup/,
+    },
+    {
+      name: 'explicit none sentinel no longer recognized',
+      mutate: (workflow: string) =>
+        replaceRequired(
+          workflow,
+          '[[ "$RETIRED_DIGESTS" == \'none\' ]] && exit 0',
+          '[[ -z "$RETIRED_DIGESTS" ]] && exit 0',
+        ),
+      expected: /retired digest configuration must require the explicit none sentinel/,
     },
     {
       name: 'retired digest format accepted loosely',


### PR DESCRIPTION
## Summary

- add a protected-main, manual PostgreSQL image publisher that accepts only the exact current `main` commit
- build portable and seeded OCI images before registry authentication, reject retired digests before publication, and make immutable digests the consumer identity
- verify both native provenance attestations before emitting the schema-versioned digest handoff
- add a parsed-YAML contract suite that freezes workflow permissions, environments, step order, action inputs, and privileged command bodies
- document the producer A → publish → consumer B rollout and the required GitHub environment policy

## Why

The PostgreSQL 18 rollout needs immutable image digests before CI, local development, Railway, and homelab consumers can be updated. Publishing from feature-branch workflow code would put unmerged Dockerfiles inside the registry credential boundary. This prerequisite keeps publication controlled by reviewed code already on protected `main`.

## Validation

- publisher contract tests: 82/82
- focused `vp check`
- full `vp run typecheck`
- frozen dependency install
- workflow YAML parsing
- `bash -n` and ShellCheck on every inline script
- independent frozen-diff release review: no P0/P1/P2 findings
- rebased onto `main` at `beda6c54`; gates re-run after the rebase

## Review follow-ups

Both open threads are addressed and independently re-reviewed:

- **P1 — invalid Dockerfile frontend override.** `BUILDKIT_SYNTAX` selects a frontend *image*; `dockerfile.v0` is BuildKit's internal identifier, so both builds would have failed resolving the frontend. The override is gone from both build steps, and the pinned daemon now uses its bundled frontend. Two independent runtime checks still reject a `# syntax=` directive — the unprivileged `validate-main` check and the offline revalidation immediately before the builds — both BOM- and whitespace-tolerant. The parsed contract now rejects *any* `build-args` on either build and pins both revalidation patterns, with mutation coverage for each.
- **P2 — contract path triggers.** `vite.config.ts` and `scripts/vite.config.ts` are now in the trigger list and in `CONTRACT_PATHS`, with a mutation test per file asserting removal is rejected.

## Rollout prerequisite — done

The `postgres-image-publisher` environment now exists: required reviewer `marcodejongh`, administrator bypass **off**, custom deployment branch policy containing exactly `main`. `RETIRED_DB_IMAGE_DIGESTS` is set to the sentinel `none`. Both were verified against the workflow's own jq predicates before this PR was marked ready.

### Accepted risk: self-review permitted

The environment audit previously required `prevent_self_review == true`. Boardsesh has one maintainer, a GitHub App cannot be an environment reviewer, and a team needs a second human — so that setting would leave nobody able to approve a dispatch. All three audits (`authorize-current-main`, and the re-checks inside `publish-images` and `attest-published-digests`) now require the field to be **present and boolean** rather than `true`, so a missing or reshaped API field still fails closed.

Unchanged: exact live-main binding, admin bypass off, main-only deployment policy, `reviewers | length > 0`, no candidate code inside the credential boundary, verified provenance attestations. The mutation test is retained against the new clause, so deleting the check outright is still caught. The uncovered case is compromise of the maintainer account specifically; any other account still cannot publish. `docs/postgres-image-publishing.md` records the tradeoff and the condition for reverting it — flipping the setting back to `true` needs no code change.

## Release Notes

none

