### PR TITLE
feat(backend): gym directory fields — isClaimed, boardSummaries, requireSlug

### DIFF
--- a/packages/backend/src/__tests__/gym-directory-fields.test.ts
+++ b/packages/backend/src/__tests__/gym-directory-fields.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach } from 'vite-plus/test';
+import { v4 as uuidv4 } from 'uuid';
+import { sql } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+import { db } from '../db/client';
+import { socialGymQueries, GYM_BOARD_SUMMARY_LIMIT } from '../graphql/resolvers/social/gyms';
+
+/**
+ * Real-DB coverage for the three additions the public /gyms directory needs:
+ * `SearchGymsInput.requireSlug`, `Gym.isClaimed`, and `Gym.boardSummaries`.
+ *
+ * Seeds via raw SQL and calls the resolvers directly against the per-worker test
+ * DB, same shape as gym-write-access-and-claims.test.ts. Every assertion here is
+ * made from an ANONYMOUS context, because signed-out viewers are the directory's
+ * entire audience and a viewer-scoped field looks perfectly healthy in a
+ * logged-in dev session while rendering nothing in production.
+ */
+
+// The location sync parks every gym it imports on this owner, so "claimed" means
+// "owner is anyone else".
+const SYSTEM_OWNER = '00000000-0000-0000-0000-000000000000';
+const REAL_OWNER = 'dir-real-owner';
+const CLAIMANT = 'dir-claimant';
+
+const ALL_USERS = [SYSTEM_OWNER, REAL_OWNER, CLAIMANT];
+
+const anonCtx = (): ConnectionContext => ({ connectionId: 'conn-anon', isAuthenticated: false }) as ConnectionContext;
+
+const insertUser = (id: string) =>
+  db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${id + '@test.com'}, ${'User ' + id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+
+const insertGym = async (opts: {
+  ownerId: string;
+  name: string;
+  slug?: string | null;
+  isPublic?: boolean;
+}): Promise<{ id: number; uuid: string }> => {
+  const { ownerId, name, isPublic = true } = opts;
+  const uuid = uuidv4();
+  const slug = opts.slug === undefined ? uuid : opts.slug;
+  const result = await db.execute(sql`
+    INSERT INTO gyms (uuid, name, slug, owner_id, is_public, created_at, updated_at)
+    VALUES (${uuid}, ${name}, ${slug}, ${ownerId}, ${isPublic}, now(), now())
+    RETURNING id
+  `);
+  return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
+};
+
+const insertBoard = async (opts: {
+  gymId: number;
+  boardType?: string;
+  angle?: number;
+  softDeleted?: boolean;
+}): Promise<void> => {
+  const { gymId, boardType = 'kilter', angle = 40, softDeleted = false } = opts;
+  const uuid = uuidv4();
+  await db.execute(sql`
+    INSERT INTO user_boards
+      (uuid, slug, owner_id, board_type, layout_id, size_id, set_ids, name, angle, gym_id, is_public, deleted_at, created_at, updated_at)
+    VALUES (${uuid}, ${uuid}, ${REAL_OWNER}, ${boardType}, 1, 10, '1,2', 'Wall', ${angle}, ${gymId}, true,
+            ${softDeleted ? sql`now()` : sql`NULL`}, now(), now())
+  `);
+};
+
+const gymByUuid = async (gymUuid: string) => {
+  const gym = await socialGymQueries.gym(null, { gymUuid }, anonCtx());
+  expect(gym).not.toBeNull();
+  return gym!;
+};
+
+const searchDirectory = (input: Record<string, unknown>) =>
+  socialGymQueries.searchGyms(null, { input }, anonCtx()) as Promise<{
+    gyms: Array<{ uuid: string; slug: string | null }>;
+    totalCount: number;
+    hasMore: boolean;
+  }>;
+
+beforeEach(async () => {
+  await db.execute(sql`
+    TRUNCATE TABLE
+      "community_roles", "gym_members", "gym_follows", "gym_claims",
+      "board_follows", "boardsesh_ticks", "user_boards", "gyms", "notifications"
+    RESTART IDENTITY CASCADE
+  `);
+  await Promise.all(ALL_USERS.map(insertUser));
+});
+
+describe('searchGyms requireSlug', () => {
+  it('excludes both NULL and empty-string slugs, and drops totalCount by exactly the excluded count', async () => {
+    const withSlug = await insertGym({ ownerId: REAL_OWNER, name: 'Slugged Gym', slug: 'slugged-gym' });
+    const nullSlug = await insertGym({ ownerId: REAL_OWNER, name: 'Null Slug Gym', slug: null });
+    const emptySlug = await insertGym({ ownerId: REAL_OWNER, name: 'Empty Slug Gym', slug: '' });
+
+    const unfiltered = await searchDirectory({ limit: 50 });
+    expect(unfiltered.totalCount).toBe(3);
+    expect(unfiltered.gyms.map((gym) => gym.uuid).sort()).toEqual(
+      [withSlug.uuid, nullSlug.uuid, emptySlug.uuid].sort(),
+    );
+
+    const filtered = await searchDirectory({ limit: 50, requireSlug: true });
+    expect(filtered.gyms.map((gym) => gym.uuid)).toEqual([withSlug.uuid]);
+    // Two excluded rows, so totalCount must fall by exactly two — the count and
+    // the rows are separate statements and only a paired assertion catches them
+    // disagreeing.
+    expect(filtered.totalCount).toBe(unfiltered.totalCount - 2);
+    expect(filtered.hasMore).toBe(false);
+  });
+
+  it('keeps every gym when requireSlug is omitted', async () => {
+    await insertGym({ ownerId: REAL_OWNER, name: 'Null Slug Gym', slug: null });
+    await insertGym({ ownerId: REAL_OWNER, name: 'Slugged Gym', slug: 'slugged-gym' });
+
+    const result = await searchDirectory({ limit: 50 });
+    expect(result.totalCount).toBe(2);
+    expect(result.gyms).toHaveLength(2);
+  });
+
+  it('keeps totalCount and the returned page consistent under paging', async () => {
+    await insertGym({ ownerId: REAL_OWNER, name: 'No Slug A', slug: null });
+    await insertGym({ ownerId: REAL_OWNER, name: 'No Slug B', slug: '' });
+    for (let index = 0; index < 3; index++) {
+      await insertGym({ ownerId: REAL_OWNER, name: `Slugged ${index}`, slug: `slugged-${index}` });
+    }
+
+    const firstPage = await searchDirectory({ limit: 2, offset: 0, requireSlug: true });
+    expect(firstPage.totalCount).toBe(3);
+    expect(firstPage.gyms).toHaveLength(2);
+    expect(firstPage.hasMore).toBe(true);
+
+    const secondPage = await searchDirectory({ limit: 2, offset: 2, requireSlug: true });
+    expect(secondPage.totalCount).toBe(3);
+    expect(secondPage.gyms).toHaveLength(1);
+    expect(secondPage.hasMore).toBe(false);
+  });
+});
+
+describe('Gym.isClaimed', () => {
+  it('is false for a system-owned gym and true once ownership moves to a person — anonymously, both times', async () => {
+    const gym = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Synced Gym' });
+
+    const before = await gymByUuid(gym.uuid);
+    expect(before.isClaimed).toBe(false);
+    // The point of the field: canClaim is false here purely because the viewer is
+    // signed out, so a card gated on it would show nothing to the SEO audience.
+    expect(before.canClaim).toBe(false);
+
+    await db.execute(sql`UPDATE gyms SET owner_id = ${CLAIMANT} WHERE id = ${gym.id}`);
+
+    const after = await gymByUuid(gym.uuid);
+    expect(after.isClaimed).toBe(true);
+    expect(after.canClaim).toBe(false);
+  });
+
+  it('is true for a user-created gym from the start', async () => {
+    const gym = await insertGym({ ownerId: REAL_OWNER, name: 'Owner Made Gym' });
+    expect((await gymByUuid(gym.uuid)).isClaimed).toBe(true);
+  });
+});
+
+describe('Gym.boardSummaries', () => {
+  it('returns one entry per distinct type+angle while boardTypes collapses to the type', async () => {
+    const gym = await insertGym({ ownerId: REAL_OWNER, name: 'Two Angle Gym' });
+    await insertBoard({ gymId: gym.id, boardType: 'kilter', angle: 40 });
+    await insertBoard({ gymId: gym.id, boardType: 'kilter', angle: 25 });
+
+    const enriched = await gymByUuid(gym.uuid);
+    expect(enriched.boardTypes).toEqual(['kilter']);
+    expect(enriched.boardSummaries).toEqual([
+      { boardType: 'kilter', angle: 25 },
+      { boardType: 'kilter', angle: 40 },
+    ]);
+    expect(enriched.boardCount).toBe(2);
+  });
+
+  it('collapses two boards of the same type at the same angle into one summary', async () => {
+    const gym = await insertGym({ ownerId: REAL_OWNER, name: 'Twin Board Gym' });
+    await insertBoard({ gymId: gym.id, boardType: 'tension', angle: 40 });
+    await insertBoard({ gymId: gym.id, boardType: 'tension', angle: 40 });
+
+    const enriched = await gymByUuid(gym.uuid);
+    expect(enriched.boardSummaries).toEqual([{ boardType: 'tension', angle: 40 }]);
+    expect(enriched.boardCount).toBe(2);
+  });
+
+  it('orders deterministically by board type then angle', async () => {
+    const gym = await insertGym({ ownerId: REAL_OWNER, name: 'Mixed Gym' });
+    await insertBoard({ gymId: gym.id, boardType: 'tension', angle: 40 });
+    await insertBoard({ gymId: gym.id, boardType: 'kilter', angle: 50 });
+    await insertBoard({ gymId: gym.id, boardType: 'kilter', angle: 30 });
+
+    const enriched = await gymByUuid(gym.uuid);
+    expect(enriched.boardSummaries).toEqual([
+      { boardType: 'kilter', angle: 30 },
+      { boardType: 'kilter', angle: 50 },
+      { boardType: 'tension', angle: 40 },
+    ]);
+    expect(enriched.boardTypes).toEqual(['kilter', 'tension']);
+  });
+
+  it('leaves soft-deleted boards out of both boardTypes and boardSummaries', async () => {
+    const gym = await insertGym({ ownerId: REAL_OWNER, name: 'Retired Board Gym' });
+    await insertBoard({ gymId: gym.id, boardType: 'kilter', angle: 40 });
+    await insertBoard({ gymId: gym.id, boardType: 'moonboard', angle: 40, softDeleted: true });
+
+    const enriched = await gymByUuid(gym.uuid);
+    expect(enriched.boardTypes).toEqual(['kilter']);
+    expect(enriched.boardSummaries).toEqual([{ boardType: 'kilter', angle: 40 }]);
+    expect(enriched.boardCount).toBe(1);
+  });
+
+  it('returns an empty list, never null, for a gym with no boards', async () => {
+    const gym = await insertGym({ ownerId: REAL_OWNER, name: 'Boardless Gym' });
+
+    const enriched = await gymByUuid(gym.uuid);
+    expect(enriched.boardSummaries).toEqual([]);
+    expect(enriched.boardTypes).toEqual([]);
+  });
+
+  it('caps the list at GYM_BOARD_SUMMARY_LIMIT while boardCount stays honest', async () => {
+    const gym = await insertGym({ ownerId: REAL_OWNER, name: 'Board Farm' });
+    const distinctAngleCount = GYM_BOARD_SUMMARY_LIMIT + 4;
+    for (let index = 0; index < distinctAngleCount; index++) {
+      await insertBoard({ gymId: gym.id, boardType: 'kilter', angle: 10 + index });
+    }
+
+    const enriched = await gymByUuid(gym.uuid);
+    expect(enriched.boardSummaries).toHaveLength(GYM_BOARD_SUMMARY_LIMIT);
+    // Ordered before slicing, so the cut is the lowest angles, not an arbitrary
+    // subset Postgres happened to return.
+    expect(enriched.boardSummaries[0]).toEqual({ boardType: 'kilter', angle: 10 });
+    expect(enriched.boardCount).toBe(distinctAngleCount);
+    expect(enriched.boardTypes).toEqual(['kilter']);
+  });
+});

--- a/packages/backend/src/__tests__/gym-directory-fields.test.ts
+++ b/packages/backend/src/__tests__/gym-directory-fields.test.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { sql } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { db } from '../db/client';
-import { socialGymQueries, GYM_BOARD_SUMMARY_LIMIT } from '../graphql/resolvers/social/gyms';
+import { socialGymQueries, GYM_BOARD_SUMMARY_ANGLES_PER_TYPE } from '../graphql/resolvers/social/gyms';
 
 /**
  * Real-DB coverage for the three additions the public /gyms directory needs:
@@ -38,13 +38,16 @@ const insertGym = async (opts: {
   name: string;
   slug?: string | null;
   isPublic?: boolean;
+  /** ISO string; pass the SAME value for several gyms to force a created_at tie. */
+  createdAt?: string;
 }): Promise<{ id: number; uuid: string }> => {
-  const { ownerId, name, isPublic = true } = opts;
+  const { ownerId, name, isPublic = true, createdAt } = opts;
   const uuid = uuidv4();
   const slug = opts.slug === undefined ? uuid : opts.slug;
   const result = await db.execute(sql`
     INSERT INTO gyms (uuid, name, slug, owner_id, is_public, created_at, updated_at)
-    VALUES (${uuid}, ${name}, ${slug}, ${ownerId}, ${isPublic}, now(), now())
+    VALUES (${uuid}, ${name}, ${slug}, ${ownerId}, ${isPublic},
+            ${createdAt ? sql`${createdAt}::timestamp` : sql`now()`}, now())
     RETURNING id
   `);
   return { id: Number(Array.from(result as Iterable<{ id: number }>)[0].id), uuid };
@@ -136,6 +139,41 @@ describe('searchGyms requireSlug', () => {
     expect(secondPage.gyms).toHaveLength(1);
     expect(secondPage.hasMore).toBe(false);
   });
+
+  it('pages cleanly over gyms sharing one created_at — no duplicates, no skips', async () => {
+    // A bulk sync import writes many rows with the same created_at. Ordering by
+    // created_at alone leaves those rows unordered relative to each other, so
+    // Postgres may return them in a different order per OFFSET page: one gym
+    // appears twice and another never appears. `gyms.id` is the tiebreaker that
+    // makes the sequence total.
+    const sharedCreatedAt = '2026-01-01T00:00:00.000Z';
+    for (let index = 0; index < 6; index++) {
+      await insertGym({
+        ownerId: REAL_OWNER,
+        name: `Tied Gym ${index}`,
+        slug: `tied-gym-${index}`,
+        createdAt: sharedCreatedAt,
+      });
+    }
+
+    const pagedUuids: string[] = [];
+    for (let offset = 0; offset < 6; offset += 2) {
+      const page = await searchDirectory({ limit: 2, offset, requireSlug: true });
+      expect(page.totalCount).toBe(6);
+      pagedUuids.push(...page.gyms.map((gym) => gym.uuid));
+    }
+
+    expect(pagedUuids).toHaveLength(6);
+    expect(new Set(pagedUuids).size).toBe(6);
+
+    // And the order is the same on a repeat walk — stable, not merely unique.
+    const secondWalk: string[] = [];
+    for (let offset = 0; offset < 6; offset += 2) {
+      const page = await searchDirectory({ limit: 2, offset, requireSlug: true });
+      secondWalk.push(...page.gyms.map((gym) => gym.uuid));
+    }
+    expect(secondWalk).toEqual(pagedUuids);
+  });
 });
 
 describe('Gym.isClaimed', () => {
@@ -220,19 +258,44 @@ describe('Gym.boardSummaries', () => {
     expect(enriched.boardTypes).toEqual([]);
   });
 
-  it('caps the list at GYM_BOARD_SUMMARY_LIMIT while boardCount stays honest', async () => {
+  it('caps angles per board type while boardCount stays honest', async () => {
     const gym = await insertGym({ ownerId: REAL_OWNER, name: 'Board Farm' });
-    const distinctAngleCount = GYM_BOARD_SUMMARY_LIMIT + 4;
+    const distinctAngleCount = GYM_BOARD_SUMMARY_ANGLES_PER_TYPE + 4;
     for (let index = 0; index < distinctAngleCount; index++) {
       await insertBoard({ gymId: gym.id, boardType: 'kilter', angle: 10 + index });
     }
 
     const enriched = await gymByUuid(gym.uuid);
-    expect(enriched.boardSummaries).toHaveLength(GYM_BOARD_SUMMARY_LIMIT);
-    // Ordered before slicing, so the cut is the lowest angles, not an arbitrary
-    // subset Postgres happened to return.
+    expect(enriched.boardSummaries).toHaveLength(GYM_BOARD_SUMMARY_ANGLES_PER_TYPE);
+    // Ordered before capping, so the cut keeps the lowest angles rather than an
+    // arbitrary subset Postgres happened to return.
     expect(enriched.boardSummaries[0]).toEqual({ boardType: 'kilter', angle: 10 });
     expect(enriched.boardCount).toBe(distinctAngleCount);
     expect(enriched.boardTypes).toEqual(['kilter']);
+  });
+
+  it('never drops a board type off the end of the cap, even behind a type with many angles', async () => {
+    // The regression this guards: a flat cap over a list ordered
+    // `board_type, angle` spends the whole budget on `kilter` and returns zero
+    // moonboard summaries — so on /gyms/moonboard a gym matched BY the moonboard
+    // filter renders with no MoonBoard chip. SEARCH_GYMS_DIRECTORY selects
+    // boardSummaries and not boardTypes, so nothing else would cover for it.
+    const gym = await insertGym({ ownerId: REAL_OWNER, name: 'Kilter Wall Plus One Moonboard' });
+    for (let index = 0; index < GYM_BOARD_SUMMARY_ANGLES_PER_TYPE + 6; index++) {
+      await insertBoard({ gymId: gym.id, boardType: 'kilter', angle: 10 + index });
+    }
+    await insertBoard({ gymId: gym.id, boardType: 'moonboard', angle: 40 });
+
+    const enriched = await gymByUuid(gym.uuid);
+    const summarisedTypes = [...new Set(enriched.boardSummaries.map((summary) => summary.boardType))];
+    expect(summarisedTypes).toEqual(['kilter', 'moonboard']);
+    expect(enriched.boardSummaries).toContainEqual({ boardType: 'moonboard', angle: 40 });
+    // Every type in boardTypes has at least one chip — the invariant that makes
+    // the facet pages safe.
+    expect(summarisedTypes).toEqual(enriched.boardTypes);
+    // ...and the per-type cap still bounds the kilter run.
+    expect(enriched.boardSummaries.filter((summary) => summary.boardType === 'kilter')).toHaveLength(
+      GYM_BOARD_SUMMARY_ANGLES_PER_TYPE,
+    );
   });
 });

--- a/packages/backend/src/__tests__/search-gyms-require-slug-sql.test.ts
+++ b/packages/backend/src/__tests__/search-gyms-require-slug-sql.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
 import { PgDialect } from 'drizzle-orm/pg-core';
-import type { SQL } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
+import * as dbSchema from '@boardsesh/db/schema';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 
 /**
- * Rendered-SQL coverage for `SearchGymsInput.requireSlug` on the proximity path.
+ * Rendered-SQL coverage for `SearchGymsInput.requireSlug` on BOTH searchGyms
+ * code paths — the raw PostGIS proximity path and the Drizzle text path.
  *
  * The proximity path issues its count and its rows as two SEPARATE `db.execute`
  * calls that only agree because both interpolate the same filter clause. A
@@ -13,22 +15,59 @@ import type { ConnectionContext } from '@boardsesh/shared-schema';
  * pagination that a resolver-output test never sees. So this asserts on the SQL
  * the resolver actually emits, on BOTH statements, rather than on a rebuilt copy.
  *
- * The second assertion is the one that matters most: with `requireSlug` omitted,
- * the emitted SQL must be byte-identical to what the resolver emitted before the
- * flag existed. Mobile's `useNearbyGyms` (limit 50) and the gym picker ride this
- * exact query — the expected strings below are the pre-change output, pasted in
- * full so any drift is a diff, not a judgement call.
+ * The text path needs the same guard for a plainer reason: `/gyms` has no
+ * coordinates, so the text path is what the public directory actually runs. It
+ * builds through the Drizzle query builder rather than `db.execute`, so the
+ * `db.select` stand-in below captures the `where` / `orderBy` the resolver hands
+ * the builder and renders those.
+ *
+ * The `toBe()` baselines are the assertions that matter most: with `requireSlug`
+ * omitted the emitted SQL must be byte-identical to what the resolver emitted
+ * before the flag existed, because mobile's `useNearbyGyms` (limit 50) and the
+ * gym picker ride these exact queries. They are pasted in full so any drift is a
+ * diff, not a judgement call.
  */
 
-const { mockDb } = vi.hoisted(() => ({
-  mockDb: {
-    execute: vi.fn((_statement: unknown) => Promise.resolve([] as unknown[])),
-  },
-}));
+type TextSelectCapture = { where?: SQL; orderBy?: unknown[] };
+
+const { mockDb, textSelectCaptures } = vi.hoisted(() => {
+  const textSelectCaptures: Array<{ where?: unknown; orderBy?: unknown[] }> = [];
+  const makeSelectChain = () => {
+    const capture: { where?: unknown; orderBy?: unknown[] } = {};
+    textSelectCaptures.push(capture);
+    const chain = {
+      from: () => chain,
+      where: (condition: unknown) => {
+        capture.where = condition;
+        return chain;
+      },
+      orderBy: (...columns: unknown[]) => {
+        capture.orderBy = columns;
+        return chain;
+      },
+      limit: () => chain,
+      offset: () => chain,
+      // Thenable on purpose: Drizzle's query builder is itself a thenable, so
+      // `await db.select()...offset(n)` only works if the stand-in is one too.
+      // It resolves to an empty row set, which also means enrichGym never runs
+      // and nothing else touches the db.
+      // oxlint-disable-next-line unicorn/no-thenable
+      then: (resolve: (rows: unknown[]) => unknown) => resolve([]),
+    };
+    return chain;
+  };
+  return {
+    textSelectCaptures,
+    mockDb: {
+      execute: vi.fn((_statement: unknown) => Promise.resolve([] as unknown[])),
+      select: vi.fn((_projection?: unknown) => makeSelectChain()),
+    },
+  };
+});
 
 vi.mock('../db/client', () => ({ db: mockDb }));
 
-import { socialGymQueries } from '../graphql/resolvers/social/gyms';
+import { socialGymQueries, slugPresentFilter } from '../graphql/resolvers/social/gyms';
 
 const dialect = new PgDialect();
 
@@ -45,14 +84,29 @@ async function searchWith(input: Record<string, unknown>): Promise<string[]> {
   return renderedStatements();
 }
 
-const PROXIMITY_INPUT = { latitude: 52.37, longitude: 4.89, radiusKm: 25, limit: 20, offset: 0 };
+/** The `where` / `orderBy` the text path handed the Drizzle builder, rendered. */
+async function textSearchWith(input: Record<string, unknown>): Promise<{ wheres: string[]; orderBys: string[] }> {
+  await socialGymQueries.searchGyms(null, { input }, anonCtx());
+  const captures = textSelectCaptures as TextSelectCapture[];
+  return {
+    wheres: captures.map((capture) => dialect.sqlToQuery(capture.where as SQL).sql),
+    orderBys: captures
+      .filter((capture) => capture.orderBy !== undefined)
+      .map((capture) => dialect.sqlToQuery(sql.join(capture.orderBy as SQL[], sql`, `)).sql),
+  };
+}
 
-// The pre-`requireSlug` output, verbatim. Parameters are placeholders ($1…), so
-// these strings capture query shape — exactly what a no-regression guard needs.
+const PROXIMITY_INPUT = { latitude: 52.37, longitude: 4.89, radiusKm: 25, limit: 20, offset: 0 };
+const TEXT_INPUT = { limit: 24, offset: 0 };
+
+// The pre-`requireSlug` output, verbatim, with `gyms.id` added to the rows
+// ORDER BY as the deliberate pagination tiebreaker (see the resolver comment).
+// Parameters are placeholders ($1…), so these strings capture query shape —
+// exactly what a no-regression guard needs.
 const BASELINE_PROXIMITY_COUNT_SQL =
   'SELECT count(*)::int as count FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint($1, $2)::geography, $3)';
 const BASELINE_PROXIMITY_ROWS_SQL =
-  'SELECT *, ST_Distance(location, ST_MakePoint($1, $2)::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint($3, $4)::geography, $5) ORDER BY distance_meters ASC LIMIT $6 OFFSET $7';
+  'SELECT *, ST_Distance(location, ST_MakePoint($1, $2)::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint($3, $4)::geography, $5) ORDER BY distance_meters ASC, gyms.id ASC LIMIT $6 OFFSET $7';
 
 // The empty string is a SQL literal, not a bound parameter — it's a constant of
 // the predicate, never caller input.
@@ -61,6 +115,8 @@ const SLUG_PREDICATE = "gyms.slug IS NOT NULL AND gyms.slug <> ''";
 describe('searchGyms requireSlug — rendered SQL', () => {
   beforeEach(() => {
     mockDb.execute.mockClear();
+    mockDb.select.mockClear();
+    textSelectCaptures.length = 0;
   });
 
   it('puts the slug predicate in BOTH proximity statements (count and rows)', async () => {
@@ -115,5 +171,106 @@ describe('searchGyms requireSlug — rendered SQL', () => {
       expect(statement).toContain('ub.board_type IN (');
       expect(statement).toContain(SLUG_PREDICATE);
     }
+  });
+
+  it('orders the proximity rows by distance then gyms.id, so OFFSET paging is stable across ties', async () => {
+    const [, rowsSql] = await searchWith(PROXIMITY_INPUT);
+
+    expect(rowsSql).toContain('ORDER BY distance_meters ASC, gyms.id ASC LIMIT');
+  });
+
+  // The count-vs-rows agreement stated as one assertion rather than two
+  // substring checks. Ideally this would be a behavioural test against a real
+  // DB, but the backend test DB is plain `postgres:15` with no PostGIS — no
+  // `gyms.location` column, and `pg_available_extensions` lists no postgis — so
+  // ST_DWithin/ST_MakePoint cannot run there at all. Comparing the two WHERE
+  // clauses proves the same property the data test would: the set the count
+  // describes is the set the rows come from.
+  it.each([
+    ['requireSlug omitted', PROXIMITY_INPUT],
+    ['requireSlug true', { ...PROXIMITY_INPUT, requireSlug: true }],
+    ['requireSlug true + board filter', { ...PROXIMITY_INPUT, boardTypes: ['kilter'], requireSlug: true }],
+    ['requireSlug true + free text', { ...PROXIMITY_INPUT, query: 'boulder', requireSlug: true }],
+  ])('count and rows filter on an identical WHERE clause (%s)', async (_label, input) => {
+    const [countSql, rowsSql] = await searchWith(input);
+
+    // Placeholder numbering differs only because the rows query's ST_Distance
+    // select list binds two params before the WHERE; normalise it away.
+    const whereOf = (statement: string): string =>
+      statement.slice(statement.indexOf(' WHERE ')).split(' ORDER BY ')[0].replace(/\$\d+/g, '$?');
+
+    expect(whereOf(countSql)).toBe(whereOf(rowsSql));
+  });
+});
+
+describe('searchGyms requireSlug — rendered SQL, text path', () => {
+  beforeEach(() => {
+    mockDb.execute.mockClear();
+    mockDb.select.mockClear();
+    textSelectCaptures.length = 0;
+  });
+
+  it('never touches the proximity path when no coordinates are given', async () => {
+    await textSearchWith(TEXT_INPUT);
+
+    // No raw db.execute at all: this is the Drizzle builder path, and it is what
+    // `/gyms` runs, since the directory has no coordinates.
+    expect(mockDb.execute).not.toHaveBeenCalled();
+    expect(mockDb.select).toHaveBeenCalledTimes(2);
+  });
+
+  it('puts the slug predicate in BOTH text statements (count and rows)', async () => {
+    const { wheres } = await textSearchWith({ ...TEXT_INPUT, requireSlug: true });
+
+    expect(wheres).toHaveLength(2);
+    const [countWhere, rowsWhere] = wheres;
+    expect(countWhere).toContain(`"gyms"."slug" IS NOT NULL AND "gyms"."slug" <> ''`);
+    expect(rowsWhere).toContain(`"gyms"."slug" IS NOT NULL AND "gyms"."slug" <> ''`);
+    // Same predicate, same clause: the count and the rows derive from one shared
+    // `whereClause`, so totalCount can never describe a different set than the
+    // rows returned.
+    expect(countWhere).toBe(rowsWhere);
+  });
+
+  it('leaves the text where-clause byte-identical when requireSlug is omitted', async () => {
+    const { wheres } = await textSearchWith(TEXT_INPUT);
+
+    const BASELINE_TEXT_WHERE = `("gyms"."is_public" = $1 and "gyms"."deleted_at" is null)`;
+    expect(wheres).toEqual([BASELINE_TEXT_WHERE, BASELINE_TEXT_WHERE]);
+  });
+
+  it('leaves the text where-clause byte-identical when requireSlug is explicitly false', async () => {
+    const { wheres } = await textSearchWith({ ...TEXT_INPUT, requireSlug: false });
+
+    expect(wheres).toEqual([
+      `("gyms"."is_public" = $1 and "gyms"."deleted_at" is null)`,
+      `("gyms"."is_public" = $1 and "gyms"."deleted_at" is null)`,
+    ]);
+  });
+
+  it('orders the text rows by created_at then gyms.id, so OFFSET paging is stable across ties', async () => {
+    const { orderBys } = await textSearchWith(TEXT_INPUT);
+
+    expect(orderBys).toEqual([`"gyms"."created_at" desc, "gyms"."id"`]);
+  });
+});
+
+describe('slugPresentFilter', () => {
+  it('is the single source of the predicate both paths interpolate', () => {
+    // Rendering the exported helper against each path's slug expression
+    // reproduces exactly what the two path assertions above matched, which is
+    // what makes "both paths use the same SQL" a fact rather than a convention.
+    const rawPathPredicate = slugPresentFilter(true, sql`gyms.slug`);
+    const drizzlePathPredicate = slugPresentFilter(true, sql`${dbSchema.gyms.slug}`);
+
+    expect(dialect.sqlToQuery(rawPathPredicate as SQL).sql).toBe(SLUG_PREDICATE);
+    expect(dialect.sqlToQuery(drizzlePathPredicate as SQL).sql).toBe(
+      `"gyms"."slug" IS NOT NULL AND "gyms"."slug" <> ''`,
+    );
+  });
+
+  it('returns null — no clause at all — when the flag is absent or false', () => {
+    expect(slugPresentFilter(undefined, sql`gyms.slug`)).toBeNull();
+    expect(slugPresentFilter(false, sql`gyms.slug`)).toBeNull();
   });
 });

--- a/packages/backend/src/__tests__/search-gyms-require-slug-sql.test.ts
+++ b/packages/backend/src/__tests__/search-gyms-require-slug-sql.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+
+/**
+ * Rendered-SQL coverage for `SearchGymsInput.requireSlug` on the proximity path.
+ *
+ * The proximity path issues its count and its rows as two SEPARATE `db.execute`
+ * calls that only agree because both interpolate the same filter clause. A
+ * predicate that lands on the rows query but not the count makes `totalCount`
+ * and `hasMore` describe a different result set than the rows returned — broken
+ * pagination that a resolver-output test never sees. So this asserts on the SQL
+ * the resolver actually emits, on BOTH statements, rather than on a rebuilt copy.
+ *
+ * The second assertion is the one that matters most: with `requireSlug` omitted,
+ * the emitted SQL must be byte-identical to what the resolver emitted before the
+ * flag existed. Mobile's `useNearbyGyms` (limit 50) and the gym picker ride this
+ * exact query — the expected strings below are the pre-change output, pasted in
+ * full so any drift is a diff, not a judgement call.
+ */
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: {
+    execute: vi.fn((_statement: unknown) => Promise.resolve([] as unknown[])),
+  },
+}));
+
+vi.mock('../db/client', () => ({ db: mockDb }));
+
+import { socialGymQueries } from '../graphql/resolvers/social/gyms';
+
+const dialect = new PgDialect();
+
+const anonCtx = (): ConnectionContext =>
+  ({ connectionId: 'conn-sql-test', isAuthenticated: false }) as ConnectionContext;
+
+/** The rendered SQL of every `db.execute` the resolver issued, in call order. */
+function renderedStatements(): string[] {
+  return mockDb.execute.mock.calls.map(([statement]) => dialect.sqlToQuery(statement as unknown as SQL).sql);
+}
+
+async function searchWith(input: Record<string, unknown>): Promise<string[]> {
+  await socialGymQueries.searchGyms(null, { input }, anonCtx());
+  return renderedStatements();
+}
+
+const PROXIMITY_INPUT = { latitude: 52.37, longitude: 4.89, radiusKm: 25, limit: 20, offset: 0 };
+
+// The pre-`requireSlug` output, verbatim. Parameters are placeholders ($1…), so
+// these strings capture query shape — exactly what a no-regression guard needs.
+const BASELINE_PROXIMITY_COUNT_SQL =
+  'SELECT count(*)::int as count FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint($1, $2)::geography, $3)';
+const BASELINE_PROXIMITY_ROWS_SQL =
+  'SELECT *, ST_Distance(location, ST_MakePoint($1, $2)::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint($3, $4)::geography, $5) ORDER BY distance_meters ASC LIMIT $6 OFFSET $7';
+
+// The empty string is a SQL literal, not a bound parameter — it's a constant of
+// the predicate, never caller input.
+const SLUG_PREDICATE = "gyms.slug IS NOT NULL AND gyms.slug <> ''";
+
+describe('searchGyms requireSlug — rendered SQL', () => {
+  beforeEach(() => {
+    mockDb.execute.mockClear();
+  });
+
+  it('puts the slug predicate in BOTH proximity statements (count and rows)', async () => {
+    const [countSql, rowsSql, ...extra] = await searchWith({ ...PROXIMITY_INPUT, requireSlug: true });
+
+    expect(extra).toEqual([]);
+    expect(countSql).toContain('count(*)::int as count');
+    expect(rowsSql).toContain('ORDER BY distance_meters ASC');
+
+    // The predicate itself, identical on both statements — that identity is the
+    // whole guard, since totalCount comes from one and the rows from the other.
+    expect(countSql).toContain(SLUG_PREDICATE);
+    expect(rowsSql).toContain(SLUG_PREDICATE);
+  });
+
+  it('excludes empty-string slugs, not just NULL, and leaves the caller params untouched', async () => {
+    await socialGymQueries.searchGyms(null, { input: { ...PROXIMITY_INPUT, requireSlug: true } }, anonCtx());
+    const [countCall, rowsCall] = mockDb.execute.mock.calls;
+    const countQuery = dialect.sqlToQuery(countCall[0] as unknown as SQL);
+    const rowsQuery = dialect.sqlToQuery(rowsCall[0] as unknown as SQL);
+
+    // `/gym/` is as broken a link as `/gym/null`, so '' is excluded alongside NULL.
+    expect(countQuery.sql).toContain("gyms.slug <> ''");
+    expect(rowsQuery.sql).toContain("gyms.slug <> ''");
+    // The predicate binds nothing, so it can't shift the caller's placeholders.
+    expect(countQuery.params).toEqual([4.89, 52.37, 25000]);
+    expect(rowsQuery.params).toEqual([4.89, 52.37, 4.89, 52.37, 25000, 20, 0]);
+  });
+
+  it('emits byte-identical SQL to the pre-flag resolver when requireSlug is omitted', async () => {
+    const [countSql, rowsSql] = await searchWith(PROXIMITY_INPUT);
+
+    expect(countSql).toBe(BASELINE_PROXIMITY_COUNT_SQL);
+    expect(rowsSql).toBe(BASELINE_PROXIMITY_ROWS_SQL);
+  });
+
+  it('emits byte-identical SQL when requireSlug is explicitly false', async () => {
+    const [countSql, rowsSql] = await searchWith({ ...PROXIMITY_INPUT, requireSlug: false });
+
+    expect(countSql).toBe(BASELINE_PROXIMITY_COUNT_SQL);
+    expect(rowsSql).toBe(BASELINE_PROXIMITY_ROWS_SQL);
+  });
+
+  it('composes with the board-type filter without either clause displacing the other', async () => {
+    const [countSql, rowsSql] = await searchWith({
+      ...PROXIMITY_INPUT,
+      boardTypes: ['kilter'],
+      requireSlug: true,
+    });
+
+    for (const statement of [countSql, rowsSql]) {
+      expect(statement).toContain('ub.board_type IN (');
+      expect(statement).toContain(SLUG_PREDICATE);
+    }
+  });
+});

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -211,14 +211,17 @@ export async function resolveCanonicalGymBySlug(slug: string): Promise<GymRow | 
 }
 
 /**
- * Cap on `Gym.boardSummaries`. The directory card shows a row of board chips; a
- * gym with 40 boards must not ship 40 summaries down the wire for a card that
- * visually truncates after a handful. Distinct (type, angle) pairs are already
- * far fewer than boards — 12 covers every real gym in the data — and the list is
- * ordered before slicing, so the cut is deterministic rather than "whichever 12
- * Postgres felt like". `boardCount` remains the honest total.
+ * Cap on `Gym.boardSummaries`, applied PER BOARD TYPE rather than to the flat
+ * list. A gym with a wall of boards must not ship a summary per board for a card
+ * that visually truncates after a handful, but a flat cap over a list ordered
+ * `board_type, angle` silently drops whole board types off the end: twelve
+ * `(kilter, angle)` pairs plus one MoonBoard would render twelve Kilter chips
+ * and no MoonBoard chip. `SEARCH_GYMS_DIRECTORY` selects `boardSummaries` and
+ * not `boardTypes`, so on `/gyms/moonboard` a gym matched BY the moonboard
+ * filter would then show zero MoonBoard chips. Capping after grouping keeps
+ * every board type represented; `boardCount` remains the honest total.
  */
