### PR TITLE
feat(shared): use rocódromo for every Spanish gym string

### DIFF
--- a/docs/i18n-spanish-glossary.md
+++ b/docs/i18n-spanish-glossary.md
@@ -32,25 +32,38 @@ Fix the surrounding grammar when you swap the word — articles and adjectives h
 - **`aurora.card.boardSuffix` = `"Board"`** in `settings.json`. It renders as `{boardName} Board` → "Kilter Board" / "Tension Board", so it must stay English.
 - **JSON keys** (`board`, `boardTypeLabel`, `boardsTitle`, …) and **ICU placeholders** (`{{board}}`, which interpolates a board's name). Only translate values.
 
+## The gym is a **rocódromo**
+
+Every gym in Boardsesh is a climbing gym, so the word is always **`rocódromo`** — never `gimnasio`, which is the generic fitness gym. There is no conditional: if a Spanish string names the place where the wall lives, it says rocódromo.
+
+- Masculine, like `gimnasio`, so articles and adjectives stay put: **el** rocódromo, **un** rocódromo, **del/al** rocódromo, **este** rocódromo.
+- Plural: **rocódromos** (los rocódromos, tus rocódromos).
+- Capitalise it the same way the old word was capitalised: sentence-initial `Gimnasio` → `Rocódromo`.
+
+Two things it does **not** touch:
+
+- **URLs, slugs and email examples drop the accent** — `hola@rocodromo.com`, `https://turocodromo.com`, `tu-rocodromo`. Accented characters do not belong in a placeholder someone is meant to type into a URL or address field.
+- **`plafón` is a different word.** The board is the plafón, the building is the rocódromo. A find/replace that turns one into the other is a bug — `gym-term-consistency.test.ts` guards both directions.
+
 ## Other climbing terms
 
 These are already used consistently in the catalogs — keep using them so we don't drift.
 
-| English                 | Spanish                            |
-| ----------------------- | ---------------------------------- |
-| hold                    | presa                              |
-| climb / boulder problem | bloque                             |
-| route                   | vía                                |
-| send (logged ascent)    | encadene                           |
-| attempt                 | intento                            |
-| wall                    | muro                               |
-| gym                     | gimnasio (climbing gym: rocódromo) |
-| angle                   | ángulo                             |
-| grade                   | grado                              |
-| session                 | sesión                             |
-| queue                   | cola                               |
-| climber                 | escalador / escaladora             |
-| Party Mode              | Modo Fiesta                        |
+| English                 | Spanish                |
+| ----------------------- | ---------------------- |
+| hold                    | presa                  |
+| climb / boulder problem | bloque                 |
+| route                   | vía                    |
+| send (logged ascent)    | encadene               |
+| attempt                 | intento                |
+| wall                    | muro                   |
+| gym                     | rocódromo              |
+| angle                   | ángulo                 |
+| grade                   | grado                  |
+| session                 | sesión                 |
+| queue                   | cola                   |
+| climber                 | escalador / escaladora |
+| Party Mode              | Modo Fiesta            |
 
 Kept in English by convention (technical board-config terms): **layout**, **set / sets**, **logbook**, **setter**, **beta**.
 

--- a/marketing/outreach/sharma-gyms-email.md
+++ b/marketing/outreach/sharma-gyms-email.md
@@ -86,7 +86,7 @@ Puedes ver la aplicación y probarla en boardsesh.com
 - Turnos sin preguntas del tipo «¿quién es el siguiente?»: una cola compartida en los teléfonos de todos, para que la rotación se gestione sola.
 - Escalad juntos en tiempo real: el «Modo Grupo» comparte una sesión entre los teléfonos; la siguiente vía se ilumina para quien esté en el rocódromo.
 - Traslada tu Logbook de escalada desde Kilter: migración en un solo paso, sin perder el historial.
-- Crea una lista de proyectos antes de llegar: organiza tus proyectos en casa y envíalos al gimnasio.
+- Crea una lista de proyectos antes de llegar: organiza tus proyectos en casa y envíalos al rocódromo.
 - Un solo inicio de sesión para todas: Kilter, Tension, MoonBoard y más en camino.
 - Es gratis, sin anuncios, y sin pagos. Además, puede ser selfhosted si alguien quiere gestionar su propia instancia.
 

--- a/packages/shared/i18n/locales/es/admin.json
+++ b/packages/shared/i18n/locales/es/admin.json
@@ -18,7 +18,7 @@
   "tabs": {
     "roles": "Roles",
     "settings": "Ajustes",
-    "gyms": "Gimnasios"
+    "gyms": "Rocódromos"
   },
   "roles": {
     "heading": "Roles de la comunidad",
@@ -120,24 +120,24 @@
     }
   },
   "gymSettings": {
-    "heading": "Ajustes de gimnasios",
+    "heading": "Ajustes de rocódromos",
     "autoApprove": {
       "label": "Aprobar reclamaciones automáticamente",
-      "description": "Entrega los gimnasios sin dueño a quien los reclame. Las reclamaciones sobre un gimnasio que ya tiene dueño te siguen llegando a ti.",
+      "description": "Entrega los rocódromos sin dueño a quien los reclame. Las reclamaciones sobre un rocódromo que ya tiene dueño te siguen llegando a ti.",
       "queueNote": "Las reclamaciones que ya están en la cola se quedan ahí."
     },
     "snackbar": {
       "enabled": "Aprobación automática activada.",
       "disabled": "Aprobación automática desactivada.",
       "saveFailed": "No se pudo guardar. Inténtalo de nuevo.",
-      "loadFailed": "No se pudieron cargar los ajustes de gimnasios."
+      "loadFailed": "No se pudieron cargar los ajustes de rocódromos."
     }
   },
   "nav": {
     "retention": "Panel de retención",
-    "gymClaims": "Reclamaciones de gimnasios",
+    "gymClaims": "Reclamaciones de rocódromos",
     "feedback": "Reportes de errores",
-    "gymDuplicates": "Gimnasios duplicados",
+    "gymDuplicates": "Rocódromos duplicados",
     "locationSync": "Bloqueos de sincronización de ubicaciones"
   },
   "feedback": {
@@ -235,7 +235,7 @@
     }
   },
   "gymClaims": {
-    "title": "Reclamaciones de gimnasios",
+    "title": "Reclamaciones de rocódromos",
     "backToAdmin": "Volver al panel",
     "heading": "Reclamaciones pendientes",
     "empty": "No hay reclamaciones pendientes",
@@ -254,7 +254,7 @@
     },
     "table": {
       "claimant": "Solicitante",
-      "gym": "Gimnasio",
+      "gym": "Rocódromo",
       "method": "Método",
       "detail": "Detalle",
       "date": "Fecha",
@@ -268,7 +268,7 @@
     "intro": "Libera una edición manual solo cuando la ficha original deba volver a prevalecer. Esto no ejecuta una sincronización; la próxima actualización de una fuente coincidente puede reemplazar detalles o recuperar una ficha eliminada.",
     "tabs": {
       "label": "Tipo de ficha",
-      "gyms": "Gimnasios",
+      "gyms": "Rocódromos",
       "boards": "Plafones"
     },
     "search": {
@@ -304,8 +304,8 @@
       "title": "¿Liberar este bloqueo de sincronización?",
       "body": "La próxima sincronización de ubicación coincidente podrá actualizar {{name}} de nuevo. Revisa los avisos y registra por qué se libera el bloqueo.",
       "deletedWarning": "Esta ficha está eliminada. Una fuente coincidente puede recuperarla en la próxima sincronización.",
-      "ownerProtectedWarning": "Este gimnasio tiene propietario o una reclamación aprobada. La protección de propiedad sigue activa después de liberar el bloqueo.",
-      "noSourceWarning": "Ahora mismo no hay ninguna fuente de sincronización vinculada a este gimnasio. Liberar el bloqueo no tendrá efecto hasta que coincida una fuente.",
+      "ownerProtectedWarning": "Este rocódromo tiene propietario o una reclamación aprobada. La protección de propiedad sigue activa después de liberar el bloqueo.",
+      "noSourceWarning": "Ahora mismo no hay ninguna fuente de sincronización vinculada a este rocódromo. Liberar el bloqueo no tendrá efecto hasta que coincida una fuente.",
       "moonBoardWarning": "Las sincronizaciones de ubicaciones de MoonBoard se lanzan a mano, no siguen ninguna programación. Tras liberar el bloqueo, los cambios de la fuente se aplicarán cuando alguien lance la siguiente sincronización de ubicaciones de MoonBoard.",
       "reasonLabel": "Motivo",
       "reasonPlaceholder": "¿Por qué deben volver a prevalecer los datos originales?",
@@ -322,7 +322,7 @@
     }
   },
   "gymDuplicates": {
-    "title": "Gimnasios duplicados",
+    "title": "Rocódromos duplicados",
     "backToAdmin": "Volver al panel",
     "heading": "Cola de revisión de duplicados",
     "tabs": {
@@ -348,17 +348,17 @@
     "merge": "Fusionar",
     "dismiss": "No es un duplicado",
     "confirm": {
-      "title": "¿Fusionar estos gimnasios?",
-      "body": "Esto une {{count}} gimnasios duplicados en {{canonical}} y le mueve {{boards}} plafones, {{follows}} seguidores, {{members}} miembros, {{kiosks}} kioscos y {{claims}} reclamaciones. No se puede deshacer.",
+      "title": "¿Fusionar estos rocódromos?",
+      "body": "Esto une {{count}} rocódromos duplicados en {{canonical}} y le mueve {{boards}} plafones, {{follows}} seguidores, {{members}} miembros, {{kiosks}} kioscos y {{claims}} reclamaciones. No se puede deshacer.",
       "cancel": "Cancelar",
       "confirm": "Fusionar",
-      "overrideWarning": "Atención: vas a conservar una ficha del sistema como superviviente frente a un gimnasio que alguien posee o ha reclamado. Su gimnasio se fusionará con el del sistema. Hazlo solo si la ficha del sistema es realmente la correcta.",
+      "overrideWarning": "Atención: vas a conservar una ficha del sistema como superviviente frente a un rocódromo que alguien posee o ha reclamado. Su rocódromo se fusionará con el del sistema. Hazlo solo si la ficha del sistema es realmente la correcta.",
       "confirmOverride": "Fusionar de todos modos"
     },
     "kioskWarning": "El kiosco «{{name}}» pasó de /{{previous}} a /{{next}}",
     "snackbar": {
-      "merged": "Gimnasios fusionados",
-      "mergeFailed": "No se pudieron fusionar los gimnasios",
+      "merged": "Rocódromos fusionados",
+      "mergeFailed": "No se pudieron fusionar los rocódromos",
       "dismissed": "Marcado como no duplicado",
       "dismissFailed": "No se pudo descartar el grupo"
     },
@@ -367,14 +367,14 @@
     "retry": "Reintentar",
     "loadMore": "Cargar más",
     "orphans": {
-      "summary": "{{count}} gimnasios del sistema sin fuente de sincronización de ubicación",
-      "empty": "No hay gimnasios huérfanos",
-      "name": "Gimnasio",
+      "summary": "{{count}} rocódromos del sistema sin fuente de sincronización de ubicación",
+      "empty": "No hay rocódromos huérfanos",
+      "name": "Rocódromo",
       "address": "Dirección",
       "counts": "Totales"
     },
     "ownerReports": {
-      "note": "Los propietarios ahora pueden señalar duplicados desde la página de su gimnasio. Por ahora esos reportes llegan por correo al equipo, así que revisa la bandeja junto a esta cola."
+      "note": "Los propietarios ahora pueden señalar duplicados desde la página de su rocódromo. Por ahora esos reportes llegan por correo al equipo, así que revisa la bandeja junto a esta cola."
     }
   }
 }

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -24,32 +24,32 @@
       }
     },
     "gymEdit": {
-      "screenTitle": "Editar gimnasio",
+      "screenTitle": "Editar rocódromo",
       "save": "Guardar cambios",
       "updateError": "No se pudieron guardar los cambios. Inténtalo de nuevo.",
-      "updateSuccess": "Gimnasio actualizado",
-      "notFound": "No encontramos ese gimnasio",
-      "noAccess": "No tienes permiso para editar este gimnasio",
+      "updateSuccess": "Rocódromo actualizado",
+      "notFound": "No encontramos ese rocódromo",
+      "noAccess": "No tienes permiso para editar este rocódromo",
       "back": "Volver",
       "name": "Nombre",
-      "namePlaceholder": "Nombre del gimnasio",
+      "namePlaceholder": "Nombre del rocódromo",
       "description": "Descripción",
       "descriptionPlaceholder": "Cuéntales a los escaladores qué hay en el muro",
       "address": "Dirección",
       "addressPlaceholder": "Calle, ciudad",
       "contactEmail": "Correo de contacto",
-      "contactEmailPlaceholder": "hola@gimnasio.com",
+      "contactEmailPlaceholder": "hola@rocodromo.com",
       "contactPhone": "Teléfono de contacto",
       "contactPhonePlaceholder": "Número de teléfono",
       "latitude": "Latitud",
       "longitude": "Longitud",
       "coordinatePlaceholder": "Grados decimales",
       "invalidCoordinate": "Introduce una coordenada válida",
-      "public": "Gimnasio público",
+      "public": "Rocódromo público",
       "publicHint": "Muéstralo en el mapa para que los escaladores lo encuentren",
       "website": "Sitio web",
-      "websitePlaceholder": "https://tugimnasio.com",
-      "websiteHint": "Lo usamos para verificar la propiedad cuando alguien reclama el gimnasio"
+      "websitePlaceholder": "https://turocodromo.com",
+      "websiteHint": "Lo usamos para verificar la propiedad cuando alguien reclama el rocódromo"
     },
     "manage": {
       "ownedHeader": "Tus plafones",
@@ -83,7 +83,7 @@
       "nearbyShowing": "Mostrando cercanos",
       "yourBoardsTitle": "Tus plafones",
       "popularTitle": "Configuraciones populares",
-      "findGym": "Buscar gimnasio",
+      "findGym": "Buscar rocódromo",
       "create": "Crear plafón",
       "followed": "{{name}} añadido a tus plafones",
       "followError": "No se pudo añadir {{name}} a tus plafones"
@@ -100,7 +100,7 @@
       "unlisted": "No listado",
       "hideLocation": "Ocultar ubicación exacta",
       "location": "Ubicación",
-      "locationPlaceholder": "Casa, nombre del gimnasio o ciudad",
+      "locationPlaceholder": "Casa, nombre del rocódromo o ciudad",
       "useMyLocation": "Usar mi ubicación",
       "serial": "Número de serie del controlador",
       "serialPlaceholder": "p. ej. ABC-12345",
@@ -114,8 +114,8 @@
       "timerPairCta": "Vincular temporizador",
       "timerChangeCta": "Cambiar temporizador",
       "timerRemoveCta": "Quitar",
-      "gym": "Gimnasio",
-      "gymNone": "No está en un gimnasio",
+      "gym": "Rocódromo",
+      "gymNone": "No está en un rocódromo",
       "clearLocation": "Borrar ubicación",
       "duplicate": {
         "title": "Ya tienes esta configuración",
@@ -123,7 +123,7 @@
         "bodyWithLocation": "Ya tienes «{{name}}» en {{location}}, con el mismo layout, tamaño y sets de presas.",
         "useExisting": "Usar ese plafón",
         "addAnother": "Añadir un plafón nuevo aquí",
-        "addAnotherHint": "Elige esto si es otro muro: otro gimnasio, otra sala.",
+        "addAnotherHint": "Elige esto si es otro muro: otro rocódromo, otra sala.",
         "cancel": "Seguir editando",
         "switchError": "No se pudo cambiar a ese plafón. Inténtalo de nuevo."
       }
@@ -166,38 +166,38 @@
       "cancel": "Ahora no"
     },
     "gyms": {
-      "title": "Gimnasios cerca de ti",
-      "subtitle": "Toca un gimnasio para usar su plafón",
-      "locationNeeded": "Comparte tu ubicación para encontrar gimnasios cerca",
+      "title": "Rocódromos cerca de ti",
+      "subtitle": "Toca un rocódromo para usar su plafón",
+      "locationNeeded": "Comparte tu ubicación para encontrar rocódromos cerca",
       "grantLocation": "Usar mi ubicación",
-      "empty": "Aún no hay gimnasios cerca",
+      "empty": "Aún no hay rocódromos cerca",
       "noBoards": "Aún no hay plafones aquí",
       "boardCount_one": "{{count}} plafón",
       "boardCount_other": "{{count}} plafones",
-      "searchPlaceholder": "Busca una ciudad, gimnasio o plafón",
+      "searchPlaceholder": "Busca una ciudad, rocódromo o plafón",
       "showingPlace": "Mostrando {{place}}",
       "clearSearch": "Borrar búsqueda",
       "closeMap": "Cerrar",
       "otherBoardsTitle": "Plafones cercanos",
       "multiBoardChip": "2+ tipos de plafón",
-      "editGym": "Editar gimnasio",
+      "editGym": "Editar rocódromo",
       "editBoard": "Editar plafón"
     },
     "myGyms": {
-      "moreRowTitle": "Mis gimnasios",
-      "moreRowSubtitle": "Entra a tus gimnasios y ajusta sus datos",
-      "screenTitle": "Mis gimnasios",
-      "loadError": "No pudimos cargar tus gimnasios. Inténtalo de nuevo.",
+      "moreRowTitle": "Mis rocódromos",
+      "moreRowSubtitle": "Entra a tus rocódromos y ajusta sus datos",
+      "screenTitle": "Mis rocódromos",
+      "loadError": "No pudimos cargar tus rocódromos. Inténtalo de nuevo.",
       "retry": "Reintentar",
-      "emptyTitle": "Aún no tienes gimnasios",
-      "emptyBody": "Reclama tu gimnasio para mantener sus plafones y datos al día.",
-      "findGym": "Buscar tu gimnasio",
+      "emptyTitle": "Aún no tienes rocódromos",
+      "emptyBody": "Reclama tu rocódromo para mantener sus plafones y datos al día.",
+      "findGym": "Buscar tu rocódromo",
       "kioskHint": "La configuración del kiosco vive en la pantalla grande: ábrela en un navegador para preparar tus TVs.",
       "kioskHintDismiss": "Entendido",
       "manageKiosks": "Gestionar kioscos y TVs",
       "manageKiosksFor": "Gestionar kioscos y TVs de {{gym}}",
       "manageError": "No se pudo abrir la consola de gestión. Ábrela en un navegador.",
-      "manageUnavailable": "Este gimnasio aún no está listo para kioscos.",
+      "manageUnavailable": "Este rocódromo aún no está listo para kioscos.",
       "roleOwner": "Propietario",
       "noAddress": "Sin dirección todavía"
     },
