### PR TITLE
feat(web): per-gym QR and store-link attribution

### DIFF
--- a/docs/gym-funnel-analytics.md
+++ b/docs/gym-funnel-analytics.md
@@ -195,16 +195,37 @@ Printed QR codes point at a normal Boardsesh URL carrying two extra params:
 The member list reads as three live mediums. It is one. `Gym QR Scanned` fires
 from the QR landing tracker, which mounts on `/gym/[gym_slug]` and nowhere else.
 The kiosk's per-board QR (`app/components/kiosk/board-slot/board-install-qr.tsx`)
-encodes `/b/{slug}`, and `app/b/[board_slug]/page.tsx` is a bare
-`redirect('/b/{slug}/{angle}/list')` — it renders no tracker, and the redirect
-target is a literal path, so the `?src=qr&medium=` params do not even survive the
-hop.
+encodes `/b/{slug}`, which renders no tracker. #4379 gave that code its
+`?src=qr&medium=kiosk` params and stopped `app/b/[board_slug]/page.tsx` dropping
+the query on the way to `/b/{slug}/{angle}/list`, so a kiosk scan is now
+attributable from a server log — but the destination still has no tracker, so it
+still fires no `Gym QR Scanned`. The poster is the only scan count there is.
 
 `kiosk` and `board` stay in `GYM_QR_MEDIUMS` anyway: the parser has to accept all
 three so that pointing a future kiosk or board QR at a gym page is a call-site
 change rather than a vocabulary change that invalidates codes already printed on
 walls. Until then, expect `medium: 'poster'` and only `poster` in PostHog — a
 `kiosk` or `board` row appearing means someone shipped a new producer.