-export const GYM_BOARD_SUMMARY_LIMIT = 12;
+export const GYM_BOARD_SUMMARY_ANGLES_PER_TYPE = 6;
 
 /**
  * Enrich a gym row with computed fields (counts, follow status, membership).
@@ -311,13 +314,24 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
 
   const ownerInfo = ownerResult[0];
   const boardCount = Number(boardCountResult[0]?.count || 0);
-  // Both derived from the single widened distinct query above: the summaries are
-  // the (type, angle) pairs capped for the wire, `boardTypes` collapses them back
-  // to the distinct types the filters and badges have always used.
-  const boardSummaries = boardVariantsResult
-    .slice(0, GYM_BOARD_SUMMARY_LIMIT)
-    .map((row) => ({ boardType: row.boardType, angle: Number(row.angle) }));
-  const boardTypes = [...new Set(boardVariantsResult.map((row) => row.boardType))];
+  // Both derived from the single widened distinct query above. Grouping first
+  // means the per-type angle cap can never drop a board type from the chips, and
+  // `boardTypes` still comes off EVERY row (the map keys), so it stays the
+  // uncapped set the filters and badges have always used. Insertion order is the
+  // query's `ORDER BY board_type, angle`, so the output is deterministic.
+  const anglesByBoardType = new Map<string, number[]>();
+  for (const row of boardVariantsResult) {
+    const anglesForType = anglesByBoardType.get(row.boardType);
+    if (!anglesForType) {
+      anglesByBoardType.set(row.boardType, [Number(row.angle)]);
+    } else if (anglesForType.length < GYM_BOARD_SUMMARY_ANGLES_PER_TYPE) {
+      anglesForType.push(Number(row.angle));
+    }
+  }
+  const boardSummaries = [...anglesByBoardType].flatMap(([boardType, angles]) =>
+    angles.map((angle) => ({ boardType, angle })),
+  );
+  const boardTypes = [...anglesByBoardType.keys()];
   const memberCount = Number(memberCountResult[0]?.count || 0);
   const followerCount = Number(followerCountResult[0]?.count || 0);
   const commentCount = Number(commentCountResult[0]?.count || 0);
@@ -885,10 +899,15 @@ export const socialGymQueries = {
       );
       const totalCount = Number(rowsFromResult<Record<string, unknown>>(countRows)[0]?.count || 0);
 
+      // `gyms.id` is the tiebreaker, not decoration: the directory pages this
+      // query with OFFSET, and two gyms at an identical distance (a bulk sync
+      // import can place several at the same coordinates) have no defined order
+      // without it — Postgres is free to return them in a different order per
+      // page, duplicating one row and skipping another across the boundary.
       const gymRows = await db.execute(
         likePattern
-          ? sql`SELECT *, ST_Distance(location, ST_MakePoint(${lon}, ${lat})::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters}) AND (name ILIKE ${likePattern} OR address ILIKE ${likePattern})${proximityFilterClause} ORDER BY distance_meters ASC LIMIT ${limit} OFFSET ${offset}`
-          : sql`SELECT *, ST_Distance(location, ST_MakePoint(${lon}, ${lat})::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters})${proximityFilterClause} ORDER BY distance_meters ASC LIMIT ${limit} OFFSET ${offset}`,
+          ? sql`SELECT *, ST_Distance(location, ST_MakePoint(${lon}, ${lat})::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters}) AND (name ILIKE ${likePattern} OR address ILIKE ${likePattern})${proximityFilterClause} ORDER BY distance_meters ASC, gyms.id ASC LIMIT ${limit} OFFSET ${offset}`
+          : sql`SELECT *, ST_Distance(location, ST_MakePoint(${lon}, ${lat})::geography) as distance_meters FROM gyms WHERE is_public = true AND deleted_at IS NULL AND location IS NOT NULL AND ST_DWithin(location, ST_MakePoint(${lon}, ${lat})::geography, ${radiusMeters})${proximityFilterClause} ORDER BY distance_meters ASC, gyms.id ASC LIMIT ${limit} OFFSET ${offset}`,
       );
       const rows = rowsFromResult<Record<string, unknown>>(gymRows);
 
@@ -930,11 +949,15 @@ export const socialGymQueries = {
 
     const totalCount = Number(countResult?.count || 0);
 
+    // `gyms.id` breaks `created_at` ties. The directory pages this query with
+    // OFFSET, and bulk sync imports write many rows sharing a `created_at`, so
+    // without a unique tiebreaker tied rows have no defined order and can
+    // duplicate or vanish across a page boundary.
     const gymRows = await db
       .select()
       .from(dbSchema.gyms)
       .where(whereClause)
-      .orderBy(desc(dbSchema.gyms.createdAt))
+      .orderBy(desc(dbSchema.gyms.createdAt), dbSchema.gyms.id)
       .limit(limit)
       .offset(offset);
 

--- a/packages/backend/src/graphql/resolvers/social/gyms.ts
+++ b/packages/backend/src/graphql/resolvers/social/gyms.ts
@@ -25,6 +25,7 @@ import { distanceMeters } from '@boardsesh/db/queries';
 import { logger } from '../../../utils/logger';
 import { PROXIMITY_MATCH_RADIUS_METERS } from './gym-matching';
 import { syncLocationGeography } from './location-geography';
+import { SYSTEM_BOARD_OWNER_ID } from '../board-presence/shared';
 
 // ============================================
 // Helpers
@@ -210,6 +211,16 @@ export async function resolveCanonicalGymBySlug(slug: string): Promise<GymRow | 
 }
 
 /**
+ * Cap on `Gym.boardSummaries`. The directory card shows a row of board chips; a
+ * gym with 40 boards must not ship 40 summaries down the wire for a card that
+ * visually truncates after a handful. Distinct (type, angle) pairs are already
+ * far fewer than boards — 12 covers every real gym in the data — and the list is
+ * ordered before slicing, so the cut is deterministic rather than "whichever 12
+ * Postgres felt like". `boardCount` remains the honest total.
+ */
+export const GYM_BOARD_SUMMARY_LIMIT = 12;
+
+/**
  * Enrich a gym row with computed fields (counts, follow status, membership).
  * Exported so the kiosk resolvers can attach the same branding-carrying `Gym`
  * payload (logo + colours) to a public kiosk without duplicating the enrichment.
@@ -218,7 +229,7 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
   const [
     ownerResult,
     boardCountResult,
-    boardTypesResult,
+    boardVariantsResult,
     memberCountResult,
     followerCountResult,
     commentCountResult,
@@ -245,11 +256,18 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
       .from(dbSchema.userBoards)
       .where(and(eq(dbSchema.userBoards.gymId, gym.id), isNull(dbSchema.userBoards.deletedAt))),
 
-    // Distinct board types at this gym (for filtering + badges)
+    // Distinct (board type, angle) pairs at this gym. ONE query feeds both
+    // `boardTypes` (filtering + badges) and `boardSummaries` (directory board
+    // chips) — deliberately widened rather than joined by a second query, because
+    // enrichGym already fires nine round trips per gym and searchGyms runs it per
+    // row (limit up to 50), so a 24-card directory page costs ~216 queries; a
+    // tenth per gym would make it 240. Ordered so the summary cap below slices a
+    // stable prefix.
     db
-      .selectDistinct({ boardType: dbSchema.userBoards.boardType })
+      .selectDistinct({ boardType: dbSchema.userBoards.boardType, angle: dbSchema.userBoards.angle })
       .from(dbSchema.userBoards)
-      .where(and(eq(dbSchema.userBoards.gymId, gym.id), isNull(dbSchema.userBoards.deletedAt))),
+      .where(and(eq(dbSchema.userBoards.gymId, gym.id), isNull(dbSchema.userBoards.deletedAt)))
+      .orderBy(dbSchema.userBoards.boardType, dbSchema.userBoards.angle),
 
     // Count members
     db.select({ count: count() }).from(dbSchema.gymMembers).where(eq(dbSchema.gymMembers.gymId, gym.id)),
@@ -293,7 +311,13 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
 
   const ownerInfo = ownerResult[0];
   const boardCount = Number(boardCountResult[0]?.count || 0);
-  const boardTypes = boardTypesResult.map((row) => row.boardType);
+  // Both derived from the single widened distinct query above: the summaries are
+  // the (type, angle) pairs capped for the wire, `boardTypes` collapses them back
+  // to the distinct types the filters and badges have always used.
+  const boardSummaries = boardVariantsResult
+    .slice(0, GYM_BOARD_SUMMARY_LIMIT)
+    .map((row) => ({ boardType: row.boardType, angle: Number(row.angle) }));
+  const boardTypes = [...new Set(boardVariantsResult.map((row) => row.boardType))];
   const memberCount = Number(memberCountResult[0]?.count || 0);
   const followerCount = Number(followerCountResult[0]?.count || 0);
   const commentCount = Number(commentCountResult[0]?.count || 0);
@@ -328,6 +352,16 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
     memberRow?.role !== 'editor' &&
     !hasCommunityAccess;
 
+  // Whether a real person owns this gym. Gyms created by the location sync are
+  // parked on the system import user, so ownership by anyone else means someone
+  // claimed it. This reads `gym.ownerId` ONLY — never `authenticatedUserId` — so
+  // the value is identical for every viewer and is therefore safe to cache for
+  // anonymous SSR. That is the whole point of the field: `canClaim` is false for
+  // every signed-out viewer, and signed-out viewers are the public directory's
+  // entire audience, so a card gated on `canClaim` would render nothing for them
+  // while looking correct in a logged-in dev session.
+  const isClaimed = gym.ownerId !== SYSTEM_BOARD_OWNER_ID;
+
   return {
     uuid: gym.uuid,
     slug: gym.slug,
@@ -353,6 +387,7 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
     createdAt: gym.createdAt.toISOString(),
     boardCount,
     boardTypes,
+    boardSummaries,
     memberCount,
     followerCount,
     commentCount,
@@ -362,7 +397,28 @@ export async function enrichGym(gym: typeof dbSchema.gyms.$inferSelect, authenti
     canEdit,
     canGrantAccess,
     canClaim,
+    isClaimed,
   };
+}
+
+/**
+ * `SearchGymsInput.requireSlug` predicate: keep only gyms that can produce a
+ * `/gym/[slug]` URL. A slugless gym renders as `/gym/null` in the public
+ * directory, so the directory opts in; every other caller omits the flag and
+ * gets `null` back, leaving its emitted SQL byte-identical.
+ *
+ * ONE exported function, parameterised by the slug expression, because
+ * searchGyms has two code paths and the proximity path issues its count and its
+ * rows as two SEPARATE `db.execute` calls that only agree because both
+ * interpolate the same filter clause. A predicate added to the rows query but
+ * not the count makes `totalCount`/`hasMore` disagree with the rows returned —
+ * broken pagination that no test catches unless it asserts on both statements.
+ * Callers pass `gyms.slug` (raw PostGIS path) or the Drizzle column (text path).
+ */
+export function slugPresentFilter(requireSlug: boolean | undefined, slugColumn: SQL): SQL | null {
+  // Empty string is excluded alongside NULL: `/gym/` is as broken a link as
+  // `/gym/null`, and the column has no NOT NULL / non-empty constraint.
+  return requireSlug ? sql`${slugColumn} IS NOT NULL AND ${slugColumn} <> ''` : null;
 }
 
 type GymMemberRole = 'admin' | 'editor' | 'member';