@@ -210,7 +210,7 @@
     },
     "gymGrant": {
       "sectionTitle": "Acceso de edición",
-      "description": "Permite que escaladores de confianza editen los detalles de este gimnasio. No podrán eliminarlo ni gestionar a los miembros.",
+      "description": "Permite que escaladores de confianza editen los detalles de este rocódromo. No podrán eliminarlo ni gestionar a los miembros.",
       "searchLabel": "Buscar escaladores",
       "searchPlaceholder": "Buscar por nombre",
       "clearSearch": "Borrar búsqueda",
@@ -236,9 +236,9 @@
       "title": "Reclamar {{gym}}",
       "close": "Cerrar",
       "done": "Listo",
-      "sectionTitle": "¿Es tuyo este gimnasio?",
+      "sectionTitle": "¿Es tuyo este rocódromo?",
       "sectionDescription": "Reclámalo para mantener la ficha y los plafones al día.",
-      "claimAction": "Reclamar este gimnasio",
+      "claimAction": "Reclamar este rocódromo",
       "errorGeneric": "Algo salió mal. Inténtalo de nuevo.",
       "switchToAdmin": "¿No tienes un correo de trabajo? Solicita una revisión",
       "switchToDomain": "Verificar con un correo de trabajo",
@@ -252,14 +252,14 @@
       "admin": {
         "description": "Dinos que gestionas {{gym}} y nuestro equipo revisará tu solicitud.",
         "messageLabel": "Mensaje (opcional)",
-        "messagePlaceholder": "Cualquier cosa que nos ayude a verificar que gestionas este gimnasio",
+        "messagePlaceholder": "Cualquier cosa que nos ayude a verificar que gestionas este rocódromo",
         "submit": "Solicitar revisión",
         "sent": "Hemos avisado a nuestro equipo. Se pondrán en contacto pronto."
       },
       "approved": {
         "sent": "{{gym}} ya es tuyo.",
-        "manageCta": "Configura tu gimnasio",
-        "manageError": "No se pudo abrir la configuración del gimnasio. Ábrela en un navegador."
+        "manageCta": "Configura tu rocódromo",
+        "manageError": "No se pudo abrir la configuración del rocódromo. Ábrela en un navegador."
       }
     },
     "offline": {
@@ -320,14 +320,14 @@
     },
     "gymPicker": {
       "title": "¿Dónde está este plafón?",
-      "subtitle": "Elige el gimnasio donde está para que los escaladores lo encuentren en el mapa.",
-      "searchPlaceholder": "Buscar gimnasios",
-      "noGym": "No está en un gimnasio",
+      "subtitle": "Elige el rocódromo donde está para que los escaladores lo encuentren en el mapa.",
+      "searchPlaceholder": "Buscar rocódromos",
+      "noGym": "No está en un rocódromo",
       "noGymHint": "Seguirá apareciendo en el mapa con su propio marcador.",
-      "addNew": "Mi gimnasio no aparece",
-      "empty": "No hay gimnasios cerca",
-      "sharedEditHint": "El personal de este gimnasio podrá editar los datos de este plafón.",
-      "linkError": "No se pudo vincular ese gimnasio. Puede estar demasiado lejos de tu plafón. El resto de cambios sí se guardaron."
+      "addNew": "Mi rocódromo no aparece",
+      "empty": "No hay rocódromos cerca",
+      "sharedEditHint": "El personal de este rocódromo podrá editar los datos de este plafón.",
+      "linkError": "No se pudo vincular ese rocódromo. Puede estar demasiado lejos de tu plafón. El resto de cambios sí se guardaron."
     }
   },
   "boardEntity": {
@@ -341,7 +341,7 @@
       "comments": "Comentarios"
     },
     "actions": {
-      "addToGym": "Añadir al gimnasio",
+      "addToGym": "Añadir al rocódromo",
       "edit": "Editar",
       "delete": "Eliminar"
     },