+
+`/b/...` is itself a www climbing surface that #4358 is deleting. When it goes,
+the kiosk QR needs a new target; the params and the builders in
+`app/lib/gym-attribution.ts` survive that move unchanged.
+
+### Carrying the params through a redirect
+
+Two redirects would otherwise silently unattribute a scan, and both now re-emit
+the pair through `gymQrAttributionQuery` (`app/lib/gym-attribution.ts`):
+
+- `app/b/[board_slug]/page.tsx` → `/b/{slug}/{angle}/list`
+- the merged-twin 308 in `app/gym/[gym_slug]/page.tsx` → `/gym/{canonical}`
+
+The second is the one that matters: a poster is laminated and stuck to a wall,
+and the gym it names can be merged into another listing a year later. The helper
+is a strict allowlist — it re-serialises `src` and `medium` from the contract's
+own constants after `parseGymQrLanding` has accepted them, so nothing a crafted
+link carries (`?medium=evil`, someone else's `utm_campaign`, a `?next=` URL)
+rides through a redirect into a URL we publish. It returns `''`, not `'?'`, so an
+ordinary visit still redirects to a clean URL.
 
 ## Amendments to issue #4374
 
@@ -290,6 +311,28 @@ the wiring PR. It is deliberately not in `@boardsesh/analytics`: `App Install
 Click` is web-only with no mobile counterpart, and a shared package should not
 own an event neither platform shares — that is the same rule that keeps the
 seven gym events out of `SHARED_EVENTS`.
+
+The CTA itself is **`app/gym/[gym_slug]/gym-install-cta.tsx`** (#4379). It
+renders both stores as real anchors — no platform sniffing, because an effect
+that picks one store leaves the server HTML with no install link at all — and
+uses the canonical slug (`gym.slug ?? gym_slug`), so a scan that 308s off a
+merged twin's URL still reports one campaign rather than two.
+
+### Why the Play link carries `referrer`, not just `utm_*`
+
+`playStoreUrlForGym` (`app/lib/gym-attribution.ts`) sets
+`utm_source=boardsesh&utm_medium=qr&utm_campaign=gym-<slug>` **and** a `referrer`
+param holding a percent-encoded copy of the same three. The `referrer` is the
+one that does the work: Play populates the Install Referrer API from that query
+parameter, and `packages/mobile/src/lib/install-referrer.ts` reads the string
+back with `new URLSearchParams(raw)` to pull the three `utm_*` values into
+`Install Attributed`. A link with only the bare `utm_*` params reads correctly to
+a human, matches #4379's literal wording, and attributes **zero** installs,
+because the app never sees them. The bare params stay because the Play console's
+own acquisition reports read those.
+
+iOS carries none of this. The App Store URL is unchanged — Apple has no
+equivalent to read a referrer back, and iOS attribution is out of scope (#3402).
 
 ## Properties deliberately not carried
 

--- a/docs/gym-funnel-analytics.md
+++ b/docs/gym-funnel-analytics.md
@@ -224,8 +224,16 @@ and the gym it names can be merged into another listing a year later. The helper
 is a strict allowlist — it re-serialises `src` and `medium` from the contract's
 own constants after `parseGymQrLanding` has accepted them, so nothing a crafted
 link carries (`?medium=evil`, someone else's `utm_campaign`, a `?next=` URL)
-rides through a redirect into a URL we publish. It returns `''`, not `'?'`, so an
-ordinary visit still redirects to a clean URL.
+rides through a redirect into a URL we publish. Its entire reachable output is
+three fixed strings plus the empty one, and it returns `''` rather than `'?'`, so
+an ordinary visit still redirects to a clean URL.
+
+Known gap, worth knowing before anyone reads a kiosk number: the board list
+(`/b/{slug}/{angle}/list`) has no equivalent of `stripGymQrParams`, so the params
+stay in the address bar after a kiosk scan. A climber who then shares that URL
+passes the attribution on, and every recipient looks like another kiosk scan.
+The gym page does strip them; the board list should too if `medium: 'kiosk'` ever
+gets a real counter.
 
 ## Amendments to issue #4374
 
@@ -328,8 +336,13 @@ parameter, and `packages/mobile/src/lib/install-referrer.ts` reads the string
 back with `new URLSearchParams(raw)` to pull the three `utm_*` values into
 `Install Attributed`. A link with only the bare `utm_*` params reads correctly to
 a human, matches #4379's literal wording, and attributes **zero** installs,
-because the app never sees them. The bare params stay because the Play console's
-own acquisition reports read those.
+because the app never sees them.
+
+The bare `utm_*` params stay on the link anyway, but do not assume a consumer
+for them: they are kept because they are harmless and make the link readable at a
+glance (and greppable in a log) without decoding the nested `referrer`. Whether
+Play's own acquisition reporting reads them has not been verified here — the
+mechanism this section documents is `referrer`, and that is the one to rely on.
 
 iOS carries none of this. The App Store URL is unchanged — Apple has no
 equivalent to read a referrer back, and iOS attribution is out of scope (#3402).

--- a/packages/shared/analytics/src/gym-funnel.ts
+++ b/packages/shared/analytics/src/gym-funnel.ts
@@ -110,11 +110,14 @@ export type GymClaimResultStatus = 'email_sent' | 'approved' | 'admin_review' | 
  * currently has a producer that can reach a gym page. `Gym QR Scanned` fires
  * from the QR landing tracker, which mounts on `/gym/[gym_slug]` and nowhere
  * else. The kiosk's per-board QR (`components/kiosk/board-slot/board-install-qr.tsx`)
- * encodes `/b/{slug}`, and `app/b/[board_slug]/page.tsx` is a bare
- * `redirect('/b/{slug}/{angle}/list')` — it renders no tracker AND the redirect
- * is built from a literal path, so the `?src=qr&medium=` params do not even
- * survive the hop. A `kiosk` or `board` scan therefore cannot fire this event
- * today.
+ * encodes `/b/{slug}`, and `app/b/[board_slug]/page.tsx` redirects to
+ * `/b/{slug}/{angle}/list`, which renders no tracker. A `kiosk` or `board` scan
+ * therefore cannot fire this event today.
+ *
+ * The params themselves DO survive that hop as of #4379 — the redirect carries
+ * them through `gymQrAttributionQuery` (`packages/web/app/lib/gym-attribution.ts`),
+ * so a kiosk scan is attributable from a server log. It is the missing tracker
+ * at the destination, and only that, which keeps the event unfireable.
  *
  * Both members are kept anyway: the param contract has to parse all three so a
  * future gym-page-targeted kiosk or board QR is a call-site change, not a

--- a/packages/shared/i18n/locales/de/kiosk.json
+++ b/packages/shared/i18n/locales/de/kiosk.json
@@ -84,6 +84,12 @@
     "hoursHeading": "Öffnungszeiten",
     "hoursConfirmed": "Bestätigt am {{date}}",
     "visitWebsite": "Website besuchen",
+    "install": {
+      "heading": "Hol dir die App für diese Wand",
+      "body": "Beleuchte die Boards in {{gymName}} vom Handy aus und logg jede Begehung.",
+      "googlePlay": "Jetzt bei Google Play",
+      "appStore": "Laden im App Store"
+    },
     "noBoardsYet": "Hier sind noch keine Boards gelistet.",
     "explorePlaylists": "Sieh, was Kletterer*innen zusammenstellen",
     "claimTitle": "Ist das deine Halle?",

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -84,6 +84,12 @@
     "hoursHeading": "Opening hours",
     "hoursConfirmed": "Confirmed {{date}}",
     "visitWebsite": "Visit website",
+    "install": {
+      "heading": "Get the app for this wall",
+      "body": "Light up the boards at {{gymName}} from your phone and log every send.",
+      "googlePlay": "Get it on Google Play",
+      "appStore": "Download on the App Store"
+    },
     "noBoardsYet": "No boards listed here yet.",
     "explorePlaylists": "See what people are building",
     "claimTitle": "Is this your gym?",

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -88,7 +88,7 @@
       "heading": "Consigue la app para este muro",
       "body": "Enciende los plafones de {{gymName}} desde el móvil y registra cada encadene.",
       "googlePlay": "Disponible en Google Play",
-      "appStore": "Descárgalo en el App Store"
+      "appStore": "Descárgala en el App Store"
     },
     "noBoardsYet": "Aún no hay plafones aquí.",
     "explorePlaylists": "Mira las playlists que monta la gente",

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -84,6 +84,12 @@
     "hoursHeading": "Horario",
     "hoursConfirmed": "Confirmado el {{date}}",
     "visitWebsite": "Visitar el sitio web",
+    "install": {
+      "heading": "Consigue la app para este muro",
+      "body": "Enciende los plafones de {{gymName}} desde el móvil y registra cada encadene.",
+      "googlePlay": "Disponible en Google Play",
+      "appStore": "Descárgalo en el App Store"
+    },
     "noBoardsYet": "Aún no hay plafones aquí.",
     "explorePlaylists": "Mira las playlists que monta la gente",
     "claimTitle": "¿Es tuyo este rocódromo?",

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -84,6 +84,12 @@
     "hoursHeading": "Horaires d'ouverture",
     "hoursConfirmed": "Confirmé le {{date}}",
     "visitWebsite": "Visiter le site web",
+    "install": {
+      "heading": "Prends l'appli pour ce mur",
+      "body": "Allume les boards de {{gymName}} depuis ton téléphone et fais la croix sur chaque bloc.",
+      "googlePlay": "Disponible sur Google Play",
+      "appStore": "Télécharger dans l'App Store"
+    },
     "noBoardsYet": "Aucune board ici pour l'instant.",
     "explorePlaylists": "Découvre les playlists des grimpeurs",
     "claimTitle": "C'est ta salle ?",

--- a/packages/web/app/b/[board_slug]/__tests__/page.test.ts
+++ b/packages/web/app/b/[board_slug]/__tests__/page.test.ts
@@ -77,6 +77,17 @@ describe('/b/[board_slug] redirect', () => {
     ).resolves.toBe('/b/main-kilter/40/list?src=qr&medium=board');
   });
 
+  it('percent-encodes the slug so a "#" cannot swallow the params', async () => {
+    // The printed URL already guards this (`gymQrUrl`, pinned by its own test);
+    // the redirect that carries it has to agree, or the shape guarded on the
+    // poster re-breaks on the hop.
+    resolveBoardBySlug.mockResolvedValue({ slug: 'kilter#1', angle: 40 });
+
+    await expect(redirectTargetFor('kilter#1', { src: 'qr', medium: 'kiosk' })).resolves.toBe(
+      '/b/kilter%231/40/list?src=qr&medium=kiosk',
+    );
+  });
+
   it('404s an unknown board without redirecting anywhere', async () => {
     resolveBoardBySlug.mockResolvedValue(null);
 

--- a/packages/web/app/b/[board_slug]/__tests__/page.test.ts
+++ b/packages/web/app/b/[board_slug]/__tests__/page.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+// Next's real `redirect` throws a NEXT_REDIRECT control-flow error rather than
+// returning, and the route's code after it never runs. Mocking it as a plain
+// spy would let execution fall off the end of the function; throwing a sentinel
+// keeps the control flow honest AND makes the assertion a single catch.
+class RedirectSignal extends Error {
+  constructor(readonly target: string) {
+    super(`redirect:${target}`);
+  }
+}
+const notFound = vi.hoisted(() => vi.fn(() => undefined));
+vi.mock('next/navigation', () => ({
+  notFound,
+  redirect: (target: string) => {
+    throw new RedirectSignal(target);
+  },
+}));
+
+const resolveBoardBySlug = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/board-slug-utils', () => ({ resolveBoardBySlug }));
+
+const BoardSlugPage = (await import('../page')).default;
+
+async function redirectTargetFor(
+  boardSlug: string,
+  searchParams: Record<string, string | string[] | undefined>,
+): Promise<string> {
+  try {
+    await BoardSlugPage({
+      params: Promise.resolve({ board_slug: boardSlug }),
+      searchParams: Promise.resolve(searchParams),
+    });
+  } catch (error) {
+    if (error instanceof RedirectSignal) return error.target;
+    throw error;
+  }
+  throw new Error('expected a redirect');
+}
+
+beforeEach(() => {
+  resolveBoardBySlug.mockReset();
+  notFound.mockReset();
+  resolveBoardBySlug.mockResolvedValue({ slug: 'main-kilter', angle: 40 });
+});
+
+describe('/b/[board_slug] redirect', () => {
+  it('carries the kiosk QR attribution params onto the board list', () => {
+    // Before this change the target was a bare template string, so the whole
+    // query was dropped and a kiosk scan arrived indistinguishable from someone
+    // typing the URL.
+    return expect(redirectTargetFor('main-kilter', { src: 'qr', medium: 'kiosk' })).resolves.toBe(
+      '/b/main-kilter/40/list?src=qr&medium=kiosk',
+    );
+  });
+
+  it('redirects to a clean URL with no trailing "?" when there were no params', () => {
+    return expect(redirectTargetFor('main-kilter', {})).resolves.toBe('/b/main-kilter/40/list');
+  });
+
+  it('drops a crafted medium instead of echoing it into the redirect target', () => {
+    return expect(redirectTargetFor('main-kilter', { src: 'qr', medium: 'evil' })).resolves.toBe(
+      '/b/main-kilter/40/list',
+    );
+  });
+
+  it('drops every other param a crafted link carries', () => {
+    return expect(
+      redirectTargetFor('main-kilter', {
+        src: 'qr',
+        medium: 'board',
+        utm_campaign: 'someone-elses',
+        next: 'https://evil.example.com',
+      }),
+    ).resolves.toBe('/b/main-kilter/40/list?src=qr&medium=board');
+  });
+
+  it('404s an unknown board without redirecting anywhere', async () => {
+    resolveBoardBySlug.mockResolvedValue(null);
+
+    await BoardSlugPage({
+      params: Promise.resolve({ board_slug: 'nope' }),
+      searchParams: Promise.resolve({ src: 'qr', medium: 'kiosk' }),
+    });
+
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/b/[board_slug]/page.tsx
+++ b/packages/web/app/b/[board_slug]/page.tsx
@@ -1,21 +1,36 @@
 import { notFound, redirect } from 'next/navigation';
+import type { GymQrSearchParams } from '@boardsesh/analytics';
 import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
+import { gymQrAttributionQuery } from '@/app/lib/gym-attribution';
 
 type BoardSlugPageParams = {
   board_slug: string;
 };
 
+type BoardSlugPageProps = {
+  params: Promise<BoardSlugPageParams>;
+  searchParams: Promise<GymQrSearchParams>;
+};
+
 /**
  * Redirect /b/[slug] → /b/[slug]/{board.angle}/list
  * When no angle is specified in the URL, use the board's configured default angle.
+ *
+ * The target used to be a bare template string, which dropped the entire query
+ * — including the `?src=qr&medium=kiosk` a scanned kiosk code carries, so a
+ * kiosk scan reached the board list with no trace of where it came from.
+ * `gymQrAttributionQuery` re-emits only `src` and `medium`, and only after the
+ * contract's parser has accepted both, so nothing else a crafted link carries
+ * rides through the hop. It returns `''` for an ordinary visit, so the clean
+ * URL stays clean.
  */
-export default async function BoardSlugPage(props: { params: Promise<BoardSlugPageParams> }) {
-  const params = await props.params;
+export default async function BoardSlugPage(props: BoardSlugPageProps) {
+  const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
   const board = await resolveBoardBySlug(params.board_slug);
 
   if (!board) {
     return notFound();
   }
 
-  redirect(`/b/${board.slug}/${board.angle}/list`);
+  redirect(`/b/${board.slug}/${board.angle}/list${gymQrAttributionQuery(searchParams)}`);
 }

--- a/packages/web/app/b/[board_slug]/page.tsx
+++ b/packages/web/app/b/[board_slug]/page.tsx
@@ -23,6 +23,11 @@ type BoardSlugPageProps = {
  * contract's parser has accepted both, so nothing else a crafted link carries
  * rides through the hop. It returns `''` for an ordinary visit, so the clean
  * URL stays clean.
+ *
+ * The slug is percent-encoded for the same reason `gymQrUrl` encodes it: now
+ * that a query rides behind the slug, a `#` in one would open a fragment and
+ * swallow the params. Board slugs are generated, so this is a guard rather than
+ * a fix — but the printed URL and the redirect that carries it must agree.
  */
 export default async function BoardSlugPage(props: BoardSlugPageProps) {
   const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
@@ -32,5 +37,6 @@ export default async function BoardSlugPage(props: BoardSlugPageProps) {
     return notFound();
   }
 
-  redirect(`/b/${board.slug}/${board.angle}/list${gymQrAttributionQuery(searchParams)}`);
+  const listPath = `/b/${encodeURIComponent(board.slug)}/${board.angle}/list`;
+  redirect(`${listPath}${gymQrAttributionQuery(searchParams)}`);
 }

--- a/packages/web/app/components/kiosk/board-slot/__tests__/board-install-qr.test.tsx
+++ b/packages/web/app/components/kiosk/board-slot/__tests__/board-install-qr.test.tsx
@@ -19,11 +19,13 @@ vi.mock('qrcode.react', () => ({
 }));
 
 describe('BoardInstallQr', () => {
-  it('encodes /b/{slug} against the canonical site URL', () => {
+  it('encodes /b/{slug} with the kiosk attribution params against the canonical site URL', () => {
     render(<BoardInstallQr slug="main-kilter" />);
     // Derived from SITE_URL rather than a hardcoded domain, so the assertion
-    // tracks the base URL instead of pinning the production host.
-    expect(screen.getByTestId('qr').getAttribute('data-value')).toBe(`${SITE_URL}/b/main-kilter`);
+    // tracks the base URL instead of pinning the production host. The params are
+    // spelled out: this string gets printed onto a kiosk screen, and a scan that
+    // loses `medium=kiosk` is indistinguishable from someone typing the URL.
+    expect(screen.getByTestId('qr').getAttribute('data-value')).toBe(`${SITE_URL}/b/main-kilter?src=qr&medium=kiosk`);
   });
 
   it('renders the install caption from the kiosk catalog', () => {

--- a/packages/web/app/components/kiosk/board-slot/board-install-qr.tsx
+++ b/packages/web/app/components/kiosk/board-slot/board-install-qr.tsx
@@ -18,12 +18,18 @@
 import React from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { useTranslation } from 'react-i18next';
-import { absoluteUrl } from '@/app/lib/seo/base-url';
+import { boardQrUrl } from '@/app/lib/gym-attribution';
 import styles from './board-install-qr.module.css';
 
 export default function BoardInstallQr({ slug }: { slug: string }) {
   const { t } = useTranslation('kiosk');
-  const installUrl = absoluteUrl(`/b/${slug}`);
+  // Carries `?src=qr&medium=kiosk` (#4379). It cannot fire `Gym QR Scanned` —
+  // that tracker only mounts on `/gym/[gym_slug]` and this code points at
+  // `/b/{slug}` — but the params now survive `/b/[board_slug]`'s redirect
+  // instead of being dropped, so the scan is attributable from server logs and
+  // to the first-party counters in #4387, and re-aiming this code at a gym page
+  // later is a code change rather than a reprint.
+  const installUrl = boardQrUrl(slug, 'kiosk');
 
   return (
     <div className={styles.tile}>

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-install-cta.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-install-cta.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { IOS_APP_STORE_URL } from '@/app/lib/store-urls';
+import { playStoreUrlForGym } from '@/app/lib/gym-attribution';
+
+const track = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/analytics', () => ({ track }));
+
+const GymInstallCta = (await import('../gym-install-cta')).default;
+
+function renderCta(gymSlug = 'boulderwelt-munich') {
+  render(
+    <GymInstallCta gymSlug={gymSlug} googlePlayLabel="Get it on Google Play" appStoreLabel="Get it on the App Store" />,
+  );
+}
+
+function anchorFor(label: string): HTMLAnchorElement | null {
+  return screen.getByText(label).closest('a');
+}
+
+beforeEach(() => {
+  track.mockReset();
+});
+
+describe('GymInstallCta', () => {
+  it('renders both stores as real anchors so the server HTML is complete', () => {
+    // No platform sniffing: an effect that picks one store leaves a crawler
+    // (and anyone reading before hydration) with zero install links.
+    renderCta();
+
+    expect(anchorFor('Get it on Google Play')?.getAttribute('href')).toBe(playStoreUrlForGym('boulderwelt-munich'));
+    expect(anchorFor('Get it on the App Store')?.getAttribute('href')).toBe(IOS_APP_STORE_URL);
+  });
+
+  it('opens both stores in a new tab without leaking the opener', () => {
+    renderCta();
+
+    for (const label of ['Get it on Google Play', 'Get it on the App Store']) {
+      const anchor = anchorFor(label);
+      expect(anchor?.getAttribute('target')).toBe('_blank');
+      expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer');
+    }
+  });
+
+  it('fires App Install Click with the gym-page placement and slug for Play', () => {
+    renderCta();
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchorFor('Get it on Google Play')?.dispatchEvent(clickEvent);
+
+    // The handler adds the event and nothing else — the anchor still navigates,
+    // so middle-click and "copy link address" behave as they always did.
+    expect(clickEvent.defaultPrevented).toBe(false);
+    expect(track).toHaveBeenCalledWith('App Install Click', {
+      platform: 'android',
+      source: 'google-play',
+      placement: 'gym-page',
+      gymSlug: 'boulderwelt-munich',
+    });
+  });
+
+  it('fires App Install Click with the gym-page placement and slug for the App Store', () => {
+    renderCta();
+
+    const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true });
+    anchorFor('Get it on the App Store')?.dispatchEvent(clickEvent);
+
+    expect(clickEvent.defaultPrevented).toBe(false);
+    // `source` keeps its historic value — PH-13 breaks the install funnel down
+    // by it, and that number has to stay comparable across this change.
+    expect(track).toHaveBeenCalledWith('App Install Click', {
+      platform: 'ios',
+      source: 'app-store',
+      placement: 'gym-page',
+      gymSlug: 'boulderwelt-munich',
+    });
+  });
+
+  it('leaves the App Store URL free of attribution params', () => {
+    // iOS attribution is explicitly out of scope (#3402), and Apple has no
+    // Install Referrer equivalent to read them back.
+    renderCta();
+
+    expect(anchorFor('Get it on the App Store')?.getAttribute('href')).toBe(IOS_APP_STORE_URL);
+  });
+
+  it('names the campaign after the slug it was given', () => {
+    renderCta('vertical-life-wien');
+
+    expect(anchorFor('Get it on Google Play')?.getAttribute('href')).toContain('utm_campaign=gym-vertical-life-wien');
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-install-cta.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-install-cta.test.tsx
@@ -43,6 +43,20 @@ describe('GymInstallCta', () => {
     }
   });
 
+  it('gives both stores the same button weight', () => {
+    // `App Install Click` exists to be broken down by platform (PH-13). A filled
+    // Play button beside an outlined App Store one would tilt the very split
+    // this CTA was built to measure, so the variants have to match.
+    renderCta();
+
+    const playClasses = anchorFor('Get it on Google Play')?.className ?? '';
+    const appStoreClasses = anchorFor('Get it on the App Store')?.className ?? '';
+    expect(playClasses).toContain('MuiButton-contained');
+    expect(appStoreClasses).toContain('MuiButton-contained');
+    expect(playClasses).not.toContain('MuiButton-outlined');
+    expect(appStoreClasses).not.toContain('MuiButton-outlined');
+  });
+
   it('fires App Install Click with the gym-page placement and slug for Play', () => {
     renderCta();
 

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-page-merged-redirect.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-page-merged-redirect.test.tsx
@@ -105,6 +105,16 @@ describe('merged-gym 308 redirect', () => {
     await expect(redirectTargetFor('old-nord', { src: 'qr', medium: 'evil' })).resolves.toBe('/gym/boulderwelt-nord');
   });
 
+  it('percent-encodes the canonical slug so a "#" cannot swallow the params', async () => {
+    // `gymQrUrl` encodes the printed URL for exactly this reason; the redirect
+    // that carries it has to agree.
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: mergedGym('boulder#1') });
+
+    await expect(redirectTargetFor('old-hash', { src: 'qr', medium: 'poster' })).resolves.toBe(
+      '/gym/boulder%231?src=qr&medium=poster',
+    );
+  });
+
   it('does not echo any other param a crafted link carries', async () => {
     executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: mergedGym('boulderwelt-city') });
 

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-page-merged-redirect.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-page-merged-redirect.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { Gym } from '@boardsesh/shared-schema';
+
+vi.mock('server-only', () => ({}));
+
+// Next's real `permanentRedirect` throws NEXT_REDIRECT and nothing after it
+// runs. A plain spy would let the page fall through into rendering, so the
+// sentinel keeps the control flow honest and makes the assertion one catch.
+class RedirectSignal extends Error {
+  constructor(readonly target: string) {
+    super(`permanentRedirect:${target}`);
+  }
+}
+class NotFoundSignal extends Error {}
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new NotFoundSignal('notFound');
+  },
+  permanentRedirect: (target: string) => {
+    throw new RedirectSignal(target);
+  },
+}));
+
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({
+    t: (key: string) => key,
+    locale: 'en-US',
+  })),
+}));
+
+vi.mock('@/app/lib/i18n/get-locale', () => ({ getLocale: vi.fn(async () => 'en-US') }));
+
+vi.mock('@/app/lib/auth/server-auth', () => ({
+  getServerAuthToken: vi.fn(async () => undefined),
+}));
+
+const executeAuthenticatedGraphQL = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/server-graphql', () => ({ executeAuthenticatedGraphQL }));
+
+const GymPage = (await import('../page')).default;
+
+function mergedGym(canonicalSlug: string): Gym {
+  return {
+    uuid: `uuid-${canonicalSlug}`,
+    slug: canonicalSlug,
+    name: 'Boulderwelt',
+    isPublic: true,
+    canEdit: false,
+  } as unknown as Gym;
+}
+
+// `fetchGymBySlug` is wrapped in React's `cache()`, so each test uses a slug of
+// its own instead of relying on the mock being re-read for the same arguments.
+async function redirectTargetFor(
+  requestedSlug: string,
+  searchParams: Record<string, string | string[] | undefined>,
+): Promise<string> {
+  try {
+    await GymPage({
+      params: Promise.resolve({ gym_slug: requestedSlug }),
+      searchParams: Promise.resolve(searchParams),
+    });
+  } catch (error) {
+    if (error instanceof RedirectSignal) return error.target;
+    throw error;
+  }
+  throw new Error('expected a redirect');
+}
+
+beforeEach(() => {
+  executeAuthenticatedGraphQL.mockReset();
+});
+
+describe('merged-gym 308 redirect', () => {
+  it('keeps a printed poster attributable after the gym is merged into another listing', async () => {
+    // #4379's headline acceptance criterion. The poster is laminated and on a
+    // wall; the gym it names gets merged a year later. Before this change the
+    // 308 dropped the query, so every scan of that poster landed on the
+    // canonical page with no params — no `Gym QR Scanned`, no attribution, and
+    // nothing to tell the gym the poster was working.
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: mergedGym('boulderwelt-ost') });
+
+    await expect(redirectTargetFor('old-boulderwelt', { src: 'qr', medium: 'poster' })).resolves.toBe(
+      '/gym/boulderwelt-ost?src=qr&medium=poster',
+    );
+  });
+
+  it('redirects to a clean URL with no trailing "?" when there were no params', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: mergedGym('boulderwelt-west') });
+
+    await expect(redirectTargetFor('old-west', {})).resolves.toBe('/gym/boulderwelt-west');
+  });
+
+  it('carries a kiosk scan through the merge too', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: mergedGym('boulderwelt-sued') });
+
+    await expect(redirectTargetFor('old-sued', { src: 'qr', medium: 'kiosk' })).resolves.toBe(
+      '/gym/boulderwelt-sued?src=qr&medium=kiosk',
+    );
+  });
+
+  it('does not echo a crafted medium through the redirect', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: mergedGym('boulderwelt-nord') });
+
+    await expect(redirectTargetFor('old-nord', { src: 'qr', medium: 'evil' })).resolves.toBe('/gym/boulderwelt-nord');
+  });
+
+  it('does not echo any other param a crafted link carries', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: mergedGym('boulderwelt-city') });
+
+    await expect(
+      redirectTargetFor('old-city', {
+        src: 'qr',
+        medium: 'poster',
+        utm_campaign: 'someone-elses',
+        next: 'https://evil.example.com',
+        claim: '1',
+      }),
+    ).resolves.toBe('/gym/boulderwelt-city?src=qr&medium=poster');
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-page-qr-landing.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-page-qr-landing.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import React from 'react';
+import type { Gym } from '@boardsesh/shared-schema';
+
+// #4379's acceptance criterion is "still lands AND still counts". The redirect
+// tests cover "lands" and the tracker's own tests cover "counts once mounted" —
+// this file covers the join nobody else touches: that `GymPage` actually mounts
+// the tracker for a QR landing, and refuses to for anything else. Without it the
+// whole "counts" half rests on one unasserted line of JSX.
+
+vi.mock('server-only', () => ({}));
+
+class NotFoundSignal extends Error {}
+class RedirectSignal extends Error {}
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new NotFoundSignal('notFound');
+  },
+  permanentRedirect: () => {
+    throw new RedirectSignal('permanentRedirect');
+  },
+}));
+
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({ t: (key: string) => key, locale: 'en-US' })),
+}));
+vi.mock('@/app/lib/i18n/get-locale', () => ({ getLocale: vi.fn(async () => 'en-US') }));
+vi.mock('@/app/lib/auth/server-auth', () => ({ getServerAuthToken: vi.fn(async () => undefined) }));
+vi.mock('@/app/lib/analytics', () => ({ track: vi.fn() }));
+
+const executeAuthenticatedGraphQL = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/server-graphql', () => ({ executeAuthenticatedGraphQL }));
+
+const GymPage = (await import('../page')).default;
+// Imported, not mocked: `page.tsx` resolves the same module instance, so element
+// type identity is enough to find them in the returned tree.
+const GymQrLandingTracker = (await import('../gym-qr-landing-tracker')).default;
+const GymInstallCta = (await import('../gym-install-cta')).default;
+
+function gym(slug: string, overrides: Partial<Gym> = {}): Gym {
+  return {
+    uuid: `uuid-${slug}`,
+    slug,
+    name: 'Boulderwelt',
+    isPublic: true,
+    canEdit: false,
+    ...overrides,
+  } as unknown as Gym;
+}
+
+/**
+ * Collect every element of a given component type from a rendered-but-not-mounted
+ * tree. `GymPage` is an async server component, so it is awaited for its element
+ * tree rather than rendered: RTL cannot mount a promise, and mounting the whole
+ * page would drag in every client island just to assert one mount decision.
+ */
+function findAll(node: React.ReactNode, type: unknown): React.ReactElement[] {
+  const found: React.ReactElement[] = [];
+  const visit = (current: React.ReactNode): void => {
+    if (Array.isArray(current)) {
+      for (const child of current) visit(child);
+      return;
+    }
+    if (!React.isValidElement(current)) return;
+    if (current.type === type) found.push(current);
+    visit((current.props as { children?: React.ReactNode }).children);
+  };
+  visit(node);
+  return found;
+}
+
+// `fetchGymBySlug` is wrapped in React's `cache()`, so each test uses its own slug.
+const renderPage = (slug: string, searchParams: Record<string, string | string[] | undefined>) =>
+  GymPage({ params: Promise.resolve({ gym_slug: slug }), searchParams: Promise.resolve(searchParams) });
+
+beforeEach(() => {
+  executeAuthenticatedGraphQL.mockReset();
+});
+
+describe('gym page QR landing', () => {
+  it('mounts the scan tracker with the parsed medium for a poster landing', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gym('landing-poster') });
+
+    const trackers = findAll(await renderPage('landing-poster', { src: 'qr', medium: 'poster' }), GymQrLandingTracker);
+
+    expect(trackers).toHaveLength(1);
+    expect(trackers[0]?.props).toMatchObject({ gymSlug: 'landing-poster', medium: 'poster' });
+  });
+
+  it('mounts it for a kiosk landing too', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gym('landing-kiosk') });
+
+    const trackers = findAll(await renderPage('landing-kiosk', { src: 'qr', medium: 'kiosk' }), GymQrLandingTracker);
+
+    expect(trackers[0]?.props).toMatchObject({ gymSlug: 'landing-kiosk', medium: 'kiosk' });
+  });
+
+  it('mounts nothing for an ordinary visit', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gym('landing-plain') });
+
+    expect(findAll(await renderPage('landing-plain', {}), GymQrLandingTracker)).toHaveLength(0);
+  });
+
+  it('mounts nothing for a medium outside the vocabulary', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gym('landing-bogus') });
+
+    expect(findAll(await renderPage('landing-bogus', { src: 'qr', medium: 'evil' }), GymQrLandingTracker)).toHaveLength(
+      0,
+    );
+  });
+
+  it('gives the install CTA the canonical slug, not the one in the address bar', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gym('landing-cta') });
+
+    const ctas = findAll(await renderPage('landing-cta', { src: 'qr', medium: 'poster' }), GymInstallCta);
+
+    expect(ctas).toHaveLength(1);
+    expect(ctas[0]?.props).toMatchObject({ gymSlug: 'landing-cta' });
+  });
+
+  it('falls back to the URL slug when the gym has an empty slug', async () => {
+    // `||`, not `??`: an empty-string slug skips the merged-twin 308 above
+    // (a truthiness guard) and would otherwise name the campaign `gym-`.
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gym('landing-empty', { slug: '' }) });
+
+    const ctas = findAll(await renderPage('landing-empty', {}), GymInstallCta);
+
+    expect(ctas[0]?.props).toMatchObject({ gymSlug: 'landing-empty' });
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/gym-install-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-install-cta.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Android from '@mui/icons-material/Android';
+import Apple from '@mui/icons-material/Apple';
+import { track } from '@/app/lib/analytics';
+import { APP_INSTALL_CLICK_EVENT, buildAppInstallClickProperties } from '@/app/lib/app-install-event';
+import { playStoreUrlForGym } from '@/app/lib/gym-attribution';
+import { IOS_APP_STORE_URL } from '@/app/lib/store-urls';
+
+type GymInstallCtaProps = {
+  /**
+   * The CANONICAL gym slug, not the slug in the address bar. A poster printed
+   * for a since-merged gym 308s onto the canonical slug, and the campaign value
+   * has to be the same string either way or one gym's installs land in two
+   * campaigns.
+   */
+  gymSlug: string;
+  /**
+   * Store button labels, already translated by the server component that
+   * renders this island — same arrangement as `GymPageCtaLink`. Passing them in
+   * keeps this island off the client i18n bundle for a page that is otherwise
+   * server-rendered, and store button wording is the store's own localised
+   * naming rather than our voice.
+   */
+  googlePlayLabel: string;
+  appStoreLabel: string;
+};
+
+/**
+ * The gym page's install CTA — the producer #4374's AC2 was waiting on.
+ *
+ * BOTH stores render, always. No platform sniffing: a `useEffect` that picks
+ * one store leaves the server HTML with zero install links, so a crawler (and
+ * anyone reading the page before hydration) sees nothing. Two real anchors with
+ * real `href`s cost one extra button and keep the page complete without JS.
+ *
+ * The click handler only adds the event — it never calls `preventDefault`, so
+ * middle-click, long-press and "copy link" behave like the plain anchors these
+ * are. Both open in a new tab, so the document is not unloading and a plain
+ * `track()` lands without a flush-before-navigation dance.
+ *
+ * Only the Play link carries attribution. Play reads it back through the
+ * Install Referrer API; Apple has no equivalent here and iOS attribution is
+ * explicitly out of scope (#3402), so the App Store URL is unchanged.
+ */
+export default function GymInstallCta({ gymSlug, googlePlayLabel, appStoreLabel }: GymInstallCtaProps) {
+  const handlePlayClick = () => {
+    track(
+      APP_INSTALL_CLICK_EVENT,
+      buildAppInstallClickProperties({
+        platform: 'android',
+        source: 'google-play',
+        placement: 'gym-page',
+        gymSlug,
+      }),
+    );
+  };
+
+  const handleAppStoreClick = () => {
+    track(
+      APP_INSTALL_CLICK_EVENT,
+      buildAppInstallClickProperties({
+        platform: 'ios',
+        source: 'app-store',
+        placement: 'gym-page',
+        gymSlug,
+      }),
+    );
+  };
+
+  return (
+    <Box sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap' }}>
+      <Button
+        component="a"
+        href={playStoreUrlForGym(gymSlug)}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={handlePlayClick}
+        variant="contained"
+        startIcon={<Android />}
+        sx={{ textTransform: 'none' }}
+      >
+        {googlePlayLabel}
+      </Button>
+      <Button
+        component="a"
+        href={IOS_APP_STORE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={handleAppStoreClick}
+        variant="outlined"
+        startIcon={<Apple />}
+        sx={{ textTransform: 'none' }}
+      >
+        {appStoreLabel}
+      </Button>
+    </Box>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/gym-install-cta.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-install-cta.tsx
@@ -3,8 +3,7 @@
 import React from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Android from '@mui/icons-material/Android';
-import Apple from '@mui/icons-material/Apple';
+import InstallMobileOutlined from '@mui/icons-material/InstallMobileOutlined';
 import { track } from '@/app/lib/analytics';
 import { APP_INSTALL_CLICK_EVENT, buildAppInstallClickProperties } from '@/app/lib/app-install-event';
 import { playStoreUrlForGym } from '@/app/lib/gym-attribution';
@@ -45,6 +44,17 @@ type GymInstallCtaProps = {
  * Only the Play link carries attribution. Play reads it back through the
  * Install Referrer API; Apple has no equivalent here and iOS attribution is
  * explicitly out of scope (#3402), so the App Store URL is unchanged.
+ *
+ * TWO DELIBERATE VISUAL RULES, both of which look like polish and are not:
+ *
+ *  - NO MANUFACTURER GLYPH. An Apple mark or an Android robot beside our own
+ *    text is not what either company's guidelines sanction — those cover the
+ *    official "Download on the App Store" / "Get it on Google Play" badges, used
+ *    whole. `home-page-content.tsx` sidesteps this the same way, putting the
+ *    Boardsesh mark on its iOS card. One neutral install icon on both.
+ *  - IDENTICAL VARIANTS. `App Install Click` exists to be broken down by
+ *    platform (PH-13), so a filled Play button next to an outlined App Store one
+ *    would tilt the split this CTA was built to measure.
  */
 export default function GymInstallCta({ gymSlug, googlePlayLabel, appStoreLabel }: GymInstallCtaProps) {
   const handlePlayClick = () => {
@@ -80,7 +90,7 @@ export default function GymInstallCta({ gymSlug, googlePlayLabel, appStoreLabel 
         rel="noopener noreferrer"
         onClick={handlePlayClick}
         variant="contained"
-        startIcon={<Android />}
+        startIcon={<InstallMobileOutlined />}
         sx={{ textTransform: 'none' }}
       >
         {googlePlayLabel}
@@ -91,8 +101,8 @@ export default function GymInstallCta({ gymSlug, googlePlayLabel, appStoreLabel 
         target="_blank"
         rel="noopener noreferrer"
         onClick={handleAppStoreClick}
-        variant="outlined"
-        startIcon={<Apple />}
+        variant="contained"
+        startIcon={<InstallMobileOutlined />}
         sx={{ textTransform: 'none' }}
       >
         {appStoreLabel}

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -143,8 +143,12 @@ export default async function GymPage(props: GymRouteProps) {
   // `Gym QR Scanned`. Only `src` and `medium` are re-emitted, and only after the
   // contract's parser has accepted them, so a crafted `?medium=evil` cannot ride
   // through a redirect to a URL we publish.
+  //
+  // The slug is percent-encoded now that a query rides behind it: a `#` in one
+  // would open a fragment and swallow the params, the same case `gymQrUrl`
+  // already guards when it builds the printed URL.
   if (gym.slug && gym.slug !== gym_slug) {
-    permanentRedirect(`/gym/${gym.slug}${gymQrAttributionQuery(searchParams)}`);
+    permanentRedirect(`/gym/${encodeURIComponent(gym.slug)}${gymQrAttributionQuery(searchParams)}`);
   }
 
   const locale = await getLocale();
@@ -302,10 +306,14 @@ export default async function GymPage(props: GymRouteProps) {
           {gym.canEdit && <GymPageManageButton gymSlug={gym_slug} />}
         </Box>
 
-        {/* The install CTA a poster scan lands on. `gym.slug ?? gym_slug` is the
+        {/* The install CTA a poster scan lands on. `gym.slug || gym_slug` is the
             canonical slug: a merged twin's URL 308s onto `gym.slug` above, and a
             slug-less legacy gym has no canonical to fall back to, so the two
-            paths have to agree on one campaign string per gym. */}
+            paths have to agree on one campaign string per gym.
+            `||`, not `??` — `slug` is nullable AND the redirect guard above is a
+            truthiness check, so an empty-string slug reaches here having skipped
+            the 308. `??` would pass it straight through and name the campaign
+            `gym-`, collecting every such gym's installs in one bucket. */}
         <Box sx={{ mb: 3 }}>
           <Typography
             variant="subtitle1"
@@ -318,7 +326,7 @@ export default async function GymPage(props: GymRouteProps) {
             {t('gymPage.install.body', { gymName: gym.name })}
           </Typography>
           <GymInstallCta
-            gymSlug={gym.slug ?? gym_slug}
+            gymSlug={gym.slug || gym_slug}
             googlePlayLabel={t('gymPage.install.googlePlay')}
             appStoreLabel={t('gymPage.install.appStore')}
           />

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -24,6 +24,7 @@ import {
 } from '@boardsesh/graphql/operations';
 import { boardTypeLabel } from '@boardsesh/board-constants';
 import { parseGymQrLanding } from '@boardsesh/analytics';
+import { gymQrAttributionQuery } from '@/app/lib/gym-attribution';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
 import { getLocale } from '@/app/lib/i18n/get-locale';
@@ -45,6 +46,7 @@ import GymOwnerPrompts from './gym-owner-prompts';
 import GymReportDuplicateCta from './gym-report-duplicate-cta';
 import { formatHoursConfirmedDate } from './gym-hours-display';
 import GymPageCtaLink from './gym-page-cta-link';
+import GymInstallCta from './gym-install-cta';
 import GymQrLandingTracker from './gym-qr-landing-tracker';
 import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 import { resolveGymLogoDisplayUrl } from '@/app/lib/gym-logo-display-url';
@@ -133,8 +135,16 @@ export default async function GymPage(props: GymRouteProps) {
   // The requested slug belonged to a merged twin: the backend resolved it to the
   // canonical gym, whose slug differs. Send the old URL (e.g. a printed kiosk QR)
   // to the canonical one with a 308 rather than serving the gym under a dead slug.
+  //
+  // The attribution params ride along, the same way the manage route carries
+  // `?tab=`. A poster is laminated and stuck to a wall; the gym it names can be
+  // merged into another listing a year later, and without this the 308 dropped
+  // the query and every scan of that poster landed unattributed and fired no
+  // `Gym QR Scanned`. Only `src` and `medium` are re-emitted, and only after the
+  // contract's parser has accepted them, so a crafted `?medium=evil` cannot ride
+  // through a redirect to a URL we publish.
   if (gym.slug && gym.slug !== gym_slug) {
-    permanentRedirect(`/gym/${gym.slug}`);
+    permanentRedirect(`/gym/${gym.slug}${gymQrAttributionQuery(searchParams)}`);
   }
 
   const locale = await getLocale();
@@ -290,6 +300,28 @@ export default async function GymPage(props: GymRouteProps) {
             <GymPageCtaLink cta="website" gymUuid={gym.uuid} href={websiteHref} label={t('gymPage.visitWebsite')} />
           )}
           {gym.canEdit && <GymPageManageButton gymSlug={gym_slug} />}
+        </Box>
+
+        {/* The install CTA a poster scan lands on. `gym.slug ?? gym_slug` is the
+            canonical slug: a merged twin's URL 308s onto `gym.slug` above, and a
+            slug-less legacy gym has no canonical to fall back to, so the two
+            paths have to agree on one campaign string per gym. */}
+        <Box sx={{ mb: 3 }}>
+          <Typography
+            variant="subtitle1"
+            component="h2"
+            sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, mb: 0.5 }}
+          >
+            {t('gymPage.install.heading')}
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 1.5, color: themeTokens.neutral[700] }}>
+            {t('gymPage.install.body', { gymName: gym.name })}
+          </Typography>
+          <GymInstallCta
+            gymSlug={gym.slug ?? gym_slug}
+            googlePlayLabel={t('gymPage.install.googlePlay')}
+            appStoreLabel={t('gymPage.install.appStore')}
+          />
         </Box>
 
         {/* Self-gating: GymOwnerPrompts renders nothing for a non-editor (or a

--- a/packages/web/app/lib/__tests__/gym-attribution.test.ts
+++ b/packages/web/app/lib/__tests__/gym-attribution.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { SITE_URL } from '@/app/lib/seo/base-url';
+import {
+  boardQrUrl,
+  gymInstallCampaign,
+  gymQrAttributionQuery,
+  gymQrUrl,
+  playStoreUrlForGym,
+} from '../gym-attribution';
+
+describe('gymQrUrl', () => {
+  it('builds the absolute poster URL a printed code encodes', () => {
+    // Spelled out in full rather than assembled from the constants: this exact
+    // string gets laminated and stuck to a wall, where a wrong character cannot
+    // be patched afterwards.
+    expect(gymQrUrl('boulderwelt-munich')).toBe(`${SITE_URL}/gym/boulderwelt-munich?src=qr&medium=poster`);
+  });
+
+  it('takes a non-poster medium for a code aimed at a gym page from elsewhere', () => {
+    expect(gymQrUrl('boulderwelt-munich', 'kiosk')).toBe(`${SITE_URL}/gym/boulderwelt-munich?src=qr&medium=kiosk`);
+  });
+
+  it('percent-encodes a slug that is not URL-safe', () => {
+    // Slugs are generated lowercase-and-hyphens today. A rule that loosens
+    // later must not silently print a URL with a raw space or `#` in it — a
+    // fragment in the path would eat the params entirely.
+    expect(gymQrUrl('café münchen')).toBe(`${SITE_URL}/gym/caf%C3%A9%20m%C3%BCnchen?src=qr&medium=poster`);
+    expect(gymQrUrl('boulder#1')).toBe(`${SITE_URL}/gym/boulder%231?src=qr&medium=poster`);
+  });
+});
+
+describe('boardQrUrl', () => {
+  it('builds the kiosk per-board URL', () => {
+    expect(boardQrUrl('main-kilter', 'kiosk')).toBe(`${SITE_URL}/b/main-kilter?src=qr&medium=kiosk`);
+  });
+
+  it('builds a per-wall board URL', () => {
+    expect(boardQrUrl('main-kilter', 'board')).toBe(`${SITE_URL}/b/main-kilter?src=qr&medium=board`);
+  });
+
+  it('percent-encodes a slug that is not URL-safe', () => {
+    expect(boardQrUrl('kilter 45', 'kiosk')).toBe(`${SITE_URL}/b/kilter%2045?src=qr&medium=kiosk`);
+  });
+});
+
+describe('gymQrAttributionQuery', () => {
+  it('re-emits both params for a real scan', () => {
+    expect(gymQrAttributionQuery({ src: 'qr', medium: 'poster' })).toBe('?src=qr&medium=poster');
+    expect(gymQrAttributionQuery({ src: 'qr', medium: 'kiosk' })).toBe('?src=qr&medium=kiosk');
+  });
+
+  it('returns an empty string — not a bare "?" — for a plain visit', () => {
+    // The return value is concatenated straight onto a redirect target, so
+    // anything other than `''` here publishes a URL ending in a dangling `?`.
+    expect(gymQrAttributionQuery({})).toBe('');
+  });
+
+  it('returns an empty string when only one half of the pair is present', () => {
+    expect(gymQrAttributionQuery({ src: 'qr' })).toBe('');
+    expect(gymQrAttributionQuery({ medium: 'poster' })).toBe('');
+  });
+
+  it('returns an empty string for a medium outside the vocabulary', () => {
+    expect(gymQrAttributionQuery({ src: 'qr', medium: 'evil' })).toBe('');
+    expect(gymQrAttributionQuery({ src: 'qr', medium: 'POSTER' })).toBe('');
+    expect(gymQrAttributionQuery({ src: 'email', medium: 'poster' })).toBe('');
+  });
+
+  it('returns an empty string for an array-valued param', () => {
+    // `?medium=poster&medium=kiosk` is a hand-edited or crawler-mangled URL, not
+    // a scan. Picking one would let a crafted link choose its own attribution.
+    expect(gymQrAttributionQuery({ src: 'qr', medium: ['poster', 'kiosk'] })).toBe('');
+    expect(gymQrAttributionQuery({ src: ['qr'], medium: 'poster' })).toBe('');
+  });
+
+  it('drops every param that is not src or medium', () => {
+    // The allowlist is the security property: this string is appended to a
+    // redirect target, so nothing a caller typed may ride through it.
+    expect(
+      gymQrAttributionQuery({
+        src: 'qr',
+        medium: 'poster',
+        utm_campaign: 'someone-elses',
+        tab: 'members',
+        claim: '1',
+        redirect: 'https://evil.example.com',
+      }),
+    ).toBe('?src=qr&medium=poster');
+  });
+});
+
+describe('playStoreUrlForGym', () => {
+  it('names the campaign after the gym', () => {
+    expect(gymInstallCampaign('boulderwelt-munich')).toBe('gym-boulderwelt-munich');
+  });
+
+  it('builds the exact Play URL, with referrer as well as the bare utm params', () => {
+    expect(playStoreUrlForGym('boulderwelt-munich')).toBe(
+      'https://play.google.com/store/apps/details?id=com.boardsesh.app' +
+        '&utm_source=boardsesh&utm_medium=qr&utm_campaign=gym-boulderwelt-munich' +
+        '&referrer=utm_source%3Dboardsesh%26utm_medium%3Dqr%26utm_campaign%3Dgym-boulderwelt-munich',
+    );
+  });
+
+  it('round-trips the referrer back through the mobile parser contract', () => {
+    // THIS is the consumer contract, not an implementation detail.
+    // `packages/mobile/src/lib/install-referrer.ts` reads Play's Install
+    // Referrer string with `new URLSearchParams(raw)` and pulls `utm_source`,
+    // `utm_medium` and `utm_campaign` out of it — and Play populates that string
+    // from the `referrer` QUERY PARAM of the store URL, not from the bare
+    // `utm_*` params. A link carrying only the bare params looks right to a
+    // human, matches #4379's literal wording, and attributes zero installs.
+    const referrer = new URL(playStoreUrlForGym('boulderwelt-munich')).searchParams.get('referrer');
+    expect(referrer).not.toBeNull();
+
+    const parsed = new URLSearchParams(referrer ?? '');
+    expect(parsed.get('utm_source')).toBe('boardsesh');
+    expect(parsed.get('utm_medium')).toBe('qr');
+    expect(parsed.get('utm_campaign')).toBe('gym-boulderwelt-munich');
+  });
+
+  it('keeps the referrer parseable for a slug carrying characters that need escaping', () => {
+    const url = new URL(playStoreUrlForGym('a&b=c gym'));
+    const parsed = new URLSearchParams(url.searchParams.get('referrer') ?? '');
+    // The nested query string is encoded once as a param value, so the inner
+    // `&` and `=` cannot break out and forge a fourth utm param.
+    expect(parsed.get('utm_campaign')).toBe('gym-a&b=c gym');
+    expect(url.searchParams.get('utm_campaign')).toBe('gym-a&b=c gym');
+  });
+
+  it('leaves the app id intact', () => {
+    expect(new URL(playStoreUrlForGym('any-gym')).searchParams.get('id')).toBe('com.boardsesh.app');
+  });
+});

--- a/packages/web/app/lib/app-install-event.ts
+++ b/packages/web/app/lib/app-install-event.ts
@@ -27,7 +27,8 @@ export type AppInstallSource = 'app-store' | 'google-play' | 'capacitor-retireme
  * install card or the Capacitor dead-end screen, neither of which has ever
  * carried a placement — adding one would change their existing payloads.
  *
- * `gym-page` has no producer yet; the gym-page install CTA is #4379.
+ * `gym-page` is produced by `app/gym/[gym_slug]/gym-install-cta.tsx` (#4379),
+ * and is the only placement that also sets `gymSlug`.
  */
 export type AppInstallPlacement = 'hero' | 'gym-page';
 

--- a/packages/web/app/lib/gym-attribution.ts
+++ b/packages/web/app/lib/gym-attribution.ts
@@ -1,0 +1,133 @@
+// URL builders for per-gym QR and store-link attribution (#4379).
+//
+// The vocabulary — the param names, the `medium` union, the parser, and the
+// `buildGymQrHref`/`stripGymQrParams` pair — lives in `@boardsesh/analytics`'s
+// gym-funnel module and is imported here, never restated. This file adds only
+// the www-specific URLs built on top of it: what a printed code encodes, what
+// survives a redirect, and where the Play Store link points.
+//
+// Everything here is pure and synchronous so a server component, a client
+// island and a test all call the same function and get the same string. A QR
+// that goes on a laminated poster cannot be patched after it is printed.
+
+import {
+  buildGymQrHref,
+  parseGymQrLanding,
+  GYM_QR_MEDIUM_PARAM,
+  GYM_QR_SRC_PARAM,
+  GYM_QR_SRC_VALUE,
+  type GymQrMedium,
+  type GymQrSearchParams,
+} from '@boardsesh/analytics';
+import { absoluteUrl } from '@/app/lib/seo/base-url';
+import { ANDROID_PLAY_STORE_URL } from '@/app/lib/store-urls';
+
+/**
+ * The `utm_source` every Boardsesh-owned printed or on-wall surface reports.
+ * One value across all of them: the interesting split is `utm_medium`
+ * (which surface) and `utm_campaign` (which gym), not who owns the link.
+ */
+export const GYM_UTM_SOURCE = 'boardsesh';
+
+/**
+ * `utm_medium` for the store links reached from a gym page. `qr` rather than
+ * `web`, because the traffic this measures arrives by scanning a code on the
+ * wall — a QR poster scan is the acquisition path #4379 exists to count.
+ */
+export const GYM_UTM_MEDIUM = 'qr';
+
+/** `utm_campaign` value for one gym. `gym-` prefixed so campaigns from other surfaces stay distinguishable. */
+export function gymInstallCampaign(gymSlug: string): string {
+  return `gym-${gymSlug}`;
+}
+
+/**
+ * The absolute URL a printed gym QR encodes.
+ *
+ * Absolute, not a path: a phone camera needs a full URL, and a poster PDF has
+ * no origin to resolve against. The slug is percent-encoded because it lands in
+ * a path segment — gym slugs are generated lowercase-and-hyphens today, but this
+ * string is printed and a slug rule that loosens later must not silently emit a
+ * URL with a raw space or `#` in it.
+ */
+export function gymQrUrl(gymSlug: string, medium: GymQrMedium = 'poster'): string {
+  return absoluteUrl(buildGymQrHref(`/gym/${encodeURIComponent(gymSlug)}`, medium));
+}
+
+/**
+ * The absolute URL a per-board QR encodes — the kiosk's install code, and any
+ * future code stuck to one wall.
+ *
+ * IMPORTANT and deliberate: `/b/{slug}` does NOT reach the QR landing tracker,
+ * which only mounts on `/gym/[gym_slug]`. A `medium=kiosk` or `medium=board`
+ * scan therefore cannot fire `Gym QR Scanned` — see the module comment on
+ * `GYM_QR_MEDIUMS`. The params are still carried through
+ * `app/b/[board_slug]/page.tsx`'s redirect so a first-party counter (#4387) or
+ * a server log can attribute the visit, and so pointing one of these codes at a
+ * gym page later is a one-line change rather than a reprint.
+ */
+export function boardQrUrl(boardSlug: string, medium: GymQrMedium): string {
+  return absoluteUrl(buildGymQrHref(`/b/${encodeURIComponent(boardSlug)}`, medium));
+}
+
+/**
+ * The QR attribution params, re-emitted as a query string, for a redirect that
+ * would otherwise drop them — or `''` when the request carries no valid pair.
+ *
+ * STRICT ALLOWLIST, and that is the whole point. A redirect target built by
+ * appending the caller's own search string would let anything a crafted link
+ * carries ride through a 308 into a URL we published (`?medium=evil`,
+ * `?utm_campaign=…`, a tracking param, a param the destination route reads).
+ * Only `src` and `medium` come out, only after `parseGymQrLanding` has accepted
+ * them, and the two values are then re-serialised from the contract's constants
+ * and the parsed union member rather than copied out of the request. Nothing a
+ * caller typed reaches the output string.
+ *
+ * Returns `''` — not `'?'` — when there is nothing to carry, so a plain visit
+ * redirects to a clean URL with no dangling question mark.
+ */
+export function gymQrAttributionQuery(searchParams: GymQrSearchParams): string {
+  const landing = parseGymQrLanding(searchParams);
+  if (!landing) return '';
+  const params = new URLSearchParams();
+  params.set(GYM_QR_SRC_PARAM, GYM_QR_SRC_VALUE);
+  params.set(GYM_QR_MEDIUM_PARAM, landing.medium);
+  return `?${params.toString()}`;
+}
+
+/**
+ * The Google Play URL a gym page's Android install button points at.
+ *
+ * It sets `referrer` AND the bare `utm_*` params, and the `referrer` is the one
+ * that actually does the work. Play populates the Install Referrer API from the
+ * **`referrer` query parameter** of the store URL, and
+ * `packages/mobile/src/lib/install-referrer.ts` reads that string back with
+ * `new URLSearchParams(raw)` to pull `utm_source`, `utm_medium` and
+ * `utm_campaign` out of it. So `referrer` carries a nested, percent-encoded
+ * copy of the same three params — a link with only the bare `utm_*` params
+ * reads fine to a human, satisfies #4379's literal wording, and produces zero
+ * attributed installs, because the mobile parser never sees them.
+ *
+ * The bare `utm_*` params stay because the Play web console's acquisition
+ * reports read those, and they cost nothing.
+ *
+ * iOS is untouched: the App Store link keeps its existing URL. Apple has no
+ * install-referrer equivalent here and iOS attribution is out of scope (#3402).
+ */
+export function playStoreUrlForGym(gymSlug: string): string {
+  const campaign = gymInstallCampaign(gymSlug);
+  // The value Play hands the app verbatim; the mobile parser splits it as a
+  // query string, so it is built as one and then encoded once as a param value.
+  const referrer = new URLSearchParams({
+    utm_source: GYM_UTM_SOURCE,
+    utm_medium: GYM_UTM_MEDIUM,
+    utm_campaign: campaign,
+  });
+
+  const url = new URL(ANDROID_PLAY_STORE_URL);
+  url.searchParams.set('utm_source', GYM_UTM_SOURCE);
+  url.searchParams.set('utm_medium', GYM_UTM_MEDIUM);
+  url.searchParams.set('utm_campaign', campaign);
+  url.searchParams.set('referrer', referrer.toString());
+  return url.toString();
+}


### PR DESCRIPTION
Closes #4374 · Part of #4379 (part 1 of 2 — the printable poster is part 2) · Part of epic #4372, Tier 1.

Every claim so far was processed by hand, no channel attribution exists anywhere, and zero of 445 install clicks fired from a gym page. This makes a scan traceable: the QR carries `?src=qr&medium=…`, the store link carries a per-gym campaign, and the gym page finally has an install CTA to fire `App Install Click` from — which is #4374's last outstanding acceptance criterion, and why this closes it.

## Two redirects were dropping the query — without fixing them, this PR is a no-op

- **`/b/[board_slug]`** didn't declare `searchParams` at all. It awaited only `params` and redirected to a literal template string, so every query param was dropped unconditionally. A kiosk scan arrived at the board list indistinguishable from someone typing the URL.
- **The merged-gym 308** on `/gym/[slug]` had the same shape. That one matters more: it's #4379's headline requirement that *a printed QR for a since-merged gym still lands and still counts*. A poster on a wall outlives the gym record it was printed for, and the whole never-404 promise rests on that redirect preserving attribution.

Both now re-append the params through a **strict allowlist** that re-emits only `src` and `medium`, so a crafted `?medium=evil` or an arbitrary extra param can't ride through a redirect target. Returns an empty string, not a bare `?`, for a plain visit.

## The Play link needs `referrer`, not just `utm_*`

`packages/mobile/src/lib/install-referrer.ts` parses `utm_source`/`utm_medium`/`utm_campaign` out of the Play **Install Referrer string**, which Play populates from the `referrer` query parameter. Bare `utm_*` on the store URL never reach the app — they'd satisfy the issue's literal wording and produce **zero** attributed installs.

So the Play URL sets both: the bare params (which Play Console's own acquisition reports read) and a percent-encoded `referrer` copy. The test round-trips the built URL's `referrer` back through `URLSearchParams` and asserts the three values, because that's the actual consumer contract rather than a string we happen to emit.

App Store behaviour is unchanged; iOS attribution stays out of scope (#3402).

## Only `poster` can produce a scan event

Stating it plainly so a zero isn't read as a bug. The landing tracker mounts only on `/gym/[slug]`. A `medium=kiosk` or `medium=board` code points at `/b/[slug]`, so it now *carries* its params through the redirect but still has nothing on the far side to fire `Gym QR Scanned`. Both mediums stay in the vocabulary because printed codes on walls outlive a vocabulary change.

Related: the kiosk QR targets `/b/{slug}`, a www climbing surface #4358 is deleting. Flagging, not fixing here.

## Note for the poster PR

`buildGymQrHref` returns a path, not a URL — absolute-URL construction and slug encoding live in `gymQrUrl`/`boardQrUrl` here. The poster should call `gymQrUrl(slug)` rather than rebuild the string, or the printed code and the tracked code can drift.

`docs/gym-funnel-analytics.md` claimed the `/b/` redirect drops the query. That's now false, so it's corrected there rather than left to mislead.

## Release Notes

Scan a gym's QR code and the app knows which poster or kiosk sent you — so gyms can finally see what their signage is actually doing.
