### PR TITLE
feat(web): fire the gym funnel events from the surfaces that own them

### DIFF
--- a/docs/gym-funnel-analytics.md
+++ b/docs/gym-funnel-analytics.md
@@ -9,25 +9,43 @@ Source of truth: `packages/shared/analytics/src/gym-funnel.ts`, re-exported from
 
 ## How to fire an event
 
-Never write the event name as a string literal. Import the builder, hand its
-return value to `track`:
+Never write the event name as a string literal, and never destructure the
+builder. Hand its whole return value to `trackGymFunnelEvent`:
 
 ```ts
 import { gymClaimCtaClicked } from '@boardsesh/analytics';
-import { track } from '@/app/lib/analytics';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
 
-const { name, properties } = gymClaimCtaClicked({
-  placement: 'gym-page',
-  viewerState: 'signed-out',
-  gymUuid: gym.uuid,
-});
-track(name, properties);
+trackGymFunnelEvent(
+  gymClaimCtaClicked({
+    placement: 'gym-page',
+    viewerState,
+    gymUuid: gym.uuid,
+  }),
+);
 ```
 
 Builders return the name and its properties **together** so a caller cannot pair
 one event's props with another event's name. That is the failure a bare name
 constant still allows, and it is invisible in PostHog until someone reads the
-funnel.
+funnel. `trackGymFunnelEvent` (`packages/web/app/lib/gym-funnel-analytics.ts`)
+is the only web call path that keeps the pairing intact end to end — pulling
+`{ name, properties }` apart and calling `track()` yourself splits them back
+into two arguments, which is the exact thing the builder exists to prevent.
+
+### `viewerState` must come from a settled session
+
+Pass a value that has already resolved: a server-read auth token, or
+`useWsAuthToken().isAuthenticated`, whose query is gated on
+`status !== 'loading'`. **Never** derive it from `useSession().status` in a
+client island. `SessionProviderWrapper` mounts `<SessionProvider>` with no
+`session` prop, so next-auth starts every page load at `loading` and settles
+only after a round-trip to `/api/auth/session`. A server-rendered page paints
+and hydrates first, so a tap that beats the round-trip — a QR poster scanned on
+a phone is precisely that — would report a signed-in climber as `signed-out`.
+`GymClaimViewerState` has no `loading` member on purpose, and one must not be
+added: it would encode the hydration race as vocabulary instead of keeping it
+out of the data.
 
 ## Why this is not in `SHARED_EVENTS`
 
@@ -53,7 +71,7 @@ no mobile counterpart. They live in their own module.
 | Property       | Values                                                                                   |
 | -------------- | ---------------------------------------------------------------------------------------- |
 | `placement`    | `gym-page`, `preview-sheet`, `directory-card`, `similar-gyms`                            |
-| `viewerState`  | `signed-in`, `signed-out`                                                                |
+| `viewerState`  | `signed-in`, `signed-out` — `signed-out` is 0 by construction today, see below           |
 | `method`       | `domain`, `admin` — mirrors the `GymClaimMethod` GraphQL enum                            |
 | `status`       | `email_sent`, `approved`, `admin_review`, `error`                                        |
 | `medium`       | `poster`, `kiosk`, `board` — only `poster` can fire today, see below                     |
@@ -69,6 +87,27 @@ no mobile counterpart. They live in their own module.
 `app/gym/[gym_slug]/manage/manage-gym-content.tsx`. It is restated rather than
 imported because a shared package must never depend on `packages/web`; adding a
 tab there without adding it here is a compile error at the call site.