@@ -360,9 +360,9 @@
     "snackbar": {
       "deleted": "Plafón eliminado",
       "deleteFailed": "Error al eliminar el plafón",
-      "linkedToGym": "Plafón vinculado al gimnasio",
-      "unlinkedFromGym": "Plafón desvinculado del gimnasio",
-      "linkFailed": "Error al vincular el plafón al gimnasio"
+      "linkedToGym": "Plafón vinculado al rocódromo",
+      "unlinkedFromGym": "Plafón desvinculado del rocódromo",
+      "linkFailed": "Error al vincular el plafón al rocódromo"
     },
     "comments": {
       "title": "Discusión del plafón"
@@ -437,11 +437,11 @@
     }
   },
   "editGym": {
-    "title": "Editar gimnasio",
+    "title": "Editar rocódromo",
     "submitLabel": "Guardar cambios",
     "snackbar": {
-      "updated": "¡Gimnasio actualizado!",
-      "updateFailed": "Error al actualizar el gimnasio"
+      "updated": "¡Rocódromo actualizado!",
+      "updateFailed": "Error al actualizar el rocódromo"
     }
   },
   "mapLocationPicker": {
@@ -476,7 +476,7 @@
     "pinchToZoom": "Pellizca para hacer zoom"
   },
   "gymMemberManagement": {
-    "removeConfirm": "¿Quitar a este miembro del gimnasio?",
+    "removeConfirm": "¿Quitar a este miembro del rocódromo?",
     "empty": "Aún no hay miembros",
     "unknownUser": "Usuario desconocido",
     "loadMore": "Ver más ({{count}} de {{total}})",
@@ -493,7 +493,7 @@
     "roleHelp": {
       "title": "Qué puede hacer cada rol",
       "admin": "Los administradores gestionan todo, incluidos los plafones, los kioscos, la marca y el personal.",
-      "editor": "Los editores pueden cambiar el gimnasio, los plafones y los kioscos, pero no eliminarlo ni gestionar al personal.",
+      "editor": "Los editores pueden cambiar el rocódromo, los plafones y los kioscos, pero no eliminarlo ni gestionar al personal.",
       "member": "Los miembros forman parte del equipo y no pueden editar nada."
     },
     "grant": {
@@ -507,7 +507,7 @@
       },
       "dialog": {
         "title": "Dar acceso de edición",
-        "description": "Busca a un escalador para que edite los detalles de este gimnasio. No podrá eliminarlo ni gestionar miembros.",
+        "description": "Busca a un escalador para que edite los detalles de este rocódromo. No podrá eliminarlo ni gestionar miembros.",
         "searchLabel": "Buscar escaladores",
         "searchPlaceholder": "Buscar por nombre",
         "change": "Cambiar",
@@ -517,23 +517,23 @@
     }
   },
   "gymSelector": {
-    "loading": "Cargando gimnasios...",
-    "linkToGym": "Vincular a un gimnasio",
-    "noGym": "Sin gimnasio",
+    "loading": "Cargando rocódromos...",
+    "linkToGym": "Vincular a un rocódromo",
+    "noGym": "Sin rocódromo",
     "createNew": "Crear nuevo"
   },
   "similarGyms": {
-    "heading": "Parece que tu gimnasio ya está aquí",
+    "heading": "Parece que tu rocódromo ya está aquí",
     "subtitle": "Reclama el tuyo para gestionarlo, o añade uno nuevo abajo.",
     "distanceMeters": "a {{meters}} m",
     "distanceKm": "a {{km}} km",
     "providerBadge": "Desde {{provider}}",
-    "viewGym": "Ver el gimnasio",
-    "claim": "Este es mi gimnasio: reclamarlo",
-    "createAnyway": "¿Ninguno es el tuyo? Añade tu gimnasio con el botón de abajo."
+    "viewGym": "Ver el rocódromo",
+    "claim": "Este es mi rocódromo: reclamarlo",
+    "createAnyway": "¿Ninguno es el tuyo? Añade tu rocódromo con el botón de abajo."
   },
   "gymEntity": {
-    "notFound": "Gimnasio no encontrado",
+    "notFound": "Rocódromo no encontrado",
     "tabs": {
       "members": "Miembros",
       "comments": "Comentarios"
@@ -550,31 +550,31 @@
       "comments": "comentarios"
     },
     "delete": {
-      "title": "Eliminar gimnasio",
+      "title": "Eliminar rocódromo",
       "confirm": "¿Eliminar \"{{name}}\"? No se puede deshacer.",
       "cancel": "Cancelar",
       "delete": "Eliminar"
     },
     "snackbar": {
-      "deleted": "Gimnasio eliminado",
-      "deleteFailed": "Error al eliminar el gimnasio"
+      "deleted": "Rocódromo eliminado",
+      "deleteFailed": "Error al eliminar el rocódromo"
     },
     "comments": {
-      "title": "Discusión del gimnasio"
+      "title": "Discusión del rocódromo"
     },
     "follow": {
-      "entityLabel": "gimnasio"
+      "entityLabel": "rocódromo"
     }
   },
   "gymForm": {
     "fields": {
-      "name": "Nombre del gimnasio",
+      "name": "Nombre del rocódromo",
       "slug": "URL personalizada",
       "description": "Descripción",
       "address": "Dirección",
       "contactEmail": "Correo de contacto",
       "contactPhone": "Teléfono de contacto",
-      "isPublic": "Gimnasio público",
+      "isPublic": "Rocódromo público",
       "website": "Sitio web"
     },
     "placeholders": {
@@ -583,21 +583,21 @@
       "address": "p. ej., Calle Mayor 123, Ciudad",
       "contactEmail": "Correo de contacto opcional",
       "contactPhone": "Teléfono de contacto opcional",
-      "website": "p. ej., https://tugimnasio.com"
+      "website": "p. ej., https://turocodromo.com"
     },
     "actions": {
       "cancel": "Cancelar"
     },
     "create": {
-      "title": "Crear gimnasio",
-      "submit": "Crear gimnasio",
-      "authRequired": "Debes iniciar sesión para crear un gimnasio",
-      "errorMessage": "Error al crear el gimnasio",
-      "nameRequired": "Se requiere el nombre del gimnasio",
-      "createdNamed": "¡Gimnasio \"{{name}}\" creado!"
+      "title": "Crear rocódromo",
+      "submit": "Crear rocódromo",
+      "authRequired": "Debes iniciar sesión para crear un rocódromo",
+      "errorMessage": "Error al crear el rocódromo",
+      "nameRequired": "Se requiere el nombre del rocódromo",
+      "createdNamed": "¡Rocódromo \"{{name}}\" creado!"
     },
     "helpers": {
-      "website": "Se usa para verificar la propiedad cuando alguien reclama este gimnasio"
+      "website": "Se usa para verificar la propiedad cuando alguien reclama este rocódromo"
     }
   },
   "claimGym": {
@@ -615,31 +615,31 @@
       "emailPlaceholder": "tu@{{domain}}",
       "submit": "Enviar correo de verificación",
       "sent": "Revisa tu bandeja en {{email}} y haz clic en el enlace para terminar.",
-      "mismatch": "Ese correo no es de {{domain}}. Usa una dirección del dominio del sitio web del gimnasio, o solicita una revisión."
+      "mismatch": "Ese correo no es de {{domain}}. Usa una dirección del dominio del sitio web del rocódromo, o solicita una revisión."
     },
     "admin": {
       "description": "Dinos que gestionas {{gym}} y nuestro equipo revisará tu solicitud.",
       "messageLabel": "Mensaje (opcional)",
-      "messagePlaceholder": "Cualquier cosa que nos ayude a verificar que gestionas este gimnasio",
+      "messagePlaceholder": "Cualquier cosa que nos ayude a verificar que gestionas este rocódromo",
       "submit": "Solicitar revisión",
       "sent": "Hemos avisado a nuestro equipo. Se pondrán en contacto pronto."
     },
     "approved": {
       "body": "{{gym}} es tuyo. Configúralo cuando quieras.",
-      "manageCta": "Configura tu gimnasio"
+      "manageCta": "Configura tu rocódromo"
     }
   },
   "claimLanding": {
     "backHome": "Volver a Boardsesh",
     "success": {
-      "title": "El gimnasio es tuyo",
+      "title": "El rocódromo es tuyo",
       "body": "Ahora eres el propietario. Mantén la ficha y los plafones al día, e invita a tu grupo a ayudar.",
-      "setupCta": "Configura tu gimnasio"
+      "setupCta": "Configura tu rocódromo"
     },
     "error": {
       "title": "Ese enlace no funcionó",
       "reasons": {
-        "invalid": "Este enlace de reclamación no es válido. Vuelve a iniciar la reclamación desde el gimnasio.",
+        "invalid": "Este enlace de reclamación no es válido. Vuelve a iniciar la reclamación desde el rocódromo.",
         "expired": "Este enlace ha caducado. Vuelve a iniciar la reclamación para obtener uno nuevo.",
         "used": "Este enlace ya se ha usado.",
         "serverError": "Algo salió mal por nuestra parte. Inténtalo de nuevo en un momento."
@@ -651,10 +651,10 @@
     "title": "Reportar un duplicado",
     "description": "¿Aparece {{gym}} dos veces? Señálanos el otro listado y los fusionamos.",
     "searchLabel": "Encuentra el listado duplicado",
-    "searchPlaceholder": "Nombre del gimnasio",
+    "searchPlaceholder": "Nombre del rocódromo",
     "noResults": "Aún no hay coincidencias. Prueba con otro nombre.",
     "noteLabel": "¿Algo más? (opcional)",
-    "notePlaceholder": "Qué te hace pensar que es el mismo gimnasio",
+    "notePlaceholder": "Qué te hace pensar que es el mismo rocódromo",
     "submit": "Enviar reporte",
     "cancel": "Cancelar",
     "done": "Listo",

--- a/packages/shared/i18n/locales/es/feed.json
+++ b/packages/shared/i18n/locales/es/feed.json
@@ -24,7 +24,7 @@
       "scope": {
         "myCrew": "Mi crew",
         "everyone": "Todos",
-        "findGym": "Busca un gimnasio cerca",
+        "findGym": "Busca un rocódromo cerca",
         "hint": "Cambia de quién ves las vías"
       }
     }

--- a/packages/shared/i18n/locales/es/marketing.json
+++ b/packages/shared/i18n/locales/es/marketing.json
@@ -56,7 +56,7 @@
       "discordDescription": "Comparte beta, reporta fallos y ayuda a decidir qué viene"
     },
     "gymCard": {
-      "ownerSubtitle": "El gimnasio de tu equipo, a un toque",
+      "ownerSubtitle": "El rocódromo de tu equipo, a un toque",
       "manage": "Gestionar",
       "viewPage": "Ver página"
     },

--- a/packages/shared/i18n/locales/es/notifications.json
+++ b/packages/shared/i18n/locales/es/notifications.json
@@ -27,7 +27,7 @@
     "newClimbsSyncedSetter": "{{setter}} montó nuevos bloques",
     "newClimbsSynced": "{{actor}} montó nuevos bloques",
     "gymClaimApproved": "Ahora gestionas {{gym}}",
-    "gymClaimApprovedGeneric": "Ya eres el propietario: se aprobó tu reclamación del gimnasio",
+    "gymClaimApprovedGeneric": "Ya eres el propietario: se aprobó tu reclamación del rocódromo",
     "default": "Tienes una nueva notificación"
   },
   "errors": {

--- a/packages/shared/i18n/src/__tests__/gym-term-consistency.test.ts
+++ b/packages/shared/i18n/src/__tests__/gym-term-consistency.test.ts
@@ -32,6 +32,19 @@ const SLUG_EXAMPLE_KEY_PATHS = new Set([
 // The board is a `plafón`, the gym is a `rocódromo`. A sloppy find/replace in
 // either direction eats one of them; pin the board term so we notice.
 const BOARD_TERM = 'plafón';
+// Floor, not an exact count: 188 Spanish strings say `plafón` today. A bare
+// "at least one" assertion would survive a replace that ate 187 of them — which
+// is precisely the accident being guarded against — so hold a floor just under
+// today's number. Ordinary copy churn stays green; a sweep goes red. Raise this
+// if the catalogs grow; never lower it to turn a red test green.
+const BOARD_TERM_FLOOR = 180;
+
+// Remove URLs and email addresses from a token so the accent check can look at
+// what is left. `rocodromo` is correct inside an address someone types; anywhere
+// else it is a dropped accent.
+function withoutAddresses(token: string): string {
+  return token.replace(/https?:\/\/\S+/gi, ' ').replace(/\S+@\S+/g, ' ');
+}
 
 type CatalogEntry = { file: string; keyPath: string; value: string };
 
@@ -86,8 +99,10 @@ describe('Spanish gym terminology', () => {
       .flatMap((entry) =>
         entry.value
           .split(/\s+/)
-          .filter((token) => UNACCENTED_TERM.test(token))
-          .filter((token) => !token.includes('@') && !token.includes('://'))
+          // Exempt only the address itself, not the whole token it sits in:
+          // stripping the URL/email first means a genuine missing accent glued to
+          // one — "https://x.com/tu-rocodromo,rocodromo" — is still caught.
+          .filter((token) => UNACCENTED_TERM.test(withoutAddresses(token)))
           .map((token) => `${entry.file}:${entry.keyPath} — ${token}`),
       );
 
@@ -104,7 +119,10 @@ describe('Spanish gym terminology', () => {
 
   it('still calls the board a plafón', () => {
     const boardTermUses = spanishStrings.filter((entry) => entry.value.includes(BOARD_TERM));
-    expect(boardTermUses.length).toBeGreaterThan(0);
+    expect(
+      boardTermUses.length,
+      `Spanish catalogs say "${BOARD_TERM}" in only ${boardTermUses.length} strings, below the floor of ${BOARD_TERM_FLOOR}. A find/replace on the gym term has probably eaten the board term too.`,
+    ).toBeGreaterThanOrEqual(BOARD_TERM_FLOOR);
   });
 
   it('pins the gym term on the strings that drifted', () => {

--- a/packages/shared/i18n/src/__tests__/gym-term-consistency.test.ts
+++ b/packages/shared/i18n/src/__tests__/gym-term-consistency.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const LOCALES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'locales');
+const SPANISH_DIR = join(LOCALES_DIR, 'es');
+
+// Spanish has one word for the place the wall lives: `rocódromo`. `gimnasio` is
+// the generic fitness gym and read wrong to climbers, so every catalog was swept
+// in one pass — this test is what stops the split coming back one string at a
+// time. See docs/i18n-spanish-glossary.md.
+//
+// The regex is deliberately the bare stem `gimnasi`, which also catches
+// `gimnasia` (gymnastics). That is safe today: `gimnasia` appears nowhere in the
+// catalogs, and Boardsesh has no gymnastics copy to write. If a legitimate
+// gymnastics string ever lands, exclude that key path explicitly rather than
+// loosening the stem — the whole point is that `gimnasio`/`gimnasios` can never
+// slip through.
+const BANNED_GYM_TERM = /gimnasi/i;
+
+// `rocódromo` carries an accent in prose. Accented characters do not belong in a
+// value someone is meant to type into a URL or an address field, so email, URL
+// and slug placeholders use the bare `rocodromo`. Anything else unaccented is a
+// missing accent, not an example.
+const UNACCENTED_TERM = /rocodromo/i;
+const SLUG_EXAMPLE_KEY_PATHS = new Set([
+  // "tu-rocodromo" — the URL-slug placeholder on the kiosk setup screen.
+  'kiosk.json:manage.slugGuard.placeholder',
+]);
+
+// The board is a `plafón`, the gym is a `rocódromo`. A sloppy find/replace in
+// either direction eats one of them; pin the board term so we notice.
+const BOARD_TERM = 'plafón';
+
+type CatalogEntry = { file: string; keyPath: string; value: string };
+
+function collectStrings(node: unknown, prefix: string, file: string, into: CatalogEntry[]): void {
+  if (typeof node === 'string') {
+    into.push({ file, keyPath: prefix, value: node });
+    return;
+  }
+  if (node === null || typeof node !== 'object') return;
+  for (const [key, child] of Object.entries(node)) {
+    collectStrings(child, prefix ? `${prefix}.${key}` : key, file, into);
+  }
+}
+
+function loadSpanishStrings(): CatalogEntry[] {
+  const entries: CatalogEntry[] = [];
+  for (const file of readdirSync(SPANISH_DIR).filter((name) => name.endsWith('.json'))) {
+    const catalog: unknown = JSON.parse(readFileSync(join(SPANISH_DIR, file), 'utf8'));
+    collectStrings(catalog, '', file, entries);
+  }
+  return entries;
+}
+
+const spanishStrings = loadSpanishStrings();
+
+describe('Spanish gym terminology', () => {
+  it('loads the Spanish catalogs', () => {
+    expect(spanishStrings.length).toBeGreaterThan(0);
+  });
+
+  it('never says gimnasio', () => {
+    const offenders = spanishStrings
+      .filter((entry) => BANNED_GYM_TERM.test(entry.value))
+      .map((entry) => `${entry.file}:${entry.keyPath} — ${entry.value}`);
+
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ''
+        : [
+            `${offenders.length} Spanish string(s) still say "gimnasio". Boardsesh gyms are climbing gyms:`,
+            'use "rocódromo" (masculine, plural "rocódromos"). See docs/i18n-spanish-glossary.md.',
+            ...offenders.map((offender) => `  - ${offender}`),
+          ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('only drops the accent in email, URL and slug examples', () => {
+    const offenders = spanishStrings
+      .filter((entry) => UNACCENTED_TERM.test(entry.value))
+      .filter((entry) => !SLUG_EXAMPLE_KEY_PATHS.has(`${entry.file}:${entry.keyPath}`))
+      .flatMap((entry) =>
+        entry.value
+          .split(/\s+/)
+          .filter((token) => UNACCENTED_TERM.test(token))
+          .filter((token) => !token.includes('@') && !token.includes('://'))
+          .map((token) => `${entry.file}:${entry.keyPath} — ${token}`),
+      );
+
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ''
+        : [
+            'Unaccented "rocodromo" outside an email, URL or slug example — prose needs the accent:',
+            ...offenders.map((offender) => `  - ${offender}`),
+          ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('still calls the board a plafón', () => {
+    const boardTermUses = spanishStrings.filter((entry) => entry.value.includes(BOARD_TERM));
+    expect(boardTermUses.length).toBeGreaterThan(0);
+  });
+
+  it('pins the gym term on the strings that drifted', () => {
+    const byPath = new Map(spanishStrings.map((entry) => [`${entry.file}:${entry.keyPath}`, entry.value]));
+
+    expect(byPath.get('boards.json:gymEntity.follow.entityLabel')).toBe('rocódromo');
+    expect(byPath.get('kiosk.json:gymPage.claimTitle')).toBe('¿Es tuyo este rocódromo?');
+  });
+});

--- a/packages/web/app/legal/legal-content.tsx
+++ b/packages/web/app/legal/legal-content.tsx
@@ -184,7 +184,7 @@ export default function LegalContent() {
                 <Typography variant="body1" component="p">
                   <strong>{t('legal.dmca.contactLabel')}</strong>{' '}
                   {/* i18n-ignore-next-line -- contact email, not translated */}
-                  <MuiLink href="mailto:legal@mdj.ac">legal@mdj.ac</MuiLink>
+                  <MuiLink href="mailto:legal@boardsesh.com">legal@boardsesh.com</MuiLink>
                 </Typography>
               </section>
 


### PR DESCRIPTION
Part of #3672 (part 1 of 2) · Part of epic #4372, Tier 1.

Spanish called the same thing two different words. `kiosk.json` said **rocódromo** — the climbing gym — while `boards.json`, `admin.json`, `notifications.json`, `marketing.json` and `feed.json` said **gimnasio**, which is a treadmills-and-dumbbells gym. Both words appear on the same screen today: the gym page renders its claim call-out from `kiosk` and its follow button and comments header from `boards`.

This sweeps all of them to rocódromo so a Spanish-speaking climber reads one word everywhere.

## What changed

- 108 values across five `locales/es/` catalogs. Done by hand, not by find-and-replace — plurals, sentence-initial capitalisation and the URL/email examples each needed different handling.
- URL, email and slug examples keep the **unaccented** `rocodromo`: `hola@rocodromo.com`, `https://turocodromo.com`.
- `docs/i18n-spanish-glossary.md` now states the term unconditionally. It previously read "gimnasio (climbing gym: rocódromo)", which is what let the split open in the first place — every Boardsesh gym is a climbing gym, so there is no case where gimnasio is right.
- New `gym-term-consistency.test.ts` fails on any `gimnasi*` string in `locales/es/`, on a missing accent outside a URL/email example, and on `plafón` disappearing from the catalogs (the guard against a sloppy replace eating the board term).
- Unrelated but asked for: the `/legal` DMCA contact now points at `legal@boardsesh.com` instead of `legal@mdj.ac`.

## Values only

No key, placeholder or count changes — verified by snapshotting all 3,680 `file + keyPath + [placeholders]` triples before and after and diffing them. So `catalog-completeness.test.ts` and the mobile namespace-subset check are untouched by construction, not by luck.

## This changes mobile copy too

`MOBILE_NAMESPACES` includes `boards`, `notifications` and `feed` — three of the five catalogs here ship to the React Native app. Spanish strings in the mobile app change as a result of this web-labelled PR. It is a JSON-only change, so it is not a native fingerprint input and rides an OTA; no rebuild needed.

## Release Notes

En español, un gimnasio ahora es un rocódromo en toda la app — una sola palabra en cada pantalla, en vez de dos.
