### PR TITLE
feat(web): let signed-out climbers start a gym claim

### DIFF
--- a/docs/gym-funnel-analytics.md
+++ b/docs/gym-funnel-analytics.md
@@ -71,7 +71,7 @@ no mobile counterpart. They live in their own module.
 | Property       | Values                                                                                   |
 | -------------- | ---------------------------------------------------------------------------------------- |
 | `placement`    | `gym-page`, `preview-sheet`, `directory-card`, `similar-gyms`                            |
-| `viewerState`  | `signed-in`, `signed-out` — `signed-out` is 0 by construction today, see below           |
+| `viewerState`  | `signed-in`, `signed-out` — only the gym page can fire `signed-out`, see below           |
 | `method`       | `domain`, `admin` — mirrors the `GymClaimMethod` GraphQL enum                            |
 | `status`       | `email_sent`, `approved`, `admin_review`, `error`                                        |
 | `medium`       | `poster`, `kiosk`, `board` — only `poster` can fire today, see below                     |
@@ -88,26 +88,34 @@ no mobile counterpart. They live in their own module.
 imported because a shared package must never depend on `packages/web`; adding a
 tab there without adding it here is a compile error at the call site.
 
-### `viewerState: signed-out` is 0 by construction — do not read it as an answer
+### `viewerState: signed-out` only exists on the gym page — split by `placement`
 
 **Read this before using `Gym Claim CTA Clicked` to answer H4** ("does a visible
-self-serve claim CTA convert unclaimed gyms"). Every claim entry point that
-exists today is gated on an authenticated viewer, so a signed-out climber is
-never shown a claim CTA and can never fire the event:
+self-serve claim CTA convert unclaimed gyms"). Since #3672 the gym page shows
+the claim call-out to anonymous visitors, so `signed-out` is real data there:
 
-- `app/gym/[gym_slug]/page.tsx` renders the call-out only when `gym.canClaim`,
-  and the resolver computes `canClaim = !!authenticatedUserId && …`
+- `app/gym/[gym_slug]/page.tsx` renders it whenever the gym is public and
+  `resolveClaimCtaVariant` (`app/gym/[gym_slug]/gym-claim-cta-logic.ts`) doesn't
+  return `hidden`. `hidden` is the signed-in viewer who already covers the gym —
+  the resolver's `canClaim = !!authenticatedUserId && …` is false for owners,
+  gym admins/editors and covering community leaders
   (`packages/backend/src/graphql/resolvers/social/gyms.ts`).
-- `app/components/gym-entity/gym-detail.tsx` gates on the same `canClaim`.
+- The anonymous arm sends the owner through the auth modal with a
+  `callbackUrl` back to `/gym/<slug>?claim=1`, so the claim intent survives an
+  OAuth round-trip and the dialog re-opens on return.
+
+The other two entry points still can't fire it, so an unsplit `signed-out` share
+under-reads:
+
+- `app/components/gym-entity/gym-detail.tsx` gates on `canClaim` directly.
 - `app/components/gym-entity/similar-gym-suggestions.tsx` gates on
   `gym.isClaimable`, which `computeClaimableFlags` only computes for an
   authenticated viewer (`…/social/gym-matching.ts`).
 
-So the property is a constant `signed-in` in production. A `signed-out` split of
-0% is the gate working, **not** evidence about how signed-out climbers behave —
-H4 cannot be answered from this event until #3672 ships a CTA anonymous visitors
-can see. The property is wired end to end anyway so that PR is a server-side
-one-line change rather than a re-instrumentation.
+**Filter on `placement = 'gym-page'` before reading the `viewerState` split.**
+Across all placements the denominator includes two surfaces where `signed-out`
+is still 0 by construction, which drags the anonymous share toward 0 for reasons
+that have nothing to do with how signed-out climbers behave.
 
 ## Two rules that are easy to break
 

--- a/docs/gym-funnel-analytics.md
+++ b/docs/gym-funnel-analytics.md
@@ -104,7 +104,7 @@ the claim call-out to anonymous visitors, so `signed-out` is real data there:
   `callbackUrl` back to `/gym/<slug>?claim=1`, so the claim intent survives an
   OAuth round-trip and the dialog re-opens on return.
 
-The other two entry points still can't fire it, so an unsplit `signed-out` share
+The other two entry points won't fire it, so an unsplit `signed-out` share
 under-reads:
 
 - `app/components/gym-entity/gym-detail.tsx` gates on `canClaim` directly.
@@ -112,9 +112,14 @@ under-reads:
   `gym.isClaimable`, which `computeClaimableFlags` only computes for an
   authenticated viewer (`…/social/gym-matching.ts`).
 
+Both of those read `viewerState` off `useWsAuthToken().isAuthenticated`, which
+is `false` while the token is in flight — their render gates make that race
+unreachable in practice, so treat their `signed-out` count as noise if one ever
+appears rather than as a signal.
+
 **Filter on `placement = 'gym-page'` before reading the `viewerState` split.**
-Across all placements the denominator includes two surfaces where `signed-out`
-is still 0 by construction, which drags the anonymous share toward 0 for reasons
+Across all placements the denominator includes two surfaces that effectively
+never report `signed-out`, which drags the anonymous share toward 0 for reasons
 that have nothing to do with how signed-out climbers behave.
 
 ## Two rules that are easy to break

--- a/docs/gym-funnel-analytics.md
+++ b/docs/gym-funnel-analytics.md
@@ -88,21 +88,33 @@ no mobile counterpart. They live in their own module.
 imported because a shared package must never depend on `packages/web`; adding a
 tab there without adding it here is a compile error at the call site.
 
-### `viewerState: signed-out` only exists on the gym page — split by `placement`
+### `viewerState: signed-out` is gym-page-only AND unclaimed-gym-only
 
 **Read this before using `Gym Claim CTA Clicked` to answer H4** ("does a visible
 self-serve claim CTA convert unclaimed gyms"). Since #3672 the gym page shows
-the claim call-out to anonymous visitors, so `signed-out` is real data there:
+the claim call-out to anonymous visitors, so `signed-out` is real data there —
+but on a narrower population than "public gyms":
 
 - `app/gym/[gym_slug]/page.tsx` renders it whenever the gym is public and
   `resolveClaimCtaVariant` (`app/gym/[gym_slug]/gym-claim-cta-logic.ts`) doesn't
-  return `hidden`. `hidden` is the signed-in viewer who already covers the gym —
-  the resolver's `canClaim = !!authenticatedUserId && …` is false for owners,
-  gym admins/editors and covering community leaders
+  return `hidden`. `hidden` covers the signed-in viewer who already covers the
+  gym — the resolver's `canClaim = !!authenticatedUserId && …` is false for
+  owners, gym admins/editors and covering community leaders
   (`packages/backend/src/graphql/resolvers/social/gyms.ts`).
+- **The anonymous arm additionally requires `gym.isClaimed === false`.** An
+  anonymous visitor to a gym that already has a real owner sees nothing, so a
+  claimed gym contributes zero `signed-out` events no matter how much anonymous
+  traffic it takes. The signed-in arm is not gated this way: asking for a gym
+  someone else owns is a deliberate path that routes to admin review.
 - The anonymous arm sends the owner through the auth modal with a
   `callbackUrl` back to `/gym/<slug>?claim=1`, so the claim intent survives an
   OAuth round-trip and the dialog re-opens on return.
+
+**The `signed-out` denominator is anonymous pageviews of _unclaimed_ public
+gyms, not of all gym pages.** Dividing `signed-out` claim clicks by total gym
+pageviews understates the conversion rate by whatever share of traffic lands on
+claimed gyms — which is the well-run, heavily-visited end of the directory.
+Restrict both sides of the ratio to unclaimed gyms before quoting a number.
 
 The other two entry points won't fire it, so an unsplit `signed-out` share
 under-reads:

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -610,7 +610,8 @@
     "switchToAdmin": "Keine Arbeits-E-Mail? Prüfung anfragen",
     "switchToDomain": "Stattdessen mit Arbeits-E-Mail bestätigen",
     "errors": {
-      "generic": "Da ging etwas schief. Versuch es nochmal."
+      "generic": "Da ging etwas schief. Versuch es nochmal.",
+      "tokenUnavailable": "Wir konnten deine Anmeldung nicht bestätigen. Lade die Seite neu und versuch es nochmal."
     },
     "domain": {
       "description": "Du verwaltest {{gym}}? Gib deine E-Mail-Adresse bei {{domain}} ein und wir schicken dir einen Bestätigungslink.",

--- a/packages/shared/i18n/locales/de/kiosk.json
+++ b/packages/shared/i18n/locales/de/kiosk.json
@@ -89,6 +89,9 @@
     "claimTitle": "Ist das deine Halle?",
     "claimBody": "Übernimm sie und steuere die Boards, den Auftritt und das, was an der Wand läuft.",
     "claimCta": "Diese Halle übernehmen",
+    "claimCtaSignedOut": "Anmelden und übernehmen",
+    "claimAuthTitle": "Übernimm deine Halle",
+    "claimAuthBody": "Melde dich an, wir bringen dich direkt hierher zurück, um sie zu übernehmen.",
     "owner": {
       "linkBoards": {
         "title": "Verknüpf deine Boards",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -610,7 +610,8 @@
     "switchToAdmin": "Don't have a work email? Request a review",
     "switchToDomain": "Verify with a work email instead",
     "errors": {
-      "generic": "Something went wrong. Try again."
+      "generic": "Something went wrong. Try again.",
+      "tokenUnavailable": "We couldn't confirm you're logged in. Reload the page and try again."
     },
     "domain": {
       "description": "Manage {{gym}}? Enter your email at {{domain}} and we'll send a link to confirm.",

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -89,6 +89,9 @@
     "claimTitle": "Is this your gym?",
     "claimBody": "Claim it to run the boards, the branding, and what shows up on the wall.",
     "claimCta": "Claim this gym",
+    "claimCtaSignedOut": "Log in and claim it",
+    "claimAuthTitle": "Claim your gym",
+    "claimAuthBody": "Log in and we'll drop you straight back here to claim it.",
     "owner": {
       "linkBoards": {
         "title": "Link your boards",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -610,7 +610,8 @@
     "switchToAdmin": "¿No tienes un correo de trabajo? Solicita una revisión",
     "switchToDomain": "Verificar con un correo de trabajo",
     "errors": {
-      "generic": "Algo salió mal. Inténtalo de nuevo."
+      "generic": "Algo salió mal. Inténtalo de nuevo.",
+      "tokenUnavailable": "No hemos podido confirmar tu sesión. Recarga la página e inténtalo de nuevo."
     },
     "domain": {
       "description": "¿Gestionas {{gym}}? Introduce tu correo en {{domain}} y te enviaremos un enlace para confirmar.",

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -89,6 +89,9 @@
     "claimTitle": "¿Es tuyo este rocódromo?",
     "claimBody": "Reclámalo para gestionar los plafones, la marca y lo que se ve en el muro.",
     "claimCta": "Reclamar este rocódromo",
+    "claimCtaSignedOut": "Inicia sesión y reclámalo",
+    "claimAuthTitle": "Reclama tu rocódromo",
+    "claimAuthBody": "Inicia sesión y te devolvemos aquí mismo para reclamarlo.",
     "owner": {
       "linkBoards": {
         "title": "Vincula tus plafones",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -610,7 +610,8 @@
     "switchToAdmin": "Pas d’e-mail professionnel ? Demandez une vérification",
     "switchToDomain": "Vérifier plutôt avec un e-mail professionnel",
     "errors": {
-      "generic": "Une erreur est survenue. Réessayez."
+      "generic": "Une erreur est survenue. Réessayez.",
+      "tokenUnavailable": "On n'arrive pas à confirmer ta connexion. Recharge la page et réessaie."
     },
     "domain": {
       "description": "Vous gérez {{gym}} ? Saisissez votre e-mail chez {{domain}} et nous enverrons un lien de confirmation.",

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -89,6 +89,9 @@
     "claimTitle": "C'est ta salle ?",
     "claimBody": "Revendique-la pour gérer les boards, l'identité visuelle et ce qui s'affiche sur le mur.",
     "claimCta": "Revendiquer cette salle",
+    "claimCtaSignedOut": "Connecte-toi et revendique-la",
+    "claimAuthTitle": "Revendique ta salle",
+    "claimAuthBody": "Connecte-toi, on te ramène ici pour la revendiquer.",
     "owner": {
       "linkBoards": {
         "title": "Relie tes boards",

--- a/packages/web/app/components/auth/__tests__/auth-modal-callback-url.test.tsx
+++ b/packages/web/app/components/auth/__tests__/auth-modal-callback-url.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * The OAuth return path, end to end through the modal.
+ *
+ * `SocialLoginButtons` defaults its callback to '/', and a social sign-in
+ * leaves the page entirely — so any intent the caller had (claim this gym, pin
+ * this playlist) is lost on the homepage unless `callbackUrl` reaches the
+ * buttons. `onSuccess` cannot cover it: that only fires on the email/password
+ * path, which never leaves the page.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { AuthModalProvider, useAuthModal } from '@/app/components/providers/auth-modal-provider';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+vi.mock('next-auth/react', () => ({
+  signIn: vi.fn(),
+}));
+
+const socialLoginButtons = vi.hoisted(() => vi.fn((_props: { callbackUrl?: string }) => null));
+vi.mock('@/app/components/auth/social-login-buttons', () => ({
+  default: socialLoginButtons,
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+const { default: AuthModal } = await import('../auth-modal');
+
+const lastSocialProps = () => socialLoginButtons.mock.calls.at(-1)?.[0];
+
+beforeEach(() => {
+  socialLoginButtons.mockClear();
+});
+
+describe('AuthModal — callbackUrl', () => {
+  it('forwards the caller callback URL to the OAuth buttons', () => {
+    render(<AuthModal open onClose={vi.fn()} callbackUrl="/gym/boulderwelt?claim=1" />);
+
+    expect(lastSocialProps()?.callbackUrl).toBe('/gym/boulderwelt?claim=1');
+  });
+
+  it('passes nothing when the caller has no return path, leaving the buttons on their default', () => {
+    render(<AuthModal open onClose={vi.fn()} />);
+
+    expect(lastSocialProps()?.callbackUrl).toBeUndefined();
+  });
+});
+
+describe('AuthModalProvider — callbackUrl', () => {
+  it('carries callbackUrl from openAuthModal all the way to the OAuth buttons', () => {
+    const { result } = renderHook(() => useAuthModal(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => <AuthModalProvider>{children}</AuthModalProvider>,
+    });
+
+    act(() => {
+      result.current.openAuthModal({ callbackUrl: '/gym/boulderwelt?claim=1' });
+    });
+
+    expect(lastSocialProps()?.callbackUrl).toBe('/gym/boulderwelt?claim=1');
+  });
+});

--- a/packages/web/app/components/auth/auth-modal.tsx
+++ b/packages/web/app/components/auth/auth-modal.tsx
@@ -39,9 +39,11 @@ type AuthModalProps = {
   onSuccess?: () => void;
   title?: string;
   description?: string;
+  /** Forwarded to the OAuth buttons; they default to '/' when it's absent. */
+  callbackUrl?: string;
 };
 
-export default function AuthModal({ open, onClose, onSuccess, title, description }: AuthModalProps) {
+export default function AuthModal({ open, onClose, onSuccess, title, description, callbackUrl }: AuthModalProps) {
   const { t } = useTranslation('auth');
   const resolvedTitle = title ?? t('modal.title');
   const resolvedDescription = description ?? t('modal.description');
@@ -480,7 +482,7 @@ export default function AuthModal({ open, onClose, onSuccess, title, description
             </Typography>
           </MuiDivider>
 
-          <SocialLoginButtons />
+          <SocialLoginButtons callbackUrl={callbackUrl} />
         </Stack>
       </DialogContent>
     </Dialog>

--- a/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-token-gating.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-token-gating.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Submitting before the ws auth token has arrived.
+ *
+ * `submit()` opens with `if (!token) return`, and `useWsAuthToken`'s query key
+ * includes the session status — so the token is briefly null right after a
+ * sign-in. With the buttons left enabled that first tap did nothing at all: no
+ * request, no error, no spinner. Signing in through the auth modal and landing
+ * straight on this dialog makes that the common path, not an edge case.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/app/test-utils/test-providers';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const authTokenState = vi.hoisted(() => ({ token: null as string | null }));
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({
+    token: authTokenState.token,
+    isAuthenticated: authTokenState.token !== null,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), replace: vi.fn() }),
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: vi.fn() }),
+}));
+
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent: vi.fn() }));
+
+const ClaimGymDialog = (await import('../claim-gym-dialog')).default;
+
+// The web test setup ships no jest-dom, so `toBeDisabled` throws "Invalid Chai
+// property" — read the DOM property instead.
+const isDisabled = (label: string) => (screen.getByRole('button', { name: label }) as HTMLButtonElement).disabled;
+
+const renderDialog = (website: string | null) =>
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <ClaimGymDialog gymUuid="gym-uuid-1" gymName="Bonsist" website={website} open onClose={vi.fn()} />
+    </QueryClientProvider>,
+  );
+
+beforeEach(() => {
+  authTokenState.token = null;
+});
+
+describe('ClaimGymDialog — submit gating on the ws auth token', () => {
+  it('disables the admin-review submit while the token is still null', () => {
+    renderDialog(null);
+
+    expect(isDisabled('Request review')).toBe(true);
+  });
+
+  it('enables the admin-review submit once the token lands', () => {
+    authTokenState.token = 'test-token';
+
+    renderDialog(null);
+
+    expect(isDisabled('Request review')).toBe(false);
+  });
+
+  it('disables the domain submit with a null token even when the email is filled in', () => {
+    renderDialog('https://bonsist.example');
+
+    fireEvent.change(screen.getByLabelText('Work email'), { target: { value: 'owner@bonsist.example' } });
+
+    expect(isDisabled('Send verification email')).toBe(true);
+  });
+});

--- a/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-token-gating.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog-token-gating.test.tsx
@@ -22,13 +22,17 @@ vi.mock('react-i18next', () => ({
   Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
 }));
 
-const authTokenState = vi.hoisted(() => ({ token: null as string | null }));
+const authTokenState = vi.hoisted(() => ({
+  token: null as string | null,
+  isLoading: false,
+  error: null as string | null,
+}));
 vi.mock('@/app/hooks/use-ws-auth-token', () => ({
   useWsAuthToken: () => ({
     token: authTokenState.token,
     isAuthenticated: authTokenState.token !== null,
-    isLoading: false,
-    error: null,
+    isLoading: authTokenState.isLoading,
+    error: authTokenState.error,
   }),
 }));
 
@@ -57,7 +61,11 @@ const renderDialog = (website: string | null) =>
 
 beforeEach(() => {
   authTokenState.token = null;
+  authTokenState.isLoading = false;
+  authTokenState.error = null;
 });
+
+const TOKEN_FAILURE_COPY = "We couldn't confirm you're logged in. Reload the page and try again.";
 
 describe('ClaimGymDialog — submit gating on the ws auth token', () => {
   it('disables the admin-review submit while the token is still null', () => {
@@ -72,6 +80,35 @@ describe('ClaimGymDialog — submit gating on the ws auth token', () => {
     renderDialog(null);
 
     expect(isDisabled('Request review')).toBe(false);
+  });
+
+  it('explains the dead button once the token request has given up', () => {
+    // useWsAuthToken retries three times and then stops. Without this the
+    // button is permanently disabled with nothing on screen to explain it —
+    // strictly worse than the silent no-op the disabled state replaced.
+    authTokenState.error = 'Failed to fetch auth token: 500';
+
+    renderDialog(null);
+
+    expect(screen.getByText(TOKEN_FAILURE_COPY)).toBeTruthy();
+    expect(isDisabled('Request review')).toBe(true);
+  });
+
+  it('stays quiet while the token is still in flight', () => {
+    authTokenState.isLoading = true;
+
+    renderDialog(null);
+
+    expect(screen.queryByText(TOKEN_FAILURE_COPY)).toBeNull();
+    expect(isDisabled('Request review')).toBe(true);
+  });
+
+  it('shows no failure copy once the token lands', () => {
+    authTokenState.token = 'test-token';
+
+    renderDialog(null);
+
+    expect(screen.queryByText(TOKEN_FAILURE_COPY)).toBeNull();
   });
 
   it('disables the domain submit with a null token even when the email is filled in', () => {

--- a/packages/web/app/components/gym-entity/__tests__/gym-card.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/gym-card.test.tsx
@@ -51,4 +51,48 @@ describe('GymCard', () => {
     expect(screen.queryByRole('link', { name: 'Garage Gym' })).toBeNull();
     expect(screen.getByText('Garage Gym')).toBeTruthy();
   });
+
+  // The card is rendered as a div so the gym-name <a> can nest inside it, which
+  // costs it the native button's keyboard handling. ButtonBase puts that back —
+  // these lock it in, since losing it strands keyboard users on the card.
+  describe('keyboard activation', () => {
+    it('exposes the card as a button to assistive tech', () => {
+      render(<GymCard gym={makeGym()} onClick={vi.fn()} />);
+      const card = screen.getByRole('button');
+      expect(card.tagName).toBe('DIV');
+      expect(card.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('opens the preview sheet on Enter', () => {
+      const onClick = vi.fn();
+      render(<GymCard gym={makeGym()} onClick={onClick} />);
+
+      fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' });
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens the preview sheet on Space, which activates on key up', () => {
+      const onClick = vi.fn();
+      render(<GymCard gym={makeGym()} onClick={onClick} />);
+      const card = screen.getByRole('button');
+
+      fireEvent.keyDown(card, { key: ' ' });
+      expect(onClick).not.toHaveBeenCalled();
+
+      fireEvent.keyUp(card, { key: ' ' });
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('is not keyboard-reachable when there is no sheet to open', () => {
+      render(<GymCard gym={makeGym()} />);
+      const card = screen.getByRole('button');
+
+      expect(card.getAttribute('tabindex')).toBe('-1');
+      fireEvent.keyDown(card, { key: 'Enter' });
+      // Nothing to assert a call against — the point is that it doesn't throw
+      // and the card never advertises an action it can't perform.
+      expect(card.className).toContain('Mui-disabled');
+    });
+  });
 });

--- a/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
+++ b/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
@@ -243,7 +243,11 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
         <MuiButton
           variant="contained"
           onClick={submitDomainClaim}
-          disabled={submitting || !email.trim()}
+          // `!token` matters here: `submit()` bails on a missing token, and
+          // useWsAuthToken's query key includes the session status, so right
+          // after signing in through the auth modal the token is still in
+          // flight. Without this the first tap is a silent no-op.
+          disabled={submitting || !token || !email.trim()}
           sx={{ textTransform: 'none' }}
         >
           {submitting ? <CircularProgress size={18} color="inherit" /> : t('claimGym.domain.submit')}
@@ -254,7 +258,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
         <MuiButton
           variant="contained"
           onClick={() => submit({ input: { gymUuid, message: message.trim() || undefined } })}
-          disabled={submitting}
+          disabled={submitting || !token}
           sx={{ textTransform: 'none' }}
         >
           {submitting ? <CircularProgress size={18} color="inherit" /> : t('claimGym.admin.submit')}

--- a/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
+++ b/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
@@ -50,7 +50,7 @@ function graphqlErrorMessage(error: unknown): string | null {
 
 export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClose }: ClaimGymDialogProps) {
   const { t } = useTranslation('boards');
-  const { token } = useWsAuthToken();
+  const { token, isLoading: tokenLoading } = useWsAuthToken();
   const router = useRouter();
   const queryClient = useQueryClient();
   const domain = extractDomain(website);
@@ -147,6 +147,12 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
 
   const succeeded = sentTo !== null || adminSent || approved;
 
+  // The submit buttons below are disabled without a token, and `useWsAuthToken`
+  // gives up after three retries — so a dead /api/internal/ws-auth would leave
+  // a permanently dead button with nothing on screen to explain it. Say so.
+  const tokenUnavailable = !token && !tokenLoading;
+  const blockingError = error ?? (tokenUnavailable ? t('claimGym.errors.tokenUnavailable') : null);
+
   let body: React.ReactNode;
   if (approved) {
     body = (
@@ -182,7 +188,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
     body = (
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         <DialogContentText>{t('claimGym.domain.description', { gym: gymName, domain })}</DialogContentText>
-        {error && <Alert severity="error">{error}</Alert>}
+        {blockingError && <Alert severity="error">{blockingError}</Alert>}
         <TextField
           label={t('claimGym.domain.emailLabel')}
           value={email}
@@ -208,7 +214,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
     body = (
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
         <DialogContentText>{t('claimGym.admin.description', { gym: gymName })}</DialogContentText>
-        {error && <Alert severity="error">{error}</Alert>}
+        {blockingError && <Alert severity="error">{blockingError}</Alert>}
         <TextField
           label={t('claimGym.admin.messageLabel')}
           value={message}

--- a/packages/web/app/components/providers/auth-modal-provider.tsx
+++ b/packages/web/app/components/providers/auth-modal-provider.tsx
@@ -6,6 +6,13 @@ import AuthModal from '@/app/components/auth/auth-modal';
 type AuthModalConfig = {
   title?: string;
   description?: string;
+  /**
+   * Where OAuth drops the climber back. `onSuccess` only ever fires for the
+   * email/password path, which stays on the page; a social sign-in leaves the
+   * app entirely and comes back through next-auth's redirect, so an intent that
+   * isn't in this URL is gone (SocialLoginButtons otherwise defaults to '/').
+   */
+  callbackUrl?: string;
   onSuccess?: () => void;
 };
 
@@ -27,7 +34,7 @@ export function AuthModalProvider({ children }: { children: React.ReactNode }) {
 
   const openAuthModal = useCallback((cfg: AuthModalConfig = {}) => {
     onSuccessRef.current = cfg.onSuccess;
-    setConfig({ title: cfg.title, description: cfg.description });
+    setConfig({ title: cfg.title, description: cfg.description, callbackUrl: cfg.callbackUrl });
     setHasOpenedOnce(true);
     setOpen(true);
   }, []);
@@ -53,6 +60,7 @@ export function AuthModalProvider({ children }: { children: React.ReactNode }) {
           onSuccess={handleSuccess}
           title={config.title}
           description={config.description}
+          callbackUrl={config.callbackUrl}
         />
       )}
     </AuthModalContext.Provider>

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta-logic.test.ts
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta-logic.test.ts
@@ -8,27 +8,60 @@ import {
 } from '../gym-claim-cta-logic';
 
 describe('resolveClaimCtaVariant', () => {
-  it('offers the claim to a signed-in viewer the backend says may claim', () => {
-    expect(resolveClaimCtaVariant({ serverCanClaim: true, serverHasSession: true })).toBe('signed-in');
+  describe('signed in', () => {
+    it('offers the claim to a viewer the backend says may claim an unclaimed gym', () => {
+      expect(resolveClaimCtaVariant({ serverCanClaim: true, serverHasSession: true, gymIsClaimed: false })).toBe(
+        'signed-in',
+      );
+    });
+
+    it('still offers it on a gym someone else already owns', () => {
+      // A signed-in non-member asking for a claimed gym is a deliberate path —
+      // the backend routes it to admin review. `isClaimed` narrows the
+      // anonymous arm only.
+      expect(resolveClaimCtaVariant({ serverCanClaim: true, serverHasSession: true, gymIsClaimed: true })).toBe(
+        'signed-in',
+      );
+    });
+
+    it.each([true, false])('hides it from a viewer who already covers the gym (claimed: %s)', (gymIsClaimed) => {
+      // Owners, gym admins/editors and covering community leaders all come back
+      // `canClaim: false` from the resolver — the gating this PR must not widen.
+      expect(resolveClaimCtaVariant({ serverCanClaim: false, serverHasSession: true, gymIsClaimed })).toBe('hidden');
+    });
   });
 
-  it('hides the call-out from a signed-in viewer who already covers the gym', () => {
-    // Owners, gym admins/editors and covering community leaders all come back
-    // `canClaim: false` from the resolver — the gating this PR must not widen.
-    expect(resolveClaimCtaVariant({ serverCanClaim: false, serverHasSession: true })).toBe('hidden');
-  });
+  describe('signed out', () => {
+    it('shows the anonymous arm on an unclaimed gym', () => {
+      // The whole point: `canClaim` is false for every anonymous request, so
+      // reading it alone would hide the CTA from the gym owner who just googled
+      // their own gym.
+      expect(resolveClaimCtaVariant({ serverCanClaim: false, serverHasSession: false, gymIsClaimed: false })).toBe(
+        'signed-out',
+      );
+    });
 
-  it('shows the anonymous arm to a visitor with no session', () => {
-    // The whole point: `canClaim` is false for every anonymous request, so
-    // reading it alone would hide the CTA from the gym owner who just googled
-    // their own gym.
-    expect(resolveClaimCtaVariant({ serverCanClaim: false, serverHasSession: false })).toBe('signed-out');
-  });
+    it('hides the anonymous arm once the gym has a real owner', () => {
+      // "Is this your gym?" directly under the displayed name of the person who
+      // already runs it reads as a mistake.
+      expect(resolveClaimCtaVariant({ serverCanClaim: false, serverHasSession: false, gymIsClaimed: true })).toBe(
+        'hidden',
+      );
+    });
 
-  it('still takes the anonymous arm if canClaim ever arrives without a session', () => {
-    // Unreachable through the resolver, but with no session there is no
-    // signed-in viewer whose dialog could be opened.
-    expect(resolveClaimCtaVariant({ serverCanClaim: true, serverHasSession: false })).toBe('signed-out');
+    it('still takes the anonymous arm if canClaim ever arrives without a session', () => {
+      // Unreachable through the resolver, but with no session there is no
+      // signed-in viewer whose dialog could be opened.
+      expect(resolveClaimCtaVariant({ serverCanClaim: true, serverHasSession: false, gymIsClaimed: false })).toBe(
+        'signed-out',
+      );
+    });
+
+    it('keeps the claimed gate ahead of that, too', () => {
+      expect(resolveClaimCtaVariant({ serverCanClaim: true, serverHasSession: false, gymIsClaimed: true })).toBe(
+        'hidden',
+      );
+    });
   });
 });
 

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta-logic.test.ts
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta-logic.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  CLAIM_PARAM,
+  CLAIM_PARAM_VALUE,
+  buildClaimReturnPath,
+  resolveClaimCtaVariant,
+  shouldAutoOpenClaimDialog,
+} from '../gym-claim-cta-logic';
+
+describe('resolveClaimCtaVariant', () => {
+  it('offers the claim to a signed-in viewer the backend says may claim', () => {
+    expect(resolveClaimCtaVariant({ serverCanClaim: true, serverHasSession: true })).toBe('signed-in');
+  });
+
+  it('hides the call-out from a signed-in viewer who already covers the gym', () => {
+    // Owners, gym admins/editors and covering community leaders all come back
+    // `canClaim: false` from the resolver — the gating this PR must not widen.
+    expect(resolveClaimCtaVariant({ serverCanClaim: false, serverHasSession: true })).toBe('hidden');
+  });
+
+  it('shows the anonymous arm to a visitor with no session', () => {
+    // The whole point: `canClaim` is false for every anonymous request, so
+    // reading it alone would hide the CTA from the gym owner who just googled
+    // their own gym.
+    expect(resolveClaimCtaVariant({ serverCanClaim: false, serverHasSession: false })).toBe('signed-out');
+  });
+
+  it('still takes the anonymous arm if canClaim ever arrives without a session', () => {
+    // Unreachable through the resolver, but with no session there is no
+    // signed-in viewer whose dialog could be opened.
+    expect(resolveClaimCtaVariant({ serverCanClaim: true, serverHasSession: false })).toBe('signed-out');
+  });
+});
+
+describe('shouldAutoOpenClaimDialog', () => {
+  it('auto-opens for the exact scalar claim value', () => {
+    expect(shouldAutoOpenClaimDialog(CLAIM_PARAM_VALUE)).toBe(true);
+  });
+
+  it('does not auto-open for a repeated param, which Next hands over as an array', () => {
+    expect(shouldAutoOpenClaimDialog(['1', '1'])).toBe(false);
+  });
+
+  it.each([undefined, '0', 'true', ''])('does not auto-open for %o', (rawParam) => {
+    expect(shouldAutoOpenClaimDialog(rawParam)).toBe(false);
+  });
+});
+
+describe('buildClaimReturnPath', () => {
+  it('returns to the same gym page with the claim intent intact', () => {
+    expect(buildClaimReturnPath('boulderwelt-ost')).toBe('/gym/boulderwelt-ost?claim=1');
+  });
+
+  it('builds the path from the same constants the reader parses', () => {
+    expect(buildClaimReturnPath('x')).toBe(`/gym/x?${CLAIM_PARAM}=${CLAIM_PARAM_VALUE}`);
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
@@ -259,12 +259,18 @@ function GatedClaimCta({
   isPublic,
   canClaim,
   hasSession,
+  isClaimed = false,
 }: {
   isPublic: boolean;
   canClaim: boolean;
   hasSession: boolean;
+  isClaimed?: boolean;
 }) {
-  const variant = resolveClaimCtaVariant({ serverCanClaim: canClaim, serverHasSession: hasSession });
+  const variant = resolveClaimCtaVariant({
+    serverCanClaim: canClaim,
+    serverHasSession: hasSession,
+    gymIsClaimed: isClaimed,
+  });
   if (!isPublic || variant === 'hidden') return null;
   return (
     <GymClaimCta gymUuid="gym-1" gymName="Boulderwelt" gymSlug="boulderwelt" website={null} viewerState={variant} />
@@ -285,9 +291,23 @@ describe('claim CTA visibility gating', () => {
     expect(screen.getByRole('button', { name: 'Claim this gym' })).toBeTruthy();
   });
 
-  it('renders the anonymous arm on a public gym', () => {
+  it('renders the anonymous arm on a public gym nobody has claimed', () => {
     render(<GatedClaimCta isPublic canClaim={false} hasSession={false} />);
     expect(screen.getByRole('button', { name: 'Log in and claim it' })).toBeTruthy();
+  });
+
+  it('never renders the anonymous arm on a gym that already has an owner', () => {
+    // The owner's name is displayed directly above where the box would sit.
+    const { container } = render(<GatedClaimCta isPublic canClaim={false} hasSession={false} isClaimed />);
+
+    expect(container.innerHTML).toBe('');
+    expect(trackGymFunnelEvent).not.toHaveBeenCalled();
+  });
+
+  it('still renders the signed-in arm on a claimed gym', () => {
+    // Asking for a gym someone else owns is an existing, deliberate path.
+    render(<GatedClaimCta isPublic canClaim hasSession isClaimed />);
+    expect(screen.getByRole('button', { name: 'Claim this gym' })).toBeTruthy();
   });
 
   it('never renders the anonymous arm on a private gym', () => {

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { resolveClaimCtaVariant } from '../gym-claim-cta-logic';
 
 vi.mock('react-i18next', () => ({
   useTranslation: (ns?: string) => ({
@@ -18,15 +19,51 @@ vi.mock('@/app/components/gym-entity/claim-gym-dialog', () => ({
 const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
 vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent }));
 
+const openAuthModal = vi.hoisted(() => vi.fn());
+vi.mock('@/app/components/providers/auth-modal-provider', () => ({
+  useAuthModal: () => ({ openAuthModal }),
+}));
+
+const routerRefresh = vi.hoisted(() => vi.fn());
+const routerReplace = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: routerRefresh, replace: routerReplace, push: vi.fn() }),
+}));
+
 const GymClaimCta = (await import('../gym-claim-cta')).default;
+
+type AuthModalConfig = {
+  title?: string;
+  description?: string;
+  callbackUrl?: string;
+  onSuccess?: () => void;
+};
+
+const lastAuthModalConfig = (): AuthModalConfig => openAuthModal.mock.calls.at(-1)?.[0] as AuthModalConfig;
+
+const renderCta = (props: Partial<React.ComponentProps<typeof GymClaimCta>> = {}) =>
+  render(
+    <GymClaimCta
+      gymUuid="gym-1"
+      gymName="Boulderwelt"
+      gymSlug="boulderwelt"
+      website={null}
+      viewerState="signed-in"
+      {...props}
+    />,
+  );
 
 beforeEach(() => {
   trackGymFunnelEvent.mockReset();
+  openAuthModal.mockReset();
+  routerRefresh.mockReset();
+  routerReplace.mockReset();
+  window.history.replaceState(null, '', '/gym/boulderwelt');
 });
 
-describe('GymClaimCta — gym-page placement', () => {
+describe('GymClaimCta — signed-in arm', () => {
   it('reports the click with the server-derived viewer state', () => {
-    render(<GymClaimCta gymUuid="gym-1" gymName="Boulderwelt" website={null} viewerState="signed-in" />);
+    renderCta();
 
     fireEvent.click(screen.getByRole('button', { name: 'Claim this gym' }));
 
@@ -37,14 +74,41 @@ describe('GymClaimCta — gym-page placement', () => {
     });
   });
 
-  it('passes a signed-out viewer through unchanged rather than inferring one', () => {
-    // Unreachable today — the resolver's `canClaim` requires an authenticated
-    // user, so the server never renders this CTA for a signed-out visitor. The
-    // prop is wired end to end so #3672's anonymous CTA reports the truth
-    // without touching this component.
-    render(<GymClaimCta gymUuid="gym-1" gymName="Boulderwelt" website={null} viewerState="signed-out" />);
+  it('opens the dialog directly, without routing through auth', () => {
+    renderCta();
 
+    expect(screen.queryByTestId('claim-dialog')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Claim this gym' }));
+
+    expect(screen.getByTestId('claim-dialog')).toBeTruthy();
+    expect(openAuthModal).not.toHaveBeenCalled();
+  });
+});
+
+describe('GymClaimCta — signed-out arm', () => {
+  it('renders the same call-out copy so anonymous visitors get it server-rendered', () => {
+    renderCta({ viewerState: 'signed-out' });
+
+    expect(screen.getByText('Is this your gym?')).toBeTruthy();
+    expect(screen.getByText('Claim it to run the boards, the branding, and what shows up on the wall.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Log in and claim it' })).toBeTruthy();
+  });
+
+  it('sends the owner through auth with a callback back to this gym page', () => {
+    renderCta({ viewerState: 'signed-out' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Log in and claim it' }));
+
+    // OAuth leaves the page, so this URL is the only place the claim intent
+    // survives — without it SocialLoginButtons defaults the return to '/'.
+    expect(lastAuthModalConfig().callbackUrl).toBe('/gym/boulderwelt?claim=1');
+    expect(screen.queryByTestId('claim-dialog')).toBeNull();
+  });
+
+  it('reports the click as signed-out — the state that was unreachable before this arm existed', () => {
+    renderCta({ viewerState: 'signed-out' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Log in and claim it' }));
 
     expect(trackGymFunnelEvent).toHaveBeenCalledWith({
       name: 'Gym Claim CTA Clicked',
@@ -52,11 +116,89 @@ describe('GymClaimCta — gym-page placement', () => {
     });
   });
 
-  it('opens the dialog as well as reporting', () => {
-    render(<GymClaimCta gymUuid="gym-1" gymName="Boulderwelt" website={null} viewerState="signed-in" />);
+  it('opens the claim dialog and refreshes the server render once auth succeeds', () => {
+    renderCta({ viewerState: 'signed-out' });
+    fireEvent.click(screen.getByRole('button', { name: 'Log in and claim it' }));
+
+    // Fired by the modal, not by a React event handler, so it needs the act
+    // wrapper the way the provider's own success path would deliver it.
+    act(() => lastAuthModalConfig().onSuccess?.());
+
+    expect(screen.getByTestId('claim-dialog')).toBeTruthy();
+    // `canClaim` is server-computed, so the refresh is what clears the call-out
+    // for someone who turns out to already have edit access.
+    expect(routerRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GymClaimCta — returning from auth on ?claim=1', () => {
+  it('auto-opens the dialog and strips the param without a router navigation', () => {
+    window.history.replaceState(null, '', '/gym/boulderwelt?claim=1&src=qr');
+
+    renderCta({ claimParam: '1' });
+
+    expect(screen.getByTestId('claim-dialog')).toBeTruthy();
+    expect(window.location.search).toBe('?src=qr');
+    // `router.replace` refetches the RSC payload and would remount this island,
+    // closing the dialog it just opened.
+    expect(routerReplace).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-open on the signed-out arm, which has no session to claim with', () => {
+    renderCta({ viewerState: 'signed-out', claimParam: '1' });
 
     expect(screen.queryByTestId('claim-dialog')).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: 'Claim this gym' }));
-    expect(screen.getByTestId('claim-dialog')).toBeTruthy();
+  });
+
+  it('does not auto-open for a repeated param', () => {
+    renderCta({ claimParam: ['1', '1'] });
+
+    expect(screen.queryByTestId('claim-dialog')).toBeNull();
+  });
+});
+
+/**
+ * Mirrors the render condition in `page.tsx`. The gating lives on the server,
+ * so the island itself always paints — these assertions are about who ever gets
+ * it mounted at all (the #3672 visibility-gating gap).
+ */
+function GatedClaimCta({
+  isPublic,
+  canClaim,
+  hasSession,
+}: {
+  isPublic: boolean;
+  canClaim: boolean;
+  hasSession: boolean;
+}) {
+  const variant = resolveClaimCtaVariant({ serverCanClaim: canClaim, serverHasSession: hasSession });
+  if (!isPublic || variant === 'hidden') return null;
+  return (
+    <GymClaimCta gymUuid="gym-1" gymName="Boulderwelt" gymSlug="boulderwelt" website={null} viewerState={variant} />
+  );
+}
+
+describe('claim CTA visibility gating', () => {
+  it('renders nothing for a signed-in viewer who already covers the gym', () => {
+    // Owner, gym admin/editor, covering community leader: all `canClaim: false`.
+    const { container } = render(<GatedClaimCta isPublic canClaim={false} hasSession />);
+
+    expect(container.innerHTML).toBe('');
+    expect(trackGymFunnelEvent).not.toHaveBeenCalled();
+  });
+
+  it('renders the claim button for a signed-in viewer who may claim', () => {
+    render(<GatedClaimCta isPublic canClaim hasSession />);
+    expect(screen.getByRole('button', { name: 'Claim this gym' })).toBeTruthy();
+  });
+
+  it('renders the anonymous arm on a public gym', () => {
+    render(<GatedClaimCta isPublic canClaim={false} hasSession={false} />);
+    expect(screen.getByRole('button', { name: 'Log in and claim it' })).toBeTruthy();
+  });
+
+  it('never renders the anonymous arm on a private gym', () => {
+    const { container } = render(<GatedClaimCta isPublic={false} canClaim={false} hasSession={false} />);
+    expect(container.innerHTML).toBe('');
   });
 });

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import React from 'react';
 import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
@@ -31,6 +31,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 const GymClaimCta = (await import('../gym-claim-cta')).default;
+const GymClaimParamCleanup = (await import('../gym-claim-param-cleanup')).default;
 
 type AuthModalConfig = {
   title?: string;
@@ -132,28 +133,120 @@ describe('GymClaimCta — signed-out arm', () => {
 });
 
 describe('GymClaimCta — returning from auth on ?claim=1', () => {
-  it('auto-opens the dialog and strips the param without a router navigation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Let the deferred URL cleanup run. */
+  const flushStrip = () => act(() => void vi.runAllTimers());
+
+  it('opens the dialog immediately and strips the param without a router navigation', () => {
     window.history.replaceState(null, '', '/gym/boulderwelt?claim=1&src=qr');
 
     renderCta({ claimParam: '1' });
 
+    // Immediate: a dialog that waits a tick to appear reads as a dropped tap.
     expect(screen.getByTestId('claim-dialog')).toBeTruthy();
+
+    flushStrip();
+
     expect(window.location.search).toBe('?src=qr');
     // `router.replace` refetches the RSC payload and would remount this island,
     // closing the dialog it just opened.
     expect(routerReplace).not.toHaveBeenCalled();
   });
 
-  it('does not auto-open on the signed-out arm, which has no session to claim with', () => {
-    renderCta({ viewerState: 'signed-out', claimParam: '1' });
+  it('defers the strip so a replaceState patch installed after mount still handles it', () => {
+    // Next patches `history.replaceState` in the root Router's own mount
+    // effect, and React flushes passive effects child-first — so at the moment
+    // this island's effect runs, the patch is not installed yet. Stripping
+    // through the unpatched function leaves the router's canonicalUrl on
+    // `?claim=1`, and the next commit writes the param back.
+    window.history.replaceState(null, '', '/gym/boulderwelt?claim=1');
+    const nativeReplaceState = window.history.replaceState.bind(window.history);
 
-    expect(screen.queryByTestId('claim-dialog')).toBeNull();
+    renderCta({ claimParam: '1' });
+
+    // Stands in for the patch, installed the way Next installs it: after this
+    // island's effect has already run.
+    const patchedReplaceState = vi.fn(nativeReplaceState);
+    window.history.replaceState = patchedReplaceState;
+    try {
+      expect(window.location.search).toBe('?claim=1');
+
+      flushStrip();
+
+      expect(patchedReplaceState).toHaveBeenCalledTimes(1);
+      expect(window.location.search).toBe('');
+    } finally {
+      window.history.replaceState = nativeReplaceState;
+    }
   });
 
-  it('does not auto-open for a repeated param', () => {
-    renderCta({ claimParam: ['1', '1'] });
+  it('strips the param on the signed-out arm too, without opening anything', () => {
+    // Someone opened a shared `?claim=1` link while logged out. The param is
+    // just as stale for them, and there is no session to claim with.
+    window.history.replaceState(null, '', '/gym/boulderwelt?claim=1');
+
+    renderCta({ viewerState: 'signed-out', claimParam: '1' });
+    flushStrip();
 
     expect(screen.queryByTestId('claim-dialog')).toBeNull();
+    expect(window.location.search).toBe('');
+  });
+
+  it('does not auto-open or strip for a repeated param', () => {
+    window.history.replaceState(null, '', '/gym/boulderwelt?claim=1&claim=1');
+
+    renderCta({ claimParam: ['1', '1'] });
+    flushStrip();
+
+    expect(screen.queryByTestId('claim-dialog')).toBeNull();
+    expect(window.location.search).toBe('?claim=1&claim=1');
+  });
+
+  it('cancels the pending strip when the island unmounts first', () => {
+    window.history.replaceState(null, '', '/gym/boulderwelt?claim=1');
+
+    const { unmount } = renderCta({ claimParam: '1' });
+    unmount();
+    flushStrip();
+
+    expect(window.location.search).toBe('?claim=1');
+  });
+});
+
+describe('GymClaimParamCleanup', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears a stale claim param on the pages where no call-out renders', () => {
+    // An owner or covering community leader who came back from auth: their
+    // variant is `hidden`, so nothing would otherwise clear the param.
+    window.history.replaceState(null, '', '/gym/boulderwelt?claim=1&src=qr');
+
+    render(<GymClaimParamCleanup claimParam="1" />);
+    act(() => void vi.runAllTimers());
+
+    expect(window.location.search).toBe('?src=qr');
+  });
+
+  it('leaves an untouched URL alone', () => {
+    window.history.replaceState(null, '', '/gym/boulderwelt?src=qr');
+
+    render(<GymClaimParamCleanup />);
+    act(() => void vi.runAllTimers());
+
+    expect(window.location.search).toBe('?src=qr');
   });
 });
 

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-follow-button-visibility.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-follow-button-visibility.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+// A mutable holder so each case can pick who is looking at the page. A plain
+// module-level constant would pin the whole file to one viewer.
+const sessionState = vi.hoisted(() => ({ userId: null as string | null }));
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: sessionState.userId ? { user: { id: sessionState.userId } } : null,
+    status: sessionState.userId ? 'authenticated' : 'unauthenticated',
+  }),
+}));
+
+const authTokenState = vi.hoisted(() => ({ isAuthenticated: true }));
+vi.mock('@/app/hooks/use-ws-auth-token', () => ({
+  useWsAuthToken: () => ({
+    token: authTokenState.isAuthenticated ? 'test-token' : null,
+    isAuthenticated: authTokenState.isAuthenticated,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('@/app/components/providers/snackbar-provider', () => ({
+  useSnackbar: () => ({ showMessage: vi.fn() }),
+}));
+
+vi.mock('@boardsesh/graphql/operations', () => ({
+  FOLLOW_GYM: 'FOLLOW_GYM',
+  UNFOLLOW_GYM: 'UNFOLLOW_GYM',
+}));
+
+vi.mock('@/app/lib/graphql/client', () => ({
+  createGraphQLHttpClient: () => ({ request: vi.fn() }),
+}));
+
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent: vi.fn() }));
+
+const GymFollowButton = (await import('../gym-follow-button')).default;
+
+const OWNER_ID = 'owner-1';
+
+beforeEach(() => {
+  sessionState.userId = null;
+  authTokenState.isAuthenticated = true;
+});
+
+describe('GymFollowButton visibility', () => {
+  it('hides itself from the gym owner — you do not follow your own gym', () => {
+    sessionState.userId = OWNER_ID;
+
+    const { container } = render(<GymFollowButton gymUuid="gym-1" ownerId={OWNER_ID} isFollowedByMe={false} />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows for any other signed-in climber', () => {
+    sessionState.userId = 'someone-else';
+
+    render(<GymFollowButton gymUuid="gym-1" ownerId={OWNER_ID} isFollowedByMe={false} />);
+
+    expect(screen.getByRole('button', { name: 'Follow' })).toBeTruthy();
+  });
+
+  it('shows Following when the viewer already follows the gym', () => {
+    sessionState.userId = 'someone-else';
+
+    render(<GymFollowButton gymUuid="gym-1" ownerId={OWNER_ID} isFollowedByMe />);
+
+    expect(screen.getByRole('button', { name: 'Following' })).toBeTruthy();
+  });
+
+  it('renders nothing for a signed-out visitor, who has nothing to follow with', () => {
+    authTokenState.isAuthenticated = false;
+
+    const { container } = render(<GymFollowButton gymUuid="gym-1" ownerId={OWNER_ID} isFollowedByMe={false} />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('still renders while the session is settling, even for the owner', () => {
+    // `useSession()` starts at null on every load. The owner check is a hide,
+    // not a show, so a null session must not hide the button from everyone —
+    // it resolves to the owner's own id a round-trip later.
+    sessionState.userId = null;
+
+    render(<GymFollowButton gymUuid="gym-1" ownerId={OWNER_ID} isFollowedByMe={false} />);
+
+    expect(screen.getByRole('button', { name: 'Follow' })).toBeTruthy();
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/gym-claim-cta-logic.ts
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-cta-logic.ts
@@ -24,6 +24,12 @@ type ClaimCtaInputs = {
   serverCanClaim: boolean;
   /** Whether the request carried an auth cookie (`getServerAuthToken()`). */
   serverHasSession: boolean;
+  /**
+   * `gym.isClaimed` — viewer-independent, `ownerId !== SYSTEM_BOARD_OWNER_ID`
+   * on the backend. Gates the anonymous arm only: "Is this your gym?" under the
+   * displayed name of the person who already runs it reads as a mistake.
+   */
+  gymIsClaimed: boolean;
 };
 
 /**
@@ -32,28 +38,47 @@ type ClaimCtaInputs = {
  * with one has already had `canClaim` computed against the real user (owner,
  * gym admin/editor and covering community leader all come back false).
  *
- * Switched on a joined key rather than nested ifs so the four input states are
+ * `gymIsClaimed` only ever narrows the anonymous arm. A signed-in non-member
+ * asking for a gym someone else already owns is a deliberate, long-standing
+ * path — the backend routes it to admin review — so the signed-in arm ignores
+ * it entirely.
+ *
+ * Switched on a joined key rather than nested ifs so the eight input states are
  * enumerated in one place. There is deliberately no `default` arm: the declared
  * return type makes an unhandled combination a "lacks ending return statement"
  * compile error instead of a silent `undefined`.
  */
-export function resolveClaimCtaVariant({ serverCanClaim, serverHasSession }: ClaimCtaInputs): GymClaimCtaVariant {
-  const inputs = `${serverCanClaim}:${serverHasSession}` as `${boolean}:${boolean}`;
+export function resolveClaimCtaVariant({
+  serverCanClaim,
+  serverHasSession,
+  gymIsClaimed,
+}: ClaimCtaInputs): GymClaimCtaVariant {
+  const inputs = `${serverCanClaim}:${serverHasSession}:${gymIsClaimed}` as `${boolean}:${boolean}:${boolean}`;
   switch (inputs) {
-    case 'true:true':
+    // Signed in: `canClaim` is the whole answer, claimed or not.
+    case 'true:true:true':
+    case 'true:true:false':
       // A signed-in viewer the backend says may claim this gym.
       return 'signed-in';
-    case 'false:true':
+    case 'false:true:true':
+    case 'false:true:false':
       // Signed in and already covered — owner, admin/editor, community leader.
       return 'hidden';
-    case 'true:false':
-    // Unreachable: `canClaim` needs an authenticated user. Falls through to the
-    // anonymous arm anyway, because with no session there is no signed-in
-    // viewer whose dialog we could open.
-    case 'false:false':
+
+    // Anonymous: the arm exists for gyms nobody has claimed yet.
+    case 'true:false:false':
+    // Unreachable: `canClaim` needs an authenticated user. Grouped with the
+    // real anonymous case anyway, because with no session there is no
+    // signed-in viewer whose dialog we could open.
+    case 'false:false:false':
       // The case this whole flow exists for: a gym owner who just googled their
       // own gym and has never signed in.
       return 'signed-out';
+    case 'true:false:true':
+    case 'false:false:true':
+      // Someone already runs this gym, and their name is on the page directly
+      // above where the call-out would sit.
+      return 'hidden';
   }
 }
 

--- a/packages/web/app/gym/[gym_slug]/gym-claim-cta-logic.ts
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-cta-logic.ts
@@ -1,0 +1,72 @@
+import type { GymClaimViewerState } from '@boardsesh/analytics';
+
+/**
+ * Which arm of the claim call-out the server should render, if any.
+ *
+ * `signed-in` and `signed-out` line up 1:1 with `GymClaimViewerState`, so the
+ * variant doubles as the analytics property the island reports — one decision,
+ * not two that can drift.
+ */
+export type GymClaimCtaVariant = GymClaimViewerState | 'hidden';
+
+/** The query param a returning signer carries back to the gym page. */
+export const CLAIM_PARAM = 'claim';
+
+/** Its only accepted value. Anything else means "don't auto-open". */
+export const CLAIM_PARAM_VALUE = '1';
+
+type ClaimCtaInputs = {
+  /**
+   * `gym.canClaim` from the backend. The resolver computes it as
+   * `!!authenticatedUserId && …`, so it is false for every anonymous request
+   * regardless of whether the gym is actually claimable.
+   */
+  serverCanClaim: boolean;
+  /** Whether the request carried an auth cookie (`getServerAuthToken()`). */
+  serverHasSession: boolean;
+};
+
+/**
+ * The session cookie — not `canClaim` — decides which arm can run at all: a
+ * request with no session has no signed-in viewer to gate on, and a request
+ * with one has already had `canClaim` computed against the real user (owner,
+ * gym admin/editor and covering community leader all come back false).
+ *
+ * Switched on a joined key rather than nested ifs so the four input states are
+ * enumerated in one place. There is deliberately no `default` arm: the declared
+ * return type makes an unhandled combination a "lacks ending return statement"
+ * compile error instead of a silent `undefined`.
+ */
+export function resolveClaimCtaVariant({ serverCanClaim, serverHasSession }: ClaimCtaInputs): GymClaimCtaVariant {
+  const inputs = `${serverCanClaim}:${serverHasSession}` as `${boolean}:${boolean}`;
+  switch (inputs) {
+    case 'true:true':
+      // A signed-in viewer the backend says may claim this gym.
+      return 'signed-in';
+    case 'false:true':
+      // Signed in and already covered — owner, admin/editor, community leader.
+      return 'hidden';
+    case 'true:false':
+    // Unreachable: `canClaim` needs an authenticated user. Falls through to the
+    // anonymous arm anyway, because with no session there is no signed-in
+    // viewer whose dialog we could open.
+    case 'false:false':
+      // The case this whole flow exists for: a gym owner who just googled their
+      // own gym and has never signed in.
+      return 'signed-out';
+  }
+}
+
+/**
+ * True only for the exact scalar `'1'`. Next hands a repeated param
+ * (`?claim=1&claim=1`, which a crawler or a double-appended redirect produces)
+ * as an array, and an array must not auto-open a dialog.
+ */
+export function shouldAutoOpenClaimDialog(rawParam: string | string[] | undefined): boolean {
+  return rawParam === CLAIM_PARAM_VALUE;
+}
+
+/** Where the auth flow drops the owner back: the same gym page, claim intact. */
+export function buildClaimReturnPath(gymSlug: string): string {
+  return `/gym/${gymSlug}?${CLAIM_PARAM}=${CLAIM_PARAM_VALUE}`;
+}

--- a/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
@@ -12,7 +12,8 @@ import ClaimGymDialog from '@/app/components/gym-entity/claim-gym-dialog';
 import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
 import { themeTokens } from '@/app/theme/theme-config';
-import { CLAIM_PARAM, buildClaimReturnPath, shouldAutoOpenClaimDialog } from './gym-claim-cta-logic';
+import { buildClaimReturnPath, shouldAutoOpenClaimDialog } from './gym-claim-cta-logic';
+import { useClaimParamStrip } from './use-claim-param-strip';
 
 type GymClaimCtaProps = {
   gymUuid: string;
@@ -46,18 +47,20 @@ export default function GymClaimCta({ gymUuid, gymName, gymSlug, website, viewer
   const router = useRouter();
   const [open, setOpen] = useState(false);
 
-  // The owner came back from OAuth on `?claim=1`. Re-open the dialog they were
-  // heading for, then drop the param with a plain history swap: `router.replace`
-  // refetches the RSC payload and remounts this island, closing the dialog it
-  // was just called to open. Deps are server props, which a client-side history
-  // swap doesn't change, so this settles after one run.
+  const returningFromAuth = shouldAutoOpenClaimDialog(claimParam);
+
+  // The owner came back from OAuth on `?claim=1`: re-open the dialog they were
+  // heading for. Immediate, unlike the URL cleanup below — a dialog that waits
+  // a tick to appear reads as a dropped tap. Deps are server props, which the
+  // cleanup's history swap doesn't change, so this settles after one run.
   useEffect(() => {
-    if (viewerState !== 'signed-in' || !shouldAutoOpenClaimDialog(claimParam)) return;
+    if (viewerState !== 'signed-in' || !returningFromAuth) return;
     setOpen(true);
-    const currentUrl = new URL(window.location.href);
-    currentUrl.searchParams.delete(CLAIM_PARAM);
-    window.history.replaceState(null, '', `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`);
-  }, [viewerState, claimParam]);
+  }, [viewerState, returningFromAuth]);
+
+  // Runs on both arms: the signed-out one lands here when someone opens a
+  // shared `?claim=1` link, and the param is just as stale for them.
+  useClaimParamStrip(returningFromAuth);
 
   const handleClick = () => {
     trackGymFunnelEvent(gymClaimCtaClicked({ placement: 'gym-page', viewerState, gymUuid }));

--- a/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-cta.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
@@ -8,12 +9,15 @@ import Button from '@mui/material/Button';
 import VerifiedUserOutlined from '@mui/icons-material/VerifiedUserOutlined';
 import { gymClaimCtaClicked, type GymClaimViewerState } from '@boardsesh/analytics';
 import ClaimGymDialog from '@/app/components/gym-entity/claim-gym-dialog';
+import { useAuthModal } from '@/app/components/providers/auth-modal-provider';
 import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
 import { themeTokens } from '@/app/theme/theme-config';
+import { CLAIM_PARAM, buildClaimReturnPath, shouldAutoOpenClaimDialog } from './gym-claim-cta-logic';
 
 type GymClaimCtaProps = {
   gymUuid: string;
   gymName: string;
+  gymSlug: string;
   website?: string | null;
   /**
    * Derived on the SERVER from the request's auth cookie and passed down, not
@@ -21,18 +25,64 @@ type GymClaimCtaProps = {
    * every page load and settles after a round-trip, so a tap that beats
    * hydration — the whole point of a QR poster — would report a signed-in
    * climber as signed-out.
+   *
+   * It also picks the arm: `signed-in` opens the claim dialog straight away,
+   * `signed-out` sends the owner through auth first.
    */
   viewerState: GymClaimViewerState;
+  /** The raw `?claim=` value, straight off the server's searchParams. */
+  claimParam?: string | string[];
 };
 
 /**
  * Client island: the prominent "claim this gym" call-out on the public gym
- * page. The server only renders it when the viewer can actually claim the gym
- * (gym.canClaim), and it reuses the exact ClaimGymDialog the preview sheet opens.
+ * page. Both arms render the same box and the same copy, so an anonymous
+ * visitor — the gym owner who just googled their own gym — gets the call-out
+ * server-rendered and crawlable instead of gated behind a session.
  */
-export default function GymClaimCta({ gymUuid, gymName, website, viewerState }: GymClaimCtaProps) {
+export default function GymClaimCta({ gymUuid, gymName, gymSlug, website, viewerState, claimParam }: GymClaimCtaProps) {
   const { t } = useTranslation('kiosk');
+  const { openAuthModal } = useAuthModal();
+  const router = useRouter();
   const [open, setOpen] = useState(false);
+
+  // The owner came back from OAuth on `?claim=1`. Re-open the dialog they were
+  // heading for, then drop the param with a plain history swap: `router.replace`
+  // refetches the RSC payload and remounts this island, closing the dialog it
+  // was just called to open. Deps are server props, which a client-side history
+  // swap doesn't change, so this settles after one run.
+  useEffect(() => {
+    if (viewerState !== 'signed-in' || !shouldAutoOpenClaimDialog(claimParam)) return;
+    setOpen(true);
+    const currentUrl = new URL(window.location.href);
+    currentUrl.searchParams.delete(CLAIM_PARAM);
+    window.history.replaceState(null, '', `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`);
+  }, [viewerState, claimParam]);
+
+  const handleClick = () => {
+    trackGymFunnelEvent(gymClaimCtaClicked({ placement: 'gym-page', viewerState, gymUuid }));
+
+    if (viewerState === 'signed-in') {
+      setOpen(true);
+      return;
+    }
+
+    openAuthModal({
+      title: t('gymPage.claimAuthTitle'),
+      description: t('gymPage.claimAuthBody'),
+      // OAuth leaves the page entirely, so the intent has to survive in the URL.
+      // Without it every social signer lands back on the homepage.
+      callbackUrl: buildClaimReturnPath(gymSlug),
+      onSuccess: () => {
+        // Email/password never leaves the page, so open the dialog right here.
+        setOpen(true);
+        // `canClaim` is server-computed: refreshing with the fresh cookie clears
+        // the call-out for an owner who turns out to already have edit access,
+        // instead of letting them submit into a backend rejection.
+        router.refresh();
+      },
+    });
+  };
 
   return (
     <Box
@@ -52,13 +102,10 @@ export default function GymClaimCta({ gymUuid, gymName, website, viewerState }: 
       <Button
         variant="contained"
         startIcon={<VerifiedUserOutlined />}
-        onClick={() => {
-          trackGymFunnelEvent(gymClaimCtaClicked({ placement: 'gym-page', viewerState, gymUuid }));
-          setOpen(true);
-        }}
+        onClick={handleClick}
         sx={{ textTransform: 'none' }}
       >
-        {t('gymPage.claimCta')}
+        {viewerState === 'signed-in' ? t('gymPage.claimCta') : t('gymPage.claimCtaSignedOut')}
       </Button>
       <ClaimGymDialog
         gymUuid={gymUuid}

--- a/packages/web/app/gym/[gym_slug]/gym-claim-param-cleanup.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-param-cleanup.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { shouldAutoOpenClaimDialog } from './gym-claim-cta-logic';
+import { useClaimParamStrip } from './use-claim-param-strip';
+
+type GymClaimParamCleanupProps = {
+  /** The raw `?claim=` value, straight off the server's searchParams. */
+  claimParam?: string | string[];
+};
+
+/**
+ * Clears a stale `?claim=1` on the pages where GymClaimCta isn't there to do
+ * it: an owner or covering community leader coming back from auth (their
+ * variant resolves to `hidden`, so nothing renders), and anyone opening a
+ * shared claim link for a gym they can't be offered. Purely cosmetic — the
+ * canonical URL never carries the param — but leaving it in the address bar
+ * invites a reload that looks like the claim is still pending.
+ */
+export default function GymClaimParamCleanup({ claimParam }: GymClaimParamCleanupProps) {
+  useClaimParamStrip(shouldAutoOpenClaimDialog(claimParam));
+  return null;
+}

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -39,6 +39,7 @@ import CommentSection from '@/app/components/social/comment-section';
 import GymPageManageButton from './gym-page-manage-button';
 import GymFollowButton from './gym-follow-button';
 import GymClaimCta from './gym-claim-cta';
+import GymClaimParamCleanup from './gym-claim-param-cleanup';
 import { CLAIM_PARAM, resolveClaimCtaVariant } from './gym-claim-cta-logic';
 import GymOwnerPrompts from './gym-owner-prompts';
 import GymReportDuplicateCta from './gym-report-duplicate-cta';
@@ -164,6 +165,8 @@ export default async function GymPage(props: GymRouteProps) {
     serverCanClaim: gym.canClaim,
     serverHasSession: Boolean(token),
   });
+  const claimParam = searchParams[CLAIM_PARAM];
+  const showsClaimCta = gym.isPublic && claimCtaVariant !== 'hidden';
 
   const jsonLd = gym.isPublic
     ? {
@@ -308,15 +311,20 @@ export default async function GymPage(props: GymRouteProps) {
             leaning on `isGymViewable`: a private gym reaches this line only via
             its own editors, and the anonymous arm has to stay impossible there
             even if the viewability rule is loosened later. */}
-        {gym.isPublic && claimCtaVariant !== 'hidden' && (
+        {showsClaimCta ? (
           <GymClaimCta
             gymUuid={gym.uuid}
             gymName={gym.name}
             gymSlug={gym_slug}
             website={gym.website}
             viewerState={claimCtaVariant}
-            claimParam={searchParams[CLAIM_PARAM]}
+            claimParam={claimParam}
           />
+        ) : (
+          /* No call-out to clear the return-from-auth param, so clear it here:
+             an owner or community leader who signed in and turned out to
+             already cover this gym would otherwise sit on a live `?claim=1`. */
+          <GymClaimParamCleanup claimParam={claimParam} />
         )}
 
         <GymReportDuplicateCta

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -39,6 +39,7 @@ import CommentSection from '@/app/components/social/comment-section';
 import GymPageManageButton from './gym-page-manage-button';
 import GymFollowButton from './gym-follow-button';
 import GymClaimCta from './gym-claim-cta';
+import { CLAIM_PARAM, resolveClaimCtaVariant } from './gym-claim-cta-logic';
 import GymOwnerPrompts from './gym-owner-prompts';
 import GymReportDuplicateCta from './gym-report-duplicate-cta';
 import { formatHoursConfirmedDate } from './gym-hours-display';
@@ -155,6 +156,14 @@ export default async function GymPage(props: GymRouteProps) {
   // A printed code carries `?src=qr&medium=…`. Anything else — a bare visit, a
   // hand-edited param, a crawler-mangled URL — parses to null and mounts nothing.
   const qrLanding = parseGymQrLanding(searchParams);
+
+  // Which arm of the claim call-out to render — `hidden` for a signed-in viewer
+  // who already covers this gym (owner, admin/editor, community leader), the
+  // anonymous arm for everyone with no session.
+  const claimCtaVariant = resolveClaimCtaVariant({
+    serverCanClaim: gym.canClaim,
+    serverHasSession: Boolean(token),
+  });
 
   const jsonLd = gym.isPublic
     ? {
@@ -293,18 +302,20 @@ export default async function GymPage(props: GymRouteProps) {
         />
 
         {/* `viewerState` is the server's answer, taken from the request cookie
-            above. Reading it in the island with useSession() would report the
+            above — reading it in the island with useSession() would report the
             pre-hydration `loading` state as signed-out on exactly the taps this
-            event cares about. Today `canClaim` is itself false for a signed-out
-            viewer (the resolver requires an authenticated user), so this is
-            `signed-in` by construction — until #3672 shows the CTA anonymously,
-            at which point this prop is already carrying the truth. */}
-        {gym.canClaim && (
+            event cares about. The `isPublic` clause is spelled out rather than
+            leaning on `isGymViewable`: a private gym reaches this line only via
+            its own editors, and the anonymous arm has to stay impossible there
+            even if the viewability rule is loosened later. */}
+        {gym.isPublic && claimCtaVariant !== 'hidden' && (
           <GymClaimCta
             gymUuid={gym.uuid}
             gymName={gym.name}
+            gymSlug={gym_slug}
             website={gym.website}
-            viewerState={token ? 'signed-in' : 'signed-out'}
+            viewerState={claimCtaVariant}
+            claimParam={searchParams[CLAIM_PARAM]}
           />
         )}
 

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -161,9 +161,12 @@ export default async function GymPage(props: GymRouteProps) {
   // Which arm of the claim call-out to render — `hidden` for a signed-in viewer
   // who already covers this gym (owner, admin/editor, community leader), the
   // anonymous arm for everyone with no session.
+  // One derivation, on the server: the island is handed the answer as
+  // `viewerState` and never recomputes it.
   const claimCtaVariant = resolveClaimCtaVariant({
     serverCanClaim: gym.canClaim,
     serverHasSession: Boolean(token),
+    gymIsClaimed: gym.isClaimed,
   });
   const claimParam = searchParams[CLAIM_PARAM];
   const showsClaimCta = gym.isPublic && claimCtaVariant !== 'hidden';
@@ -323,7 +326,8 @@ export default async function GymPage(props: GymRouteProps) {
         ) : (
           /* No call-out to clear the return-from-auth param, so clear it here:
              an owner or community leader who signed in and turned out to
-             already cover this gym would otherwise sit on a live `?claim=1`. */
+             already cover this gym — or an anonymous visitor on a gym someone
+             already runs — would otherwise sit on a live `?claim=1`. */
           <GymClaimParamCleanup claimParam={claimParam} />
         )}
 

--- a/packages/web/app/gym/[gym_slug]/use-claim-param-strip.ts
+++ b/packages/web/app/gym/[gym_slug]/use-claim-param-strip.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import { CLAIM_PARAM } from './gym-claim-cta-logic';
+
+/**
+ * Drops `?claim=1` from the address bar once the return-from-auth hop is done.
+ *
+ * Deferred to a macrotask on purpose. Next installs its `pushState`/
+ * `replaceState` patch in the root `Router`'s own mount effect
+ * (`next/dist/client/components/app-router.js`), and React flushes passive
+ * effects child-first — so on the hydration commit this island's effect runs
+ * while `window.history.replaceState` is still the **native** one. Calling that
+ * directly breaks two things:
+ *
+ * - it overwrites the entry's state, dropping Next's `{ __NA, … }`, and
+ *   `onPopState` bails on `if (!event.state) return` — a later Back moves the
+ *   address bar without moving the rendered page; and
+ * - it never runs `applyUrlFromHistoryPushReplace`, so the router's
+ *   `canonicalUrl` keeps `?claim=1` and the next `HistoryUpdater` insertion
+ *   effect writes the param straight back. That is reachable on the happy
+ *   path — an auto-approved domain claim calls `router.refresh()`.
+ *
+ * Passing `window.history.state` instead of `null` fixes only the first half:
+ * the patch short-circuits on `data.__NA` and skips the canonical-URL update.
+ * Waiting a tick means the patched `replaceState` handles the call and does
+ * both — and unlike `router.replace`, it refetches no RSC payload, so the
+ * island (and any dialog it has open) is not remounted.
+ */
+export function useClaimParamStrip(active: boolean): void {
+  useEffect(() => {
+    if (!active) return;
+
+    const timer = setTimeout(() => {
+      const currentUrl = new URL(window.location.href);
+      currentUrl.searchParams.delete(CLAIM_PARAM);
+      window.history.replaceState(null, '', `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`);
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [active]);
+}


### PR DESCRIPTION
Closes #3672 · Part of epic #4372, Tier 1.

A signed-out gym owner who googles their own gym is the likeliest person to claim it, and they're the one person who could never see the claim call-out. `canClaim` is `!!authenticatedUserId && …`, so it's false for every anonymous viewer — the front door was invisible to exactly the people it exists for. The claim path drew zero pageviews in 90 days, and all 26 claims ever made were processed by hand.

Now an anonymous visitor to a public gym page sees the call-out, signs in through the modal, and lands back on the same gym with the claim dialog open.

## The load-bearing fix

`openAuthModal` had no `callbackUrl`, so every OAuth signer was sent to the homepage and the claim intent evaporated on the way. Threading it through was smaller than expected — `SocialLoginButtons` already accepted and used `callbackUrl` for both the web and Capacitor paths; only the two layers above it were missing it. Passing `undefined` keeps the old `'/'` default, so no existing caller changes behaviour.

## Gating

One pure function decides both what renders and what the analytics say, so they can't drift:

- no session → `signed-out` (the new arm)
- session + `canClaim` → `signed-in` (unchanged)
- session + no `canClaim` → hidden

Owners, gym admins and editors, and covering community leaders still never see it. The render condition also keeps an explicit `gym.isPublic` clause, so the anonymous arm stays impossible on a private gym even if the viewability rule is loosened later. The switch has no `default` arm and an annotated return type, so a future variant fails typecheck rather than silently falling through to something plausible.

Both arms render the same call-out box and copy, so the SEO text is server-rendered for anonymous visitors rather than appearing only after hydration.

## Also fixed

The claim dialog's submit buttons stayed enabled while `submit()` opened with `if (!token) return`. Since `useWsAuthToken`'s query key includes the session status, the first tap after logging in through the modal was a silent no-op — an edge case before this PR, the common path after it.

## This makes `viewerState: 'signed-out'` reachable

`docs/gym-funnel-analytics.md` previously stated that value was zero by construction. That section is rewritten rather than deleted: the gym page can now produce it, but the two other claim entry points (the preview sheet and the create-gym duplicate check) still can't, so the doc now tells the reader to filter on `placement = 'gym-page'` before reading the split. Reading it unfiltered would understate the signed-out share with rows that could never have been anything else.

## Only on gyms nobody runs yet

The anonymous arm is gated on `Gym.isClaimed` (from #4505 — viewer-independent, derived from `owner_id`). Without that gate, "Is this your gym? Log in and claim it" would render on a well-run claimed gym with that owner's name displayed right above the box.

The signed-in arm is deliberately **not** gated that way — a signed-in non-member claiming an owned gym is an existing, intentional path that ends in admin review. Only the anonymous arm narrows.

This matters for reading the funnel later, so it's in `docs/gym-funnel-analytics.md` too: gym-page `signed-out` is now reachable only on **unclaimed** gyms. Any conversion rate has to use that same population on both sides — claimed gyms contribute zero `signed-out` events no matter how much anonymous traffic they get, and they're the well-run, heavily-visited end of the directory.

## Tests

Includes the three island gaps #3672 asks for. Two notes on what they turned out to be: "an authenticated non-claimer renders nothing" isn't a property of the island at all (it always paints once mounted) — it's a property of the page's render condition, so the test mirrors that condition in a small harness. And `GymFollowButton` owner-self-hide already had a test, but its file pins `useSession` to a constant, so the real gap was every other case: owner hidden, other climber shown, signed-out renders nothing, and an unsettled session still renders (the hide must not fire before the session resolves).

## Release Notes

Own a gym? You can start a claim straight from its page now, without signing in first — log in when prompted and you'll land right back where you were, ready to claim it.