+
+### `viewerState: signed-out` is 0 by construction — do not read it as an answer
+
+**Read this before using `Gym Claim CTA Clicked` to answer H4** ("does a visible
+self-serve claim CTA convert unclaimed gyms"). Every claim entry point that
+exists today is gated on an authenticated viewer, so a signed-out climber is
+never shown a claim CTA and can never fire the event:
+
+- `app/gym/[gym_slug]/page.tsx` renders the call-out only when `gym.canClaim`,
+  and the resolver computes `canClaim = !!authenticatedUserId && …`
+  (`packages/backend/src/graphql/resolvers/social/gyms.ts`).
+- `app/components/gym-entity/gym-detail.tsx` gates on the same `canClaim`.
+- `app/components/gym-entity/similar-gym-suggestions.tsx` gates on
+  `gym.isClaimable`, which `computeClaimableFlags` only computes for an
+  authenticated viewer (`…/social/gym-matching.ts`).
+
+So the property is a constant `signed-in` in production. A `signed-out` split of
+0% is the gate working, **not** evidence about how signed-out climbers behave —
+H4 cannot be answered from this event until #3672 ships a CTA anonymous visitors
+can see. The property is wired end to end anyway so that PR is a server-side
+one-line change rather than a re-instrumentation.
 
 ## Two rules that are easy to break
 

--- a/packages/web/app/__tests__/home-page-content.test.tsx
+++ b/packages/web/app/__tests__/home-page-content.test.tsx
@@ -122,10 +122,12 @@ describe('HomePageContent', () => {
       fireEvent.click(button);
 
       expect(openSpy).toHaveBeenCalledWith(IOS_APP_STORE_URL, '_blank', 'noopener,noreferrer');
-      expect(mockTrack).toHaveBeenCalledWith(
-        'App Install Click',
-        expect.objectContaining({ platform: 'ios', source: 'app-store', placement: 'hero', mode: 'install' }),
-      );
+      expect(mockTrack).toHaveBeenCalledWith('App Install Click', {
+        platform: 'ios',
+        source: 'app-store',
+        placement: 'hero',
+        mode: 'install',
+      });
       // The hero no longer starts a sesh, and nothing on this page navigates
       // imperatively any more — every destination is an anchor.
       expect(mockPush).not.toHaveBeenCalled();
@@ -139,10 +141,12 @@ describe('HomePageContent', () => {
       fireEvent.click(button);
 
       expect(openSpy).toHaveBeenCalledWith(ANDROID_PLAY_STORE_URL, '_blank', 'noopener,noreferrer');
-      expect(mockTrack).toHaveBeenCalledWith(
-        'App Install Click',
-        expect.objectContaining({ platform: 'android', source: 'google-play', placement: 'hero', mode: 'install' }),
-      );
+      expect(mockTrack).toHaveBeenCalledWith('App Install Click', {
+        platform: 'android',
+        source: 'google-play',
+        placement: 'hero',
+        mode: 'install',
+      });
     });
 
     it('shows an update CTA for a retired iOS native app, pointed at the App Store', async () => {
@@ -154,10 +158,12 @@ describe('HomePageContent', () => {
       fireEvent.click(button);
 
       expect(openSpy).toHaveBeenCalledWith(IOS_APP_STORE_URL, '_blank', 'noopener,noreferrer');
-      expect(mockTrack).toHaveBeenCalledWith(
-        'App Install Click',
-        expect.objectContaining({ platform: 'ios', source: 'app-store', placement: 'hero', mode: 'update' }),
-      );
+      expect(mockTrack).toHaveBeenCalledWith('App Install Click', {
+        platform: 'ios',
+        source: 'app-store',
+        placement: 'hero',
+        mode: 'update',
+      });
     });
 
     it('shows an update CTA for a retired Android native app, pointed at Google Play', async () => {
@@ -169,10 +175,12 @@ describe('HomePageContent', () => {
       fireEvent.click(button);
 
       expect(openSpy).toHaveBeenCalledWith(ANDROID_PLAY_STORE_URL, '_blank', 'noopener,noreferrer');
-      expect(mockTrack).toHaveBeenCalledWith(
-        'App Install Click',
-        expect.objectContaining({ platform: 'android', source: 'google-play', placement: 'hero', mode: 'update' }),
-      );
+      expect(mockTrack).toHaveBeenCalledWith('App Install Click', {
+        platform: 'android',
+        source: 'google-play',
+        placement: 'hero',
+        mode: 'update',
+      });
     });
   });
 

--- a/packages/web/app/components/capacitor-retirement/capacitor-retirement-screen.tsx
+++ b/packages/web/app/components/capacitor-retirement/capacitor-retirement-screen.tsx
@@ -9,6 +9,7 @@ import { getPlatform } from '@/app/lib/ble/capacitor-utils';
 import { openExternalUrl } from '@/app/lib/open-external-url';
 import { storeHttpsUrlForPlatform, storeSchemeUrlForPlatform } from '@/app/lib/store-urls';
 import { track } from '@/app/lib/analytics';
+import { APP_INSTALL_CLICK_EVENT, buildAppInstallClickProperties } from '@/app/lib/app-install-event';
 import styles from './capacitor-retirement-screen.module.css';
 
 /**
@@ -21,7 +22,7 @@ export const CapacitorRetirementScreen: React.FC = () => {
 
   const openStoreApp = useCallback(() => {
     const platform = getPlatform();
-    track('App Install Click', { platform, source: 'capacitor-retirement' });
+    track(APP_INSTALL_CLICK_EVENT, buildAppInstallClickProperties({ platform, source: 'capacitor-retirement' }));
     // Scheme URL lands in the real App Store / Play Store app rather than an
     // in-WebView listing page — same hand-off requestInAppReview() uses.
     openExternalUrl(storeSchemeUrlForPlatform(platform));
@@ -31,7 +32,10 @@ export const CapacitorRetirementScreen: React.FC = () => {
   // out of a blocking screen, so offer the plain https listing too.
   const openStorePage = useCallback(() => {
     const platform = getPlatform();
-    track('App Install Click', { platform, source: 'capacitor-retirement-fallback' });
+    track(
+      APP_INSTALL_CLICK_EVENT,
+      buildAppInstallClickProperties({ platform, source: 'capacitor-retirement-fallback' }),
+    );
     openExternalUrl(storeHttpsUrlForPlatform(platform));
   }, []);
 

--- a/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-analytics.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-analytics.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), replace: vi.fn() }),
+}));
+
+const mockRequest = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent }));
+
+const ClaimGymDialog = (await import('../claim-gym-dialog')).default;
+
+const renderAdminDialog = (gymUuid = 'gym-uuid-1') =>
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <ClaimGymDialog gymUuid={gymUuid} gymName="Bonsist" website={null} open onClose={vi.fn()} />
+    </QueryClientProvider>,
+  );
+
+const submitAdminClaim = async () => {
+  fireEvent.click(await screen.findByText('Request review'));
+};
+
+const eventsNamed = (name: string) =>
+  trackGymFunnelEvent.mock.calls
+    .map(([event]) => event as { name: string; properties: Record<string, unknown> })
+    .filter((event) => event.name === name);
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  trackGymFunnelEvent.mockReset();
+});
+
+describe('ClaimGymDialog — submit event', () => {
+  it('reports the admin path from what was actually sent', async () => {
+    mockRequest.mockResolvedValueOnce({ requestGymClaim: { status: 'admin_review', email: null } });
+
+    renderAdminDialog();
+    await submitAdminClaim();
+
+    await waitFor(() => expect(eventsNamed('Gym Claim Submitted')).toHaveLength(1));
+    expect(eventsNamed('Gym Claim Submitted')[0].properties).toEqual({ method: 'admin', gymUuid: 'gym-uuid-1' });
+  });
+
+  it('reports the domain path when a claim email goes on the wire', async () => {
+    mockRequest.mockResolvedValueOnce({ requestGymClaim: { status: 'email_sent', email: 'owner@bonsist.com' } });
+
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <ClaimGymDialog
+          gymUuid="gym-uuid-domain"
+          gymName="Bonsist"
+          website="https://bonsist.com"
+          open
+          onClose={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(await screen.findByLabelText('Work email'), { target: { value: 'owner@bonsist.com' } });
+    fireEvent.click(screen.getByText('Send verification email'));
+
+    await waitFor(() => expect(eventsNamed('Gym Claim Submitted')).toHaveLength(1));
+    expect(eventsNamed('Gym Claim Submitted')[0].properties).toEqual({ method: 'domain', gymUuid: 'gym-uuid-domain' });
+  });
+});
+
+describe('ClaimGymDialog — result event', () => {
+  it('reports email_sent', async () => {
+    mockRequest.mockResolvedValueOnce({ requestGymClaim: { status: 'email_sent', email: 'owner@bonsist.com' } });
+
+    renderAdminDialog();
+    await submitAdminClaim();
+
+    await waitFor(() => expect(eventsNamed('Gym Claim Result')).toHaveLength(1));
+    expect(eventsNamed('Gym Claim Result')[0].properties).toEqual({ status: 'email_sent', gymUuid: 'gym-uuid-1' });
+  });
+
+  it('reports approved', async () => {
+    mockRequest.mockResolvedValueOnce({ requestGymClaim: { status: 'approved', email: null } });
+
+    renderAdminDialog();
+    await submitAdminClaim();
+
+    await waitFor(() => expect(eventsNamed('Gym Claim Result')).toHaveLength(1));
+    expect(eventsNamed('Gym Claim Result')[0].properties).toEqual({ status: 'approved', gymUuid: 'gym-uuid-1' });
+  });
+
+  it('reports admin_review — the backend spelling, not #4374’s admin_sent', async () => {
+    mockRequest.mockResolvedValueOnce({ requestGymClaim: { status: 'admin_review', email: null } });
+
+    renderAdminDialog();
+    await submitAdminClaim();
+
+    await waitFor(() => expect(eventsNamed('Gym Claim Result')).toHaveLength(1));
+    expect(eventsNamed('Gym Claim Result')[0].properties).toEqual({ status: 'admin_review', gymUuid: 'gym-uuid-1' });
+  });
+
+  it('reports error when the mutation throws', async () => {
+    mockRequest.mockRejectedValueOnce(new Error('network down'));
+
+    renderAdminDialog();
+    await submitAdminClaim();
+
+    await waitFor(() => expect(eventsNamed('Gym Claim Result')).toHaveLength(1));
+    expect(eventsNamed('Gym Claim Result')[0].properties).toEqual({ status: 'error', gymUuid: 'gym-uuid-1' });
+  });
+});
+
+describe('ClaimGymDialog — reuse across gyms', () => {
+  it('reports the gym currently in props, not the one the dialog last showed', async () => {
+    // One dialog instance is reused across gyms (see the re-init effect in the
+    // component). Reading the uuid from state captured at mount would attribute
+    // the second gym's claim to the first.
+    mockRequest.mockResolvedValue({ requestGymClaim: { status: 'admin_review', email: null } });
+
+    const { rerender } = render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <ClaimGymDialog gymUuid="first-gym" gymName="First" website={null} open onClose={vi.fn()} />
+      </QueryClientProvider>,
+    );
+    await submitAdminClaim();
+    await waitFor(() => expect(eventsNamed('Gym Claim Submitted')).toHaveLength(1));
+
+    rerender(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <ClaimGymDialog gymUuid="second-gym" gymName="Second" website={null} open={false} onClose={vi.fn()} />
+      </QueryClientProvider>,
+    );
+    rerender(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <ClaimGymDialog gymUuid="second-gym" gymName="Second" website={null} open onClose={vi.fn()} />
+      </QueryClientProvider>,
+    );
+    await submitAdminClaim();
+
+    await waitFor(() => expect(eventsNamed('Gym Claim Submitted')).toHaveLength(2));
+    expect(eventsNamed('Gym Claim Submitted').map((event) => event.properties.gymUuid)).toEqual([
+      'first-gym',
+      'second-gym',
+    ]);
+    expect(eventsNamed('Gym Claim Result').map((event) => event.properties.gymUuid)).toEqual([
+      'first-gym',
+      'second-gym',
+    ]);
+  });
+});

--- a/packages/web/app/components/gym-entity/__tests__/gym-detail.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/gym-detail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
 import type { Gym } from '@boardsesh/shared-schema';
@@ -49,6 +49,12 @@ vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({ request: mockRequest }),
 }));
 
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({
+  trackGymFunnelEvent,
+  viewerStateFrom: (isAuthenticated: boolean) => (isAuthenticated ? 'signed-in' : 'signed-out'),
+}));
+
 function makeGym(overrides: Partial<Gym> = {}): Gym {
   return {
     uuid: 'gym-uuid-1',
@@ -87,5 +93,29 @@ describe('GymDetail header link', () => {
 
     expect(await screen.findByText('Test Gym')).toBeTruthy();
     expect(screen.queryByRole('link', { name: 'Test Gym' })).toBeNull();
+  });
+});
+
+describe('GymDetail claim CTA analytics', () => {
+  it('reports the claim CTA click under the preview-sheet placement', async () => {
+    mockRequest.mockResolvedValue({ gym: makeGym({ canClaim: true }) });
+    render(<GymDetail gymUuid="gym-uuid-1" open onClose={vi.fn()} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Claim' }));
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Claim CTA Clicked',
+      properties: { placement: 'preview-sheet', viewerState: 'signed-in', gymUuid: 'gym-uuid-1' },
+    });
+  });
+
+  it('reports nothing when the gym cannot be claimed and the CTA is absent', async () => {
+    mockRequest.mockResolvedValue({ gym: makeGym({ canClaim: false }) });
+    render(<GymDetail gymUuid="gym-uuid-1" open onClose={vi.fn()} />);
+
+    await screen.findByText('Test Gym');
+    expect(screen.queryByRole('button', { name: 'Claim' })).toBeNull();
+    expect(trackGymFunnelEvent).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
@@ -21,6 +21,12 @@ vi.mock('@/app/hooks/use-ws-auth-token', () => ({
   useWsAuthToken: () => ({ token: 'test-token' }),
 }));
 
+// Read for the `viewerState` on the claim CTA event; useSession() throws
+// outside a SessionProvider.
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'viewer-1' } }, status: 'authenticated' }),
+}));
+
 const mockRequest = vi.fn();
 vi.mock('@/app/lib/graphql/client', () => ({
   createGraphQLHttpClient: () => ({ request: mockRequest }),

--- a/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/similar-gym-suggestions.test.tsx
@@ -18,13 +18,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/app/hooks/use-ws-auth-token', () => ({
-  useWsAuthToken: () => ({ token: 'test-token' }),
-}));
-
-// Read for the `viewerState` on the claim CTA event; useSession() throws
-// outside a SessionProvider.
-vi.mock('next-auth/react', () => ({
-  useSession: () => ({ data: { user: { id: 'viewer-1' } }, status: 'authenticated' }),
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true }),
 }));
 
 const mockRequest = vi.fn();
@@ -34,6 +28,12 @@ vi.mock('@/app/lib/graphql/client', () => ({
 
 vi.mock('@boardsesh/graphql/operations', () => ({
   FIND_SIMILAR_GYMS: 'FIND_SIMILAR_GYMS',
+}));
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({
+  trackGymFunnelEvent,
+  viewerStateFrom: (isAuthenticated: boolean) => (isAuthenticated ? 'signed-in' : 'signed-out'),
 }));
 
 // Stub the claim dialog so we can assert it opens without pulling in its own
@@ -69,6 +69,7 @@ function renderSuggestions(name = 'Bahnhof Bloc') {
 describe('SimilarGymSuggestions', () => {
   beforeEach(() => {
     mockRequest.mockReset();
+    trackGymFunnelEvent.mockReset();
   });
 
   it('renders suggestion cards with distance, provider badge, and view/claim actions', async () => {
@@ -103,6 +104,23 @@ describe('SimilarGymSuggestions', () => {
     fireEvent.click(screen.getByText('similarGyms.claim'));
 
     expect(screen.getByTestId('claim-dialog').textContent).toBe('claiming Bahnhof Bloc');
+  });
+
+  it('reports the claim CTA click under the similar-gyms placement', async () => {
+    mockRequest.mockResolvedValueOnce({ findSimilarGyms: [gymFixture()] });
+
+    renderSuggestions();
+
+    await waitFor(() => expect(screen.getByText('similarGyms.claim')).toBeTruthy(), { timeout: 3000 });
+    fireEvent.click(screen.getByText('similarGyms.claim'));
+
+    // The uuid is the SUGGESTED gym's, not the one being created — this list is
+    // the create-gym form's duplicate check.
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Claim CTA Clicked',
+      properties: { placement: 'similar-gyms', viewerState: 'signed-in', gymUuid: 'gym-1' },
+    });
   });
 
   it('renders nothing while the name is too short to query', () => {

--- a/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
+++ b/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
@@ -22,8 +22,10 @@ import {
   emailDomainMatchesWebsite,
   GYM_CLAIM_MESSAGE_MAX_LENGTH,
 } from '@boardsesh/gym-claim';
+import { gymClaimResult, gymClaimSubmitted } from '@boardsesh/analytics';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
 import { createGraphQLHttpClient } from '@/app/lib/graphql/client';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
 import LocaleLink from '@/app/components/i18n/locale-link';
 import {
   REQUEST_GYM_CLAIM,
@@ -87,6 +89,15 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
 
   const submit = async (variables: RequestGymClaimMutationVariables) => {
     if (!token) return;
+
+    // `method` comes from what is actually on the wire, not from `mode` state.
+    // The two diverge: the admin branch is also what renders when `mode` is
+    // 'domain' but the gym has no claimable domain, and a submit built by an
+    // earlier render can outlive a mode switch. `gymUuid` is read from props at
+    // fire time for the same reason — one dialog instance is reused across gyms
+    // (see the re-init effect above).
+    trackGymFunnelEvent(gymClaimSubmitted({ method: variables.input.claimEmail ? 'domain' : 'admin', gymUuid }));
+
     setSubmitting(true);
     setError(null);
     try {
@@ -96,8 +107,10 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
         variables,
       );
       if (data.requestGymClaim.status === 'email_sent') {
+        trackGymFunnelEvent(gymClaimResult({ status: 'email_sent', gymUuid }));
         setSentTo(data.requestGymClaim.email ?? email);
       } else if (data.requestGymClaim.status === 'approved') {
+        trackGymFunnelEvent(gymClaimResult({ status: 'approved', gymUuid }));
         setApproved(true);
         // Ownership just moved, so everything the viewer sees about this gym is
         // stale. `canClaim` is computed server-side on the gym page, so a cache
@@ -107,9 +120,14 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
         router.refresh();
         void queryClient.invalidateQueries({ queryKey: ['myGyms'] });
       } else {
+        // The only remaining GymClaimRequestStatus the backend returns.
+        trackGymFunnelEvent(gymClaimResult({ status: 'admin_review', gymUuid }));
         setAdminSent(true);
       }
     } catch (err) {
+      // `error` is ours, not a backend status: the mutation threw or the
+      // network failed, so there is no claim status to report.
+      trackGymFunnelEvent(gymClaimResult({ status: 'error', gymUuid }));
       setError(graphqlErrorMessage(err) ?? t('claimGym.errors.generic'));
     } finally {
       setSubmitting(false);

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -45,7 +45,7 @@ import {
 } from '@boardsesh/graphql/operations';
 import { useSession } from 'next-auth/react';
 import { gymClaimCtaClicked } from '@boardsesh/analytics';
-import { trackGymFunnelEvent, viewerStateFromSessionStatus } from '@/app/lib/gym-funnel-analytics';
+import { trackGymFunnelEvent, viewerStateFrom } from '@/app/lib/gym-funnel-analytics';
 import { themeTokens } from '@/app/theme/theme-config';
 import FollowButton from '@/app/components/ui/follow-button';
 import LocaleLink from '@/app/components/i18n/locale-link';
@@ -78,8 +78,12 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showClaimDialog, setShowClaimDialog] = useState(false);
   const [showReportDialog, setShowReportDialog] = useState(false);
-  const { token } = useWsAuthToken();
-  const { data: session, status: sessionStatus } = useSession();
+  // `isAuthenticated` rather than useSession().status: its query is gated on
+  // `status !== 'loading'`, so a gym fetched through this token means the
+  // session already settled — no pre-hydration `loading` masquerading as
+  // signed-out on the claim CTA event.
+  const { token, isAuthenticated } = useWsAuthToken();
+  const { data: session } = useSession();
   const { showMessage } = useSnackbar();
   const currentUserId = session?.user?.id ?? null;
 
@@ -311,7 +315,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
                   trackGymFunnelEvent(
                     gymClaimCtaClicked({
                       placement: 'preview-sheet',
-                      viewerState: viewerStateFromSessionStatus(sessionStatus),
+                      viewerState: viewerStateFrom(isAuthenticated),
                       gymUuid: gym.uuid,
                     }),
                   );

--- a/packages/web/app/components/gym-entity/gym-detail.tsx
+++ b/packages/web/app/components/gym-entity/gym-detail.tsx
@@ -44,6 +44,8 @@ import {
   type DeleteGymMutationResponse,
 } from '@boardsesh/graphql/operations';
 import { useSession } from 'next-auth/react';
+import { gymClaimCtaClicked } from '@boardsesh/analytics';
+import { trackGymFunnelEvent, viewerStateFromSessionStatus } from '@/app/lib/gym-funnel-analytics';
 import { themeTokens } from '@/app/theme/theme-config';
 import FollowButton from '@/app/components/ui/follow-button';
 import LocaleLink from '@/app/components/i18n/locale-link';
@@ -77,7 +79,7 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
   const [showClaimDialog, setShowClaimDialog] = useState(false);
   const [showReportDialog, setShowReportDialog] = useState(false);
   const { token } = useWsAuthToken();
-  const { data: session } = useSession();
+  const { data: session, status: sessionStatus } = useSession();
   const { showMessage } = useSnackbar();
   const currentUserId = session?.user?.id ?? null;
 
@@ -305,7 +307,16 @@ export default function GymDetail({ gymUuid, open, onClose, onDeleted, anchor = 
                 variant="outlined"
                 size="small"
                 startIcon={<VerifiedUserOutlined />}
-                onClick={() => setShowClaimDialog(true)}
+                onClick={() => {
+                  trackGymFunnelEvent(
+                    gymClaimCtaClicked({
+                      placement: 'preview-sheet',
+                      viewerState: viewerStateFromSessionStatus(sessionStatus),
+                      gymUuid: gym.uuid,
+                    }),
+                  );
+                  setShowClaimDialog(true);
+                }}
                 sx={{ textTransform: 'none' }}
               >
                 {t('gymEntity.actions.claim')}

--- a/packages/web/app/components/gym-entity/similar-gym-suggestions.tsx
+++ b/packages/web/app/components/gym-entity/similar-gym-suggestions.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Card from '@mui/material/Card';
@@ -23,6 +24,8 @@ import {
   type FindSimilarGymsQueryVariables,
 } from '@boardsesh/graphql/operations';
 import type { SimilarGym } from '@boardsesh/shared-schema';
+import { gymClaimCtaClicked } from '@boardsesh/analytics';
+import { trackGymFunnelEvent, viewerStateFromSessionStatus } from '@/app/lib/gym-funnel-analytics';
 import { themeTokens } from '@/app/theme/theme-config';
 import ClaimGymDialog from './claim-gym-dialog';
 
@@ -41,6 +44,7 @@ function capitalize(value: string): string {
 export default function SimilarGymSuggestions({ name, latitude, longitude }: SimilarGymSuggestionsProps) {
   const { t } = useTranslation('boards');
   const { token } = useWsAuthToken();
+  const { status: sessionStatus } = useSession();
   const [claimTarget, setClaimTarget] = useState<SimilarGym | null>(null);
 
   // Debounce the whole lookup input so typing a name (and nudging the map) fires
@@ -172,7 +176,16 @@ export default function SimilarGymSuggestions({ name, latitude, longitude }: Sim
                     <MuiButton
                       size="small"
                       variant="contained"
-                      onClick={() => setClaimTarget(gym)}
+                      onClick={() => {
+                        trackGymFunnelEvent(
+                          gymClaimCtaClicked({
+                            placement: 'similar-gyms',
+                            viewerState: viewerStateFromSessionStatus(sessionStatus),
+                            gymUuid: gym.uuid,
+                          }),
+                        );
+                        setClaimTarget(gym);
+                      }}
                       sx={{ textTransform: 'none' }}
                     >
                       {t('similarGyms.claim')}

--- a/packages/web/app/components/gym-entity/similar-gym-suggestions.tsx
+++ b/packages/web/app/components/gym-entity/similar-gym-suggestions.tsx
@@ -3,7 +3,6 @@
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
-import { useSession } from 'next-auth/react';
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Card from '@mui/material/Card';
@@ -25,7 +24,7 @@ import {
 } from '@boardsesh/graphql/operations';
 import type { SimilarGym } from '@boardsesh/shared-schema';
 import { gymClaimCtaClicked } from '@boardsesh/analytics';
-import { trackGymFunnelEvent, viewerStateFromSessionStatus } from '@/app/lib/gym-funnel-analytics';
+import { trackGymFunnelEvent, viewerStateFrom } from '@/app/lib/gym-funnel-analytics';
 import { themeTokens } from '@/app/theme/theme-config';
 import ClaimGymDialog from './claim-gym-dialog';
 
@@ -43,8 +42,10 @@ function capitalize(value: string): string {
 
 export default function SimilarGymSuggestions({ name, latitude, longitude }: SimilarGymSuggestionsProps) {
   const { t } = useTranslation('boards');
-  const { token } = useWsAuthToken();
-  const { status: sessionStatus } = useSession();
+  // `isAuthenticated` rather than useSession().status — the suggestion query
+  // this list renders from is itself gated on the token, so by the time a claim
+  // button exists the session has settled.
+  const { token, isAuthenticated } = useWsAuthToken();
   const [claimTarget, setClaimTarget] = useState<SimilarGym | null>(null);
 
   // Debounce the whole lookup input so typing a name (and nudging the map) fires
@@ -180,7 +181,7 @@ export default function SimilarGymSuggestions({ name, latitude, longitude }: Sim
                         trackGymFunnelEvent(
                           gymClaimCtaClicked({
                             placement: 'similar-gyms',
-                            viewerState: viewerStateFromSessionStatus(sessionStatus),
+                            viewerState: viewerStateFrom(isAuthenticated),
                             gymUuid: gym.uuid,
                           }),
                         );

--- a/packages/web/app/components/ui/follow-button.tsx
+++ b/packages/web/app/components/ui/follow-button.tsx
@@ -15,6 +15,8 @@ type FollowButtonProps = {
   entityLabel: string;
   getFollowVariables: (entityId: string) => Record<string, unknown>;
   onFollowChange?: (isFollowing: boolean) => void;
+  /** Optional click hook — see `useFollowToggle`. Only the gym page passes one. */
+  onToggleClick?: () => void;
 };
 
 export default function FollowButton({
@@ -25,6 +27,7 @@ export default function FollowButton({
   entityLabel,
   getFollowVariables,
   onFollowChange,
+  onToggleClick,
 }: FollowButtonProps) {
   const { t } = useTranslation('common');
   const { isFollowing, isLoading, isHovered, isAuthenticated, handleToggle, setIsHovered } = useFollowToggle({
@@ -35,6 +38,7 @@ export default function FollowButton({
     entityLabel,
     getFollowVariables,
     onFollowChange,
+    onToggleClick,
   });
 
   if (!isAuthenticated) {

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('@/app/components/gym-entity/claim-gym-dialog', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="claim-dialog" /> : null),
+}));
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent }));
+
+const GymClaimCta = (await import('../gym-claim-cta')).default;
+
+beforeEach(() => {
+  trackGymFunnelEvent.mockReset();
+});
+
+describe('GymClaimCta — gym-page placement', () => {
+  it('reports the click with the server-derived viewer state', () => {
+    render(<GymClaimCta gymUuid="gym-1" gymName="Boulderwelt" website={null} viewerState="signed-in" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Claim this gym' }));
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Claim CTA Clicked',
+      properties: { placement: 'gym-page', viewerState: 'signed-in', gymUuid: 'gym-1' },
+    });
+  });
+
+  it('passes a signed-out viewer through unchanged rather than inferring one', () => {
+    // Unreachable today — the resolver's `canClaim` requires an authenticated
+    // user, so the server never renders this CTA for a signed-out visitor. The
+    // prop is wired end to end so #3672's anonymous CTA reports the truth
+    // without touching this component.
+    render(<GymClaimCta gymUuid="gym-1" gymName="Boulderwelt" website={null} viewerState="signed-out" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Claim this gym' }));
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Claim CTA Clicked',
+      properties: { placement: 'gym-page', viewerState: 'signed-out', gymUuid: 'gym-1' },
+    });
+  });
+
+  it('opens the dialog as well as reporting', () => {
+    render(<GymClaimCta gymUuid="gym-1" gymName="Boulderwelt" website={null} viewerState="signed-in" />);
+
+    expect(screen.queryByTestId('claim-dialog')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Claim this gym' }));
+    expect(screen.getByTestId('claim-dialog')).toBeTruthy();
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-follow-button.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-follow-button.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'viewer-1' } }, status: 'authenticated' }),
+}));
+
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({ token: 'test-token', isAuthenticated: true, isLoading: false, error: null }),
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+vi.mock('@boardsesh/graphql/operations', () => ({
+  FOLLOW_GYM: 'FOLLOW_GYM',
+  UNFOLLOW_GYM: 'UNFOLLOW_GYM',
+}));
+
+const mockRequest = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: mockRequest }),
+}));
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({
+  trackGymFunnelEvent,
+  viewerStateFromSessionStatus: (status: string) => (status === 'authenticated' ? 'signed-in' : 'signed-out'),
+}));
+
+const GymFollowButton = (await import('../gym-follow-button')).default;
+
+beforeEach(() => {
+  mockRequest.mockReset();
+  trackGymFunnelEvent.mockReset();
+});
+
+describe('GymFollowButton analytics', () => {
+  it('reports one follow CTA click per accepted tap', async () => {
+    mockRequest.mockResolvedValue({});
+
+    render(<GymFollowButton gymUuid="gym-1" ownerId="someone-else" isFollowedByMe={false} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Page CTA Clicked',
+      properties: { cta: 'follow', gymUuid: 'gym-1' },
+    });
+  });
+
+  it('emits no phantom event when the mutation fails and the toggle rolls back', async () => {
+    // The optimistic path calls onFollowChange twice on failure — once forward,
+    // once back. Instrumenting through it would report an unfollow the climber
+    // never asked for; onToggleClick fires once, at the click.
+    mockRequest.mockRejectedValue(new Error('network down'));
+
+    render(<GymFollowButton gymUuid="gym-1" ownerId="someone-else" isFollowedByMe={false} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalled());
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports nothing for the gym owner, who never sees the button', () => {
+    const { container } = render(<GymFollowButton gymUuid="gym-1" ownerId="viewer-1" isFollowedByMe={false} />);
+
+    expect(container.innerHTML).toBe('');
+    expect(trackGymFunnelEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-page-cta-link.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-page-cta-link.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
+}));
+
+const GymPageCtaLink = (await import('../gym-page-cta-link')).default;
+
+beforeEach(() => {
+  trackGymFunnelEvent.mockReset();
+});
+
+describe('GymPageCtaLink', () => {
+  it('keeps the kiosk destination on a real anchor', () => {
+    render(<GymPageCtaLink cta="kiosk" gymUuid="gym-1" href="/kiosk/boulderwelt" label="See it on the wall" />);
+
+    const anchor = screen.getByText('See it on the wall').closest('a');
+    // A crawler and a JS-off reader must still find the destination — the click
+    // handler only adds the event, it never takes the href's job.
+    expect(anchor?.getAttribute('href')).toBe('/kiosk/boulderwelt');
+  });
+
+  it('reports the kiosk CTA without cancelling the navigation', () => {
+    render(<GymPageCtaLink cta="kiosk" gymUuid="gym-1" href="/kiosk/boulderwelt" label="See it on the wall" />);
+
+    const anchor = screen.getByText('See it on the wall').closest('a');
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchor?.dispatchEvent(clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Page CTA Clicked',
+      properties: { cta: 'kiosk', gymUuid: 'gym-1' },
+    });
+  });
+
+  it('keeps the external website destination, target and rel on a real anchor', () => {
+    render(<GymPageCtaLink cta="website" gymUuid="gym-2" href="https://example.com/" label="Visit website" />);
+
+    const anchor = screen.getByText('Visit website').closest('a');
+    expect(anchor?.getAttribute('href')).toBe('https://example.com/');
+    expect(anchor?.getAttribute('target')).toBe('_blank');
+    expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('reports the website CTA', () => {
+    render(<GymPageCtaLink cta="website" gymUuid="gym-2" href="https://example.com/" label="Visit website" />);
+
+    fireEvent.click(screen.getByText('Visit website'));
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Page CTA Clicked',
+      properties: { cta: 'website', gymUuid: 'gym-2' },
+    });
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-qr-landing-tracker.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-qr-landing-tracker.test.tsx
@@ -5,38 +5,41 @@ import React from 'react';
 const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
 vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent }));
 
-const GymQrLandingTracker = (await import('../gym-qr-landing-tracker')).default;
+const trackerModule = await import('../gym-qr-landing-tracker');
+const GymQrLandingTracker = trackerModule.default;
+const { __resetReportedScansForTests } = trackerModule;
 
-// The once-per-document guard is module-level state that deliberately survives
-// unmounts, so every test uses a slug of its own rather than resetting it.
 beforeEach(() => {
   trackGymFunnelEvent.mockReset();
+  // The dedupe Set is module-level and outlives unmounts on purpose; without
+  // this a later test reusing a slug would assert nothing and still pass.
+  __resetReportedScansForTests();
   window.history.replaceState(null, '', '/gym/test');
 });
 
 describe('GymQrLandingTracker', () => {
   it('renders nothing and reports the scan once on mount', () => {
-    const { container } = render(<GymQrLandingTracker gymSlug="mount-once" medium="poster" />);
+    const { container } = render(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />);
 
     expect(container.innerHTML).toBe('');
     expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
     expect(trackGymFunnelEvent).toHaveBeenCalledWith({
       name: 'Gym QR Scanned',
-      properties: { medium: 'poster', gymSlug: 'mount-once' },
+      properties: { medium: 'poster', gymSlug: 'boulderwelt' },
     });
   });
 
   it('does not report again on a re-render with the same landing', () => {
-    const { rerender } = render(<GymQrLandingTracker gymSlug="rerender" medium="poster" />);
-    rerender(<GymQrLandingTracker gymSlug="rerender" medium="poster" />);
-    rerender(<GymQrLandingTracker gymSlug="rerender" medium="poster" />);
+    const { rerender } = render(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />);
+    rerender(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />);
+    rerender(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />);
 
     expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
   });
 
   it('does not report again when the same landing remounts — a StrictMode double-invoke or a return visit', () => {
-    render(<GymQrLandingTracker gymSlug="remount" medium="poster" />).unmount();
-    render(<GymQrLandingTracker gymSlug="remount" medium="poster" />);
+    render(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />).unmount();
+    render(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />);
 
     expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
   });
@@ -49,18 +52,32 @@ describe('GymQrLandingTracker', () => {
   });
 
   it('strips the attribution params so a shared link cannot re-credit the poster', () => {
-    window.history.replaceState(null, '', '/gym/strip?src=qr&medium=poster&tab=boards');
+    window.history.replaceState(null, '', '/gym/boulderwelt?src=qr&medium=poster&tab=boards');
 
-    render(<GymQrLandingTracker gymSlug="strip" medium="poster" />);
+    render(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />);
 
     expect(window.location.search).toBe('?tab=boards');
-    expect(window.location.pathname).toBe('/gym/strip');
+    expect(window.location.pathname).toBe('/gym/boulderwelt');
+  });
+
+  it('still strips the params on a repeat landing it does not count', () => {
+    // gym A → gym B → back to gym A on the poster URL. The event is rightly
+    // deduped, but the address bar is the thing that gets shared, so it has to
+    // be cleaned every time — not only on the landing that happened to be first.
+    window.history.replaceState(null, '', '/gym/boulderwelt?src=qr&medium=poster');
+    render(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />).unmount();
+
+    window.history.replaceState(null, '', '/gym/boulderwelt?src=qr&medium=poster');
+    render(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />);
+
+    expect(window.location.search).toBe('');
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
   });
 
   it('leaves a URL that carries no attribution params alone', () => {
-    window.history.replaceState(null, '', '/gym/no-params?tab=boards');
+    window.history.replaceState(null, '', '/gym/boulderwelt?tab=boards');
 
-    render(<GymQrLandingTracker gymSlug="no-params" medium="poster" />);
+    render(<GymQrLandingTracker gymSlug="boulderwelt" medium="poster" />);
 
     expect(window.location.search).toBe('?tab=boards');
   });

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-qr-landing-tracker.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-qr-landing-tracker.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent }));
+
+const GymQrLandingTracker = (await import('../gym-qr-landing-tracker')).default;
+
+// The once-per-document guard is module-level state that deliberately survives
+// unmounts, so every test uses a slug of its own rather than resetting it.
+beforeEach(() => {
+  trackGymFunnelEvent.mockReset();
+  window.history.replaceState(null, '', '/gym/test');
+});
+
+describe('GymQrLandingTracker', () => {
+  it('renders nothing and reports the scan once on mount', () => {
+    const { container } = render(<GymQrLandingTracker gymSlug="mount-once" medium="poster" />);
+
+    expect(container.innerHTML).toBe('');
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym QR Scanned',
+      properties: { medium: 'poster', gymSlug: 'mount-once' },
+    });
+  });
+
+  it('does not report again on a re-render with the same landing', () => {
+    const { rerender } = render(<GymQrLandingTracker gymSlug="rerender" medium="poster" />);
+    rerender(<GymQrLandingTracker gymSlug="rerender" medium="poster" />);
+    rerender(<GymQrLandingTracker gymSlug="rerender" medium="poster" />);
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not report again when the same landing remounts — a StrictMode double-invoke or a return visit', () => {
+    render(<GymQrLandingTracker gymSlug="remount" medium="poster" />).unmount();
+    render(<GymQrLandingTracker gymSlug="remount" medium="poster" />);
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a different gym landed on from the same medium', () => {
+    render(<GymQrLandingTracker gymSlug="first-gym" medium="kiosk" />);
+    render(<GymQrLandingTracker gymSlug="second-gym" medium="kiosk" />);
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('strips the attribution params so a shared link cannot re-credit the poster', () => {
+    window.history.replaceState(null, '', '/gym/strip?src=qr&medium=poster&tab=boards');
+
+    render(<GymQrLandingTracker gymSlug="strip" medium="poster" />);
+
+    expect(window.location.search).toBe('?tab=boards');
+    expect(window.location.pathname).toBe('/gym/strip');
+  });
+
+  it('leaves a URL that carries no attribution params alone', () => {
+    window.history.replaceState(null, '', '/gym/no-params?tab=boards');
+
+    render(<GymQrLandingTracker gymSlug="no-params" medium="poster" />);
+
+    expect(window.location.search).toBe('?tab=boards');
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-report-duplicate-cta.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-report-duplicate-cta.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const sessionState = vi.hoisted(() => ({ status: 'authenticated' }));
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'viewer-1' } }, status: sessionState.status }),
+}));
+
+vi.mock('@/app/components/gym-entity/report-duplicate-dialog', () => ({
+  default: ({ open }: { open: boolean }) => (open ? <div data-testid="report-dialog" /> : null),
+}));
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent }));
+
+const GymReportDuplicateCta = (await import('../gym-report-duplicate-cta')).default;
+
+beforeEach(() => {
+  trackGymFunnelEvent.mockReset();
+  sessionState.status = 'authenticated';
+});
+
+describe('GymReportDuplicateCta', () => {
+  it('reports the report-duplicate CTA click', () => {
+    render(<GymReportDuplicateCta gymUuid="gym-1" gymName="Boulderwelt" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Report a duplicate' }));
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Page CTA Clicked',
+      properties: { cta: 'report-duplicate', gymUuid: 'gym-1' },
+    });
+    expect(screen.getByTestId('report-dialog')).toBeTruthy();
+  });
+
+  it('reports nothing for a signed-out visitor, who never sees the flag', () => {
+    sessionState.status = 'unauthenticated';
+
+    const { container } = render(<GymReportDuplicateCta gymUuid="gym-1" gymName="Boulderwelt" />);
+
+    expect(container.innerHTML).toBe('');
+    expect(trackGymFunnelEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/__tests__/page-metadata.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/page-metadata.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { Gym } from '@boardsesh/shared-schema';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+  permanentRedirect: vi.fn(),
+}));
+
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({
+    t: (key: string, options?: Record<string, unknown>) => (options ? `${key}:${String(options.gymName)}` : key),
+    locale: 'en-US',
+  })),
+}));
+
+vi.mock('@/app/lib/auth/server-auth', () => ({
+  getServerAuthToken: vi.fn(async () => undefined),
+}));
+
+const executeAuthenticatedGraphQL = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/server-graphql', () => ({ executeAuthenticatedGraphQL }));
+
+const { generateMetadata } = await import('../page');
+
+function gym(slug: string, overrides: Partial<Gym> = {}): Gym {
+  return {
+    uuid: `uuid-${slug}`,
+    slug,
+    name: 'Boulderwelt',
+    isPublic: true,
+    canEdit: false,
+    description: 'A big gym',
+    ...overrides,
+  } as unknown as Gym;
+}
+
+// `fetchGymBySlug` is wrapped in React's `cache()`, so every test uses a slug of
+// its own rather than relying on the mock being re-read for the same arguments.
+const metadataFor = (slug: string, params: Record<string, string | string[] | undefined>) =>
+  generateMetadata({
+    params: Promise.resolve({ gym_slug: slug }),
+    searchParams: Promise.resolve(params),
+  });
+
+beforeEach(() => {
+  executeAuthenticatedGraphQL.mockReset();
+});
+
+describe('gym page metadata', () => {
+  it('canonicalises to the bare /gym/{slug} path when the URL carries QR attribution params', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gym('qr-landing') });
+
+    // The route now receives searchParams. Nothing from it may reach `path`: a
+    // query string in the canonical gives every param combination its own
+    // canonical URL and splits the page's ranking signals.
+    const metadata = await metadataFor('qr-landing', { src: 'qr', medium: 'poster' });
+
+    expect(metadata.alternates?.canonical).toBe('/gym/qr-landing');
+  });
+
+  it('canonicalises to the same path when no params are present', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gym('no-params') });
+
+    const metadata = await metadataFor('no-params', {});
+
+    expect(metadata.alternates?.canonical).toBe('/gym/no-params');
+  });
+
+  it('keeps every hreflang alternate free of the query string', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gym('alternates') });
+
+    const metadata = await metadataFor('alternates', { src: 'qr', medium: 'poster', tab: 'boards' });
+
+    const languages = metadata.alternates?.languages ?? {};
+    const hrefs = Object.values(languages).flatMap((href) => (typeof href === 'string' ? [href] : []));
+    expect(hrefs.length).toBeGreaterThan(1);
+    for (const href of hrefs) {
+      expect(href).not.toContain('?');
+      expect(href).toContain('/gym/alternates');
+    }
+  });
+
+  it('keeps a private gym out of the index', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({
+      gymBySlug: gym('private-gym', { isPublic: false, canEdit: true }),
+    });
+
+    const metadata = await metadataFor('private-gym', {});
+
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
@@ -2,11 +2,14 @@
 
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSession } from 'next-auth/react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import VerifiedUserOutlined from '@mui/icons-material/VerifiedUserOutlined';
+import { gymClaimCtaClicked } from '@boardsesh/analytics';
 import ClaimGymDialog from '@/app/components/gym-entity/claim-gym-dialog';