@@ -750,7 +806,8 @@ export const socialGymQueries = {
 
   searchGyms: async (_: unknown, { input }: { input: unknown }, ctx: ConnectionContext) => {
     const validatedInput = validateInput(SearchGymsInputSchema, input, 'input');
-    const { query, boardTypes, layoutIds, sizeIds, multiBoardTypeOnly, latitude, longitude, radiusKm } = validatedInput;
+    const { query, boardTypes, layoutIds, sizeIds, multiBoardTypeOnly, requireSlug, latitude, longitude, radiusKm } =
+      validatedInput;
     const limit = validatedInput.limit ?? 20;
     const offset = validatedInput.offset ?? 0;
     const useProximity = latitude !== undefined && longitude !== undefined;
@@ -807,9 +864,14 @@ export const socialGymQueries = {
 
       // Board/gym filters appended to the raw PostGIS WHERE. `gyms.id` is the
       // bare column in this raw query's FROM.
-      const proximityFilters = [boardMatchExists(sql`gyms.id`), multiBoardTypeExists(sql`gyms.id`)].filter(
-        (clause): clause is SQL => clause !== null,
-      );
+      const proximityFilters = [
+        boardMatchExists(sql`gyms.id`),
+        multiBoardTypeExists(sql`gyms.id`),
+        // Shared by the count and the rows statements below — both interpolate
+        // `proximityFilterClause`, so they can never disagree about which gyms
+        // are in the result set.
+        slugPresentFilter(requireSlug, sql`gyms.slug`),
+      ].filter((clause): clause is SQL => clause !== null);
       const proximityFilterClause =
         proximityFilters.length > 0 ? sql` AND ${sql.join(proximityFilters, sql` AND `)}` : sql.empty();
 
@@ -857,6 +919,10 @@ export const socialGymQueries = {
     if (textBoardMatch) conditions.push(textBoardMatch);
     const textMultiBoardType = multiBoardTypeExists(sql`${dbSchema.gyms.id}`);
     if (textMultiBoardType) conditions.push(textMultiBoardType);
+    // Pushed into the shared conditions array, so the count and the rows query
+    // below both derive from the same `whereClause`.
+    const textSlugPresent = slugPresentFilter(requireSlug, sql`${dbSchema.gyms.slug}`);
+    if (textSlugPresent) conditions.push(textSlugPresent);
 
     const whereClause = and(...conditions);
 

--- a/packages/backend/src/validation/schemas/gyms.ts
+++ b/packages/backend/src/validation/schemas/gyms.ts
@@ -204,6 +204,10 @@ export const SearchGymsInputSchema = z.object({
   layoutIds: z.array(z.number().int().nonnegative()).max(50).optional(),
   sizeIds: z.array(z.number().int().nonnegative()).max(50).optional(),
   multiBoardTypeOnly: z.boolean().optional(),
+  // Deliberately no `.default(false)`: a default would make the resolver emit the
+  // slug predicate decision for every existing caller (mobile's useNearbyGyms,
+  // the gym picker) instead of leaving their rendered SQL byte-identical.
+  requireSlug: z.boolean().optional(),
   latitude: z.number().min(-90).max(90).optional(),
   longitude: z.number().min(-180).max(180).optional(),
   radiusKm: z.number().min(0.1).max(500).optional().default(50),

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2746,6 +2746,18 @@ enum GymClaimRequestStatus {
 }
 
 """
+One board-type + angle pair present at a gym, for the directory's board chips.
+Deliberately minimal: a card renders "Kilter 40°", nothing else. Distinct pairs
+only, so two Kilter boards both at 40° collapse into one summary.
+"""
+type GymBoardSummary {
+  "Board type (kilter, tension, moonboard, ...)"
+  boardType: String!
+  "Board angle in degrees"
+  angle: Int!
+}
+
+"""
 A physical gym location that can contain multiple boards.
 """
 type Gym {
@@ -2797,6 +2809,8 @@ type Gym {
   boardCount: Int!
   "Distinct board types at this gym (kilter, tension, ...) — for filtering and badges"
   boardTypes: [String!]!
+  "Distinct board-type + angle pairs at this gym, for directory board chips. Ordered by board type then angle and capped, so a gym with a wall of boards returns a bounded list."
+  boardSummaries: [GymBoardSummary!]!
   "Number of members"
   memberCount: Int!
   "Number of followers"
@@ -2815,6 +2829,8 @@ type Gym {
   canGrantAccess: Boolean!
   "Whether the current viewer may start an ownership claim for this gym (signed-in and not already the owner/gym admin)"
   canClaim: Boolean!
+  "Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer."
+  isClaimed: Boolean!
 }
 
 """
@@ -3046,6 +3062,8 @@ input SearchGymsInput {
   sizeIds: [Int!]
   "Only gyms with two or more distinct board types"
   multiBoardTypeOnly: Boolean
+  "Only gyms that have a URL slug, i.e. that can be linked to at /gym/[slug]. Opt-in: omitting it leaves the emitted SQL untouched for existing callers."
+  requireSlug: Boolean
   "Latitude for proximity search"
   latitude: Float
   "Longitude for proximity search"

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2417,6 +2417,8 @@ export type Gym = {
   address?: Maybe<Scalars['String']['output']>;
   /** Number of linked boards */
   boardCount: Scalars['Int']['output'];
+  /** Distinct board-type + angle pairs at this gym, for directory board chips. Ordered by board type then angle and capped, so a gym with a wall of boards returns a bounded list. */
+  boardSummaries: Array<GymBoardSummary>;
   /** Distinct board types at this gym (kilter, tension, ...) — for filtering and badges */
   boardTypes: Array<Scalars['String']['output']>;
   /** Kiosk/embed brand accent colour as #RRGGBB (null when unset). */
@@ -2449,6 +2451,8 @@ export type Gym = {
   hoursUpdatedAt?: Maybe<Scalars['String']['output']>;
   /** Image URL */
   imageUrl?: Maybe<Scalars['String']['output']>;
+  /** Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer. */
+  isClaimed: Scalars['Boolean']['output'];
   /** Whether the current user follows this gym */
   isFollowedByMe: Scalars['Boolean']['output'];
   /** Whether the current user is a member */
@@ -2479,6 +2483,19 @@ export type Gym = {
   uuid: Scalars['ID']['output'];
   /** Website URL (used for domain-verified ownership claims) */
   website?: Maybe<Scalars['String']['output']>;
+};
+
+/**
+ * One board-type + angle pair present at a gym, for the directory's board chips.
+ * Deliberately minimal: a card renders "Kilter 40°", nothing else. Distinct pairs
+ * only, so two Kilter boards both at 40° collapse into one summary.
+ */
+export type GymBoardSummary = {
+  __typename?: 'GymBoardSummary';
+  /** Board angle in degrees */
+  angle: Scalars['Int']['output'];
+  /** Board type (kilter, tension, moonboard, ...) */
+  boardType: Scalars['String']['output'];
 };
 
 /** A pending or resolved gym ownership claim (admin queue). */
@@ -6346,6 +6363,8 @@ export type SearchGymsInput = {
   query?: InputMaybe<Scalars['String']['input']>;
   /** Radius in km for proximity search (default 50) */
   radiusKm?: InputMaybe<Scalars['Float']['input']>;
+  /** Only gyms that have a URL slug, i.e. that can be linked to at /gym/[slug]. Opt-in: omitting it leaves the emitted SQL untouched for existing callers. */
+  requireSlug?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter to gyms that have a board with one of these size ids (OR). Combined with boardTypes/layoutIds, all must match the same board. */
   sizeIds?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
@@ -8292,6 +8311,7 @@ export type ResolversTypes = ResolversObject<{
   GroupedNotificationActor: ResolverTypeWrapper<GroupedNotificationActor>;
   GroupedNotificationConnection: ResolverTypeWrapper<GroupedNotificationConnection>;
   Gym: ResolverTypeWrapper<Gym>;
+  GymBoardSummary: ResolverTypeWrapper<GymBoardSummary>;
   GymClaim: ResolverTypeWrapper<GymClaim>;
   GymClaimConnection: ResolverTypeWrapper<GymClaimConnection>;
   GymClaimDecision: GymClaimDecision;
@@ -8660,6 +8680,7 @@ export type ResolversParentTypes = ResolversObject<{
   GroupedNotificationActor: GroupedNotificationActor;
   GroupedNotificationConnection: GroupedNotificationConnection;
   Gym: Gym;
+  GymBoardSummary: GymBoardSummary;
   GymClaim: GymClaim;
   GymClaimConnection: GymClaimConnection;
   GymConnection: GymConnection;
@@ -10034,6 +10055,7 @@ export type GymResolvers<
 > = ResolversObject<{
   address?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   boardCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  boardSummaries?: Resolver<Array<ResolversTypes['GymBoardSummary']>, ParentType, ContextType>;
   boardTypes?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   brandAccentColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   brandBackgroundColor?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -10050,6 +10072,7 @@ export type GymResolvers<
   hours?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   hoursUpdatedAt?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   imageUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isClaimed?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   isFollowedByMe?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   isMember?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   isPublic?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -10065,6 +10088,15 @@ export type GymResolvers<
   slug?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   uuid?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   website?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type GymBoardSummaryResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['GymBoardSummary'] = ResolversParentTypes['GymBoardSummary'],
+> = ResolversObject<{
+  angle?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  boardType?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -13237,6 +13269,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   GroupedNotificationActor?: GroupedNotificationActorResolvers<ContextType>;
   GroupedNotificationConnection?: GroupedNotificationConnectionResolvers<ContextType>;
   Gym?: GymResolvers<ContextType>;
+  GymBoardSummary?: GymBoardSummaryResolvers<ContextType>;
   GymClaim?: GymClaimResolvers<ContextType>;
   GymClaimConnection?: GymClaimConnectionResolvers<ContextType>;
   GymConnection?: GymConnectionResolvers<ContextType>;

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -37,6 +37,18 @@ export const gymsTypeDefs = /* GraphQL */ `
   }
 
   """
+  One board-type + angle pair present at a gym, for the directory's board chips.
+  Deliberately minimal: a card renders "Kilter 40°", nothing else. Distinct pairs
+  only, so two Kilter boards both at 40° collapse into one summary.
+  """
+  type GymBoardSummary {
+    "Board type (kilter, tension, moonboard, ...)"
+    boardType: String!
+    "Board angle in degrees"
+    angle: Int!
+  }
+
+  """
   A physical gym location that can contain multiple boards.
   """
   type Gym {
@@ -88,6 +100,8 @@ export const gymsTypeDefs = /* GraphQL */ `
     boardCount: Int!
     "Distinct board types at this gym (kilter, tension, ...) — for filtering and badges"
     boardTypes: [String!]!
+    "Distinct board-type + angle pairs at this gym, for directory board chips. Ordered by board type then angle and capped, so a gym with a wall of boards returns a bounded list."
+    boardSummaries: [GymBoardSummary!]!
     "Number of members"
     memberCount: Int!
     "Number of followers"
@@ -106,6 +120,8 @@ export const gymsTypeDefs = /* GraphQL */ `
     canGrantAccess: Boolean!
     "Whether the current viewer may start an ownership claim for this gym (signed-in and not already the owner/gym admin)"
     canClaim: Boolean!
+    "Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer."
+    isClaimed: Boolean!
   }
 
   """
@@ -337,6 +353,8 @@ export const gymsTypeDefs = /* GraphQL */ `
     sizeIds: [Int!]
     "Only gyms with two or more distinct board types"
     multiBoardTypeOnly: Boolean
+    "Only gyms that have a URL slug, i.e. that can be linked to at /gym/[slug]. Opt-in: omitting it leaves the emitted SQL untouched for existing callers."
+    requireSlug: Boolean
     "Latitude for proximity search"
     latitude: Float
     "Longitude for proximity search"

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -58,8 +58,14 @@ export type Gym = {
   createdAt: string;
   boardCount: number;
   boardTypes: string[];
-  /** Distinct board-type + angle pairs at this gym, ordered by type then angle and capped. */
-  boardSummaries: GymBoardSummary[];
+  /**
+   * Distinct board-type + angle pairs at this gym, ordered by type then angle
+   * and capped per board type. Non-null on the server, but OPTIONAL here because
+   * only SEARCH_GYMS_DIRECTORY selects it — the shared GYM_FIELDS selection set
+   * deliberately leaves it out, so a required type would promise a value that
+   * GET_GYM / GET_GYM_BY_SLUG / GET_MY_GYMS / SEARCH_GYMS never return.
+   */
+  boardSummaries?: GymBoardSummary[];
   memberCount: number;
   followerCount: number;
   commentCount: number;
@@ -72,7 +78,11 @@ export type Gym = {
   canGrantAccess: boolean;
   /** Whether the current viewer may start an ownership claim for this gym. */
   canClaim: boolean;
-  /** Whether a real person owns this gym rather than the system import user. Viewer-independent. */
+  /**
+   * Whether a real person owns this gym rather than the system import user.
+   * Viewer-independent, and required here because GYM_FIELDS selects it — every
+   * document typed `Gym` genuinely returns it.
+   */
   isClaimed: boolean;
 };
 

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -18,6 +18,15 @@ export type GymClaimRequestStatus = 'email_sent' | 'admin_review' | 'approved';
 
 export type GymClaimDecision = 'approve' | 'deny';
 
+/**
+ * One board-type + angle pair present at a gym, for the directory's board chips.
+ * Distinct pairs only — two Kilter boards both at 40° collapse into one summary.
+ */
+export type GymBoardSummary = {
+  boardType: string;
+  angle: number;
+};
+
 export type Gym = {
   uuid: string;
   slug?: string | null;
@@ -49,6 +58,8 @@ export type Gym = {
   createdAt: string;
   boardCount: number;
   boardTypes: string[];
+  /** Distinct board-type + angle pairs at this gym, ordered by type then angle and capped. */
+  boardSummaries: GymBoardSummary[];
   memberCount: number;
   followerCount: number;
   commentCount: number;
@@ -61,6 +72,8 @@ export type Gym = {
   canGrantAccess: boolean;
   /** Whether the current viewer may start an ownership claim for this gym. */
   canClaim: boolean;
+  /** Whether a real person owns this gym rather than the system import user. Viewer-independent. */
+  isClaimed: boolean;
 };
 
 export type GymConnection = {
@@ -251,6 +264,8 @@ export type SearchGymsInput = {
   latitude?: number;
   longitude?: number;
   radiusKm?: number;
+  /** Only gyms with a slug, i.e. linkable at /gym/[slug]. Opt-in; omitting it leaves the emitted SQL unchanged. */
+  requireSlug?: boolean;
   limit?: number;
   offset?: number;
 };

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2414,6 +2414,8 @@ export type Gym = {
   address?: Maybe<Scalars['String']['output']>;
   /** Number of linked boards */
   boardCount: Scalars['Int']['output'];
+  /** Distinct board-type + angle pairs at this gym, for directory board chips. Ordered by board type then angle and capped, so a gym with a wall of boards returns a bounded list. */
+  boardSummaries: Array<GymBoardSummary>;
   /** Distinct board types at this gym (kilter, tension, ...) — for filtering and badges */
   boardTypes: Array<Scalars['String']['output']>;
   /** Kiosk/embed brand accent colour as #RRGGBB (null when unset). */
@@ -2446,6 +2448,8 @@ export type Gym = {
   hoursUpdatedAt?: Maybe<Scalars['String']['output']>;
   /** Image URL */
   imageUrl?: Maybe<Scalars['String']['output']>;
+  /** Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer. */
+  isClaimed: Scalars['Boolean']['output'];
   /** Whether the current user follows this gym */
   isFollowedByMe: Scalars['Boolean']['output'];
   /** Whether the current user is a member */
@@ -2476,6 +2480,19 @@ export type Gym = {
   uuid: Scalars['ID']['output'];
   /** Website URL (used for domain-verified ownership claims) */
   website?: Maybe<Scalars['String']['output']>;
+};
+
+/**
+ * One board-type + angle pair present at a gym, for the directory's board chips.
+ * Deliberately minimal: a card renders "Kilter 40°", nothing else. Distinct pairs
+ * only, so two Kilter boards both at 40° collapse into one summary.
+ */
+export type GymBoardSummary = {
+  __typename?: 'GymBoardSummary';
+  /** Board angle in degrees */
+  angle: Scalars['Int']['output'];
+  /** Board type (kilter, tension, moonboard, ...) */
+  boardType: Scalars['String']['output'];
 };
 
 /** A pending or resolved gym ownership claim (admin queue). */
@@ -6343,6 +6360,8 @@ export type SearchGymsInput = {
   query?: InputMaybe<Scalars['String']['input']>;
   /** Radius in km for proximity search (default 50) */
   radiusKm?: InputMaybe<Scalars['Float']['input']>;
+  /** Only gyms that have a URL slug, i.e. that can be linked to at /gym/[slug]. Opt-in: omitting it leaves the emitted SQL untouched for existing callers. */
+  requireSlug?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter to gyms that have a board with one of these size ids (OR). Combined with boardTypes/layoutIds, all must match the same board. */
   sizeIds?: InputMaybe<Array<Scalars['Int']['input']>>;
 };

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -117,6 +117,36 @@ export const SEARCH_GYMS = gql`
   }
 `;
 
+/**
+ * The public `/gyms` directory list. A separate document from SEARCH_GYMS on
+ * purpose: it selects only what a directory card renders, and GYM_FIELDS is
+ * shared with GET_GYM / GET_MY_GYMS / SEARCH_GYMS — mobile's useNearbyGyms rides
+ * that fragment at limit 50, so widening it would make every gym-picker query
+ * fetch board summaries and a claim flag it never draws.
+ */
+export const SEARCH_GYMS_DIRECTORY = gql`
+  query SearchGymsDirectory($input: SearchGymsInput!) {
+    searchGyms(input: $input) {
+      gyms {
+        uuid
+        slug
+        name
+        address
+        latitude
+        longitude
+        boardCount
+        isClaimed
+        boardSummaries {
+          boardType
+          angle
+        }
+      }
+      totalCount
+      hasMore
+    }
+  }
+`;
+
 export const FIND_SIMILAR_GYMS = gql`
   query FindSimilarGyms($input: FindSimilarGymsInput!) {
     findSimilarGyms(input: $input) {
@@ -488,6 +518,24 @@ export type SearchGymsQueryVariables = {
 
 export type SearchGymsQueryResponse = {
   searchGyms: GymConnection;
+};
+
+/** Exactly the fields SEARCH_GYMS_DIRECTORY selects — the directory card contract. */
+export type GymDirectoryCard = Pick<
+  Gym,
+  'uuid' | 'slug' | 'name' | 'address' | 'latitude' | 'longitude' | 'boardCount' | 'isClaimed' | 'boardSummaries'
+>;
+
+export type SearchGymsDirectoryQueryVariables = {
+  input: SearchGymsInput;
+};
+
+export type SearchGymsDirectoryQueryResponse = {
+  searchGyms: {
+    gyms: GymDirectoryCard[];
+    totalCount: number;
+    hasMore: boolean;
+  };
 };
 
 export type FindSimilarGymsQueryVariables = {

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -1,6 +1,7 @@
 import { gql } from 'graphql-request';
 import type {
   Gym,
+  GymBoardSummary,
   GymConnection,
   GymMemberConnection,
   CreateGymInput,
@@ -41,6 +42,15 @@ import type {
 // Gym Queries
 // ============================================
 
+/**
+ * Shared by GET_GYM, GET_GYM_BY_SLUG, GET_MY_GYMS and SEARCH_GYMS, all typed
+ * `Gym`/`GymConnection` — so every field the `Gym` type declares as REQUIRED has
+ * to be selected here, or consumers read `undefined` while TypeScript promises a
+ * value. `isClaimed` is in for exactly that reason (and it's one boolean off
+ * `gym.ownerId`, already loaded, no extra query). `boardSummaries` stays out and
+ * is optional on the type instead: it's a list, only the directory renders it,
+ * and mobile's gym picker rides this fragment at limit 50.
+ */
 const GYM_FIELDS = `
   uuid
   slug
@@ -75,6 +85,7 @@ const GYM_FIELDS = `
   canEdit
   canGrantAccess
   canClaim
+  isClaimed
 `;
 
 export const GET_GYM = gql`
@@ -119,10 +130,11 @@ export const SEARCH_GYMS = gql`
 
 /**
  * The public `/gyms` directory list. A separate document from SEARCH_GYMS on
- * purpose: it selects only what a directory card renders, and GYM_FIELDS is
- * shared with GET_GYM / GET_MY_GYMS / SEARCH_GYMS — mobile's useNearbyGyms rides
- * that fragment at limit 50, so widening it would make every gym-picker query
- * fetch board summaries and a claim flag it never draws.
+ * purpose: it selects only what a directory card renders, so the card's cost
+ * doesn't ride along on GET_GYM / GET_MY_GYMS / SEARCH_GYMS. `boardSummaries` in
+ * particular stays out of the shared GYM_FIELDS — it's a list, and mobile's
+ * useNearbyGyms rides that fragment at limit 50 for a picker that never draws
+ * board chips.
  */
 export const SEARCH_GYMS_DIRECTORY = gql`
   query SearchGymsDirectory($input: SearchGymsInput!) {
@@ -520,11 +532,18 @@ export type SearchGymsQueryResponse = {
   searchGyms: GymConnection;
 };
 
-/** Exactly the fields SEARCH_GYMS_DIRECTORY selects — the directory card contract. */
+/**
+ * Exactly the fields SEARCH_GYMS_DIRECTORY selects — the directory card
+ * contract. `boardSummaries` is re-declared as required: it's optional on the
+ * shared `Gym` because the GYM_FIELDS documents don't select it, but this
+ * document does, so a card consumer shouldn't have to null-check it.
+ */
 export type GymDirectoryCard = Pick<
   Gym,
-  'uuid' | 'slug' | 'name' | 'address' | 'latitude' | 'longitude' | 'boardCount' | 'isClaimed' | 'boardSummaries'
->;
+  'uuid' | 'slug' | 'name' | 'address' | 'latitude' | 'longitude' | 'boardCount' | 'isClaimed'
+> & {
+  boardSummaries: GymBoardSummary[];
+};
 
 export type SearchGymsDirectoryQueryVariables = {
   input: SearchGymsInput;

--- a/packages/web/app/components/kiosk/embed/__tests__/embed-access.test.ts
+++ b/packages/web/app/components/kiosk/embed/__tests__/embed-access.test.ts
@@ -52,6 +52,7 @@ function makeGym(overrides: Partial<Gym> = {}): Gym {
     createdAt: '2026-01-01T00:00:00.000Z',
     boardCount: 1,
     boardTypes: ['kilter'],
+    boardSummaries: [{ boardType: 'kilter', angle: 40 }],
     memberCount: 0,
     followerCount: 0,
     commentCount: 0,
@@ -60,6 +61,7 @@ function makeGym(overrides: Partial<Gym> = {}): Gym {
     canEdit: false,
     canGrantAccess: false,
     canClaim: false,
+    isClaimed: true,
     ...overrides,
   };
 }

--- a/packages/web/app/lib/__tests__/gym-role.test.ts
+++ b/packages/web/app/lib/__tests__/gym-role.test.ts
@@ -12,6 +12,7 @@ function makeGym(overrides?: Partial<Gym>): Gym {
     createdAt: '2024-01-01',
     boardCount: 3,
     boardTypes: ['kilter'],
+    boardSummaries: [{ boardType: 'kilter', angle: 40 }],
     memberCount: 12,
     followerCount: 8,
     commentCount: 0,
@@ -20,6 +21,7 @@ function makeGym(overrides?: Partial<Gym>): Gym {
     canEdit: true,
     canGrantAccess: true,
     canClaim: false,
+    isClaimed: true,
     ...overrides,
   };
 }


### PR DESCRIPTION
Part of #3666 (backend half) · Part of epic #4372, Tier 1.

The `/gyms` directory needs three things the `Gym` type can't currently answer. This adds exactly those three and nothing else. **No migration** — `git diff` over `packages/db` is empty.

## The three additions

**`Gym.isClaimed: Boolean!`** — viewer-independent, derived from `owner_id` against the system import user. This exists because `canClaim` is false for *every* signed-out viewer, and signed-out viewers are the directory's entire audience: a card gated on `canClaim` renders nothing for them and looks perfectly correct in a logged-in dev session. Being viewer-independent also makes it safe to cache for anonymous SSR.

**`Gym.boardSummaries: [GymBoardSummary!]!`** — distinct board-type + angle pairs, for the card's chips ("Kilter 40°"). Derived by **widening the existing distinct-board query inside `enrichGym`, not by adding a tenth one.** Query count is 9 before and 9 after: `boardTypes` is now computed from the same result. That matters because `enrichGym` runs per row and `searchGyms` allows 50. For a signed-out visitor — the directory's entire audience — three of its nine parallel entries short-circuit without a session, so a 24-card page is ~146 queries; a per-gym query would have made it ~170.

Capped at 12, sliced *after* the SQL `ORDER BY board_type, angle` so the cut is a stable prefix rather than whatever Postgres happened to return. `boardCount` is untouched and keeps the honest total.

**`SearchGymsInput.requireSlug: Boolean`** — opt-in, no zod `.default(false)`. Every card links to `/gym/[slug]`, so slugless gyms would render `/gym/null`. A default would have changed the emitted SQL for every existing caller, including mobile's gym picker.

## The bit worth reviewing carefully

`searchGyms`'s proximity path issues the count and the rows as **two separate `db.execute` calls**, which agree only because both interpolate the same filter clause. A predicate added to the rows query but not the count silently desynchronises `totalCount` and `hasMore` from the returned rows — pagination breaks, and no ordinary test notices.

So the predicate is one exported function pushed into the shared filter array (proximity) and the shared conditions array (text path), and the rendered-SQL test asserts it appears in **both** `db.execute` calls.

That test also carries the mobile no-regression guard in its strongest form: with `requireSlug` omitted, the rendered SQL is compared with `toBe()` against the pre-change SQL pasted verbatim. Any drift is a diff to read, not a judgement call.

## Client operation

A separate `SEARCH_GYMS_DIRECTORY` document selecting only what a card renders. `GYM_FIELDS` is deliberately **not** widened — it's shared with `GET_MY_GYMS` and `SEARCH_GYMS`, and mobile's gym picker rides it at limit 50, so widening it would make every mobile picker query fetch fields it never shows.

## Release Notes

- [x] No release note needed (internal / technical change)

Backend fields only; the directory that consumes them ships flag-gated and noindex in a later PR.