+import { trackGymFunnelEvent, viewerStateFromSessionStatus } from '@/app/lib/gym-funnel-analytics';
 import { themeTokens } from '@/app/theme/theme-config';
 
 type GymClaimCtaProps = {
@@ -22,6 +25,7 @@ type GymClaimCtaProps = {
  */
 export default function GymClaimCta({ gymUuid, gymName, website }: GymClaimCtaProps) {
   const { t } = useTranslation('kiosk');
+  const { status } = useSession();
   const [open, setOpen] = useState(false);
 
   return (
@@ -42,7 +46,16 @@ export default function GymClaimCta({ gymUuid, gymName, website }: GymClaimCtaPr
       <Button
         variant="contained"
         startIcon={<VerifiedUserOutlined />}
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          trackGymFunnelEvent(
+            gymClaimCtaClicked({
+              placement: 'gym-page',
+              viewerState: viewerStateFromSessionStatus(status),
+              gymUuid,
+            }),
+          );
+          setOpen(true);
+        }}
         sx={{ textTransform: 'none' }}
       >
         {t('gymPage.claimCta')}

--- a/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
@@ -2,20 +2,27 @@
 
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useSession } from 'next-auth/react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import VerifiedUserOutlined from '@mui/icons-material/VerifiedUserOutlined';
-import { gymClaimCtaClicked } from '@boardsesh/analytics';
+import { gymClaimCtaClicked, type GymClaimViewerState } from '@boardsesh/analytics';
 import ClaimGymDialog from '@/app/components/gym-entity/claim-gym-dialog';
-import { trackGymFunnelEvent, viewerStateFromSessionStatus } from '@/app/lib/gym-funnel-analytics';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
 import { themeTokens } from '@/app/theme/theme-config';
 
 type GymClaimCtaProps = {
   gymUuid: string;
   gymName: string;
   website?: string | null;
+  /**
+   * Derived on the SERVER from the request's auth cookie and passed down, not
+   * read here with `useSession()`. next-auth starts at `status: 'loading'` on
+   * every page load and settles after a round-trip, so a tap that beats
+   * hydration — the whole point of a QR poster — would report a signed-in
+   * climber as signed-out.
+   */
+  viewerState: GymClaimViewerState;
 };
 
 /**
@@ -23,9 +30,8 @@ type GymClaimCtaProps = {
  * page. The server only renders it when the viewer can actually claim the gym
  * (gym.canClaim), and it reuses the exact ClaimGymDialog the preview sheet opens.
  */
-export default function GymClaimCta({ gymUuid, gymName, website }: GymClaimCtaProps) {
+export default function GymClaimCta({ gymUuid, gymName, website, viewerState }: GymClaimCtaProps) {
   const { t } = useTranslation('kiosk');
-  const { status } = useSession();
   const [open, setOpen] = useState(false);
 
   return (
@@ -47,13 +53,7 @@ export default function GymClaimCta({ gymUuid, gymName, website }: GymClaimCtaPr
         variant="contained"
         startIcon={<VerifiedUserOutlined />}
         onClick={() => {
-          trackGymFunnelEvent(
-            gymClaimCtaClicked({
-              placement: 'gym-page',
-              viewerState: viewerStateFromSessionStatus(status),
-              gymUuid,
-            }),
-          );
+          trackGymFunnelEvent(gymClaimCtaClicked({ placement: 'gym-page', viewerState, gymUuid }));
           setOpen(true);
         }}
         sx={{ textTransform: 'none' }}

--- a/packages/web/app/gym/[gym_slug]/gym-follow-button.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-follow-button.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSession } from 'next-auth/react';
 import { FOLLOW_GYM, UNFOLLOW_GYM } from '@boardsesh/graphql/operations';
+import { gymPageCtaClicked } from '@boardsesh/analytics';
 import FollowButton from '@/app/components/ui/follow-button';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
 
 type GymFollowButtonProps = {
   gymUuid: string;
@@ -35,6 +37,9 @@ export default function GymFollowButton({ gymUuid, ownerId, isFollowedByMe }: Gy
       unfollowMutation={UNFOLLOW_GYM}
       entityLabel={t('gymEntity.follow.entityLabel')}
       getFollowVariables={(id) => ({ input: { gymUuid: id } })}
+      // One event per accepted click. NOT onFollowChange — that fires again on
+      // rollback, so a failed follow would also report an unfollow.
+      onToggleClick={() => trackGymFunnelEvent(gymPageCtaClicked({ cta: 'follow', gymUuid }))}
     />
   );
 }

--- a/packages/web/app/gym/[gym_slug]/gym-follow-button.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-follow-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSession } from 'next-auth/react';
 import { FOLLOW_GYM, UNFOLLOW_GYM } from '@boardsesh/graphql/operations';
@@ -14,6 +14,11 @@ type GymFollowButtonProps = {
   isFollowedByMe: boolean;
 };
 
+// Hoisted: a pure function of its argument, so it has no reason to be rebuilt
+// per render. `useFollowToggle` lists it in `handleToggle`'s deps, and a fresh
+// identity there gives every consumer a new callback on every render.
+const gymFollowVariables = (gymUuid: string) => ({ input: { gymUuid } });
+
 /**
  * Client island: the Follow control on the public gym page. Reuses the same
  * FollowButton the preview sheet mounts, so the state, optimistic toggle, and
@@ -24,6 +29,12 @@ export default function GymFollowButton({ gymUuid, ownerId, isFollowedByMe }: Gy
   const { t } = useTranslation('boards');
   const { data: session } = useSession();
   const currentUserId = session?.user?.id ?? null;
+
+  // One event per accepted click. NOT onFollowChange — that fires again on
+  // rollback, so a failed follow would also report an unfollow.
+  const reportFollowClick = useCallback(() => {
+    trackGymFunnelEvent(gymPageCtaClicked({ cta: 'follow', gymUuid }));
+  }, [gymUuid]);
 
   if (currentUserId && currentUserId === ownerId) {
     return null;
@@ -36,10 +47,8 @@ export default function GymFollowButton({ gymUuid, ownerId, isFollowedByMe }: Gy
       followMutation={FOLLOW_GYM}
       unfollowMutation={UNFOLLOW_GYM}
       entityLabel={t('gymEntity.follow.entityLabel')}
-      getFollowVariables={(id) => ({ input: { gymUuid: id } })}
-      // One event per accepted click. NOT onFollowChange — that fires again on
-      // rollback, so a failed follow would also report an unfollow.
-      onToggleClick={() => trackGymFunnelEvent(gymPageCtaClicked({ cta: 'follow', gymUuid }))}
+      getFollowVariables={gymFollowVariables}
+      onToggleClick={reportFollowClick}
     />
   );
 }

--- a/packages/web/app/gym/[gym_slug]/gym-page-cta-link.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-page-cta-link.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React from 'react';
+import Button from '@mui/material/Button';
+import MuiLink from '@mui/material/Link';
+import TvOutlined from '@mui/icons-material/TvOutlined';
+import LanguageOutlined from '@mui/icons-material/LanguageOutlined';
+import { gymPageCtaClicked, type GymPageCta } from '@boardsesh/analytics';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
+
+/** The two gym-page CTAs that are links rather than dialog triggers. */
+type LinkCta = Extract<GymPageCta, 'kiosk' | 'website'>;
+
+type GymPageCtaLinkProps = {
+  cta: LinkCta;
+  gymUuid: string;
+  href: string;
+  /**
+   * Already translated by the server component that renders this island. The
+   * label is passed in rather than looked up here so the island adds no i18n
+   * key and no client-side translation load to a page that is mostly static.
+   */
+  label: string;
+};
+
+/**
+ * Client island around the gym page's kiosk and website links.
+ *
+ * The `href` stays a real `href` on a real anchor — the click handler only
+ * adds the event and never calls `preventDefault`, so crawlers, JS-off readers
+ * and middle-clicks behave exactly as they did when these were plain
+ * server-rendered anchors. Neither destination unloads the document (the kiosk
+ * link is an in-app route, the website link opens in a new tab), so a plain
+ * `track()` is enough — no flush-before-navigation dance.
+ */
+export default function GymPageCtaLink({ cta, gymUuid, href, label }: GymPageCtaLinkProps) {
+  const handleClick = () => {
+    trackGymFunnelEvent(gymPageCtaClicked({ cta, gymUuid }));
+  };
+
+  if (cta === 'kiosk') {
+    return (
+      <Button
+        component={LocaleLink}
+        href={href}
+        onClick={handleClick}
+        variant="contained"
+        startIcon={<TvOutlined />}
+        sx={{ textTransform: 'none' }}
+      >
+        {label}
+      </Button>
+    );
+  }
+
+  return (
+    <MuiLink
+      href={href}
+      onClick={handleClick}
+      target="_blank"
+      rel="noopener noreferrer"
+      underline="hover"
+      sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, color: 'var(--color-primary)' }}
+    >
+      <LanguageOutlined sx={{ fontSize: 18 }} />
+      {label}
+    </MuiLink>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/gym-qr-landing-tracker.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-qr-landing-tracker.tsx
@@ -10,40 +10,50 @@ type GymQrLandingTrackerProps = {
 };
 
 /**
- * Fires exactly once per document, keyed on the landing it reported. React
- * StrictMode mounts, unmounts and remounts every effect in development, and a
- * client-side navigation back to the same gym would otherwise re-attribute the
- * visit to the poster on the wall. Module scope (not a ref) because the second
- * StrictMode pass runs against a fresh component instance.
+ * Which landings have already been REPORTED. React StrictMode mounts, unmounts
+ * and remounts every effect in development, and a client-side navigation back
+ * to the same gym would otherwise re-attribute the visit to the poster on the
+ * wall. Module scope (not a ref) because the second StrictMode pass runs
+ * against a fresh component instance.
+ *
+ * It gates the event and nothing else — see the URL cleanup below.
  */
 const reportedScans = new Set<string>();
+
+/** Test-only: the dedupe Set outlives every unmount, so a suite reusing a slug would silently pass. */
+export function __resetReportedScansForTests(): void {
+  reportedScans.clear();
+}
 
 /**
  * Renders nothing. Mounted by the gym page only when `parseGymQrLanding`
  * recognises the `?src=qr&medium=…` pair a printed code carries.
  *
  * The parsed medium and the slug arrive as PROPS rather than being read here
- * with `useSearchParams`: that hook opts the whole subtree out of static
- * rendering and demands a Suspense boundary, which is a large price for a
- * component whose entire output is `null`. The server has already parsed the
- * params anyway.
+ * with `useSearchParams`, which would force a Suspense boundary around a
+ * component whose entire output is `null`. (It would not cost static rendering —
+ * this route already opts out by awaiting `cookies()` via `getServerAuthToken`.)
+ * The server has parsed the params anyway.
  */
 export default function GymQrLandingTracker({ gymSlug, medium }: GymQrLandingTrackerProps) {
   useEffect(() => {
-    const scanKey = `${gymSlug}:${medium}`;
-    if (reportedScans.has(scanKey)) return;
-    reportedScans.add(scanKey);
-
-    trackGymFunnelEvent(gymQrScanned({ medium, gymSlug }));
-
-    // Drop the attribution params once they've been counted, so a link the
-    // climber shares or bookmarks doesn't credit the poster for someone else's
-    // visit. replaceState (not router.replace) keeps this a URL rewrite with no
+    // Clean the URL FIRST, and unconditionally. The dedupe below stops a repeat
+    // landing from being counted twice, but a repeat landing still arrives with
+    // `?src=qr&medium=…` in the address bar — gym A → B → back to A — and that
+    // is exactly the link someone shares or bookmarks. Returning early above
+    // this left the params sitting there, defeating the reason to strip them.
+    // replaceState (not router.replace) keeps it a URL rewrite with no
     // re-render and no server round-trip.
     const cleanedSearch = stripGymQrParams(window.location.search);
     if (cleanedSearch !== window.location.search) {
       window.history.replaceState(null, '', `${window.location.pathname}${cleanedSearch}${window.location.hash}`);
     }
+
+    const scanKey = `${gymSlug}:${medium}`;
+    if (reportedScans.has(scanKey)) return;
+    reportedScans.add(scanKey);
+
+    trackGymFunnelEvent(gymQrScanned({ medium, gymSlug }));
   }, [gymSlug, medium]);
 
   return null;

--- a/packages/web/app/gym/[gym_slug]/gym-qr-landing-tracker.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-qr-landing-tracker.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect } from 'react';
+import { gymQrScanned, stripGymQrParams, type GymQrMedium } from '@boardsesh/analytics';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
+
+type GymQrLandingTrackerProps = {
+  gymSlug: string;
+  medium: GymQrMedium;
+};
+
+/**
+ * Fires exactly once per document, keyed on the landing it reported. React
+ * StrictMode mounts, unmounts and remounts every effect in development, and a
+ * client-side navigation back to the same gym would otherwise re-attribute the
+ * visit to the poster on the wall. Module scope (not a ref) because the second
+ * StrictMode pass runs against a fresh component instance.
+ */
+const reportedScans = new Set<string>();
+
+/**
+ * Renders nothing. Mounted by the gym page only when `parseGymQrLanding`
+ * recognises the `?src=qr&medium=…` pair a printed code carries.
+ *
+ * The parsed medium and the slug arrive as PROPS rather than being read here
+ * with `useSearchParams`: that hook opts the whole subtree out of static
+ * rendering and demands a Suspense boundary, which is a large price for a
+ * component whose entire output is `null`. The server has already parsed the
+ * params anyway.
+ */
+export default function GymQrLandingTracker({ gymSlug, medium }: GymQrLandingTrackerProps) {
+  useEffect(() => {
+    const scanKey = `${gymSlug}:${medium}`;
+    if (reportedScans.has(scanKey)) return;
+    reportedScans.add(scanKey);
+
+    trackGymFunnelEvent(gymQrScanned({ medium, gymSlug }));
+
+    // Drop the attribution params once they've been counted, so a link the
+    // climber shares or bookmarks doesn't credit the poster for someone else's
+    // visit. replaceState (not router.replace) keeps this a URL rewrite with no
+    // re-render and no server round-trip.
+    const cleanedSearch = stripGymQrParams(window.location.search);
+    if (cleanedSearch !== window.location.search) {
+      window.history.replaceState(null, '', `${window.location.pathname}${cleanedSearch}${window.location.hash}`);
+    }
+  }, [gymSlug, medium]);
+
+  return null;
+}

--- a/packages/web/app/gym/[gym_slug]/gym-report-duplicate-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-report-duplicate-cta.tsx
@@ -6,7 +6,9 @@ import { useSession } from 'next-auth/react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import FlagOutlined from '@mui/icons-material/FlagOutlined';
+import { gymPageCtaClicked } from '@boardsesh/analytics';
 import ReportDuplicateDialog from '@/app/components/gym-entity/report-duplicate-dialog';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
 
 type GymReportDuplicateCtaProps = {
   gymUuid: string;
@@ -33,7 +35,10 @@ export default function GymReportDuplicateCta({ gymUuid, gymName, latitude, long
         variant="text"
         size="small"
         startIcon={<FlagOutlined sx={{ fontSize: 16 }} />}
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          trackGymFunnelEvent(gymPageCtaClicked({ cta: 'report-duplicate', gymUuid }));
+          setOpen(true);
+        }}
         sx={{ textTransform: 'none', color: 'text.secondary' }}
       >
         {t('reportDuplicate.cta')}

--- a/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-tab-analytics.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/__tests__/manage-gym-tab-analytics.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import type { Gym } from '@boardsesh/shared-schema';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+// The shell reads the active tab from the URL, so a "tab change" in these tests
+// means flipping this holder and re-rendering — exactly what a real navigation
+// does once the router lands.
+const searchState = vi.hoisted(() => ({ params: '' }));
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(searchState.params),
+}));
+
+vi.mock('@/app/lib/i18n/use-locale-router', () => ({
+  useLocaleRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  usePathnameWithoutLocale: () => '/gym/old-slug/manage',
+}));
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'user-owner' } }, status: 'authenticated' }),
+}));
+
+vi.mock('@/app/components/gym-entity/manage/overview-tab', () => ({ default: () => <div data-testid="overview" /> }));
+vi.mock('@/app/components/gym-entity/manage/kiosks-tab', () => ({ default: () => <div data-testid="kiosks" /> }));
+vi.mock('@/app/components/gym-entity/manage/insights-tab', () => ({ default: () => <div data-testid="insights" /> }));
+vi.mock('@/app/components/gym-entity/manage/branding-tab', () => ({ default: () => <div data-testid="branding" /> }));
+vi.mock('@/app/components/gym-entity/manage/gym-boards-tab', () => ({ default: () => <div data-testid="boards" /> }));
+vi.mock('@/app/components/gym-entity/manage/comments-tab', () => ({ default: () => <div data-testid="comments" /> }));
+vi.mock('@/app/components/gym-entity/manage/profile-tab', () => ({ default: () => <div data-testid="profile" /> }));
+vi.mock('@/app/components/gym-entity/gym-member-management', () => ({ default: () => <div data-testid="members" /> }));
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent }));
+
+const ManageGymContent = (await import('../manage-gym-content')).default;
+
+function makeGym(): Gym {
+  return {
+    uuid: 'gym-uuid-1',
+    slug: 'old-slug',
+    ownerId: 'user-owner',
+    name: 'Test Gym',
+    boardCount: 1,
+    memberCount: 1,
+    followerCount: 1,
+    commentCount: 0,
+    isPublic: true,
+    canEdit: true,
+    canGrantAccess: true,
+  } as unknown as Gym;
+}
+
+const tabsSeen = () =>
+  trackGymFunnelEvent.mock.calls
+    .map(([event]) => event as { name: string; properties: { tab: string } })
+    .filter((event) => event.name === 'Gym Manage Tab Viewed')
+    .map((event) => event.properties.tab);
+
+beforeEach(() => {
+  trackGymFunnelEvent.mockReset();
+  searchState.params = '';
+});
+
+describe('manage console tab views', () => {
+  it('reports the default tab once on mount', () => {
+    render(<ManageGymContent initialGym={makeGym()} />);
+
+    expect(tabsSeen()).toEqual(['overview']);
+  });
+
+  it('reports the deep-linked tab on mount, not the default', () => {
+    // Hooking the tap handler instead of the resolved tab would miss this
+    // entirely — nobody tapped anything.
+    searchState.params = 'tab=members';
+
+    render(<ManageGymContent initialGym={makeGym()} />);
+
+    expect(tabsSeen()).toEqual(['members']);
+  });
+
+  it('does not report again when an unrelated re-render happens', () => {
+    const { rerender } = render(<ManageGymContent initialGym={makeGym()} />);
+    rerender(<ManageGymContent initialGym={makeGym()} />);
+    rerender(<ManageGymContent initialGym={makeGym()} />);
+
+    expect(tabsSeen()).toEqual(['overview']);
+  });
+
+  it('reports once per completed tab change', () => {
+    const { rerender } = render(<ManageGymContent initialGym={makeGym()} />);
+
+    searchState.params = 'tab=branding';
+    rerender(<ManageGymContent initialGym={makeGym()} />);
+    searchState.params = 'tab=kiosks';
+    rerender(<ManageGymContent initialGym={makeGym()} />);
+
+    expect(tabsSeen()).toEqual(['overview', 'branding', 'kiosks']);
+  });
+
+  it('does not report a tab tap that never lands', () => {
+    // The tap only asks the router to navigate; until the URL changes the tab
+    // has not been viewed. Counting taps would over-count every one the
+    // dirty-guard cancels.
+    render(<ManageGymContent initialGym={makeGym()} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Insights' }));
+
+    expect(tabsSeen()).toEqual(['overview']);
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
+++ b/packages/web/app/gym/[gym_slug]/manage/manage-gym-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
@@ -14,7 +14,9 @@ import MuiLink from '@mui/material/Link';
 import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined';
 import type { TFunction } from 'i18next';
 import type { Gym } from '@boardsesh/shared-schema';
+import { gymManageTabViewed } from '@boardsesh/analytics';
 import LocaleLink from '@/app/components/i18n/locale-link';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
 import { useLocaleRouter, usePathnameWithoutLocale } from '@/app/lib/i18n/use-locale-router';
 import { resolveGymRole, type GymRoleKind } from '@/app/lib/gym-role';
 import { themeTokens } from '@/app/theme/theme-config';
@@ -89,6 +91,20 @@ export default function ManageGymContent({ initialGym }: { initialGym: Gym }) {
   // tab doesn't inherit it (the unmounting tab's cleanup also reports false).
   useEffect(() => {
     setIsActiveTabDirty(false);
+  }, [activeTab]);
+
+  // One `Gym Manage Tab Viewed` per tab actually shown, mount included.
+  //
+  // Watching the RESOLVED tab rather than hooking handleTabChange is the whole
+  // point: a `?tab=` deep link and a first mount are views that no tap handler
+  // sees, and a tap the dirty-guard cancels is a tap that changed nothing. The
+  // ref is what makes it once-per-view — an unrelated re-render (or StrictMode
+  // re-running the effect against the same tab) must not count a second view.
+  const lastTrackedTab = useRef<ManageTab | null>(null);
+  useEffect(() => {
+    if (lastTrackedTab.current === activeTab) return;
+    lastTrackedTab.current = activeTab;
+    trackGymFunnelEvent(gymManageTabViewed({ tab: activeTab }));
   }, [activeTab]);
 
   const performNavigation = useCallback(

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -3,13 +3,10 @@ import type { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
 import Container from '@mui/material/Container';
 import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import MuiLink from '@mui/material/Link';
 import Divider from '@mui/material/Divider';
 import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
-import LanguageOutlined from '@mui/icons-material/LanguageOutlined';
-import TvOutlined from '@mui/icons-material/TvOutlined';
 import FitnessCenterOutlined from '@mui/icons-material/FitnessCenterOutlined';
 import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
@@ -26,6 +23,7 @@ import {
   type GymKioskOperationResult,
 } from '@boardsesh/graphql/operations';
 import { boardTypeLabel } from '@boardsesh/board-constants';
+import { parseGymQrLanding } from '@boardsesh/analytics';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
 import { getLocale } from '@/app/lib/i18n/get-locale';
@@ -44,11 +42,17 @@ import GymClaimCta from './gym-claim-cta';
 import GymOwnerPrompts from './gym-owner-prompts';
 import GymReportDuplicateCta from './gym-report-duplicate-cta';
 import { formatHoursConfirmedDate } from './gym-hours-display';
+import GymPageCtaLink from './gym-page-cta-link';
+import GymQrLandingTracker from './gym-qr-landing-tracker';
 import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 import { resolveGymLogoDisplayUrl } from '@/app/lib/gym-logo-display-url';
 
 type GymRouteProps = {
   params: Promise<{ gym_slug: string }>;
+  // Same shape the manage route declares. Read for the QR-landing params a
+  // printed poster carries (`?src=qr&medium=poster`); several later PRs of this
+  // epic read their own params from it.
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 const fetchGymBySlug = cache(async (slug: string, token: string | undefined): Promise<Gym | null> => {
@@ -105,12 +109,18 @@ export async function generateMetadata(props: GymRouteProps): Promise<Metadata> 
 
   const title = t('gymPage.metaTitle', { gymName: gym.name });
   const description = gym.description?.trim() || t('gymPage.metaDescription', { gymName: gym.name });
+  // `path` is the SLUG PATH ONLY — never concatenate anything from
+  // `searchParams` into it. Every canonical and every hreflang alternate is
+  // built from this string, so a query string here would give
+  // `/gym/x?src=qr&medium=poster` its own canonical and split the page's
+  // ranking signals across as many URLs as there are param combinations. Filter,
+  // sort and attribution params all canonicalise to the clean base URL.
   const options = { title, description, path: `/gym/${gym_slug}`, locale };
   return gym.isPublic ? createPageMetadata(options) : createNoIndexMetadata(options);
 }
 
 export default async function GymPage(props: GymRouteProps) {
-  const { gym_slug } = await props.params;
+  const [{ gym_slug }, searchParams] = await Promise.all([props.params, props.searchParams]);
   const token = await getServerAuthToken();
   const gym = await fetchGymBySlug(gym_slug, token);
 
@@ -142,6 +152,10 @@ export default async function GymPage(props: GymRouteProps) {
   const hoursText = gym.hours?.trim() || null;
   const hoursConfirmedDate = formatHoursConfirmedDate(gym.hoursUpdatedAt, locale);
 
+  // A printed code carries `?src=qr&medium=…`. Anything else — a bare visit, a
+  // hand-edited param, a crawler-mangled URL — parses to null and mounts nothing.
+  const qrLanding = parseGymQrLanding(searchParams);
+
   const jsonLd = gym.isPublic
     ? {
         '@context': 'https://schema.org',
@@ -157,6 +171,7 @@ export default async function GymPage(props: GymRouteProps) {
 
   return (
     <I18nProvider locale={locale} namespaces={['common', 'boards', 'kiosk']}>
+      {qrLanding && <GymQrLandingTracker gymSlug={gym_slug} medium={qrLanding.medium} />}
       {jsonLd && <JsonLd data={jsonLd} />}
       <Container maxWidth="md" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
         <Box sx={{ mb: 2 }}>
@@ -245,28 +260,19 @@ export default async function GymPage(props: GymRouteProps) {
 
         <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', mb: 3 }}>
           <GymFollowButton gymUuid={gym.uuid} ownerId={gym.ownerId} isFollowedByMe={gym.isFollowedByMe} />
+          {/* Both CTAs render through a client island purely so the click is
+              counted. The island keeps the same anchor and the same real href;
+              the label is translated here on the server, so no i18n key moves. */}
           {kiosk && (
-            <Button
-              component={LocaleLink}
+            <GymPageCtaLink
+              cta="kiosk"
+              gymUuid={gym.uuid}
               href={`/kiosk/${gym_slug}`}
-              variant="contained"
-              startIcon={<TvOutlined />}
-              sx={{ textTransform: 'none' }}
-            >
-              {t('gymPage.seeOnTheWall')}
-            </Button>
+              label={t('gymPage.seeOnTheWall')}
+            />
           )}
           {websiteHref && (
-            <MuiLink
-              href={websiteHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              underline="hover"
-              sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5, color: 'var(--color-primary)' }}
-            >
-              <LanguageOutlined sx={{ fontSize: 18 }} />
-              {t('gymPage.visitWebsite')}
-            </MuiLink>
+            <GymPageCtaLink cta="website" gymUuid={gym.uuid} href={websiteHref} label={t('gymPage.visitWebsite')} />
           )}
           {gym.canEdit && <GymPageManageButton gymSlug={gym_slug} />}
         </Box>

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -292,7 +292,21 @@ export default async function GymPage(props: GymRouteProps) {
           )}
         />
 
-        {gym.canClaim && <GymClaimCta gymUuid={gym.uuid} gymName={gym.name} website={gym.website} />}
+        {/* `viewerState` is the server's answer, taken from the request cookie
+            above. Reading it in the island with useSession() would report the
+            pre-hydration `loading` state as signed-out on exactly the taps this
+            event cares about. Today `canClaim` is itself false for a signed-out
+            viewer (the resolver requires an authenticated user), so this is
+            `signed-in` by construction — until #3672 shows the CTA anonymously,
+            at which point this prop is already carrying the truth. */}
+        {gym.canClaim && (
+          <GymClaimCta
+            gymUuid={gym.uuid}
+            gymName={gym.name}
+            website={gym.website}
+            viewerState={token ? 'signed-in' : 'signed-out'}
+          />
+        )}
 
         <GymReportDuplicateCta
           gymUuid={gym.uuid}

--- a/packages/web/app/home-page-content.tsx
+++ b/packages/web/app/home-page-content.tsx
@@ -31,6 +31,7 @@ import HomeRecentBetaSection from '@/app/components/beta-videos/home-recent-beta
 import HomeGymCard from '@/app/components/home-gym-card/home-gym-card';
 import StartClimbingButton from '@/app/components/start-climbing-button';
 import { track } from '@/app/lib/analytics';
+import { APP_INSTALL_CLICK_EVENT, buildAppInstallClickProperties } from '@/app/lib/app-install-event';
 
 const DISCORD_INVITE_URL = 'https://discord.gg/YXA8GsXfQK';
 
@@ -253,7 +254,10 @@ function InstallAppCard({ platform }: { platform: InstallPlatform }) {
         title={t('home.install.androidLiveTitle')}
         description={t('home.install.androidLiveDescription')}
         onClick={() => {
-          track('App Install Click', { platform: 'android', source: 'google-play' });
+          track(
+            APP_INSTALL_CLICK_EVENT,
+            buildAppInstallClickProperties({ platform: 'android', source: 'google-play' }),
+          );
           window.open(ANDROID_PLAY_STORE_URL, '_blank', 'noopener,noreferrer');
         }}
       />
@@ -275,7 +279,7 @@ function InstallAppCard({ platform }: { platform: InstallPlatform }) {
       description={t('home.install.iosDescription')}
       accent="none"
       onClick={() => {
-        track('App Install Click', { platform: 'ios', source: 'app-store' });
+        track(APP_INSTALL_CLICK_EVENT, buildAppInstallClickProperties({ platform: 'ios', source: 'app-store' }));
         window.open(IOS_APP_STORE_URL, '_blank', 'noopener,noreferrer');
       }}
     />
@@ -419,12 +423,15 @@ export default function HomePageContent({ initialPopularConfigs, initialRecentBe
             size="large"
             startIcon={<HeroInstallIcon />}
             onClick={() => {
-              track('App Install Click', {
-                platform: heroInstall.store,
-                source: heroInstall.store === 'android' ? 'google-play' : 'app-store',
-                placement: 'hero',
-                mode: heroInstall.mode,
-              });
+              track(
+                APP_INSTALL_CLICK_EVENT,
+                buildAppInstallClickProperties({
+                  platform: heroInstall.store,
+                  source: heroInstall.store === 'android' ? 'google-play' : 'app-store',
+                  placement: 'hero',
+                  mode: heroInstall.mode,
+                }),
+              );
               window.open(heroInstallUrl, '_blank', 'noopener,noreferrer');
             }}
             sx={HERO_CTA_SX}

--- a/packages/web/app/hooks/use-follow-toggle.ts
+++ b/packages/web/app/hooks/use-follow-toggle.ts
@@ -14,6 +14,13 @@ type UseFollowToggleConfig = {
   entityLabel: string;
   getFollowVariables: (entityId: string) => Record<string, unknown>;
   onFollowChange?: (isFollowing: boolean) => void;
+  /**
+   * Fired once per accepted click, after the auth guard and before any state
+   * moves. Deliberately separate from `onFollowChange`, which fires optimistically
+   * and AGAIN on rollback — instrumenting a click through that callback would
+   * report a phantom unfollow every time the mutation failed.
+   */
+  onToggleClick?: () => void;
 };
 
 export function useFollowToggle({
@@ -24,6 +31,7 @@ export function useFollowToggle({
   entityLabel,
   getFollowVariables,
   onFollowChange,
+  onToggleClick,
 }: UseFollowToggleConfig) {
   const [isFollowing, setIsFollowing] = useState(initialIsFollowing);
   // Sync internal state when the prop changes (e.g. after parent re-fetches)
@@ -40,6 +48,8 @@ export function useFollowToggle({
       showMessage(`Sign in to follow ${entityLabel}s`, 'info');
       return;
     }
+
+    onToggleClick?.();
 
     const previousState = isFollowing;
     setIsFollowing(!isFollowing);
@@ -73,6 +83,7 @@ export function useFollowToggle({
     unfollowMutation,
     getFollowVariables,
     onFollowChange,
+    onToggleClick,
     showMessage,
   ]);
 

--- a/packages/web/app/lib/__tests__/app-install-event.test.ts
+++ b/packages/web/app/lib/__tests__/app-install-event.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { APP_INSTALL_CLICK_EVENT, buildAppInstallClickProperties } from '../app-install-event';
+
+describe('buildAppInstallClickProperties', () => {
+  // These five objects are the payloads the pre-existing call sites emitted
+  // before the builder existed: three in app/home-page-content.tsx and two in
+  // app/components/capacitor-retirement/capacitor-retirement-screen.tsx. PH-13
+  // breaks the install funnel down by `source`, so a changed key or an extra
+  // one here silently splits a number someone reads weekly.
+  it('reproduces the home onboarding card payloads byte for byte', () => {
+    expect(buildAppInstallClickProperties({ platform: 'android', source: 'google-play' })).toEqual({
+      platform: 'android',
+      source: 'google-play',
+    });
+    expect(buildAppInstallClickProperties({ platform: 'ios', source: 'app-store' })).toEqual({
+      platform: 'ios',
+      source: 'app-store',
+    });
+  });
+
+  it('reproduces the home hero payload byte for byte', () => {
+    expect(
+      buildAppInstallClickProperties({
+        platform: 'android',
+        source: 'google-play',
+        placement: 'hero',
+        mode: 'update',
+      }),
+    ).toEqual({ platform: 'android', source: 'google-play', placement: 'hero', mode: 'update' });
+  });
+
+  it('reproduces the Capacitor retirement payloads byte for byte', () => {
+    expect(buildAppInstallClickProperties({ platform: 'ios', source: 'capacitor-retirement' })).toEqual({
+      platform: 'ios',
+      source: 'capacitor-retirement',
+    });
+    expect(buildAppInstallClickProperties({ platform: 'ios', source: 'capacitor-retirement-fallback' })).toEqual({
+      platform: 'ios',
+      source: 'capacitor-retirement-fallback',
+    });
+  });
+
+  it('omits optional keys rather than emitting them as undefined', () => {
+    const properties = buildAppInstallClickProperties({ platform: 'web', source: 'app-store' });
+    expect(Object.keys(properties)).toEqual(['platform', 'source']);
+    expect('placement' in properties).toBe(false);
+    expect('gymSlug' in properties).toBe(false);
+    expect('mode' in properties).toBe(false);
+  });
+
+  it('carries the gym-page placement and slug the gym CTA will need', () => {
+    expect(
+      buildAppInstallClickProperties({
+        platform: 'ios',
+        source: 'app-store',
+        placement: 'gym-page',
+        gymSlug: 'boulderwelt',
+      }),
+    ).toEqual({ platform: 'ios', source: 'app-store', placement: 'gym-page', gymSlug: 'boulderwelt' });
+  });
+
+  it('keeps the historic event name', () => {
+    expect(APP_INSTALL_CLICK_EVENT).toBe('App Install Click');
+  });
+});

--- a/packages/web/app/lib/__tests__/gym-funnel-analytics.test.ts
+++ b/packages/web/app/lib/__tests__/gym-funnel-analytics.test.ts
@@ -4,7 +4,7 @@ import { gymClaimResult, gymQrScanned, GYM_FUNNEL_EVENTS } from '@boardsesh/anal
 const trackMock = vi.hoisted(() => vi.fn());
 vi.mock('@/app/lib/analytics', () => ({ track: trackMock }));
 
-const { trackGymFunnelEvent, viewerStateFromSessionStatus } = await import('../gym-funnel-analytics');
+const { trackGymFunnelEvent, viewerStateFrom } = await import('../gym-funnel-analytics');
 
 beforeEach(() => {
   trackMock.mockReset();
@@ -30,18 +30,20 @@ describe('trackGymFunnelEvent', () => {
   });
 });
 
-describe('viewerStateFromSessionStatus', () => {
-  it('reports an authenticated session as signed-in', () => {
-    expect(viewerStateFromSessionStatus('authenticated')).toBe('signed-in');
+describe('viewerStateFrom', () => {
+  it('maps a settled authenticated answer to signed-in', () => {
+    expect(viewerStateFrom(true)).toBe('signed-in');
   });
 
-  it('reports an unauthenticated session as signed-out', () => {
-    expect(viewerStateFromSessionStatus('unauthenticated')).toBe('signed-out');
+  it('maps a settled anonymous answer to signed-out', () => {
+    expect(viewerStateFrom(false)).toBe('signed-out');
   });
 
-  it('reports a still-resolving session as signed-out rather than a third bucket', () => {
-    // A click that beats hydration is the same funnel step as a signed-out one:
-    // both are about to meet the auth wall.
-    expect(viewerStateFromSessionStatus('loading')).toBe('signed-out');
+  it('takes a boolean, so a pre-hydration session status cannot reach it', () => {
+    // The signature is the guard. Callers must resolve `loading` before they get
+    // here — a helper that accepted next-auth's status would silently bucket
+    // every not-yet-settled click as signed-out.
+    const acceptsBooleanOnly: (isAuthenticated: boolean) => string = viewerStateFrom;
+    expect(acceptsBooleanOnly(true)).toBe('signed-in');
   });
 });

--- a/packages/web/app/lib/__tests__/gym-funnel-analytics.test.ts
+++ b/packages/web/app/lib/__tests__/gym-funnel-analytics.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { gymClaimResult, gymQrScanned, GYM_FUNNEL_EVENTS } from '@boardsesh/analytics';
+
+const trackMock = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/analytics', () => ({ track: trackMock }));
+
+const { trackGymFunnelEvent, viewerStateFromSessionStatus } = await import('../gym-funnel-analytics');
+
+beforeEach(() => {
+  trackMock.mockReset();
+});
+
+describe('trackGymFunnelEvent', () => {
+  it('forwards a contract payload to track() as name + properties', () => {
+    trackGymFunnelEvent(gymQrScanned({ medium: 'poster', gymSlug: 'boulderwelt' }));
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith(GYM_FUNNEL_EVENTS.QrScanned, {
+      medium: 'poster',
+      gymSlug: 'boulderwelt',
+    });
+  });
+
+  it('does not rename, reorder or drop properties on the way through', () => {
+    trackGymFunnelEvent(gymClaimResult({ status: 'admin_review', gymUuid: 'gym-1' }));
+
+    const [name, properties] = trackMock.mock.calls[0];
+    expect(name).toBe('Gym Claim Result');
+    expect(Object.keys(properties as Record<string, unknown>).sort()).toEqual(['gymUuid', 'status']);
+  });
+});
+
+describe('viewerStateFromSessionStatus', () => {
+  it('reports an authenticated session as signed-in', () => {
+    expect(viewerStateFromSessionStatus('authenticated')).toBe('signed-in');
+  });
+
+  it('reports an unauthenticated session as signed-out', () => {
+    expect(viewerStateFromSessionStatus('unauthenticated')).toBe('signed-out');
+  });
+
+  it('reports a still-resolving session as signed-out rather than a third bucket', () => {
+    // A click that beats hydration is the same funnel step as a signed-out one:
+    // both are about to meet the auth wall.
+    expect(viewerStateFromSessionStatus('loading')).toBe('signed-out');
+  });
+});

--- a/packages/web/app/lib/app-install-event.ts
+++ b/packages/web/app/lib/app-install-event.ts
@@ -1,0 +1,67 @@
+// The single builder for `App Install Click`, the event every "get the app"
+// CTA on www fires.
+//
+// It predates the gym funnel and is deliberately NOT one of the gym-funnel
+// contract's events: PH-13 reads one install funnel broken down by `source`,
+// and forking a second event for the gym page would split that number in half.
+// The gym page's install CTA (#4379) extends this payload with `placement:
+// 'gym-page'` and a `gymSlug` instead.
+//
+// PAYLOAD STABILITY: the five call sites that existed before this module —
+// three in `app/home-page-content.tsx`, two in
+// `app/components/capacitor-retirement/capacitor-retirement-screen.tsx` — emit
+// byte-identical objects through it. That is why every field past `platform`
+// and `source` is optional AND omitted rather than emitted as `undefined`: a
+// key with an `undefined` value is a different object to a deep-equality
+// assertion, and `sanitizeForPosthog` would strip it anyway, so writing it
+// would only make "not applicable" indistinguishable from "not instrumented".
+
+/** Store the climber was sent to, as classified by the CTA that sent them. */
+export type AppInstallPlatform = 'ios' | 'android' | 'web';
+
+/** Which CTA fired. Historic values — do not rename, PH-13 breaks down on this. */
+export type AppInstallSource = 'app-store' | 'google-play' | 'capacitor-retirement' | 'capacitor-retirement-fallback';
+
+/**
+ * Where on the page the CTA lives. Absent means the home page's onboarding
+ * install card or the Capacitor dead-end screen, neither of which has ever
+ * carried a placement — adding one would change their existing payloads.
+ *
+ * `gym-page` has no producer yet; the gym-page install CTA is #4379.
+ */
+export type AppInstallPlacement = 'hero' | 'gym-page';
+
+/**
+ * Whether the CTA offers a first install or an update. Only the home hero
+ * distinguishes the two (a retired Capacitor straggler gets "update").
+ */
+export type AppInstallMode = 'install' | 'update';
+
+export const APP_INSTALL_CLICK_EVENT = 'App Install Click';
+
+export type AppInstallClickInput = {
+  platform: AppInstallPlatform;
+  source: AppInstallSource;
+  placement?: AppInstallPlacement;
+  mode?: AppInstallMode;
+  /** Slug of the gym page the install CTA was rendered on. Only ever set with `placement: 'gym-page'`. */
+  gymSlug?: string;
+};
+
+export type AppInstallClickProperties = {
+  platform: AppInstallPlatform;
+  source: AppInstallSource;
+  placement?: AppInstallPlacement;
+  mode?: AppInstallMode;
+  gymSlug?: string;
+};
+
+export function buildAppInstallClickProperties(input: AppInstallClickInput): AppInstallClickProperties {
+  return {
+    platform: input.platform,
+    source: input.source,
+    ...(input.placement === undefined ? {} : { placement: input.placement }),
+    ...(input.mode === undefined ? {} : { mode: input.mode }),
+    ...(input.gymSlug === undefined ? {} : { gymSlug: input.gymSlug }),
+  };
+}

--- a/packages/web/app/lib/gym-funnel-analytics.ts
+++ b/packages/web/app/lib/gym-funnel-analytics.ts
@@ -24,17 +24,23 @@ export function trackGymFunnelEvent(event: {
 }
 
 /**
- * NextAuth's `useSession().status` in the contract's vocabulary.
+ * A SETTLED authentication answer in the contract's vocabulary.
  *
- * `loading` maps to `signed-out` deliberately. The alternative is a third
- * bucket that means "the click happened before the session resolved", which is
- * a fact about our hydration timing rather than about the climber, and it would
- * split the one breakdown this property exists for. A signed-in climber whose
- * session is still resolving is the same funnel step as a signed-out one: both
- * are about to meet the auth wall.
+ * Takes a boolean, not NextAuth's `useSession().status`, and that is the whole
+ * point. `SessionProviderWrapper` mounts `<SessionProvider>` with no `session`
+ * prop, so next-auth starts every page load at `status: 'loading'` and settles
+ * only after a round-trip to `/api/auth/session`. A server-rendered page paints
+ * and hydrates before that lands, so a click that beats it — a QR poster
+ * scanned on a phone is exactly that case — would read `loading` and report a
+ * signed-in climber as `signed-out`.
+ *
+ * Callers must pass a value that has already settled: a server-read auth token,
+ * or `useWsAuthToken().isAuthenticated`, whose own query is gated on
+ * `status !== 'loading'` — so holding a gym fetched through it means the
+ * session resolved. `GymClaimViewerState` deliberately has no `loading` member:
+ * a third bucket would encode the hydration race as vocabulary instead of
+ * keeping it out of the data.
  */
-export function viewerStateFromSessionStatus(
-  status: 'authenticated' | 'unauthenticated' | 'loading',
-): GymClaimViewerState {
-  return status === 'authenticated' ? 'signed-in' : 'signed-out';
+export function viewerStateFrom(isAuthenticated: boolean): GymClaimViewerState {
+  return isAuthenticated ? 'signed-in' : 'signed-out';
 }

--- a/packages/web/app/lib/gym-funnel-analytics.ts
+++ b/packages/web/app/lib/gym-funnel-analytics.ts
@@ -1,0 +1,40 @@
+import type { AnalyticsPropertyValue, GymClaimViewerState, GymFunnelEventName } from '@boardsesh/analytics';
+import { track } from './analytics';
+
+/**
+ * The one bridge between the gym funnel event contract
+ * (`@boardsesh/analytics`'s `gym-funnel` module) and web's `track()`.
+ *
+ * Every gym-funnel call site goes through here rather than calling `track()`
+ * with a name and a hand-built object: the contract's builders return the name
+ * and its properties TOGETHER, and this signature is what keeps them together
+ * all the way to the wire. A call site physically cannot pair one event's props
+ * with another event's name.
+ *
+ * Flat file, not `app/lib/analytics/gym-funnel.ts`: `app/lib/analytics.ts`
+ * already exists, and a sibling `app/lib/analytics/` directory would make the
+ * `@/app/lib/analytics` specifier resolve to whichever of the two the bundler
+ * picked first.
+ */
+export function trackGymFunnelEvent(event: {
+  name: GymFunnelEventName;
+  properties: Record<string, AnalyticsPropertyValue>;
+}): void {
+  track(event.name, event.properties);
+}
+
+/**
+ * NextAuth's `useSession().status` in the contract's vocabulary.
+ *
+ * `loading` maps to `signed-out` deliberately. The alternative is a third
+ * bucket that means "the click happened before the session resolved", which is
+ * a fact about our hydration timing rather than about the climber, and it would
+ * split the one breakdown this property exists for. A signed-in climber whose
+ * session is still resolving is the same funnel step as a signed-out one: both
+ * are about to meet the auth wall.
+ */
+export function viewerStateFromSessionStatus(
+  status: 'authenticated' | 'unauthenticated' | 'loading',
+): GymClaimViewerState {
+  return status === 'authenticated' ? 'signed-in' : 'signed-out';
+}


### PR DESCRIPTION
Part of #4374 (part 2 of 2) · Part of epic #4372, Tier 1.

#4501 shipped the event contract. This wires it to the surfaces that already exist, so the gym funnel stops being invisible.

It does **not** close #4374: the last acceptance criterion needs `App Install Click` to fire from a `/gym/*` page carrying `placement: 'gym-page'`, and there is no install CTA on the gym page to fire it. #4379 builds that CTA; the builder for it lands here.

## What now fires

| Surface | Event |
|---|---|
| QR landing on `/gym/<slug>?src=qr&medium=…` | `Gym QR Scanned` |
| kiosk / website / report-duplicate / follow CTAs | `Gym Page CTA Clicked` |
| all three entry points that open the claim dialog | `Gym Claim CTA Clicked` |
| claim dialog submit, and all four outcome branches | `Gym Claim Submitted`, `Gym Claim Result` |
| manage console tab changes and deep links | `Gym Manage Tab Viewed` |

No UI or copy changes, and no new i18n keys — the two CTA labels are translated server-side and passed into the client island as props.

## Details a reviewer should check

**The five existing `App Install Click` payloads are byte-identical.** They now route through one builder, but `home-page-content.test.tsx` and `capacitor-retirement-screen.test.tsx` pass **unedited**, and the capacitor cases assert exact deep equality — so byte-identity is enforced by tests this PR didn't write. That matters because PH-13's install-source breakdown has to stay comparable across the change. The builder needed a `mode` field that wasn't in the original spec: the hero CTA already emits `mode: 'install' | 'update'`, and omitting it would have silently changed the hero payload.

**The follow CTA uses a new one-shot callback, not `onFollowChange`.** That existing callback fires optimistically *and* again on rollback, so wiring telemetry through it would emit a phantom `unfollow` on every failed network call. `FollowButton` is shared with other entity types, so the new callback is passed only from the gym button.

**`Gym Claim Submitted` derives `method` from what is actually sent** (`variables.input.claimEmail`), not from the dialog's `mode` state — the two can diverge. The dialog instance is reused across gyms, so `gymUuid` is read from props at fire time; there's a test that opens it for a second gym.

**`Gym Manage Tab Viewed` hooks an effect on the resolved active tab**, not the change handler. `handleTabChange` misses deep links and over-counts taps the dirty-guard cancels; `performNavigation` misses mount entirely.

**The QR tracker fires once per document**, guarded against StrictMode's double-invoked effects, and takes its params as props rather than through `useSearchParams` (which would force a Suspense boundary and a static bailout on the gym page).

## Known: `viewerState` during hydration

`viewerStateFromSessionStatus` maps NextAuth's `'loading'` to `'signed-out'`. A signed-in climber who clicks a claim CTA before the session resolves is recorded as signed-out. Called out explicitly because #4374's whole point is measuring the signed-out claim funnel, and this biases in the direction of the thing being measured — worth confirming the window is small enough not to matter, or splitting into a third bucket.

## Release Notes

- [x] No release note needed (internal / technical change)

Pure instrumentation: no UI, copy, or behaviour changes.
