### PR TITLE
feat(web): ship the /gyms directory with Kilter, MoonBoard and Tension facets

### DIFF
--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -135,6 +135,11 @@ export const SEARCH_GYMS = gql`
  * particular stays out of the shared GYM_FIELDS — it's a list, and mobile's
  * useNearbyGyms rides that fragment at limit 50 for a picker that never draws
  * board chips.
+ *
+ * It selects nothing the card doesn't draw, and that is a rule rather than an
+ * accident: `boardCount` is redundant next to `boardSummaries`, and `hasMore`
+ * is unused because paging is driven by `totalCount` and the page size. Add a
+ * field here only when something renders it.
  */
 export const SEARCH_GYMS_DIRECTORY = gql`
   query SearchGymsDirectory($input: SearchGymsInput!) {
@@ -146,7 +151,6 @@ export const SEARCH_GYMS_DIRECTORY = gql`
         address
         latitude
         longitude
-        boardCount
         isClaimed
         boardSummaries {
           boardType
@@ -154,7 +158,6 @@ export const SEARCH_GYMS_DIRECTORY = gql`
         }
       }
       totalCount
-      hasMore
     }
   }
 `;
@@ -540,7 +543,7 @@ export type SearchGymsQueryResponse = {
  */
 export type GymDirectoryCard = Pick<
   Gym,
-  'uuid' | 'slug' | 'name' | 'address' | 'latitude' | 'longitude' | 'boardCount' | 'isClaimed'
+  'uuid' | 'slug' | 'name' | 'address' | 'latitude' | 'longitude' | 'isClaimed'
 > & {
   boardSummaries: GymBoardSummary[];
 };
@@ -553,7 +556,6 @@ export type SearchGymsDirectoryQueryResponse = {
   searchGyms: {
     gyms: GymDirectoryCard[];
     totalCount: number;
-    hasMore: boolean;
   };
 };
 

--- a/packages/shared/i18n/locales/de/gyms.json
+++ b/packages/shared/i18n/locales/de/gyms.json
@@ -62,6 +62,10 @@
     "emptyTitle": "Dazu passt noch nichts",
     "emptyBody": "Versuch eine kürzere Suche oder nimm den Board-Filter raus und stöber durch alle Hallen."
   },
+  "error": {
+    "title": "Wir kommen gerade nicht an die Hallenliste ran",
+    "body": "Bei uns hakt gerade was. Warte kurz und lad neu, oder geh direkt auf die Seite einer Halle, die du schon kennst."
+  },
   "card": {
     "boardChip": "{{board}} {{angle}}°",
     "distance": "{{distance}} km entfernt",

--- a/packages/shared/i18n/locales/de/gyms.json
+++ b/packages/shared/i18n/locales/de/gyms.json
@@ -1,0 +1,84 @@
+{
+  "metadata": {
+    "all": {
+      "title": "Kletterhallen mit Trainingsboards",
+      "description": "Finde Kletterhallen mit einem Kilter Board, MoonBoard oder Tension Board an der Wand, samt dem Winkel, auf den jedes Board eingestellt ist."
+    },
+    "kilter": {
+      "title": "Hallen mit einem Kilter Board",
+      "description": "Du suchst ein Kilter Board in deiner Nähe? Hier sind die Kletterhallen mit einem Kilter Board an der Wand, samt dem Winkel, auf den es eingestellt ist."
+    },
+    "moonboard": {
+      "title": "Hallen mit einem MoonBoard",
+      "description": "Du suchst ein MoonBoard in deiner Nähe? Hier sind die Kletterhallen mit einem MoonBoard an der Wand, samt dem Winkel, auf den es eingestellt ist."
+    },
+    "tension": {
+      "title": "Hallen mit einem Tension Board",
+      "description": "Du suchst ein Tension Board in deiner Nähe? Hier sind die Kletterhallen mit einem Tension Board an der Wand, samt dem Winkel, auf den es eingestellt ist."
+    }
+  },
+  "directory": {
+    "all": {
+      "h1": "Kletterhallen mit Trainingsboards",
+      "lead_one": "{{formattedCount}} Halle hat ein Board auf Boardsesh eingetragen. Der Eintrag zeigt die Boards an der Wand und den Winkel, auf den sie eingestellt sind, damit du weißt, was dich erwartet, bevor du losfährst.",
+      "lead_other": "{{formattedCount}} Hallen haben ein Board auf Boardsesh eingetragen. Jeder Eintrag zeigt die Boards an der Wand und den Winkel, auf den sie eingestellt sind, damit du weißt, was dich erwartet, bevor du losfährst.",
+      "detail": "{{kilterCount}} davon haben ein Kilter Board, {{moonboardCount}} ein MoonBoard und {{tensionCount}} ein Tension Board, viele sogar mehrere. Wähl unten ein Board oder such nach dem Namen."
+    },
+    "kilter": {
+      "h1": "Hallen mit einem Kilter Board",
+      "lead_one": "{{formattedCount}} Halle auf Boardsesh hat ein Kilter Board an der Wand. Der Eintrag zeigt den Winkel, auf den es eingestellt ist, damit du siehst, ob es zu deinem Projekt passt.",
+      "lead_other": "{{formattedCount}} Hallen auf Boardsesh haben ein Kilter Board an der Wand. Jeder Eintrag zeigt den Winkel, auf den es eingestellt ist, damit du die Halle findest, die zu deinem Projekt passt.",
+      "detail": "Diese Hallen tragen Kletterer*innen selbst ein, und Boardsesh gehört zu keinem Board-Hersteller. Betreibst du eine dieser Wände? Übernimm den Eintrag und halt die Angaben aktuell."
+    },
+    "moonboard": {
+      "h1": "Hallen mit einem MoonBoard",
+      "lead_one": "{{formattedCount}} Halle auf Boardsesh hat ein MoonBoard an der Wand. Der Eintrag zeigt den Winkel, auf den es eingestellt ist, damit du siehst, ob es zu deinem Projekt passt.",
+      "lead_other": "{{formattedCount}} Hallen auf Boardsesh haben ein MoonBoard an der Wand. Jeder Eintrag zeigt den Winkel, auf den es eingestellt ist, damit du die Halle findest, die zu deinem Projekt passt.",
+      "detail": "Diese Hallen tragen Kletterer*innen selbst ein, und Boardsesh gehört zu keinem Board-Hersteller. Betreibst du eine dieser Wände? Übernimm den Eintrag und halt die Angaben aktuell."
+    },
+    "tension": {
+      "h1": "Hallen mit einem Tension Board",
+      "lead_one": "{{formattedCount}} Halle auf Boardsesh hat ein Tension Board an der Wand. Der Eintrag zeigt den Winkel, auf den es eingestellt ist, damit du siehst, ob es zu deinem Projekt passt.",
+      "lead_other": "{{formattedCount}} Hallen auf Boardsesh haben ein Tension Board an der Wand. Jeder Eintrag zeigt den Winkel, auf den es eingestellt ist, damit du die Halle findest, die zu deinem Projekt passt.",
+      "detail": "Diese Hallen tragen Kletterer*innen selbst ein, und Boardsesh gehört zu keinem Board-Hersteller. Betreibst du eine dieser Wände? Übernimm den Eintrag und halt die Angaben aktuell."
+    }
+  },
+  "facets": {
+    "heading": "Nach Board stöbern",
+    "all": "Alle Hallen · {{formattedCount}}",
+    "kilter": "Kilter · {{formattedCount}}",
+    "moonboard": "MoonBoard · {{formattedCount}}",
+    "tension": "Tension · {{formattedCount}}",
+    "countHint": "Die Zahlen zählen Hallen, nicht Boards: Eine Halle mit drei Kilter-Wänden zählt einmal."
+  },
+  "search": {
+    "label": "Hallen suchen",
+    "placeholder": "Name der Halle oder Ort",
+    "submit": "Suchen"
+  },
+  "results": {
+    "heading_one": "{{formattedCount}} Halle",
+    "heading_other": "{{formattedCount}} Hallen",
+    "emptyTitle": "Dazu passt noch nichts",
+    "emptyBody": "Versuch eine kürzere Suche oder nimm den Board-Filter raus und stöber durch alle Hallen."
+  },
+  "card": {
+    "boardChip": "{{board}} {{angle}}°",
+    "distance": "{{distance}} km entfernt",
+    "claimCta": "Ist das deine Halle?"
+  },
+  "pagination": {
+    "label": "Seiten des Verzeichnisses",
+    "previous": "Zurück",
+    "next": "Weiter",
+    "page": "Seite {{page}}",
+    "current": "Seite {{page}}, aktuelle Seite"
+  },
+  "links": {
+    "heading": "Weiter stöbern",
+    "all": "Alle Hallen auf Boardsesh",
+    "kilter": "Hallen mit einem Kilter Board",
+    "moonboard": "Hallen mit einem MoonBoard",
+    "tension": "Hallen mit einem Tension Board"
+  }
+}

--- a/packages/shared/i18n/locales/en-US/gyms.json
+++ b/packages/shared/i18n/locales/en-US/gyms.json
@@ -1,0 +1,84 @@
+{
+  "metadata": {
+    "all": {
+      "title": "Climbing gyms with training boards",
+      "description": "Browse climbing gyms that have a Kilter, MoonBoard or Tension board on the wall, with the angle each board is set at."
+    },
+    "kilter": {
+      "title": "Gyms with a Kilter board",
+      "description": "Looking for a Kilter board near you? Browse the climbing gyms with a Kilter board on the wall and the angle each one is set at."
+    },
+    "moonboard": {
+      "title": "Gyms with a MoonBoard",
+      "description": "Looking for a MoonBoard near you? Browse the climbing gyms with a MoonBoard on the wall and the angle each one is set at."
+    },
+    "tension": {
+      "title": "Gyms with a Tension board",
+      "description": "Looking for a Tension board near you? Browse the climbing gyms with a Tension board on the wall and the angle each one is set at."
+    }
+  },
+  "directory": {
+    "all": {
+      "h1": "Climbing gyms with training boards",
+      "lead_one": "{{formattedCount}} gym has a board listed on Boardsesh. The listing shows the boards on its wall and the angle they are set at, so you know what you are walking into before you drive across town.",
+      "lead_other": "{{formattedCount}} gyms have a board listed on Boardsesh. Every listing shows the boards on the wall and the angle they are set at, so you know what you are walking into before you drive across town.",
+      "detail": "{{kilterCount}} of them run a Kilter board, {{moonboardCount}} a MoonBoard and {{tensionCount}} a Tension board, and plenty run more than one. Pick a board below, or search by name."
+    },
+    "kilter": {
+      "h1": "Gyms with a Kilter board",
+      "lead_one": "{{formattedCount}} gym on Boardsesh has a Kilter board on the wall. The listing shows the angle it is set at, so you can tell whether it matches the project you are on.",
+      "lead_other": "{{formattedCount}} gyms on Boardsesh have a Kilter board on the wall. Every listing shows the angle it is set at, so you can tell which one matches the project you are on.",
+      "detail": "Climbers list these gyms themselves, and Boardsesh is not affiliated with the people who make the boards. Run one of these walls? Claim the listing and keep the details straight."
+    },
+    "moonboard": {
+      "h1": "Gyms with a MoonBoard",
+      "lead_one": "{{formattedCount}} gym on Boardsesh has a MoonBoard on the wall. The listing shows the angle it is set at, so you can tell whether it matches the project you are on.",
+      "lead_other": "{{formattedCount}} gyms on Boardsesh have a MoonBoard on the wall. Every listing shows the angle it is set at, so you can tell which one matches the project you are on.",
+      "detail": "Climbers list these gyms themselves, and Boardsesh is not affiliated with the people who make the boards. Run one of these walls? Claim the listing and keep the details straight."
+    },
+    "tension": {
+      "h1": "Gyms with a Tension board",
+      "lead_one": "{{formattedCount}} gym on Boardsesh has a Tension board on the wall. The listing shows the angle it is set at, so you can tell whether it matches the project you are on.",
+      "lead_other": "{{formattedCount}} gyms on Boardsesh have a Tension board on the wall. Every listing shows the angle it is set at, so you can tell which one matches the project you are on.",
+      "detail": "Climbers list these gyms themselves, and Boardsesh is not affiliated with the people who make the boards. Run one of these walls? Claim the listing and keep the details straight."
+    }
+  },
+  "facets": {
+    "heading": "Browse by board",
+    "all": "All gyms · {{formattedCount}}",
+    "kilter": "Kilter · {{formattedCount}}",
+    "moonboard": "MoonBoard · {{formattedCount}}",
+    "tension": "Tension · {{formattedCount}}",
+    "countHint": "The numbers count gyms, not boards: a gym with three Kilter walls counts once."
+  },
+  "search": {
+    "label": "Search gyms",
+    "placeholder": "Gym name or town",
+    "submit": "Search"
+  },
+  "results": {
+    "heading_one": "{{formattedCount}} gym",
+    "heading_other": "{{formattedCount}} gyms",
+    "emptyTitle": "Nothing matches that yet",
+    "emptyBody": "Try a shorter search, or drop the board filter and browse every gym."
+  },
+  "card": {
+    "boardChip": "{{board}} {{angle}}°",
+    "distance": "{{distance}} km away",
+    "claimCta": "Is this your gym?"
+  },
+  "pagination": {
+    "label": "Directory pages",
+    "previous": "Previous",
+    "next": "Next",
+    "page": "Page {{page}}",
+    "current": "Page {{page}}, current page"
+  },
+  "links": {
+    "heading": "More ways to browse",
+    "all": "Every gym on Boardsesh",
+    "kilter": "Gyms with a Kilter board",
+    "moonboard": "Gyms with a MoonBoard",
+    "tension": "Gyms with a Tension board"
+  }
+}

--- a/packages/shared/i18n/locales/en-US/gyms.json
+++ b/packages/shared/i18n/locales/en-US/gyms.json
@@ -62,6 +62,10 @@
     "emptyTitle": "Nothing matches that yet",
     "emptyBody": "Try a shorter search, or drop the board filter and browse every gym."
   },
+  "error": {
+    "title": "We can't reach the gym list right now",
+    "body": "Something on our end is down. Give it a minute and reload, or head to a gym page you already know."
+  },
   "card": {
     "boardChip": "{{board}} {{angle}}°",
     "distance": "{{distance}} km away",

--- a/packages/shared/i18n/locales/es/gyms.json
+++ b/packages/shared/i18n/locales/es/gyms.json
@@ -62,6 +62,10 @@
     "emptyTitle": "Todavía no hay nada que encaje",
     "emptyBody": "Prueba con una búsqueda más corta o quita el filtro de plafón y explora todos los rocódromos."
   },
+  "error": {
+    "title": "Ahora mismo no podemos cargar la lista de rocódromos",
+    "body": "Algo falla por nuestra parte. Espera un momento y recarga, o ve a la ficha de un rocódromo que ya conozcas."
+  },
   "card": {
     "boardChip": "{{board}} {{angle}}°",
     "distance": "a {{distance}} km",

--- a/packages/shared/i18n/locales/es/gyms.json
+++ b/packages/shared/i18n/locales/es/gyms.json
@@ -1,0 +1,84 @@
+{
+  "metadata": {
+    "all": {
+      "title": "Rocódromos con plafones de entrenamiento",
+      "description": "Explora los rocódromos que tienen un plafón Kilter, un MoonBoard o un plafón Tension en la pared, con el ángulo al que está montado cada uno."
+    },
+    "kilter": {
+      "title": "Rocódromos con un plafón Kilter",
+      "description": "¿Buscas un plafón Kilter cerca de ti? Explora los rocódromos que tienen un plafón Kilter en la pared y el ángulo al que está montado cada uno."
+    },
+    "moonboard": {
+      "title": "Rocódromos con un MoonBoard",
+      "description": "¿Buscas un MoonBoard cerca de ti? Explora los rocódromos que tienen un MoonBoard en la pared y el ángulo al que está montado cada uno."
+    },
+    "tension": {
+      "title": "Rocódromos con un plafón Tension",
+      "description": "¿Buscas un plafón Tension cerca de ti? Explora los rocódromos que tienen un plafón Tension en la pared y el ángulo al que está montado cada uno."
+    }
+  },
+  "directory": {
+    "all": {
+      "h1": "Rocódromos con plafones de entrenamiento",
+      "lead_one": "{{formattedCount}} rocódromo tiene un plafón listado en Boardsesh. La ficha muestra los plafones de su pared y el ángulo al que están montados, así sabes qué te vas a encontrar antes de cruzar la ciudad.",
+      "lead_other": "{{formattedCount}} rocódromos tienen un plafón listado en Boardsesh. Cada ficha muestra los plafones de la pared y el ángulo al que están montados, así sabes qué te vas a encontrar antes de cruzar la ciudad.",
+      "detail": "{{kilterCount}} tienen un plafón Kilter, {{moonboardCount}} un MoonBoard y {{tensionCount}} un plafón Tension, y muchos tienen más de uno. Elige un plafón abajo o busca por nombre."
+    },
+    "kilter": {
+      "h1": "Rocódromos con un plafón Kilter",
+      "lead_one": "{{formattedCount}} rocódromo de Boardsesh tiene un plafón Kilter en la pared. La ficha muestra el ángulo al que está montado, así ves si encaja con tu proyecto.",
+      "lead_other": "{{formattedCount}} rocódromos de Boardsesh tienen un plafón Kilter en la pared. Cada ficha muestra el ángulo al que está montado, así ves cuál encaja con tu proyecto.",
+      "detail": "Son los propios escaladores quienes listan estos rocódromos, y Boardsesh no tiene relación con quienes fabrican los plafones. ¿Llevas uno de estos muros? Reclama la ficha y mantén los datos al día."
+    },
+    "moonboard": {
+      "h1": "Rocódromos con un MoonBoard",
+      "lead_one": "{{formattedCount}} rocódromo de Boardsesh tiene un MoonBoard en la pared. La ficha muestra el ángulo al que está montado, así ves si encaja con tu proyecto.",
+      "lead_other": "{{formattedCount}} rocódromos de Boardsesh tienen un MoonBoard en la pared. Cada ficha muestra el ángulo al que está montado, así ves cuál encaja con tu proyecto.",
+      "detail": "Son los propios escaladores quienes listan estos rocódromos, y Boardsesh no tiene relación con quienes fabrican los plafones. ¿Llevas uno de estos muros? Reclama la ficha y mantén los datos al día."
+    },
+    "tension": {
+      "h1": "Rocódromos con un plafón Tension",
+      "lead_one": "{{formattedCount}} rocódromo de Boardsesh tiene un plafón Tension en la pared. La ficha muestra el ángulo al que está montado, así ves si encaja con tu proyecto.",
+      "lead_other": "{{formattedCount}} rocódromos de Boardsesh tienen un plafón Tension en la pared. Cada ficha muestra el ángulo al que está montado, así ves cuál encaja con tu proyecto.",
+      "detail": "Son los propios escaladores quienes listan estos rocódromos, y Boardsesh no tiene relación con quienes fabrican los plafones. ¿Llevas uno de estos muros? Reclama la ficha y mantén los datos al día."
+    }
+  },
+  "facets": {
+    "heading": "Explora por plafón",
+    "all": "Todos los rocódromos · {{formattedCount}}",
+    "kilter": "Kilter · {{formattedCount}}",
+    "moonboard": "MoonBoard · {{formattedCount}}",
+    "tension": "Tension · {{formattedCount}}",
+    "countHint": "Los números cuentan rocódromos, no plafones: un rocódromo con tres muros Kilter cuenta una vez."
+  },
+  "search": {
+    "label": "Buscar rocódromos",
+    "placeholder": "Nombre del rocódromo o ciudad",
+    "submit": "Buscar"
+  },
+  "results": {
+    "heading_one": "{{formattedCount}} rocódromo",
+    "heading_other": "{{formattedCount}} rocódromos",
+    "emptyTitle": "Todavía no hay nada que encaje",
+    "emptyBody": "Prueba con una búsqueda más corta o quita el filtro de plafón y explora todos los rocódromos."
+  },
+  "card": {
+    "boardChip": "{{board}} {{angle}}°",
+    "distance": "a {{distance}} km",
+    "claimCta": "¿Es tuyo este rocódromo?"
+  },
+  "pagination": {
+    "label": "Páginas del directorio",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "page": "Página {{page}}",
+    "current": "Página {{page}}, página actual"
+  },
+  "links": {
+    "heading": "Más formas de explorar",
+    "all": "Todos los rocódromos en Boardsesh",
+    "kilter": "Rocódromos con un plafón Kilter",
+    "moonboard": "Rocódromos con un MoonBoard",
+    "tension": "Rocódromos con un plafón Tension"
+  }
+}

--- a/packages/shared/i18n/locales/fr/gyms.json
+++ b/packages/shared/i18n/locales/fr/gyms.json
@@ -62,6 +62,10 @@
     "emptyTitle": "Rien ne correspond pour l'instant",
     "emptyBody": "Essaie une recherche plus courte, ou enlève le filtre de board et parcours toutes les salles."
   },
+  "error": {
+    "title": "On n'arrive pas à charger la liste des salles pour le moment",
+    "body": "Quelque chose cloche de notre côté. Attends une minute et recharge, ou va directement sur la fiche d'une salle que tu connais."
+  },
   "card": {
     "boardChip": "{{board}} {{angle}}°",
     "distance": "à {{distance}} km",

--- a/packages/shared/i18n/locales/fr/gyms.json
+++ b/packages/shared/i18n/locales/fr/gyms.json
@@ -1,0 +1,84 @@
+{
+  "metadata": {
+    "all": {
+      "title": "Salles d'escalade avec des boards d'entraînement",
+      "description": "Parcours les salles d'escalade qui ont une board Kilter, un MoonBoard ou une board Tension au mur, avec l'angle auquel chacune est réglée."
+    },
+    "kilter": {
+      "title": "Salles avec une board Kilter",
+      "description": "Tu cherches une board Kilter près de chez toi ? Parcours les salles d'escalade qui ont une board Kilter au mur et l'angle auquel elle est réglée."
+    },
+    "moonboard": {
+      "title": "Salles avec un MoonBoard",
+      "description": "Tu cherches un MoonBoard près de chez toi ? Parcours les salles d'escalade qui ont un MoonBoard au mur et l'angle auquel il est réglé."
+    },
+    "tension": {
+      "title": "Salles avec une board Tension",
+      "description": "Tu cherches une board Tension près de chez toi ? Parcours les salles d'escalade qui ont une board Tension au mur et l'angle auquel elle est réglée."
+    }
+  },
+  "directory": {
+    "all": {
+      "h1": "Salles d'escalade avec des boards d'entraînement",
+      "lead_one": "{{formattedCount}} salle a une board référencée sur Boardsesh. La fiche montre les boards du mur et l'angle auquel elles sont réglées, pour savoir ce qui t'attend avant de traverser la ville.",
+      "lead_other": "{{formattedCount}} salles ont une board référencée sur Boardsesh. Chaque fiche montre les boards du mur et l'angle auquel elles sont réglées, pour savoir ce qui t'attend avant de traverser la ville.",
+      "detail": "{{kilterCount}} ont une board Kilter, {{moonboardCount}} un MoonBoard et {{tensionCount}} une board Tension, et beaucoup en ont plusieurs. Choisis une board ci-dessous ou cherche par nom."
+    },
+    "kilter": {
+      "h1": "Salles avec une board Kilter",
+      "lead_one": "{{formattedCount}} salle sur Boardsesh a une board Kilter au mur. La fiche indique l'angle auquel elle est réglée, pour voir si elle colle à ton projet.",
+      "lead_other": "{{formattedCount}} salles sur Boardsesh ont une board Kilter au mur. Chaque fiche indique l'angle auquel elle est réglée, pour trouver celle qui colle à ton projet.",
+      "detail": "Ce sont les grimpeurs qui référencent ces salles, et Boardsesh n'est lié à aucun fabricant de boards. Tu gères l'un de ces murs ? Revendique la fiche et garde les infos à jour."
+    },
+    "moonboard": {
+      "h1": "Salles avec un MoonBoard",
+      "lead_one": "{{formattedCount}} salle sur Boardsesh a un MoonBoard au mur. La fiche indique l'angle auquel il est réglé, pour voir s'il colle à ton projet.",
+      "lead_other": "{{formattedCount}} salles sur Boardsesh ont un MoonBoard au mur. Chaque fiche indique l'angle auquel il est réglé, pour trouver celle qui colle à ton projet.",
+      "detail": "Ce sont les grimpeurs qui référencent ces salles, et Boardsesh n'est lié à aucun fabricant de boards. Tu gères l'un de ces murs ? Revendique la fiche et garde les infos à jour."
+    },
+    "tension": {
+      "h1": "Salles avec une board Tension",
+      "lead_one": "{{formattedCount}} salle sur Boardsesh a une board Tension au mur. La fiche indique l'angle auquel elle est réglée, pour voir si elle colle à ton projet.",
+      "lead_other": "{{formattedCount}} salles sur Boardsesh ont une board Tension au mur. Chaque fiche indique l'angle auquel elle est réglée, pour trouver celle qui colle à ton projet.",
+      "detail": "Ce sont les grimpeurs qui référencent ces salles, et Boardsesh n'est lié à aucun fabricant de boards. Tu gères l'un de ces murs ? Revendique la fiche et garde les infos à jour."
+    }
+  },
+  "facets": {
+    "heading": "Parcourir par board",
+    "all": "Toutes les salles · {{formattedCount}}",
+    "kilter": "Kilter · {{formattedCount}}",
+    "moonboard": "MoonBoard · {{formattedCount}}",
+    "tension": "Tension · {{formattedCount}}",
+    "countHint": "Les chiffres comptent des salles, pas des boards : une salle avec trois murs Kilter compte une fois."
+  },
+  "search": {
+    "label": "Rechercher une salle",
+    "placeholder": "Nom de la salle ou ville",
+    "submit": "Rechercher"
+  },
+  "results": {
+    "heading_one": "{{formattedCount}} salle",
+    "heading_other": "{{formattedCount}} salles",
+    "emptyTitle": "Rien ne correspond pour l'instant",
+    "emptyBody": "Essaie une recherche plus courte, ou enlève le filtre de board et parcours toutes les salles."
+  },
+  "card": {
+    "boardChip": "{{board}} {{angle}}°",
+    "distance": "à {{distance}} km",
+    "claimCta": "C'est ta salle ?"
+  },
+  "pagination": {
+    "label": "Pages du répertoire",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "page": "Page {{page}}",
+    "current": "Page {{page}}, page actuelle"
+  },
+  "links": {
+    "heading": "D'autres façons de parcourir",
+    "all": "Toutes les salles sur Boardsesh",
+    "kilter": "Salles avec une board Kilter",
+    "moonboard": "Salles avec un MoonBoard",
+    "tension": "Salles avec une board Tension"
+  }
+}

--- a/packages/shared/i18n/src/config.ts
+++ b/packages/shared/i18n/src/config.ts
@@ -45,12 +45,13 @@ export const ALL_NAMESPACES = [
   'aurora',
   'boards',
   'kiosk',
+  'gyms',
 ] as const;
 export type Namespace = (typeof ALL_NAMESPACES)[number];
 
 /**
  * Namespaces available in the mobile app. Web-only namespaces (`marketing`,
- * `admin`) are excluded so Metro never bundles them.
+ * `admin`, `gyms`) are excluded so Metro never bundles them.
  */
 export const MOBILE_NAMESPACES = [
   'common',

--- a/packages/web/app/__test-helpers__/i18n-mock.ts
+++ b/packages/web/app/__test-helpers__/i18n-mock.ts
@@ -30,6 +30,7 @@ import enBoards from '@boardsesh/i18n/locales/en-US/boards.json';
 import enClimbs from '@boardsesh/i18n/locales/en-US/climbs.json';
 import enCommon from '@boardsesh/i18n/locales/en-US/common.json';
 import enFeed from '@boardsesh/i18n/locales/en-US/feed.json';
+import enGyms from '@boardsesh/i18n/locales/en-US/gyms.json';
 import enKiosk from '@boardsesh/i18n/locales/en-US/kiosk.json';
 import enMarketing from '@boardsesh/i18n/locales/en-US/marketing.json';
 import enNotifications from '@boardsesh/i18n/locales/en-US/notifications.json';
@@ -47,6 +48,7 @@ const CATALOGS: Record<string, unknown> = {
   climbs: enClimbs,
   common: enCommon,
   feed: enFeed,
+  gyms: enGyms,
   kiosk: enKiosk,
   marketing: enMarketing,
   notifications: enNotifications,

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -28,9 +28,23 @@ export const GYM_KIOSK_FLAG = 'gym-kiosk';
 // here — matching the documented "flags gate the UI entry point only" pattern.
 export const MOONBOARD_WIDE_ANGLES_FLAG = 'moonboard-wide-angles';
 
+// Gates reachability of the public `/gyms` directory and its three board-type
+// facet routes. Unlike every other key here it is resolved on the SERVER
+// (`getServerFeatureFlag`) and decides whether the route renders at all rather
+// than whether a control is visible: the directory only goes public once the
+// duplicate-gym cleanup gate clears (#4382), and a client-resolved flag lands
+// after the HTML has already shipped, so it would gate nothing.
+export const GYMS_DIRECTORY_FLAG = 'gyms-directory';
+
 // Keys read from PostHog by FeatureFlagsProvider. Each must have a matching
 // PostHog feature flag; values stay `undefined` (OFF) until that flag resolves.
 export const FEATURE_FLAG_KEYS = [BOARDSESH_GRADE_FLAG, GYM_KIOSK_FLAG, MOONBOARD_WIDE_ANGLES_FLAG] as const;
 
+// Keys resolved server-side. Deliberately not in FEATURE_FLAG_KEYS: the browser
+// provider would fetch a flag no client component reads.
+export const SERVER_FEATURE_FLAG_KEYS = [GYMS_DIRECTORY_FLAG] as const;
+
 // Vercel's flags discovery endpoint expects an allFlags export.
-export const allFlags: Array<{ key: string }> = FEATURE_FLAG_KEYS.map((key) => ({ key }));
+export const allFlags: Array<{ key: string }> = [...FEATURE_FLAG_KEYS, ...SERVER_FEATURE_FLAG_KEYS].map((key) => ({
+  key,
+}));

--- a/packages/web/app/gyms/__tests__/directory-card-model.test.ts
+++ b/packages/web/app/gyms/__tests__/directory-card-model.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vite-plus/test';
+import { boardChips, cardLocation, roundDistanceKm } from '../directory-card-model';
+
+describe('boardChips', () => {
+  it('is empty when the gym reported no boards', () => {
+    expect(boardChips([])).toEqual([]);
+    expect(boardChips(null)).toEqual([]);
+    expect(boardChips(undefined)).toEqual([]);
+  });
+
+  it('collapses identical board/angle pairs to one chip', () => {
+    expect(
+      boardChips([
+        { boardType: 'kilter', angle: 40 },
+        { boardType: 'kilter', angle: 40 },
+        { boardType: 'kilter', angle: 40 },
+      ]),
+    ).toEqual([{ key: 'kilter-40', boardType: 'kilter', angle: 40 }]);
+  });
+
+  it('keeps distinct angles of the same board', () => {
+    expect(
+      boardChips([
+        { boardType: 'kilter', angle: 50 },
+        { boardType: 'kilter', angle: 40 },
+      ]).map((chip) => chip.angle),
+    ).toEqual([40, 50]);
+  });
+
+  it('orders by the shared board-type order, then angle', () => {
+    expect(
+      boardChips([
+        { boardType: 'tension', angle: 40 },
+        { boardType: 'moonboard', angle: 25 },
+        { boardType: 'kilter', angle: 30 },
+      ]).map((chip) => chip.boardType),
+    ).toEqual(['kilter', 'tension', 'moonboard']);
+  });
+
+  it('sorts a board type it has never heard of last instead of first', () => {
+    expect(
+      boardChips([
+        { boardType: 'mystery-board', angle: 20 },
+        { boardType: 'kilter', angle: 40 },
+      ]).map((chip) => chip.boardType),
+    ).toEqual(['kilter', 'mystery-board']);
+  });
+});
+
+describe('cardLocation', () => {
+  it('prefers the free-text address the gym typed', () => {
+    expect(cardLocation({ address: ' 12 Mill Lane, Bristol ', latitude: 1, longitude: 2 }, null)).toEqual({
+      kind: 'address',
+      address: '12 Mill Lane, Bristol',
+    });
+  });
+
+  it('falls back to a distance when the request supplied an origin', () => {
+    const location = cardLocation(
+      { address: null, latitude: 51.3811, longitude: -2.359 },
+      {
+        latitude: 51.4545,
+        longitude: -2.5879,
+      },
+    );
+    expect(location?.kind).toBe('distance');
+  });
+
+  it('renders no location line at all for a pin with no origin', () => {
+    // There is no city column, so there is nothing honest to print. A
+    // synthesised locality would be a wrong address on a real gym.
+    expect(cardLocation({ address: '', latitude: 51.38, longitude: -2.35 }, null)).toBeNull();
+  });
+
+  it('renders no location line for a gym with neither address nor pin', () => {
+    expect(cardLocation({ address: null, latitude: null, longitude: null }, { latitude: 0, longitude: 0 })).toBeNull();
+  });
+});
+
+describe('roundDistanceKm', () => {
+  it('keeps one decimal within walking distance', () => {
+    expect(roundDistanceKm(1.24)).toBe(1.2);
+  });
+
+  it('drops to whole km once the decimal is noise', () => {
+    expect(roundDistanceKm(42.6)).toBe(43);
+  });
+});

--- a/packages/web/app/gyms/__tests__/directory-copy.test.ts
+++ b/packages/web/app/gyms/__tests__/directory-copy.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vite-plus/test';
+import type { TFunction } from 'i18next';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+import { DIRECTORY_FACETS, type DirectoryFacet } from '../directory-facets';
+import {
+  facetChipLabel,
+  facetDetail,
+  facetHeading,
+  facetLead,
+  facetLinkLabel,
+  facetMetaDescription,
+  facetMetaTitle,
+} from '../directory-copy';
+
+const t = ((key: string, options?: Record<string, unknown>) =>
+  tFromCatalog('gyms', key, options)) as unknown as TFunction<'gyms'>;
+
+const counts = { all: 4201, kilter: 1786, moonboard: 2586, tension: 465 };
+const formatNumber = (value: number) => new Intl.NumberFormat('en-US').format(value);
+
+describe('per-facet copy', () => {
+  it('resolves a real catalog string for every facet, not a bare key', () => {
+    for (const facet of DIRECTORY_FACETS) {
+      expect(facetMetaTitle(t, facet)).not.toContain('metadata.');
+      expect(facetMetaDescription(t, facet)).not.toContain('metadata.');
+      expect(facetHeading(t, facet)).not.toContain('directory.');
+      expect(facetLead(t, facet, counts, formatNumber)).not.toContain('directory.');
+      expect(facetDetail(t, facet, counts, formatNumber)).not.toContain('directory.');
+      expect(facetChipLabel(t, facet, counts, formatNumber)).not.toContain('facets.');
+      expect(facetLinkLabel(t, facet)).not.toContain('links.');
+    }
+  });
+
+  it('gives every facet a distinct title and h1', () => {
+    const titles = DIRECTORY_FACETS.map((facet) => facetMetaTitle(t, facet));
+    expect(new Set(titles).size).toBe(DIRECTORY_FACETS.length);
+
+    const headings = DIRECTORY_FACETS.map((facet) => facetHeading(t, facet));
+    expect(new Set(headings).size).toBe(DIRECTORY_FACETS.length);
+  });
+
+  it('names each board with the right capitalisation', () => {
+    expect(facetHeading(t, 'kilter')).toContain('Kilter');
+    expect(facetHeading(t, 'moonboard')).toContain('MoonBoard');
+    expect(facetHeading(t, 'tension')).toContain('Tension');
+  });
+
+  it('describes compatibility, never affiliation', () => {
+    const everything = DIRECTORY_FACETS.flatMap((facet: DirectoryFacet) => [
+      facetMetaTitle(t, facet),
+      facetMetaDescription(t, facet),
+      facetHeading(t, facet),
+      facetLead(t, facet, counts, formatNumber),
+      facetDetail(t, facet, counts, formatNumber),
+    ]).join(' ');
+
+    for (const forbidden of ['Kilter app', 'MoonBoard app', 'Tension app', 'official', 'partner', 'endorsed']) {
+      expect(everything.toLowerCase()).not.toContain(forbidden.toLowerCase());
+    }
+  });
+});
+
+describe('live counts', () => {
+  it('renders the facet total in the lead paragraph, locale formatted', () => {
+    expect(facetLead(t, 'kilter', counts, formatNumber)).toContain('1,786');
+    expect(facetLead(t, 'all', counts, formatNumber)).toContain('4,201');
+  });
+
+  it('picks the singular form for a facet with one gym', () => {
+    const single = { all: 1, kilter: 1, moonboard: 1, tension: 1 };
+    expect(facetLead(t, 'tension', single, formatNumber)).toContain('1 gym on Boardsesh has');
+  });
+
+  it('breaks the total down by board on /gyms', () => {
+    const detail = facetDetail(t, 'all', counts, formatNumber);
+    expect(detail).toContain('1,786');
+    expect(detail).toContain('2,586');
+    expect(detail).toContain('465');
+  });
+
+  it('puts the count on every facet chip', () => {
+    expect(facetChipLabel(t, 'moonboard', counts, formatNumber)).toBe('MoonBoard · 2,586');
+    expect(facetChipLabel(t, 'all', counts, formatNumber)).toBe('All gyms · 4,201');
+  });
+});

--- a/packages/web/app/gyms/__tests__/directory-facets.test.ts
+++ b/packages/web/app/gyms/__tests__/directory-facets.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vite-plus/test';
 import {
   DIRECTORY_FACETS,
-  DIRECTORY_MAX_PAGE,
   FACET_BASE_PATHS,
   buildDirectoryHref,
+  buildFacetSwitchHref,
   distanceKm,
-  hasActiveFilters,
+  isSearchApplication,
   paginationWindow,
   parseDirectoryQuery,
 } from '../directory-facets';
@@ -73,12 +73,16 @@ describe('parseDirectoryQuery', () => {
     expect(parseDirectoryQuery('all', { radius: '25' }).radiusKm).toBeNull();
   });
 
-  it('clamps page into range instead of 404ing a stale link', () => {
+  it('floors page at one but never clamps the top', () => {
     expect(parseDirectoryQuery('all', { page: '3' }).page).toBe(3);
     expect(parseDirectoryQuery('all', { page: '-4' }).page).toBe(1);
+    expect(parseDirectoryQuery('all', { page: '0' }).page).toBe(1);
     expect(parseDirectoryQuery('all', { page: '2.7' }).page).toBe(2);
-    expect(parseDirectoryQuery('all', { page: '9999' }).page).toBe(DIRECTORY_MAX_PAGE);
     expect(parseDirectoryQuery('all', { page: 'next' }).page).toBe(1);
+    // Deliberately NOT clamped: an out-of-range page has to reach the renderer
+    // so it can 404. Clamping served a 200 whose URL and highlighted page
+    // number disagreed.
+    expect(parseDirectoryQuery('all', { page: '9999' }).page).toBe(9999);
   });
 });
 
@@ -115,18 +119,61 @@ describe('buildDirectoryHref', () => {
   });
 });
 
-describe('hasActiveFilters', () => {
+describe('isSearchApplication', () => {
   it('is false for a bare /gyms visit', () => {
-    expect(hasActiveFilters('all', parseDirectoryQuery('all', {}))).toBe(false);
+    expect(isSearchApplication('all', parseDirectoryQuery('all', {}))).toBe(false);
   });
 
-  it('is true on a facet route, which is itself a filter', () => {
-    expect(hasActiveFilters('tension', parseDirectoryQuery('tension', {}))).toBe(true);
+  it('is false for a plain facet pageview', () => {
+    // The board type is the ROUTE, not a filter the visitor applied. Counting
+    // it made every /gyms/kilter pageview a search with queryLength 0.
+    for (const facet of ['kilter', 'moonboard', 'tension'] as const) {
+      expect(isSearchApplication(facet, parseDirectoryQuery(facet, {}))).toBe(false);
+    }
   });
 
-  it('is true once a search or a location is applied', () => {
-    expect(hasActiveFilters('all', parseDirectoryQuery('all', { q: 'bristol' }))).toBe(true);
-    expect(hasActiveFilters('all', parseDirectoryQuery('all', { lat: '51.45', lng: '-2.58' }))).toBe(true);
+  it('is false on page two and beyond, on every route', () => {
+    // ?page=N is a full navigation, so the tracker remounts. Page 2 of one
+    // search is not a second search.
+    expect(isSearchApplication('all', parseDirectoryQuery('all', { q: 'bristol', page: '2' }))).toBe(false);
+    expect(isSearchApplication('kilter', parseDirectoryQuery('kilter', { q: 'bristol', page: '3' }))).toBe(false);
+  });
+
+  it('is true for free text, on the flat route and on a facet', () => {
+    expect(isSearchApplication('all', parseDirectoryQuery('all', { q: 'bristol' }))).toBe(true);
+    expect(isSearchApplication('kilter', parseDirectoryQuery('kilter', { q: 'bristol' }))).toBe(true);
+  });
+
+  it('is true for a location', () => {
+    expect(isSearchApplication('all', parseDirectoryQuery('all', { lat: '51.45', lng: '-2.58' }))).toBe(true);
+  });
+
+  it('is true for an explicit ?boardType on the unfaceted route only', () => {
+    expect(isSearchApplication('all', parseDirectoryQuery('all', { boardType: 'soill' }))).toBe(true);
+    expect(isSearchApplication('kilter', parseDirectoryQuery('kilter', { boardType: 'soill' }))).toBe(false);
+  });
+});
+
+describe('buildFacetSwitchHref', () => {
+  it('keeps an active search when switching board', () => {
+    const query = parseDirectoryQuery('all', { q: 'bristol' });
+    expect(buildFacetSwitchHref('kilter', query)).toBe('/gyms/kilter?q=bristol');
+  });
+
+  it('keeps an active search when clearing the board filter', () => {
+    const query = parseDirectoryQuery('kilter', { q: 'bristol' });
+    expect(buildFacetSwitchHref('all', query)).toBe('/gyms?q=bristol');
+  });
+
+  it('replaces the board filter rather than merging it', () => {
+    const query = parseDirectoryQuery('kilter', {});
+    expect(buildFacetSwitchHref('tension', query)).toBe('/gyms/tension');
+    expect(buildFacetSwitchHref('all', parseDirectoryQuery('all', { boardType: 'soill' }))).toBe('/gyms');
+  });
+
+  it('keeps the location and drops the page', () => {
+    const query = parseDirectoryQuery('all', { lat: '51.45', lng: '-2.58', radius: '25', page: '4' });
+    expect(buildFacetSwitchHref('moonboard', query)).toBe('/gyms/moonboard?lat=51.45&lng=-2.58&radius=25');
   });
 });
 

--- a/packages/web/app/gyms/__tests__/directory-facets.test.ts
+++ b/packages/web/app/gyms/__tests__/directory-facets.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vite-plus/test';
+import {
+  DIRECTORY_FACETS,
+  DIRECTORY_MAX_PAGE,
+  FACET_BASE_PATHS,
+  buildDirectoryHref,
+  distanceKm,
+  hasActiveFilters,
+  paginationWindow,
+  parseDirectoryQuery,
+} from '../directory-facets';
+
+describe('facet routes', () => {
+  it('ships exactly four literal routes and no long-tail ones', () => {
+    expect([...DIRECTORY_FACETS]).toEqual(['all', 'kilter', 'moonboard', 'tension']);
+    expect(FACET_BASE_PATHS).toEqual({
+      all: '/gyms',
+      kilter: '/gyms/kilter',
+      moonboard: '/gyms/moonboard',
+      tension: '/gyms/tension',
+    });
+    // grasshopper/decoy/soill/touchstone are query-param only — DB-04 puts them
+    // one to two orders of magnitude below the three that get a page.
+    expect(Object.values(FACET_BASE_PATHS)).not.toContain('/gyms/soill');
+  });
+});
+
+describe('parseDirectoryQuery', () => {
+  it('defaults to an unfiltered first page', () => {
+    expect(parseDirectoryQuery('all', {})).toEqual({
+      query: '',
+      boardTypes: [],
+      latitude: null,
+      longitude: null,
+      radiusKm: null,
+      page: 1,
+    });
+  });
+
+  it('pins a facet route to its own board type', () => {
+    expect(parseDirectoryQuery('kilter', {}).boardTypes).toEqual(['kilter']);
+  });
+
+  it('ignores ?boardType on a facet route so the h1 never lies about the list', () => {
+    expect(parseDirectoryQuery('kilter', { boardType: 'tension' }).boardTypes).toEqual(['kilter']);
+  });
+
+  it('accepts long-tail board types as a query param on /gyms', () => {
+    expect(parseDirectoryQuery('all', { boardType: ['soill', 'decoy'] }).boardTypes).toEqual(['decoy', 'soill']);
+  });
+
+  it('drops board types nobody has ever built', () => {
+    expect(parseDirectoryQuery('all', { boardType: ['not-a-board', 'kilter'] }).boardTypes).toEqual(['kilter']);
+  });
+
+  it('trims and caps the free-text query', () => {
+    expect(parseDirectoryQuery('all', { q: '  bristol  ' }).query).toBe('bristol');
+    expect(parseDirectoryQuery('all', { q: 'x'.repeat(500) }).query).toHaveLength(80);
+  });
+
+  it('takes coordinates only as a valid pair', () => {
+    const both = parseDirectoryQuery('all', { lat: '51.45', lng: '-2.58' });
+    expect([both.latitude, both.longitude]).toEqual([51.45, -2.58]);
+
+    expect(parseDirectoryQuery('all', { lat: '51.45' }).latitude).toBeNull();
+    expect(parseDirectoryQuery('all', { lat: '95', lng: '0' }).latitude).toBeNull();
+    expect(parseDirectoryQuery('all', { lat: 'north', lng: '0' }).latitude).toBeNull();
+  });
+
+  it('clamps the radius and drops it without an origin', () => {
+    expect(parseDirectoryQuery('all', { lat: '0', lng: '0', radius: '9000' }).radiusKm).toBe(500);
+    expect(parseDirectoryQuery('all', { lat: '0', lng: '0', radius: '0' }).radiusKm).toBe(1);
+    expect(parseDirectoryQuery('all', { radius: '25' }).radiusKm).toBeNull();
+  });
+
+  it('clamps page into range instead of 404ing a stale link', () => {
+    expect(parseDirectoryQuery('all', { page: '3' }).page).toBe(3);
+    expect(parseDirectoryQuery('all', { page: '-4' }).page).toBe(1);
+    expect(parseDirectoryQuery('all', { page: '2.7' }).page).toBe(2);
+    expect(parseDirectoryQuery('all', { page: '9999' }).page).toBe(DIRECTORY_MAX_PAGE);
+    expect(parseDirectoryQuery('all', { page: 'next' }).page).toBe(1);
+  });
+});
+
+describe('buildDirectoryHref', () => {
+  const base = parseDirectoryQuery('all', {});
+
+  it('returns the clean base for page one with no filters', () => {
+    expect(buildDirectoryHref('all', base, 1)).toBe('/gyms');
+    expect(buildDirectoryHref('kilter', parseDirectoryQuery('kilter', {}), 1)).toBe('/gyms/kilter');
+  });
+
+  it('keeps a facet board type in the path, never the query', () => {
+    const kilter = parseDirectoryQuery('kilter', {});
+    expect(buildDirectoryHref('kilter', kilter, 2)).toBe('/gyms/kilter?page=2');
+  });
+
+  it('carries search, board filter and location across pages', () => {
+    const query = parseDirectoryQuery('all', {
+      q: 'bristol',
+      boardType: 'soill',
+      lat: '51.45',
+      lng: '-2.58',
+      radius: '25',
+    });
+    expect(buildDirectoryHref('all', query, 3)).toBe(
+      '/gyms?q=bristol&boardType=soill&lat=51.45&lng=-2.58&radius=25&page=3',
+    );
+  });
+
+  it('emits the same string for the same state regardless of param order in', () => {
+    const one = parseDirectoryQuery('all', { boardType: ['decoy', 'soill'], q: 'x' });
+    const two = parseDirectoryQuery('all', { q: 'x', boardType: ['soill', 'decoy'] });
+    expect(buildDirectoryHref('all', one, 1)).toBe(buildDirectoryHref('all', two, 1));
+  });
+});
+
+describe('hasActiveFilters', () => {
+  it('is false for a bare /gyms visit', () => {
+    expect(hasActiveFilters('all', parseDirectoryQuery('all', {}))).toBe(false);
+  });
+
+  it('is true on a facet route, which is itself a filter', () => {
+    expect(hasActiveFilters('tension', parseDirectoryQuery('tension', {}))).toBe(true);
+  });
+
+  it('is true once a search or a location is applied', () => {
+    expect(hasActiveFilters('all', parseDirectoryQuery('all', { q: 'bristol' }))).toBe(true);
+    expect(hasActiveFilters('all', parseDirectoryQuery('all', { lat: '51.45', lng: '-2.58' }))).toBe(true);
+  });
+});
+
+describe('distanceKm', () => {
+  it('is zero for the same point', () => {
+    expect(distanceKm({ latitude: 51.45, longitude: -2.58 }, { latitude: 51.45, longitude: -2.58 })).toBe(0);
+  });
+
+  it('matches a known separation', () => {
+    // Bristol -> Bath, about 17 km as the crow flies.
+    const km = distanceKm({ latitude: 51.4545, longitude: -2.5879 }, { latitude: 51.3811, longitude: -2.359 });
+    expect(km).toBeGreaterThan(16);
+    expect(km).toBeLessThan(19);
+  });
+});
+
+describe('paginationWindow', () => {
+  it('renders nothing when there is one page', () => {
+    expect(paginationWindow(1, 1)).toEqual([]);
+  });
+
+  it('shows the first pages from the start', () => {
+    expect(paginationWindow(1, 20)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('centres on the current page in the middle', () => {
+    expect(paginationWindow(10, 20)).toEqual([8, 9, 10, 11, 12]);
+  });
+
+  it('sticks to the end rather than running past it', () => {
+    expect(paginationWindow(20, 20)).toEqual([16, 17, 18, 19, 20]);
+  });
+
+  it('never emits more pages than exist', () => {
+    expect(paginationWindow(2, 3)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/web/app/gyms/__tests__/directory-flag-gate.test.tsx
+++ b/packages/web/app/gyms/__tests__/directory-flag-gate.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('server-only', () => ({}));
+
+const notFound = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+);
+vi.mock('next/navigation', () => ({ notFound }));
+
+const getServerFeatureFlag = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({ getServerFeatureFlag }));
+
+const getPosthogDistinctId = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinctId }));
+
+const fetchDirectoryPage = vi.hoisted(() => vi.fn());
+const fetchFacetCounts = vi.hoisted(() => vi.fn());
+vi.mock('../directory-data', () => ({ fetchDirectoryPage, fetchFacetCounts }));
+
+const getServerTranslation = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/i18n/server', () => ({ getServerTranslation, loadServerResources: vi.fn() }));
+
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({
+  trackGymFunnelEvent: vi.fn(),
+  viewerStateFrom: (isAuthenticated: boolean) => (isAuthenticated ? 'signed-in' : 'signed-out'),
+}));
+
+const { renderGymDirectory } = await import('../directory-page');
+
+const props = { searchParams: Promise.resolve({}) };
+
+beforeEach(() => {
+  notFound.mockClear();
+  getServerFeatureFlag.mockReset();
+  getPosthogDistinctId.mockReset().mockResolvedValue('user-uuid-1');
+  fetchDirectoryPage.mockReset().mockResolvedValue({ gyms: [], totalCount: 0, hasMore: false });
+  fetchFacetCounts.mockReset().mockResolvedValue({ all: 10, kilter: 4, moonboard: 5, tension: 1 });
+  getServerTranslation.mockResolvedValue({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog('gyms', key, options),
+    i18n: {},
+    locale: 'en-US',
+  });
+});
+
+describe('feature-flag gate', () => {
+  it('404s the route when the flag is off, rather than only noindexing it', async () => {
+    getServerFeatureFlag.mockResolvedValue(false);
+
+    await expect(renderGymDirectory('all', props)).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalledTimes(1);
+    // The gate fires before any data is fetched.
+    expect(fetchDirectoryPage).not.toHaveBeenCalled();
+  });
+
+  it('gates every facet route, not just /gyms', async () => {
+    getServerFeatureFlag.mockResolvedValue(false);
+
+    for (const facet of ['kilter', 'moonboard', 'tension'] as const) {
+      await expect(renderGymDirectory(facet, { searchParams: Promise.resolve({}) })).rejects.toThrow('NEXT_NOT_FOUND');
+    }
+    expect(notFound).toHaveBeenCalledTimes(3);
+  });
+
+  it('asks PostHog about the authenticated person, not an anonymous id', async () => {
+    getServerFeatureFlag.mockResolvedValue(true);
+
+    await renderGymDirectory('kilter', props);
+
+    // Person-property targeting only resolves when the evaluation names a
+    // person PostHog holds those properties for. Anything else returns false
+    // for a perfectly configured flag with nothing erroring anywhere.
+    expect(getServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', 'user-uuid-1');
+  });
+
+  it('passes a signed-out visitor through as having no person', async () => {
+    getPosthogDistinctId.mockResolvedValue(null);
+    getServerFeatureFlag.mockResolvedValue(false);
+
+    await expect(renderGymDirectory('all', props)).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(getServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', null);
+  });
+
+  it('renders once the flag is on', async () => {
+    getServerFeatureFlag.mockResolvedValue(true);
+
+    const element = await renderGymDirectory('all', props);
+
+    expect(element).toBeTruthy();
+    expect(notFound).not.toHaveBeenCalled();
+    expect(fetchDirectoryPage).toHaveBeenCalledTimes(1);
+    expect(fetchFacetCounts).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks for one page of results per request, never a drain loop', async () => {
+    getServerFeatureFlag.mockResolvedValue(true);
+
+    await renderGymDirectory('all', { searchParams: Promise.resolve({ page: '3' }) });
+
+    expect(fetchDirectoryPage).toHaveBeenCalledTimes(1);
+    expect(fetchDirectoryPage).toHaveBeenCalledWith(expect.objectContaining({ page: 3 }));
+  });
+});

--- a/packages/web/app/gyms/__tests__/directory-flag-gate.test.tsx
+++ b/packages/web/app/gyms/__tests__/directory-flag-gate.test.tsx
@@ -36,8 +36,10 @@ beforeEach(() => {
   notFound.mockClear();
   getServerFeatureFlag.mockReset();
   getPosthogDistinctId.mockReset().mockResolvedValue('user-uuid-1');
-  fetchDirectoryPage.mockReset().mockResolvedValue({ gyms: [], totalCount: 0, hasMore: false });
-  fetchFacetCounts.mockReset().mockResolvedValue({ all: 10, kilter: 4, moonboard: 5, tension: 1 });
+  fetchDirectoryPage.mockReset().mockResolvedValue({ ok: true, gyms: [], totalCount: 0 });
+  fetchFacetCounts
+    .mockReset()
+    .mockResolvedValue({ ok: true, counts: { all: 10, kilter: 4, moonboard: 5, tension: 1 } });
   getServerTranslation.mockResolvedValue({
     t: (key: string, options?: Record<string, unknown>) => tFromCatalog('gyms', key, options),
     i18n: {},
@@ -72,15 +74,29 @@ describe('feature-flag gate', () => {
     // Person-property targeting only resolves when the evaluation names a
     // person PostHog holds those properties for. Anything else returns false
     // for a perfectly configured flag with nothing erroring anywhere.
-    expect(getServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', 'user-uuid-1');
+    expect(getServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', {
+      distinctId: 'user-uuid-1',
+      allowAnonymous: true,
+    });
   });
 
-  it('passes a signed-out visitor through as having no person', async () => {
+  it('asks for a signed-out visitor too, instead of short-circuiting them to a 404', async () => {
+    getPosthogDistinctId.mockResolvedValue(null);
+    getServerFeatureFlag.mockResolvedValue(true);
+
+    await renderGymDirectory('all', props);
+
+    // `allowAnonymous` is what makes #4382's flag flip able to launch this
+    // page. Without it the directory is signed-in-only however the PostHog
+    // rollout is configured, and every crawler gets a 404.
+    expect(getServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', { distinctId: null, allowAnonymous: true });
+  });
+
+  it('still 404s a signed-out visitor when the flag says no', async () => {
     getPosthogDistinctId.mockResolvedValue(null);
     getServerFeatureFlag.mockResolvedValue(false);
 
     await expect(renderGymDirectory('all', props)).rejects.toThrow('NEXT_NOT_FOUND');
-    expect(getServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', null);
   });
 
   it('renders once the flag is on', async () => {
@@ -96,10 +112,89 @@ describe('feature-flag gate', () => {
 
   it('asks for one page of results per request, never a drain loop', async () => {
     getServerFeatureFlag.mockResolvedValue(true);
+    fetchDirectoryPage.mockResolvedValue({ ok: true, gyms: [], totalCount: 500 });
 
     await renderGymDirectory('all', { searchParams: Promise.resolve({ page: '3' }) });
 
     expect(fetchDirectoryPage).toHaveBeenCalledTimes(1);
     expect(fetchDirectoryPage).toHaveBeenCalledWith(expect.objectContaining({ page: 3 }));
+  });
+});
+
+describe('out-of-range pages', () => {
+  beforeEach(() => {
+    getServerFeatureFlag.mockResolvedValue(true);
+  });
+
+  it('404s a page past the real last page instead of serving an empty 200', async () => {
+    // 30 gyms is two pages of 24. Page 3 is not a page.
+    fetchDirectoryPage.mockResolvedValue({ ok: true, gyms: [], totalCount: 30 });
+
+    await expect(renderGymDirectory('kilter', { searchParams: Promise.resolve({ page: '3' }) })).rejects.toThrow(
+      'NEXT_NOT_FOUND',
+    );
+  });
+
+  it('serves the real last page', async () => {
+    fetchDirectoryPage.mockResolvedValue({ ok: true, gyms: [], totalCount: 30 });
+
+    await expect(renderGymDirectory('kilter', { searchParams: Promise.resolve({ page: '2' }) })).resolves.toBeTruthy();
+  });
+
+  it('404s past the crawl-trap ceiling without spending a query', async () => {
+    await expect(renderGymDirectory('all', { searchParams: Promise.resolve({ page: '9999' }) })).rejects.toThrow(
+      'NEXT_NOT_FOUND',
+    );
+    expect(fetchDirectoryPage).not.toHaveBeenCalled();
+  });
+
+  it('keeps page one of an empty result set as a 200 with the empty state', async () => {
+    // "No gyms match that search" is an answer. "Page 40 of 2" is not a page.
+    fetchDirectoryPage.mockResolvedValue({ ok: true, gyms: [], totalCount: 0 });
+
+    await expect(renderGymDirectory('all', props)).resolves.toBeTruthy();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('does not 404 every page just because the backend is down', async () => {
+    // A failed fetch has no totalCount to compare against; treating it as zero
+    // would 404 page 2 for the length of an incident.
+    fetchDirectoryPage.mockResolvedValue({ ok: false });
+
+    await expect(renderGymDirectory('all', { searchParams: Promise.resolve({ page: '2' }) })).resolves.toBeTruthy();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+});
+
+describe('backend failure', () => {
+  beforeEach(() => {
+    getServerFeatureFlag.mockResolvedValue(true);
+  });
+
+  it('renders the error state rather than a confident "0 gyms" when the list fails', async () => {
+    fetchDirectoryPage.mockResolvedValue({ ok: false });
+
+    const element = await renderGymDirectory('all', props);
+    const markup = JSON.stringify(element);
+
+    expect(markup).toContain("We can't reach the gym list right now");
+    // The count-bearing body copy is suppressed entirely — stating a false zero
+    // with total confidence is worse than an error page.
+    expect(markup).not.toContain('have a board listed on Boardsesh');
+  });
+
+  it('renders the error state when the facet counts fail', async () => {
+    fetchFacetCounts.mockResolvedValue({ ok: false });
+
+    const markup = JSON.stringify(await renderGymDirectory('all', props));
+    expect(markup).toContain("We can't reach the gym list right now");
+    expect(markup).not.toContain('have a board listed on Boardsesh');
+  });
+
+  it('keeps the h1 so the page still says what it is', async () => {
+    fetchDirectoryPage.mockResolvedValue({ ok: false });
+
+    const markup = JSON.stringify(await renderGymDirectory('kilter', props));
+    expect(markup).toContain('Gyms with a Kilter board');
   });
 });

--- a/packages/web/app/gyms/__tests__/directory-metadata.test.ts
+++ b/packages/web/app/gyms/__tests__/directory-metadata.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('server-only', () => ({}));
+
+const getServerTranslation = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/i18n/server', () => ({ getServerTranslation, loadServerResources: vi.fn() }));
+
+vi.mock('@/app/lib/graphql/server-cached-client', () => ({
+  createCachedGraphQLQuery: () => vi.fn(),
+}));
+
+// The route modules pull in the page renderer, which reaches next-auth (and
+// through it the db client) for the flag's distinct id. Metadata never needs a
+// session, so stub the module rather than standing up a database for it.
+vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinctId: vi.fn() }));
+vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({ getServerFeatureFlag: vi.fn() }));
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({
+  trackGymFunnelEvent: vi.fn(),
+  viewerStateFrom: (isAuthenticated: boolean) => (isAuthenticated ? 'signed-in' : 'signed-out'),
+}));
+
+const allRoute = await import('../page');
+const kilterRoute = await import('../kilter/page');
+const moonboardRoute = await import('../moonboard/page');
+const tensionRoute = await import('../tension/page');
+
+const ROUTES = [
+  { name: '/gyms', generateMetadata: allRoute.generateMetadata, base: '/gyms' },
+  { name: '/gyms/kilter', generateMetadata: kilterRoute.generateMetadata, base: '/gyms/kilter' },
+  { name: '/gyms/moonboard', generateMetadata: moonboardRoute.generateMetadata, base: '/gyms/moonboard' },
+  { name: '/gyms/tension', generateMetadata: tensionRoute.generateMetadata, base: '/gyms/tension' },
+];
+
+function mockLocale(locale: string) {
+  getServerTranslation.mockResolvedValue({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog('gyms', key, options),
+    i18n: {},
+    locale,
+  });
+}
+
+beforeEach(() => {
+  getServerTranslation.mockReset();
+  mockLocale('en-US');
+});
+
+describe('canonical matrix', () => {
+  it('makes every route self-canonical on its OWN clean base', async () => {
+    for (const route of ROUTES) {
+      const metadata = await route.generateMetadata();
+      // A facet page canonicalises to itself, NOT to /gyms: it is a distinct
+      // page with distinct copy, and folding it into /gyms would throw away the
+      // "<board> board near me" surface this route exists to be.
+      expect({ route: route.name, canonical: metadata.alternates?.canonical }).toEqual({
+        route: route.name,
+        canonical: route.base,
+      });
+    }
+  });
+
+  it('cannot let a query param reach the canonical, because it never sees one', async () => {
+    // Structural, not defensive: `generateMetadata` takes no arguments at all,
+    // so `?q`, `?page`, `?lat`/`?lng`/`?radius` and `?boardType` physically
+    // cannot be concatenated into `path`. Every variant collapses to the base.
+    for (const route of ROUTES) {
+      expect({ route: route.name, arity: route.generateMetadata.length }).toEqual({ route: route.name, arity: 0 });
+    }
+  });
+
+  it('carries the canonical into the locale prefix', async () => {
+    mockLocale('de');
+    const metadata = await kilterRoute.generateMetadata();
+    expect(metadata.alternates?.canonical).toBe('/de/gyms/kilter');
+  });
+
+  it('emits hreflang alternates for every locale plus x-default', async () => {
+    const metadata = await moonboardRoute.generateMetadata();
+    expect(metadata.alternates?.languages).toEqual({
+      'en-US': '/gyms/moonboard',
+      es: '/es/gyms/moonboard',
+      fr: '/fr/gyms/moonboard',
+      de: '/de/gyms/moonboard',
+      'x-default': '/gyms/moonboard',
+    });
+  });
+});
+
+describe('robots', () => {
+  it('ships noindex, follow on every route while the directory is flag-gated', async () => {
+    for (const route of ROUTES) {
+      const metadata = await route.generateMetadata();
+      // Launch (#4382) removes this and nothing else. Note the gate is BOTH:
+      // the page also 404s while the flag is off, because noindex alone would
+      // still leave a publicly reachable directory.
+      expect({ route: route.name, robots: metadata.robots }).toEqual({
+        route: route.name,
+        robots: { index: false, follow: true },
+      });
+    }
+  });
+});
+
+describe('titles and descriptions', () => {
+  it('gives every route a unique, brand-suffixed title', async () => {
+    const titles = await Promise.all(
+      ROUTES.map(async (route) => {
+        const { title } = await route.generateMetadata();
+        // `createPageMetadata` always emits the `absolute` form so the root
+        // layout's `%s | Boardsesh` template can't double-suffix it.
+        expect(title).toHaveProperty('absolute');
+        return title && typeof title === 'object' && 'absolute' in title ? title.absolute : '';
+      }),
+    );
+
+    expect(new Set(titles).size).toBe(ROUTES.length);
+    for (const title of titles) {
+      expect(title).toMatch(/ \| Boardsesh$/);
+    }
+  });
+
+  it('gives every route a unique description', async () => {
+    const descriptions = await Promise.all(ROUTES.map(async (route) => (await route.generateMetadata()).description));
+    expect(new Set(descriptions).size).toBe(ROUTES.length);
+  });
+});

--- a/packages/web/app/gyms/__tests__/gym-directory-card.test.tsx
+++ b/packages/web/app/gyms/__tests__/gym-directory-card.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import type { GymDirectoryCard as GymDirectoryCardData } from '@boardsesh/graphql/operations';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const getServerTranslation = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/i18n/server', () => ({ getServerTranslation }));
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({
+  trackGymFunnelEvent,
+  viewerStateFrom: (isAuthenticated: boolean) => (isAuthenticated ? 'signed-in' : 'signed-out'),
+}));
+
+const GymDirectoryCard = (await import('../gym-directory-card')).default;
+
+const formatNumber = (value: number) => new Intl.NumberFormat('en-US').format(value);
+
+function gym(overrides: Partial<GymDirectoryCardData> = {}): GymDirectoryCardData {
+  return {
+    uuid: 'gym-1',
+    slug: 'boulderwelt-muenchen-ost',
+    name: 'Boulderwelt München Ost',
+    address: null,
+    latitude: null,
+    longitude: null,
+    boardCount: 1,
+    isClaimed: false,
+    boardSummaries: [],
+    ...overrides,
+  };
+}
+
+async function renderCard(props: {
+  gym?: Partial<GymDirectoryCardData>;
+  origin?: { latitude: number; longitude: number } | null;
+  viewerState?: 'signed-in' | 'signed-out';
+}) {
+  const element = await GymDirectoryCard({
+    gym: gym(props.gym),
+    origin: props.origin ?? null,
+    viewerState: props.viewerState ?? 'signed-out',
+    formatNumber,
+  });
+  return render(element);
+}
+
+beforeEach(() => {
+  trackGymFunnelEvent.mockReset();
+  getServerTranslation.mockResolvedValue({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog('gyms', key, options),
+    i18n: {},
+    locale: 'en-US',
+  });
+});
+
+describe('GymDirectoryCard', () => {
+  it('links the gym name with a real href a crawler can follow', async () => {
+    await renderCard({});
+    const link = screen.getByRole('link', { name: 'Boulderwelt München Ost' });
+    expect(link.getAttribute('href')).toBe('/gym/boulderwelt-muenchen-ost');
+  });
+
+  it('renders the gym name as the card heading', async () => {
+    await renderCard({});
+    expect(screen.getByRole('heading', { level: 3 }).textContent).toBe('Boulderwelt München Ost');
+  });
+
+  it('shows the free-text address when the gym typed one', async () => {
+    await renderCard({ gym: { address: 'Hansastraße 15, München' } });
+    expect(screen.getByText('Hansastraße 15, München')).toBeTruthy();
+  });
+
+  it('falls back to a distance when there is a pin and the request had an origin', async () => {
+    await renderCard({
+      gym: { latitude: 51.3811, longitude: -2.359 },
+      origin: { latitude: 51.4545, longitude: -2.5879 },
+    });
+    expect(screen.getByText(/km away$/)).toBeTruthy();
+  });
+
+  it('shows no location line for a pin with no origin, rather than inventing a city', async () => {
+    const { container } = await renderCard({ gym: { latitude: 51.3811, longitude: -2.359 } });
+    expect(container.textContent).not.toContain('km away');
+    expect(screen.queryByTestId('LocationOnOutlinedIcon')).toBeNull();
+  });
+
+  it('renders one chip per distinct board and angle', async () => {
+    await renderCard({
+      gym: {
+        boardSummaries: [
+          { boardType: 'kilter', angle: 40 },
+          { boardType: 'kilter', angle: 40 },
+          { boardType: 'moonboard', angle: 25 },
+        ],
+      },
+    });
+    expect(screen.getByText('Kilter 40°')).toBeTruthy();
+    expect(screen.getByText('MoonBoard 25°')).toBeTruthy();
+    expect(screen.getAllByText('Kilter 40°')).toHaveLength(1);
+  });
+
+  it('renders a bare board name when no angle was recorded', async () => {
+    await renderCard({ gym: { boardSummaries: [{ boardType: 'tension', angle: 0 }] } });
+    expect(screen.getByText('Tension')).toBeTruthy();
+  });
+
+  it('offers the claim prompt on an unclaimed gym', async () => {
+    await renderCard({ gym: { isClaimed: false } });
+    expect(screen.getByRole('link', { name: 'Is this your gym?' })).toBeTruthy();
+  });
+
+  it('drops the claim prompt once a gym is claimed, and changes nothing else', async () => {
+    await renderCard({ gym: { isClaimed: true, address: 'Hansastraße 15, München' } });
+    expect(screen.queryByRole('link', { name: 'Is this your gym?' })).toBeNull();
+    // Unclaimed and claimed gyms render the same card otherwise: same heading
+    // link, same address line, no badge, no demotion.
+    expect(screen.getByRole('link', { name: 'Boulderwelt München Ost' })).toBeTruthy();
+    expect(screen.getByText('Hansastraße 15, München')).toBeTruthy();
+  });
+
+  it('uses isClaimed, not the viewer-scoped canClaim, so anonymous visitors see the prompt', async () => {
+    // `canClaim` is false for every signed-out viewer — i.e. the directory's
+    // whole audience — so gating on it would hide this from everyone.
+    await renderCard({ gym: { isClaimed: false }, viewerState: 'signed-out' });
+    expect(screen.getByRole('link', { name: 'Is this your gym?' })).toBeTruthy();
+  });
+});

--- a/packages/web/app/gyms/__tests__/gym-directory-card.test.tsx
+++ b/packages/web/app/gyms/__tests__/gym-directory-card.test.tsx
@@ -33,7 +33,6 @@ function gym(overrides: Partial<GymDirectoryCardData> = {}): GymDirectoryCardDat
     address: null,
     latitude: null,
     longitude: null,
-    boardCount: 1,
     isClaimed: false,
     boardSummaries: [],
     ...overrides,

--- a/packages/web/app/gyms/__tests__/gym-directory-claim-link.test.tsx
+++ b/packages/web/app/gyms/__tests__/gym-directory-claim-link.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { tFromCatalog } from '@/app/__test-helpers__/i18n-mock';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string, options?: Record<string, unknown>) => tFromCatalog(ns, key, options),
+    i18n: { language: 'en-US' },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children ?? null,
+}));
+
+const trackGymFunnelEvent = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/gym-funnel-analytics', () => ({ trackGymFunnelEvent }));
+
+const GymDirectoryClaimLink = (await import('../gym-directory-claim-link')).default;
+
+beforeEach(() => {
+  trackGymFunnelEvent.mockReset();
+});
+
+describe('GymDirectoryClaimLink', () => {
+  it('reports the click with the directory-card placement', () => {
+    render(<GymDirectoryClaimLink gymUuid="gym-1" gymSlug="boulderwelt" viewerState="signed-out" />);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Is this your gym?' }));
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledTimes(1);
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Claim CTA Clicked',
+      properties: { placement: 'directory-card', viewerState: 'signed-out', gymUuid: 'gym-1' },
+    });
+  });
+
+  it('passes a signed-in viewer through unchanged', () => {
+    render(<GymDirectoryClaimLink gymUuid="gym-2" gymSlug="the-climbing-hangar" viewerState="signed-in" />);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Is this your gym?' }));
+
+    expect(trackGymFunnelEvent).toHaveBeenCalledWith({
+      name: 'Gym Claim CTA Clicked',
+      properties: { placement: 'directory-card', viewerState: 'signed-in', gymUuid: 'gym-2' },
+    });
+  });
+
+  it('is a real link to the gym page, not a click handler on a div', () => {
+    render(<GymDirectoryClaimLink gymUuid="gym-1" gymSlug="boulderwelt" viewerState="signed-out" />);
+    expect(screen.getByRole('link', { name: 'Is this your gym?' }).getAttribute('href')).toBe('/gym/boulderwelt');
+  });
+});

--- a/packages/web/app/gyms/directory-card-model.ts
+++ b/packages/web/app/gyms/directory-card-model.ts
@@ -1,0 +1,94 @@
+import type { GymBoardSummary } from '@boardsesh/shared-schema';
+import { BOARD_TYPE_LABELS } from '@boardsesh/board-constants';
+import { distanceKm } from './directory-facets';
+
+/** One board chip: a board type and the angle that wall is set at. */
+export type BoardChip = {
+  /** Stable React key. */
+  key: string;
+  boardType: string;
+  /** Degrees. `0` means the gym never recorded one — render the bare board name. */
+  angle: number;
+};
+
+const BOARD_TYPE_ORDER = Object.keys(BOARD_TYPE_LABELS);
+
+/**
+ * Collapse `boardSummaries` into the chips a card renders.
+ *
+ * A gym with four Kilter walls all set at 40° is one chip, not four: the card
+ * answers "what can I climb on here", and repeating the same chip four times
+ * answers nothing while pushing the useful chips off the row. Distinct angles
+ * stay distinct — a 40° and a 50° Kilter are genuinely different sessions.
+ */
+export function boardChips(summaries: readonly GymBoardSummary[] | null | undefined): BoardChip[] {
+  if (!summaries || summaries.length === 0) {
+    return [];
+  }
+
+  const unique = new Map<string, BoardChip>();
+  for (const summary of summaries) {
+    const boardType = summary.boardType;
+    const angle = Number.isFinite(summary.angle) ? Math.round(summary.angle) : 0;
+    const key = `${boardType}-${angle}`;
+    if (!unique.has(key)) {
+      unique.set(key, { key, boardType, angle });
+    }
+  }
+
+  return [...unique.values()].sort((left, right) => {
+    const leftRank = BOARD_TYPE_ORDER.indexOf(left.boardType);
+    const rightRank = BOARD_TYPE_ORDER.indexOf(right.boardType);
+    // Unknown board types sort last rather than to the front on `-1`.
+    const leftOrder = leftRank === -1 ? BOARD_TYPE_ORDER.length : leftRank;
+    const rightOrder = rightRank === -1 ? BOARD_TYPE_ORDER.length : rightRank;
+    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+    return left.angle - right.angle;
+  });
+}
+
+/** Where a card's location line comes from, or `null` when there is nothing true to say. */
+export type CardLocation = { kind: 'address'; address: string } | { kind: 'distance'; km: number } | null;
+
+export type CardLocationInput = {
+  address?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+};
+
+/**
+ * The card's location line.
+ *
+ * The gym table has a free-text `address` (populated for ~24% of rows) and a
+ * lat/lng pin (~63%). It has NO city, region or country column. So there are
+ * exactly three honest outcomes: the address the gym typed, a distance from an
+ * origin the request supplied, or nothing at all. Reverse-geocoding a pin into
+ * "Berlin, Germany" would invent a locality for a row that never stored one,
+ * and a wrong city on a gym card is worse than no line.
+ */
+export function cardLocation(
+  gym: CardLocationInput,
+  origin: { latitude: number; longitude: number } | null,
+): CardLocation {
+  const address = gym.address?.trim();
+  if (address) {
+    return { kind: 'address', address };
+  }
+
+  if (origin && typeof gym.latitude === 'number' && typeof gym.longitude === 'number') {
+    return {
+      kind: 'distance',
+      km: distanceKm(origin, { latitude: gym.latitude, longitude: gym.longitude }),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Round a distance for display: whole km once you're far enough away that a
+ * decimal is noise, one decimal when you're close enough to walk.
+ */
+export function roundDistanceKm(km: number): number {
+  return km < 10 ? Math.round(km * 10) / 10 : Math.round(km);
+}

--- a/packages/web/app/gyms/directory-copy.ts
+++ b/packages/web/app/gyms/directory-copy.ts
@@ -1,0 +1,147 @@
+import type { TFunction } from 'i18next';
+import type { BoardFacet, DirectoryFacet } from './directory-facets';
+
+/**
+ * Every piece of per-facet copy, resolved through LITERAL `t()` call sites.
+ *
+ * The obvious implementation — `t(`directory.${facet}.h1`)` or
+ * `t(FACET_TITLE_KEYS[facet])` — is not available: `check:i18n:orphans`
+ * hard-fails on `t(variable)`, and a template literal only survives as a glob
+ * that no longer proves the four concrete keys exist. A switch costs four lines
+ * per string and buys a checker that can see, key by key, exactly which
+ * catalog entries this page reads.
+ *
+ * `t` is typed `TFunction<'gyms'>` so the checker resolves the namespace from
+ * the parameter rather than needing a `useTranslation` call in scope.
+ */
+
+/** Counts used in the body copy. All of them count GYMS, never boards. */
+export type FacetGymCounts = Record<DirectoryFacet, number>;
+
+/** A number rendered for the active locale, e.g. `1,786` / `1.786`. */
+export type FormatCount = (value: number) => string;
+
+export function facetMetaTitle(t: TFunction<'gyms'>, facet: DirectoryFacet): string {
+  switch (facet) {
+    case 'kilter':
+      return t('metadata.kilter.title');
+    case 'moonboard':
+      return t('metadata.moonboard.title');
+    case 'tension':
+      return t('metadata.tension.title');
+    default:
+      return t('metadata.all.title');
+  }
+}
+
+export function facetMetaDescription(t: TFunction<'gyms'>, facet: DirectoryFacet): string {
+  switch (facet) {
+    case 'kilter':
+      return t('metadata.kilter.description');
+    case 'moonboard':
+      return t('metadata.moonboard.description');
+    case 'tension':
+      return t('metadata.tension.description');
+    default:
+      return t('metadata.all.description');
+  }
+}
+
+export function facetHeading(t: TFunction<'gyms'>, facet: DirectoryFacet): string {
+  switch (facet) {
+    case 'kilter':
+      return t('directory.kilter.h1');
+    case 'moonboard':
+      return t('directory.moonboard.h1');
+    case 'tension':
+      return t('directory.tension.h1');
+    default:
+      return t('directory.all.h1');
+  }
+}
+
+/**
+ * First body paragraph. `count` drives plural selection; `formattedCount` is
+ * what actually renders, so the sentence reads `1,786` rather than `1786`.
+ */
+export function facetLead(
+  t: TFunction<'gyms'>,
+  facet: DirectoryFacet,
+  counts: FacetGymCounts,
+  formatCount: FormatCount,
+): string {
+  const count = counts[facet];
+  const options = { count, formattedCount: formatCount(count) };
+  switch (facet) {
+    case 'kilter':
+      return t('directory.kilter.lead', options);
+    case 'moonboard':
+      return t('directory.moonboard.lead', options);
+    case 'tension':
+      return t('directory.tension.lead', options);
+    default:
+      return t('directory.all.lead', options);
+  }
+}
+
+/** Second body paragraph. On `/gyms` it carries the per-board gym counts. */
+export function facetDetail(
+  t: TFunction<'gyms'>,
+  facet: DirectoryFacet,
+  counts: FacetGymCounts,
+  formatCount: FormatCount,
+): string {
+  switch (facet) {
+    case 'kilter':
+      return t('directory.kilter.detail');
+    case 'moonboard':
+      return t('directory.moonboard.detail');
+    case 'tension':
+      return t('directory.tension.detail');
+    default:
+      return t('directory.all.detail', {
+        kilterCount: formatCount(counts.kilter),
+        moonboardCount: formatCount(counts.moonboard),
+        tensionCount: formatCount(counts.tension),
+      });
+  }
+}
+
+/** Facet chip label, e.g. `Kilter · 1,786`. The number is gyms, not boards. */
+export function facetChipLabel(
+  t: TFunction<'gyms'>,
+  facet: DirectoryFacet,
+  counts: FacetGymCounts,
+  formatCount: FormatCount,
+): string {
+  const options = { formattedCount: formatCount(counts[facet]) };
+  switch (facet) {
+    case 'kilter':
+      return t('facets.kilter', options);
+    case 'moonboard':
+      return t('facets.moonboard', options);
+    case 'tension':
+      return t('facets.tension', options);
+    default:
+      return t('facets.all', options);
+  }
+}
+
+/** Descriptive anchor text for the cross-facet internal links. */
+export function facetLinkLabel(t: TFunction<'gyms'>, facet: DirectoryFacet): string {
+  switch (facet) {
+    case 'kilter':
+      return t('links.kilter');
+    case 'moonboard':
+      return t('links.moonboard');
+    case 'tension':
+      return t('links.tension');
+    default:
+      return t('links.all');
+  }
+}
+
+/** The board facets other than the one currently rendered. */
+export function otherBoardFacets(facet: DirectoryFacet, boardFacets: readonly BoardFacet[]): BoardFacet[] {
+  return boardFacets.filter((candidate) => candidate !== facet);
+}

--- a/packages/web/app/gyms/directory-copy.ts
+++ b/packages/web/app/gyms/directory-copy.ts
@@ -1,5 +1,5 @@
 import type { TFunction } from 'i18next';
-import type { BoardFacet, DirectoryFacet } from './directory-facets';
+import type { DirectoryFacet } from './directory-facets';
 
 /**
  * Every piece of per-facet copy, resolved through LITERAL `t()` call sites.
@@ -139,9 +139,4 @@ export function facetLinkLabel(t: TFunction<'gyms'>, facet: DirectoryFacet): str
     default:
       return t('links.all');
   }
-}
-
-/** The board facets other than the one currently rendered. */
-export function otherBoardFacets(facet: DirectoryFacet, boardFacets: readonly BoardFacet[]): BoardFacet[] {
-  return boardFacets.filter((candidate) => candidate !== facet);
 }

--- a/packages/web/app/gyms/directory-data.ts
+++ b/packages/web/app/gyms/directory-data.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import * as Sentry from '@sentry/nextjs';
 import {
   SEARCH_GYMS_DIRECTORY,
   type GymDirectoryCard,
@@ -22,13 +23,19 @@ const FACET_COUNT_REVALIDATE_SECONDS = 900;
 /** A wedged backend must cost a degraded page, not a hung request. */
 const DIRECTORY_TIMEOUT_MS = 4_000;
 
-export type DirectoryPage = {
-  gyms: GymDirectoryCard[];
-  totalCount: number;
-  hasMore: boolean;
-};
-
-const EMPTY_PAGE: DirectoryPage = { gyms: [], totalCount: 0, hasMore: false };
+/**
+ * A page of results, or an explicit failure.
+ *
+ * `ok: false` is a distinct outcome from an empty page, and keeping them apart
+ * is the whole point of this type. Collapsing a timeout into `totalCount: 0`
+ * rendered a fully-formed, confident directory whose lead paragraph read "0
+ * gyms have a board listed on Boardsesh" — a false statement about the
+ * catalogue, delivered with no hint anything went wrong. It also made a real
+ * empty page indistinguishable from an outage, so the out-of-range `?page`
+ * check could not tell "past the end" from "backend down" and would have 404ed
+ * every page during an incident.
+ */
+export type DirectoryPageResult = { ok: true; gyms: GymDirectoryCard[]; totalCount: number } | { ok: false };
 
 const runDirectoryQuery = createCachedGraphQLQuery<SearchGymsDirectoryQueryResponse, { input: SearchGymsInput }>(
   SEARCH_GYMS_DIRECTORY,
@@ -69,49 +76,57 @@ export function toSearchGymsInput(query: DirectoryQuery, offset: number, limit: 
   };
 }
 
+function reportDirectoryFailure(operation: string, error: unknown): void {
+  console.error(`${operation} failed:`, error);
+  // The flag module reports its own failures; so does this one. A directory
+  // that quietly serves "0 gyms" during an outage is exactly the class of bug
+  // nobody files, because the page looks fine.
+  Sentry.captureException(error, { tags: { surface: 'gym-directory', operation } });
+}
+
 /**
  * One page of directory results. One request per page view — no drain-until-
- * `hasMore` loop, here or in the client.
+ * done loop, here or in the client.
  */
-export async function fetchDirectoryPage(query: DirectoryQuery): Promise<DirectoryPage> {
+export async function fetchDirectoryPage(query: DirectoryQuery): Promise<DirectoryPageResult> {
   const offset = (query.page - 1) * DIRECTORY_PAGE_SIZE;
 
   try {
     const response = await runDirectoryQuery({ input: toSearchGymsInput(query, offset, DIRECTORY_PAGE_SIZE) });
     const connection = response.searchGyms;
     return {
+      ok: true,
       // A slugless gym cannot be linked. `requireSlug` should already have
       // excluded it; this is the render-side belt to that braces.
       gyms: connection.gyms.filter((gym) => Boolean(gym.slug)),
       totalCount: connection.totalCount,
-      hasMore: connection.hasMore,
     };
   } catch (error) {
-    console.error('fetchDirectoryPage failed:', error);
-    return EMPTY_PAGE;
+    reportDirectoryFailure('fetchDirectoryPage', error);
+    return { ok: false };
   }
 }
 
 export type FacetCounts = Record<DirectoryFacet, number>;
+export type FacetCountsResult = { ok: true; counts: FacetCounts } | { ok: false };
 
-const EMPTY_FACET_COUNTS: FacetCounts = { all: 0, kilter: 0, moonboard: 0, tension: 0 };
-
-async function fetchFacetTotal(boardTypes: string[]): Promise<number> {
+async function fetchFacetTotal(boardTypes: string[]): Promise<number | null> {
   try {
     const response = await runFacetCountQuery({
       input: {
         ...(boardTypes.length > 0 ? { boardTypes } : {}),
         requireSlug: true,
-        // `totalCount` is what we're after; one row is the cheapest non-zero
-        // page the connection will hand back.
+        // `totalCount` is what we're after; one row is the cheapest page the
+        // connection will hand back. It is still a full enriched row that gets
+        // thrown away — see the note on `fetchFacetCounts`.
         limit: 1,
         offset: 0,
       },
     });
     return response.searchGyms.totalCount;
   } catch (error) {
-    console.error('fetchFacetTotal failed:', error);
-    return 0;
+    reportDirectoryFailure('fetchFacetTotal', error);
+    return null;
   }
 }
 
@@ -123,8 +138,17 @@ async function fetchFacetTotal(boardTypes: string[]): Promise<number> {
  * BOARDS and will not match what renders here; that is expected and the two are
  * not meant to be reconciled. The `countHint` string on the page says so to
  * readers as well.
+ *
+ * COST, known and accepted for now: four `searchGyms` calls that each enrich a
+ * row they discard, purely to read `totalCount`. Cached for 15 minutes and
+ * shared across every visitor and every page, so it is four queries per cold
+ * render, not per request. A count-only backend path would remove them; it is
+ * not worth a GraphQL addition in this PR.
+ *
+ * A single failed total fails the whole set rather than showing three real
+ * numbers next to a fabricated zero.
  */
-export async function fetchFacetCounts(): Promise<FacetCounts> {
+export async function fetchFacetCounts(): Promise<FacetCountsResult> {
   // Spelled out rather than mapped over BOARD_FACETS so the destructuring is a
   // real tuple and a renamed facet is a compile error, not a silent zero.
   const [all, kilter, moonboard, tension] = await Promise.all([
@@ -134,5 +158,9 @@ export async function fetchFacetCounts(): Promise<FacetCounts> {
     fetchFacetTotal(['tension']),
   ]);
 
-  return { ...EMPTY_FACET_COUNTS, all, kilter, moonboard, tension };
+  if (all === null || kilter === null || moonboard === null || tension === null) {
+    return { ok: false };
+  }
+
+  return { ok: true, counts: { all, kilter, moonboard, tension } };
 }

--- a/packages/web/app/gyms/directory-data.ts
+++ b/packages/web/app/gyms/directory-data.ts
@@ -1,0 +1,138 @@
+import 'server-only';
+import {
+  SEARCH_GYMS_DIRECTORY,
+  type GymDirectoryCard,
+  type SearchGymsDirectoryQueryResponse,
+} from '@boardsesh/graphql/operations';
+import type { SearchGymsInput } from '@boardsesh/shared-schema';
+import { createCachedGraphQLQuery } from '@/app/lib/graphql/server-cached-client';
+import { DIRECTORY_PAGE_SIZE, type DirectoryFacet, type DirectoryQuery } from './directory-facets';
+
+const DIRECTORY_CACHE_TAG = 'gym-directory';
+const FACET_COUNT_CACHE_TAG = 'gym-directory-facet-counts';
+
+/**
+ * The catalog moves when a gym is added or a board is linked, i.e. a handful of
+ * times a day. Five minutes keeps the page off the backend for a crawl without
+ * making a new gym wait for a deploy to show up.
+ */
+const DIRECTORY_REVALIDATE_SECONDS = 300;
+const FACET_COUNT_REVALIDATE_SECONDS = 900;
+
+/** A wedged backend must cost a degraded page, not a hung request. */
+const DIRECTORY_TIMEOUT_MS = 4_000;
+
+export type DirectoryPage = {
+  gyms: GymDirectoryCard[];
+  totalCount: number;
+  hasMore: boolean;
+};
+
+const EMPTY_PAGE: DirectoryPage = { gyms: [], totalCount: 0, hasMore: false };
+
+const runDirectoryQuery = createCachedGraphQLQuery<SearchGymsDirectoryQueryResponse, { input: SearchGymsInput }>(
+  SEARCH_GYMS_DIRECTORY,
+  DIRECTORY_CACHE_TAG,
+  DIRECTORY_REVALIDATE_SECONDS,
+  DIRECTORY_TIMEOUT_MS,
+);
+
+// Same document, separate cache tag and a longer revalidate: the four facet
+// totals are identical for every visitor and every page of results, so they
+// should not be evicted every time somebody types a new search.
+const runFacetCountQuery = createCachedGraphQLQuery<SearchGymsDirectoryQueryResponse, { input: SearchGymsInput }>(
+  SEARCH_GYMS_DIRECTORY,
+  FACET_COUNT_CACHE_TAG,
+  FACET_COUNT_REVALIDATE_SECONDS,
+  DIRECTORY_TIMEOUT_MS,
+);
+
+/**
+ * Translate the parsed request into `SearchGymsInput`.
+ *
+ * `requireSlug` is the directory's whole reason for existing on this input:
+ * every card links to `/gym/[slug]`, so a slugless row would render an anchor
+ * to `/gym/undefined`. `searchGyms` already filters `is_public` and
+ * `deleted_at IS NULL` (which covers merged twins — merging always sets it).
+ */
+export function toSearchGymsInput(query: DirectoryQuery, offset: number, limit: number): SearchGymsInput {
+  return {
+    ...(query.query ? { query: query.query } : {}),
+    ...(query.boardTypes.length > 0 ? { boardTypes: query.boardTypes } : {}),
+    ...(query.latitude !== null && query.longitude !== null
+      ? { latitude: query.latitude, longitude: query.longitude }
+      : {}),
+    ...(query.radiusKm !== null ? { radiusKm: query.radiusKm } : {}),
+    requireSlug: true,
+    limit,
+    offset,
+  };
+}
+
+/**
+ * One page of directory results. One request per page view — no drain-until-
+ * `hasMore` loop, here or in the client.
+ */
+export async function fetchDirectoryPage(query: DirectoryQuery): Promise<DirectoryPage> {
+  const offset = (query.page - 1) * DIRECTORY_PAGE_SIZE;
+
+  try {
+    const response = await runDirectoryQuery({ input: toSearchGymsInput(query, offset, DIRECTORY_PAGE_SIZE) });
+    const connection = response.searchGyms;
+    return {
+      // A slugless gym cannot be linked. `requireSlug` should already have
+      // excluded it; this is the render-side belt to that braces.
+      gyms: connection.gyms.filter((gym) => Boolean(gym.slug)),
+      totalCount: connection.totalCount,
+      hasMore: connection.hasMore,
+    };
+  } catch (error) {
+    console.error('fetchDirectoryPage failed:', error);
+    return EMPTY_PAGE;
+  }
+}
+
+export type FacetCounts = Record<DirectoryFacet, number>;
+
+const EMPTY_FACET_COUNTS: FacetCounts = { all: 0, kilter: 0, moonboard: 0, tension: 0 };
+
+async function fetchFacetTotal(boardTypes: string[]): Promise<number> {
+  try {
+    const response = await runFacetCountQuery({
+      input: {
+        ...(boardTypes.length > 0 ? { boardTypes } : {}),
+        requireSlug: true,
+        // `totalCount` is what we're after; one row is the cheapest non-zero
+        // page the connection will hand back.
+        limit: 1,
+        offset: 0,
+      },
+    });
+    return response.searchGyms.totalCount;
+  } catch (error) {
+    console.error('fetchFacetTotal failed:', error);
+    return 0;
+  }
+}
+
+/**
+ * Live counts for the four facets.
+ *
+ * These count GYMS, one `totalCount` per board type — not boards. DB-04's
+ * board-mix numbers (moonboard 2,586 / kilter 1,786 / tension 465) count
+ * BOARDS and will not match what renders here; that is expected and the two are
+ * not meant to be reconciled. The `countHint` string on the page says so to
+ * readers as well.
+ */
+export async function fetchFacetCounts(): Promise<FacetCounts> {
+  // Spelled out rather than mapped over BOARD_FACETS so the destructuring is a
+  // real tuple and a renamed facet is a compile error, not a silent zero.
+  const [all, kilter, moonboard, tension] = await Promise.all([
+    fetchFacetTotal([]),
+    fetchFacetTotal(['kilter']),
+    fetchFacetTotal(['moonboard']),
+    fetchFacetTotal(['tension']),
+  ]);
+
+  return { ...EMPTY_FACET_COUNTS, all, kilter, moonboard, tension };
+}

--- a/packages/web/app/gyms/directory-facets.ts
+++ b/packages/web/app/gyms/directory-facets.ts
@@ -30,8 +30,17 @@ export const DIRECTORY_PAGE_SIZE = 24;
 
 /**
  * Hard ceiling on `?page`. Deep pagination is a crawl trap and, past a few
- * hundred gyms, nobody is paging by hand — they search. Out-of-range values
- * clamp rather than 404 so a stale link still lands on something.
+ * hundred gyms, nobody pages by hand — they search.
+ *
+ * Anything above it is a `notFound()`, NOT a clamp. Clamping produced a 200
+ * that contradicted itself: `?page=40` against a two-page list rendered the
+ * empty state while the nav highlighted page 2, i.e. an unbounded supply of
+ * 200-status empty URLs on a page we intend to make indexable.
+ *
+ * 40 x 24 = 960 gyms reachable by paging, against ~4,740 listed. That is a
+ * deliberate cap on the crawl path, not on the catalog: the long tail is meant
+ * to be reached through search and through #4381's sitemap, which enumerates
+ * every gym directly.
  */
 export const DIRECTORY_MAX_PAGE = 40;
 
@@ -118,8 +127,12 @@ export function parseDirectoryQuery(facet: DirectoryFacet, searchParams: Directo
   const radiusKm =
     hasValidOrigin && rawRadius !== null ? Math.min(Math.max(rawRadius, MIN_RADIUS_KM), MAX_RADIUS_KM) : null;
 
+  // Floored and floored-at-one only. Deliberately NOT clamped at the top: a
+  // page past the end has to reach the renderer so it can 404, because a clamp
+  // serves a 200 whose URL and highlighted page number disagree. `?page=0`,
+  // negatives and non-numeric all mean "page one" and are not errors.
   const rawPage = parseFiniteNumber(firstValue(searchParams.page));
-  const page = rawPage === null ? 1 : Math.min(Math.max(Math.floor(rawPage), 1), DIRECTORY_MAX_PAGE);
+  const page = rawPage === null ? 1 : Math.max(Math.floor(rawPage), 1);
 
   return {
     query,
@@ -166,9 +179,45 @@ export function buildDirectoryHref(facet: DirectoryFacet, query: DirectoryQuery,
   return search ? `${FACET_BASE_PATHS[facet]}?${search}` : FACET_BASE_PATHS[facet];
 }
 
-/** Whether the request applied a search, a board filter or a location. */
-export function hasActiveFilters(facet: DirectoryFacet, query: DirectoryQuery): boolean {
-  return query.query.length > 0 || query.boardTypes.length > 0 || query.latitude !== null || facet !== 'all';
+/**
+ * The URL a facet chip points at.
+ *
+ * Keeps the free text and the location, drops the board filter and the page.
+ * Clicking "Kilter" from `/gyms?q=bristol` has to stay a search for Bristol —
+ * silently throwing the search away turns a filter into a reset. Page resets
+ * because page 3 of one filter has nothing to do with page 3 of another, and
+ * the board filter is replaced rather than merged because that is what the chip
+ * means: "All gyms" clears it, a board chip becomes it.
+ */
+export function buildFacetSwitchHref(target: DirectoryFacet, query: DirectoryQuery): string {
+  return buildDirectoryHref(target, { ...query, boardTypes: target === 'all' ? [] : [target], page: 1 }, 1);
+}
+
+/**
+ * Whether this request is a SEARCH, in the sense `Gym Directory Searched`
+ * means it (#4374: "on search/filter application").
+ *
+ * Three things it deliberately excludes, each of which would inflate the event
+ * past usefulness:
+ *
+ *  - **A facet pageview.** On `/gyms/kilter` the board type IS the route, not a
+ *    filter the visitor applied. Counting it made every facet pageview a search
+ *    with `queryLength: 0`, which is most of the events on the page.
+ *  - **Pagination.** `?page=N` is a full navigation, so the tracker remounts
+ *    and fires again; page 2 of one search is not a second search.
+ *  - **A bare `/gyms` visit.**
+ *
+ * What counts: free text, a location, or an explicit `?boardType=` on the
+ * unfaceted route — the three things a visitor actually does to the list.
+ */
+export function isSearchApplication(facet: DirectoryFacet, query: DirectoryQuery): boolean {
+  if (query.page !== 1) {
+    return false;
+  }
+  if (query.query.length > 0 || query.latitude !== null) {
+    return true;
+  }
+  return facet === 'all' && query.boardTypes.length > 0;
 }
 
 const EARTH_RADIUS_KM = 6371;

--- a/packages/web/app/gyms/directory-facets.ts
+++ b/packages/web/app/gyms/directory-facets.ts
@@ -1,0 +1,214 @@
+import { BOARD_TYPE_LABELS } from '@boardsesh/board-constants';
+
+/**
+ * The four directory surfaces. `all` is `/gyms`; the other three are the only
+ * board types with enough linked boards to justify their own indexable route
+ * (moonboard ~2.6k, kilter ~1.8k, tension ~465 — DB-04 on #3666).
+ *
+ * These are LITERAL route folders, not a `[facet]` dynamic segment, and that is
+ * the point: `/gyms/soill` is then a plain 404 with no runtime check to get
+ * wrong, and the launch sitemap (#4381) has four static paths to enumerate
+ * rather than a list it has to keep in sync with a regex.
+ */
+export const DIRECTORY_FACETS = ['all', 'kilter', 'moonboard', 'tension'] as const;
+export type DirectoryFacet = (typeof DIRECTORY_FACETS)[number];
+
+/** The clean, self-canonical base URL of each facet. Never carries a query string. */
+export const FACET_BASE_PATHS: Record<DirectoryFacet, string> = {
+  all: '/gyms',
+  kilter: '/gyms/kilter',
+  moonboard: '/gyms/moonboard',
+  tension: '/gyms/tension',
+};
+
+/** Facets other than `all`, in the order they render. */
+export const BOARD_FACETS = ['kilter', 'moonboard', 'tension'] as const;
+export type BoardFacet = (typeof BOARD_FACETS)[number];
+
+/** Cards per page. The issue's AC: the first 24 gyms are server-rendered. */
+export const DIRECTORY_PAGE_SIZE = 24;
+
+/**
+ * Hard ceiling on `?page`. Deep pagination is a crawl trap and, past a few
+ * hundred gyms, nobody is paging by hand — they search. Out-of-range values
+ * clamp rather than 404 so a stale link still lands on something.
+ */
+export const DIRECTORY_MAX_PAGE = 40;
+
+/** Longest `?q` we pass through to the backend. */
+const MAX_QUERY_LENGTH = 80;
+
+const MIN_RADIUS_KM = 1;
+const MAX_RADIUS_KM = 500;
+
+/**
+ * Board types the directory will accept as a `?boardType=` filter on `/gyms`.
+ * Deliberately the whole vocabulary: the long-tail types (grasshopper, decoy,
+ * soill, touchstone) are reachable ONLY this way — they get no standalone route
+ * — and the three facets are here too so `/gyms?boardType=kilter` behaves
+ * instead of silently dropping the filter.
+ */
+export const FILTERABLE_BOARD_TYPES: readonly string[] = Object.keys(BOARD_TYPE_LABELS);
+
+/** Next.js' `searchParams` shape: a repeated param arrives as an array. */
+export type DirectorySearchParams = Record<string, string | string[] | undefined>;
+
+export type DirectoryQuery = {
+  /** Free-text search, trimmed and length-capped. Empty string means "no search". */
+  query: string;
+  /** Board types to filter on. Fixed to `[facet]` on a facet route. */
+  boardTypes: string[];
+  /** Proximity origin. Both coordinates are present or both are null. */
+  latitude: number | null;
+  longitude: number | null;
+  radiusKm: number | null;
+  /** 1-based. */
+  page: number;
+};
+
+function firstValue(raw: string | string[] | undefined): string | undefined {
+  if (Array.isArray(raw)) return raw[0];
+  return raw;
+}
+
+function allValues(raw: string | string[] | undefined): string[] {
+  if (Array.isArray(raw)) return raw;
+  return raw === undefined ? [] : [raw];
+}
+
+function parseFiniteNumber(raw: string | undefined): number | null {
+  if (raw === undefined) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Read the directory's query params off a request.
+ *
+ * Everything is validated rather than forwarded: a coordinate outside its real
+ * range, a `page` of `-3`, a `boardType` nobody has ever built are all dropped
+ * here so the page renders its clean default instead of the backend deciding
+ * what a nonsense filter means.
+ */
+export function parseDirectoryQuery(facet: DirectoryFacet, searchParams: DirectorySearchParams): DirectoryQuery {
+  const query = (firstValue(searchParams.q) ?? '').trim().slice(0, MAX_QUERY_LENGTH);
+
+  // A facet route IS its filter. Honouring `?boardType=` there would let
+  // `/gyms/kilter?boardType=tension` render Tension gyms under a Kilter h1.
+  const boardTypes =
+    facet === 'all'
+      ? [...new Set(allValues(searchParams.boardType).map((value) => value.trim().toLowerCase()))].filter((value) =>
+          FILTERABLE_BOARD_TYPES.includes(value),
+        )
+      : [facet];
+
+  const latitude = parseFiniteNumber(firstValue(searchParams.lat));
+  const longitude = parseFiniteNumber(firstValue(searchParams.lng));
+  const hasValidOrigin =
+    latitude !== null &&
+    longitude !== null &&
+    latitude >= -90 &&
+    latitude <= 90 &&
+    longitude >= -180 &&
+    longitude <= 180;
+
+  const rawRadius = parseFiniteNumber(firstValue(searchParams.radius));
+  const radiusKm =
+    hasValidOrigin && rawRadius !== null ? Math.min(Math.max(rawRadius, MIN_RADIUS_KM), MAX_RADIUS_KM) : null;
+
+  const rawPage = parseFiniteNumber(firstValue(searchParams.page));
+  const page = rawPage === null ? 1 : Math.min(Math.max(Math.floor(rawPage), 1), DIRECTORY_MAX_PAGE);
+
+  return {
+    query,
+    boardTypes: boardTypes.sort(),
+    latitude: hasValidOrigin ? latitude : null,
+    longitude: hasValidOrigin ? longitude : null,
+    radiusKm,
+    page,
+  };
+}
+
+/**
+ * Rebuild a directory URL for a given page, keeping every other filter.
+ *
+ * Params are emitted in a fixed order so the same filter state always produces
+ * the same string — one cache key, one crawlable URL, instead of one per
+ * accidental ordering. `page=1` is omitted so page one and the clean base are
+ * the same URL rather than two that canonicalise to each other.
+ */
+export function buildDirectoryHref(facet: DirectoryFacet, query: DirectoryQuery, page: number): string {
+  const params = new URLSearchParams();
+
+  if (query.query) {
+    params.set('q', query.query);
+  }
+  // Facet routes carry their board type in the path, never in the query.
+  if (facet === 'all') {
+    for (const boardType of query.boardTypes) {
+      params.append('boardType', boardType);
+    }
+  }
+  if (query.latitude !== null && query.longitude !== null) {
+    params.set('lat', String(query.latitude));
+    params.set('lng', String(query.longitude));
+    if (query.radiusKm !== null) {
+      params.set('radius', String(query.radiusKm));
+    }
+  }
+  if (page > 1) {
+    params.set('page', String(page));
+  }
+
+  const search = params.toString();
+  return search ? `${FACET_BASE_PATHS[facet]}?${search}` : FACET_BASE_PATHS[facet];
+}
+
+/** Whether the request applied a search, a board filter or a location. */
+export function hasActiveFilters(facet: DirectoryFacet, query: DirectoryQuery): boolean {
+  return query.query.length > 0 || query.boardTypes.length > 0 || query.latitude !== null || facet !== 'all';
+}
+
+const EARTH_RADIUS_KM = 6371;
+
+/**
+ * Great-circle distance in km.
+ *
+ * Computed here rather than read off the API because `searchGyms` returns no
+ * distance field, and the directory only ever needs it relative to an origin
+ * the REQUEST supplied. Without `?lat`/`?lng` there is no origin, so there is
+ * no distance — and a gym with a pin but no address then shows no location line
+ * at all, which is correct. There is no city column to fall back on and a
+ * synthesised locality would be a lie.
+ */
+export function distanceKm(
+  from: { latitude: number; longitude: number },
+  to: { latitude: number; longitude: number },
+): number {
+  const toRadians = (degrees: number) => (degrees * Math.PI) / 180;
+  const deltaLat = toRadians(to.latitude - from.latitude);
+  const deltaLng = toRadians(to.longitude - from.longitude);
+  const a =
+    Math.sin(deltaLat / 2) ** 2 +
+    Math.cos(toRadians(from.latitude)) * Math.cos(toRadians(to.latitude)) * Math.sin(deltaLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_KM * Math.asin(Math.min(1, Math.sqrt(a)));
+}
+
+/**
+ * The page numbers to render as anchors, plus the neighbours a crawler needs.
+ * A window rather than every page: 200 numbered links is a crawl budget bonfire.
+ */
+export function paginationWindow(currentPage: number, totalPages: number, windowSize = 5): number[] {
+  if (totalPages <= 1) return [];
+  const half = Math.floor(windowSize / 2);
+  let start = Math.max(1, currentPage - half);
+  const end = Math.min(totalPages, start + windowSize - 1);
+  start = Math.max(1, end - windowSize + 1);
+  const pages: number[] = [];
+  for (let page = start; page <= end; page += 1) {
+    pages.push(page);
+  }
+  return pages;
+}

--- a/packages/web/app/gyms/directory-page.tsx
+++ b/packages/web/app/gyms/directory-page.tsx
@@ -19,8 +19,11 @@ import { themeTokens } from '@/app/theme/theme-config';
 import {
   BOARD_FACETS,
   DIRECTORY_FACETS,
+  DIRECTORY_MAX_PAGE,
+  DIRECTORY_PAGE_SIZE,
   FACET_BASE_PATHS,
-  hasActiveFilters,
+  buildFacetSwitchHref,
+  isSearchApplication,
   parseDirectoryQuery,
   type DirectoryFacet,
   type DirectorySearchParams,
@@ -80,14 +83,57 @@ export async function renderGymDirectory(facet: DirectoryFacet, props: Directory
   // plain 404. Shipping only the `noindex` would leave a publicly reachable
   // directory of gyms the dedup pass hasn't finished merging yet.
   const distinctId = await getPosthogDistinctId();
-  if (!(await getServerFeatureFlag(GYMS_DIRECTORY_FLAG, distinctId))) {
+  // `allowAnonymous` is what makes this launchable. Without it a null distinct
+  // id short-circuits to false, so the directory would be signed-in-only
+  // forever and #4382's "flip the flag" would change nothing for the public or
+  // for a crawler. The flag's condition has to move from person-targeting to a
+  // percentage rollout at flip time; a rollout needs *a* distinct id, not a
+  // *known* one.
+  if (!(await getServerFeatureFlag(GYMS_DIRECTORY_FLAG, { distinctId, allowAnonymous: true }))) {
     notFound();
   }
 
   const searchParams = await props.searchParams;
   const query = parseDirectoryQuery(facet, searchParams);
+
+  // Past the crawl-trap ceiling, before spending a query on it. A 404 rather
+  // than a clamp: clamping serves a 200 whose URL and highlighted page disagree.
+  if (query.page > DIRECTORY_MAX_PAGE) {
+    notFound();
+  }
+
   const { t, locale } = await getServerTranslation('gyms');
-  const [page, facetCounts] = await Promise.all([fetchDirectoryPage(query), fetchFacetCounts()]);
+  const [pageResult, facetCountsResult] = await Promise.all([fetchDirectoryPage(query), fetchFacetCounts()]);
+
+  // Either fetch failing means we cannot state the counts the body copy is
+  // built around. Render the outage instead of a confident "0 gyms".
+  if (!pageResult.ok || !facetCountsResult.ok) {
+    return (
+      <I18nProvider locale={locale} namespaces={['common', 'gyms']}>
+        <Container maxWidth="lg" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+          <Typography variant="h3" component="h1" sx={{ fontWeight: themeTokens.typography.fontWeight.bold, mb: 2 }}>
+            {facetHeading(t, facet)}
+          </Typography>
+          <Typography variant="subtitle1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+            {t('error.title')}
+          </Typography>
+          <Typography variant="body1" color="text.secondary" sx={{ mt: 0.5, maxWidth: '68ch' }}>
+            {t('error.body')}
+          </Typography>
+        </Container>
+      </I18nProvider>
+    );
+  }
+
+  const facetCounts = facetCountsResult.counts;
+  const totalPages = Math.ceil(pageResult.totalCount / DIRECTORY_PAGE_SIZE);
+
+  // A page past the real end is a 404, not an empty 200. Page one of an empty
+  // result set is a legitimate 200 with the empty state — "no gyms match that
+  // search" is an answer; "page 40 of 2" is not a page.
+  if (query.page > 1 && query.page > totalPages) {
+    notFound();
+  }
 
   const numberFormat = new Intl.NumberFormat(locale);
   const formatNumber = (value: number) => numberFormat.format(value);
@@ -104,12 +150,12 @@ export async function renderGymDirectory(facet: DirectoryFacet, props: Directory
 
   return (
     <I18nProvider locale={locale} namespaces={['common', 'gyms']}>
-      {hasActiveFilters(facet, query) && (
+      {isSearchApplication(facet, query) && (
         <GymDirectorySearchTracker
           queryLength={query.query.length}
           boardTypesKey={query.boardTypes.join(',')}
           hasGeo={origin !== null}
-          resultsCount={page.totalCount}
+          resultsCount={pageResult.totalCount}
         />
       )}
 
@@ -141,7 +187,7 @@ export async function renderGymDirectory(facet: DirectoryFacet, props: Directory
                 key={candidate}
                 clickable
                 component={LocaleLink}
-                href={FACET_BASE_PATHS[candidate]}
+                href={buildFacetSwitchHref(candidate, query)}
                 label={facetChipLabel(t, candidate, facetCounts, formatNumber)}
                 color={candidate === facet ? 'primary' : 'default'}
                 variant={candidate === facet ? 'filled' : 'outlined'}
@@ -161,10 +207,10 @@ export async function renderGymDirectory(facet: DirectoryFacet, props: Directory
           component="h2"
           sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1.5 }}
         >
-          {t('results.heading', { count: page.totalCount, formattedCount: formatNumber(page.totalCount) })}
+          {t('results.heading', { count: pageResult.totalCount, formattedCount: formatNumber(pageResult.totalCount) })}
         </Typography>
 
-        {page.gyms.length === 0 ? (
+        {pageResult.gyms.length === 0 ? (
           <Box sx={{ py: 4 }}>
             <Typography variant="subtitle1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
               {t('results.emptyTitle')}
@@ -184,7 +230,7 @@ export async function renderGymDirectory(facet: DirectoryFacet, props: Directory
               p: 0,
             }}
           >
-            {page.gyms.map((gym) => (
+            {pageResult.gyms.map((gym) => (
               <GymDirectoryCard
                 key={gym.uuid}
                 gym={gym}
@@ -196,7 +242,7 @@ export async function renderGymDirectory(facet: DirectoryFacet, props: Directory
           </Box>
         )}
 
-        <GymDirectoryPagination facet={facet} query={query} totalCount={page.totalCount} />
+        <GymDirectoryPagination facet={facet} query={query} totalCount={pageResult.totalCount} />
 
         <Box component="section" sx={{ mt: 5 }}>
           <Typography

--- a/packages/web/app/gyms/directory-page.tsx
+++ b/packages/web/app/gyms/directory-page.tsx
@@ -1,0 +1,231 @@
+import 'server-only';
+import React from 'react';
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import MuiLink from '@mui/material/Link';
+import type { GymClaimViewerState } from '@boardsesh/analytics';
+import { GYMS_DIRECTORY_FLAG } from '@/app/flags';
+import { getServerFeatureFlag } from '@/app/lib/feature-flags/server-feature-flag';
+import { getPosthogDistinctId } from '@/app/lib/feature-flags/server-distinct-id';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
+import I18nProvider from '@/app/components/providers/i18n-provider';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { themeTokens } from '@/app/theme/theme-config';
+import {
+  BOARD_FACETS,
+  DIRECTORY_FACETS,
+  FACET_BASE_PATHS,
+  hasActiveFilters,
+  parseDirectoryQuery,
+  type DirectoryFacet,
+  type DirectorySearchParams,
+} from './directory-facets';
+import {
+  facetChipLabel,
+  facetDetail,
+  facetHeading,
+  facetLead,
+  facetLinkLabel,
+  facetMetaDescription,
+  facetMetaTitle,
+} from './directory-copy';
+import { fetchDirectoryPage, fetchFacetCounts } from './directory-data';
+import GymDirectoryCard from './gym-directory-card';
+import GymDirectoryMapMount from './gym-directory-map-mount';
+import GymDirectoryPagination from './gym-directory-pagination';
+import GymDirectorySearchForm from './gym-directory-search-form';
+import GymDirectorySearchTracker from './gym-directory-search-tracker';
+
+export type DirectoryRouteProps = {
+  searchParams: Promise<DirectorySearchParams>;
+};
+
+/**
+ * Metadata for one directory route.
+ *
+ * `path` is ALWAYS the route's own clean base and never carries a query string.
+ * That one line is the entire canonical policy: `/gyms/kilter?page=3`,
+ * `/gyms/kilter?q=bristol`, `/gyms/kilter?lat=…&lng=…&radius=25` and every
+ * combination of them all self-canonicalise to `/gyms/kilter` — its OWN base,
+ * not `/gyms`, because a facet page is a distinct page with distinct copy and
+ * folding it into `/gyms` would throw away the "kilter board near me" surface
+ * this issue exists to build. `/gyms?boardType=grasshopper` canonicalises to
+ * `/gyms` for the mirror-image reason: the long tail gets no page of its own.
+ *
+ * Every route is `noindex, follow` while the directory is flag-gated. Launch
+ * (#4382) removes the noindex; nothing else here has to change.
+ */
+export async function generateGymDirectoryMetadata(facet: DirectoryFacet): Promise<Metadata> {
+  const { t, locale } = await getServerTranslation('gyms');
+
+  return createNoIndexMetadata({
+    title: facetMetaTitle(t, facet),
+    description: facetMetaDescription(t, facet),
+    path: FACET_BASE_PATHS[facet],
+    locale,
+  });
+}
+
+/**
+ * The one renderer behind `/gyms`, `/gyms/kilter`, `/gyms/moonboard` and
+ * `/gyms/tension`. Each route file is a four-line delegate to this.
+ */
+export async function renderGymDirectory(facet: DirectoryFacet, props: DirectoryRouteProps) {
+  // Reachability gate, not a display gate: with the flag off the route is a
+  // plain 404. Shipping only the `noindex` would leave a publicly reachable
+  // directory of gyms the dedup pass hasn't finished merging yet.
+  const distinctId = await getPosthogDistinctId();
+  if (!(await getServerFeatureFlag(GYMS_DIRECTORY_FLAG, distinctId))) {
+    notFound();
+  }
+
+  const searchParams = await props.searchParams;
+  const query = parseDirectoryQuery(facet, searchParams);
+  const { t, locale } = await getServerTranslation('gyms');
+  const [page, facetCounts] = await Promise.all([fetchDirectoryPage(query), fetchFacetCounts()]);
+
+  const numberFormat = new Intl.NumberFormat(locale);
+  const formatNumber = (value: number) => numberFormat.format(value);
+  const origin =
+    query.latitude !== null && query.longitude !== null
+      ? { latitude: query.latitude, longitude: query.longitude }
+      : null;
+  // Settled server-side from the request's session, so a claim click that beats
+  // hydration still reports the truth. Derived inline rather than through
+  // `viewerStateFrom` so this server module doesn't pull the browser analytics
+  // client into its import graph — same call the gym page makes off its cookie.
+  const viewerState: GymClaimViewerState = distinctId !== null ? 'signed-in' : 'signed-out';
+  const crossLinks: DirectoryFacet[] = DIRECTORY_FACETS.filter((candidate) => candidate !== facet);
+
+  return (
+    <I18nProvider locale={locale} namespaces={['common', 'gyms']}>
+      {hasActiveFilters(facet, query) && (
+        <GymDirectorySearchTracker
+          queryLength={query.query.length}
+          boardTypesKey={query.boardTypes.join(',')}
+          hasGeo={origin !== null}
+          resultsCount={page.totalCount}
+        />
+      )}
+
+      <Container maxWidth="lg" sx={{ py: 4, pt: 'calc(var(--global-header-height) + 32px)' }}>
+        <Typography variant="h3" component="h1" sx={{ fontWeight: themeTokens.typography.fontWeight.bold, mb: 2 }}>
+          {facetHeading(t, facet)}
+        </Typography>
+
+        <Typography variant="body1" sx={{ mb: 1.5, maxWidth: '68ch' }}>
+          {facetLead(t, facet, facetCounts, formatNumber)}
+        </Typography>
+        <Typography variant="body1" sx={{ mb: 3, maxWidth: '68ch' }}>
+          {facetDetail(t, facet, facetCounts, formatNumber)}
+        </Typography>
+
+        <GymDirectorySearchForm facet={facet} query={query} locale={locale} />
+
+        <Box component="section" sx={{ mb: 3 }}>
+          <Typography
+            variant="subtitle2"
+            component="h2"
+            sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1 }}
+          >
+            {t('facets.heading')}
+          </Typography>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            {DIRECTORY_FACETS.map((candidate) => (
+              <Chip
+                key={candidate}
+                clickable
+                component={LocaleLink}
+                href={FACET_BASE_PATHS[candidate]}
+                label={facetChipLabel(t, candidate, facetCounts, formatNumber)}
+                color={candidate === facet ? 'primary' : 'default'}
+                variant={candidate === facet ? 'filled' : 'outlined'}
+                sx={{ borderRadius: `${themeTokens.borderRadius.full}px` }}
+              />
+            ))}
+          </Box>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+            {t('facets.countHint')}
+          </Typography>
+        </Box>
+
+        <GymDirectoryMapMount />
+
+        <Typography
+          variant="subtitle1"
+          component="h2"
+          sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1.5 }}
+        >
+          {t('results.heading', { count: page.totalCount, formattedCount: formatNumber(page.totalCount) })}
+        </Typography>
+
+        {page.gyms.length === 0 ? (
+          <Box sx={{ py: 4 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+              {t('results.emptyTitle')}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {t('results.emptyBody')}
+            </Typography>
+          </Box>
+        ) : (
+          <Box
+            component="ul"
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: '1fr', sm: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
+              gap: 2,
+              m: 0,
+              p: 0,
+            }}
+          >
+            {page.gyms.map((gym) => (
+              <GymDirectoryCard
+                key={gym.uuid}
+                gym={gym}
+                origin={origin}
+                viewerState={viewerState}
+                formatNumber={formatNumber}
+              />
+            ))}
+          </Box>
+        )}
+
+        <GymDirectoryPagination facet={facet} query={query} totalCount={page.totalCount} />
+
+        <Box component="section" sx={{ mt: 5 }}>
+          <Typography
+            variant="subtitle2"
+            component="h2"
+            sx={{ fontWeight: themeTokens.typography.fontWeight.semibold, mb: 1 }}
+          >
+            {t('links.heading')}
+          </Typography>
+          <Box component="ul" sx={{ m: 0, pl: 2.5 }}>
+            {crossLinks.map((candidate) => (
+              <Box component="li" key={candidate} sx={{ mb: 0.5 }}>
+                <MuiLink
+                  component={LocaleLink}
+                  href={FACET_BASE_PATHS[candidate]}
+                  underline="hover"
+                  sx={{ color: 'var(--color-primary)' }}
+                >
+                  {facetLinkLabel(t, candidate)}
+                </MuiLink>
+              </Box>
+            ))}
+          </Box>
+        </Box>
+      </Container>
+    </I18nProvider>
+  );
+}
+
+// Re-exported so the four route files import their whole contract from one
+// module. `BOARD_FACETS` is the list #4381's sitemap will enumerate.
+export { BOARD_FACETS, FACET_BASE_PATHS };

--- a/packages/web/app/gyms/gym-directory-card.tsx
+++ b/packages/web/app/gyms/gym-directory-card.tsx
@@ -65,7 +65,7 @@ export default async function GymDirectoryCard({ gym, origin, viewerState, forma
 
       {location && (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-          <LocationOnOutlined sx={{ fontSize: 16, color: 'var(--neutral-500)' }} />
+          <LocationOnOutlined sx={{ fontSize: themeTokens.typography.fontSize.base, color: 'var(--neutral-500)' }} />
           <Typography variant="body2" color="text.secondary">
             {location.kind === 'address'
               ? location.address

--- a/packages/web/app/gyms/gym-directory-card.tsx
+++ b/packages/web/app/gyms/gym-directory-card.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Typography from '@mui/material/Typography';
+import MuiLink from '@mui/material/Link';
+import LocationOnOutlined from '@mui/icons-material/LocationOnOutlined';
+import type { GymDirectoryCard as GymDirectoryCardData } from '@boardsesh/graphql/operations';
+import { boardTypeLabel } from '@boardsesh/board-constants';
+import type { GymClaimViewerState } from '@boardsesh/analytics';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { themeTokens } from '@/app/theme/theme-config';
+import { boardChips, cardLocation, roundDistanceKm } from './directory-card-model';
+import GymDirectoryClaimLink from './gym-directory-claim-link';
+
+type GymDirectoryCardProps = {
+  gym: GymDirectoryCardData;
+  /** Proximity origin from `?lat`/`?lng`, or null when the request had none. */
+  origin: { latitude: number; longitude: number } | null;
+  viewerState: GymClaimViewerState;
+  /** Formats a number for the active locale. */
+  formatNumber: (value: number) => string;
+};
+
+/**
+ * One gym in the directory list.
+ *
+ * The card renders only schema-real fields: name, board chips, and a location
+ * line WHEN THERE IS ONE. No photo, no description, no hours, no "verified"
+ * treatment — the long tail of gyms will never have those, and a card design
+ * that leans on them quietly demotes every gym nobody has filled in. Unclaimed
+ * gyms render identically to claimed ones, with one extra quiet prompt and no
+ * ranking or styling penalty.
+ */
+export default async function GymDirectoryCard({ gym, origin, viewerState, formatNumber }: GymDirectoryCardProps) {
+  const { t } = await getServerTranslation('gyms');
+  const chips = boardChips(gym.boardSummaries);
+  const location = cardLocation(gym, origin);
+
+  return (
+    <Box
+      component="li"
+      sx={{
+        listStyle: 'none',
+        border: '1px solid var(--neutral-200)',
+        borderRadius: `${themeTokens.borderRadius.lg}px`,
+        p: 2,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 1,
+      }}
+    >
+      <Typography variant="subtitle1" component="h3" sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}>
+        {/* A real anchor, server-rendered: this is how a crawler and a
+            middle-click both reach the gym page. */}
+        <MuiLink
+          component={LocaleLink}
+          href={`/gym/${gym.slug}`}
+          underline="hover"
+          sx={{ color: 'var(--color-primary)' }}
+        >
+          {gym.name}
+        </MuiLink>
+      </Typography>
+
+      {location && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <LocationOnOutlined sx={{ fontSize: 16, color: 'var(--neutral-500)' }} />
+          <Typography variant="body2" color="text.secondary">
+            {location.kind === 'address'
+              ? location.address
+              : t('card.distance', { distance: formatNumber(roundDistanceKm(location.km)) })}
+          </Typography>
+        </Box>
+      )}
+
+      {chips.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+          {chips.map((chip) => (
+            <Chip
+              key={chip.key}
+              size="small"
+              // Brand names are proper nouns and stay untranslated; only the
+              // "<board> <angle>°" arrangement goes through the catalog.
+              label={
+                chip.angle > 0
+                  ? t('card.boardChip', { board: boardTypeLabel(chip.boardType), angle: chip.angle })
+                  : boardTypeLabel(chip.boardType)
+              }
+              sx={{ borderRadius: `${themeTokens.borderRadius.full}px` }}
+            />
+          ))}
+        </Box>
+      )}
+
+      {!gym.isClaimed && (
+        <GymDirectoryClaimLink gymUuid={gym.uuid} gymSlug={gym.slug ?? ''} viewerState={viewerState} />
+      )}
+    </Box>
+  );
+}

--- a/packages/web/app/gyms/gym-directory-claim-link.tsx
+++ b/packages/web/app/gyms/gym-directory-claim-link.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import MuiLink from '@mui/material/Link';
+import { gymClaimCtaClicked, type GymClaimViewerState } from '@boardsesh/analytics';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
+import { themeTokens } from '@/app/theme/theme-config';
+
+type GymDirectoryClaimLinkProps = {
+  gymUuid: string;
+  gymSlug: string;
+  /**
+   * Settled on the SERVER from the request's auth cookie, never with
+   * `useSession()` — next-auth starts every page load at `loading`, and a click
+   * that beats the round-trip would report a signed-in climber as signed-out.
+   */
+  viewerState: GymClaimViewerState;
+};
+
+/**
+ * The quiet claim prompt on an unclaimed directory card.
+ *
+ * A LINK to the gym page, not a dialog: the directory's audience is anonymous
+ * (that is the point of an indexable page), the claim flow needs an account,
+ * and a modal that opens straight into an auth wall is a worse first move than
+ * landing on the gym itself. It also keeps the card crawlable — one more real
+ * `<a href>` to `/gym/[slug]`.
+ *
+ * Rendered off `gym.isClaimed`, never `canClaim`: `canClaim` is viewer-scoped
+ * and false for every signed-out visitor, so gating on it would hide the prompt
+ * from everyone the directory exists for.
+ */
+export default function GymDirectoryClaimLink({ gymUuid, gymSlug, viewerState }: GymDirectoryClaimLinkProps) {
+  const { t } = useTranslation('gyms');
+
+  return (
+    <MuiLink
+      component={LocaleLink}
+      href={`/gym/${gymSlug}`}
+      underline="hover"
+      onClick={() => {
+        trackGymFunnelEvent(gymClaimCtaClicked({ placement: 'directory-card', viewerState, gymUuid }));
+      }}
+      sx={{
+        // CSS var, not a direct themeTokens read: a token read at module scope
+        // is scheme-static and would stay light-mode grey in dark mode.
+        color: 'var(--neutral-500)',
+        fontSize: themeTokens.typography.fontSize.xs,
+      }}
+    >
+      {t('card.claimCta')}
+    </MuiLink>
+  );
+}

--- a/packages/web/app/gyms/gym-directory-map-mount.tsx
+++ b/packages/web/app/gyms/gym-directory-map-mount.tsx
@@ -1,0 +1,16 @@
+/**
+ * Mount point for the directory's "near me" map (#4380).
+ *
+ * Renders nothing today, on purpose. The map is a separate issue and a heavy
+ * dependency, and this PR ships **no leaflet import anywhere** — pulling one in
+ * "just to reserve the slot" would put a map bundle on a page that has no map.
+ * What this file reserves is the POSITION: #4380 replaces the body of this
+ * component and touches nothing else in the directory shell.
+ *
+ * It sits between the facet chips and the results list, which is where a map
+ * belongs once `?lat`/`?lng` are set — above the list it filters, below the
+ * controls that set it.
+ */
+export default function GymDirectoryMapMount(): null {
+  return null;
+}

--- a/packages/web/app/gyms/gym-directory-pagination.tsx
+++ b/packages/web/app/gyms/gym-directory-pagination.tsx
@@ -6,7 +6,6 @@ import LocaleLink from '@/app/components/i18n/locale-link';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { themeTokens } from '@/app/theme/theme-config';
 import {
-  DIRECTORY_MAX_PAGE,
   DIRECTORY_PAGE_SIZE,
   buildDirectoryHref,
   paginationWindow,
@@ -32,12 +31,15 @@ type GymDirectoryPaginationProps = {
 export default async function GymDirectoryPagination({ facet, query, totalCount }: GymDirectoryPaginationProps) {
   const { t } = await getServerTranslation('gyms');
 
-  const totalPages = Math.min(Math.ceil(totalCount / DIRECTORY_PAGE_SIZE), DIRECTORY_MAX_PAGE);
+  const totalPages = Math.ceil(totalCount / DIRECTORY_PAGE_SIZE);
   if (totalPages <= 1) {
     return null;
   }
 
-  const currentPage = Math.min(query.page, totalPages);
+  // Not clamped. The renderer 404s any `?page` past the end, so `query.page` is
+  // always a real page by the time this renders — and clamping here was what
+  // let the URL say 40 while `aria-current` said 2.
+  const currentPage = query.page;
   const pages = paginationWindow(currentPage, totalPages);
 
   return (

--- a/packages/web/app/gyms/gym-directory-pagination.tsx
+++ b/packages/web/app/gyms/gym-directory-pagination.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import MuiLink from '@mui/material/Link';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { themeTokens } from '@/app/theme/theme-config';
+import {
+  DIRECTORY_MAX_PAGE,
+  DIRECTORY_PAGE_SIZE,
+  buildDirectoryHref,
+  paginationWindow,
+  type DirectoryFacet,
+  type DirectoryQuery,
+} from './directory-facets';
+
+type GymDirectoryPaginationProps = {
+  facet: DirectoryFacet;
+  query: DirectoryQuery;
+  totalCount: number;
+};
+
+/**
+ * Real, crawlable `?page=N` anchors — Prev, a window of numbers, Next.
+ *
+ * One page per interaction by construction: each link is a navigation to the
+ * next offset, so there is no "load more" loop that can drain the catalog into
+ * one request. Every one of these URLs canonicalises back to the route's clean
+ * base (see `generateGymDirectoryMetadata`), so the numbered links are a
+ * crawl path, not 40 competing URLs.
+ */
+export default async function GymDirectoryPagination({ facet, query, totalCount }: GymDirectoryPaginationProps) {
+  const { t } = await getServerTranslation('gyms');
+
+  const totalPages = Math.min(Math.ceil(totalCount / DIRECTORY_PAGE_SIZE), DIRECTORY_MAX_PAGE);
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const currentPage = Math.min(query.page, totalPages);
+  const pages = paginationWindow(currentPage, totalPages);
+
+  return (
+    <Box
+      component="nav"
+      aria-label={t('pagination.label')}
+      sx={{ display: 'flex', gap: 1.5, flexWrap: 'wrap', alignItems: 'center', mt: 4 }}
+    >
+      {currentPage > 1 && (
+        <MuiLink
+          component={LocaleLink}
+          href={buildDirectoryHref(facet, query, currentPage - 1)}
+          rel="prev"
+          underline="hover"
+          sx={{ color: 'var(--color-primary)' }}
+        >
+          {t('pagination.previous')}
+        </MuiLink>
+      )}
+
+      {pages.map((page) =>
+        page === currentPage ? (
+          <Typography
+            key={page}
+            component="span"
+            aria-current="page"
+            variant="body2"
+            sx={{ fontWeight: themeTokens.typography.fontWeight.semibold }}
+          >
+            {t('pagination.current', { page })}
+          </Typography>
+        ) : (
+          <MuiLink
+            key={page}
+            component={LocaleLink}
+            href={buildDirectoryHref(facet, query, page)}
+            underline="hover"
+            variant="body2"
+            sx={{ color: 'var(--color-primary)' }}
+          >
+            {t('pagination.page', { page })}
+          </MuiLink>
+        ),
+      )}
+
+      {currentPage < totalPages && (
+        <MuiLink
+          component={LocaleLink}
+          href={buildDirectoryHref(facet, query, currentPage + 1)}
+          rel="next"
+          underline="hover"
+          sx={{ color: 'var(--color-primary)' }}
+        >
+          {t('pagination.next')}
+        </MuiLink>
+      )}
+    </Box>
+  );
+}

--- a/packages/web/app/gyms/gym-directory-search-form.tsx
+++ b/packages/web/app/gyms/gym-directory-search-form.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import type { Locale } from '@/app/lib/i18n/config';
+import { localeHref } from '@/app/lib/i18n/locale-href';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { FACET_BASE_PATHS, type DirectoryFacet, type DirectoryQuery } from './directory-facets';
+
+type GymDirectorySearchFormProps = {
+  facet: DirectoryFacet;
+  query: DirectoryQuery;
+  locale: Locale;
+};
+
+/**
+ * A plain `method="get"` form, no JavaScript involved.
+ *
+ * Submitting navigates to `?q=…` on the same route, which is what makes the
+ * search server-renderable, shareable as a URL, and usable before hydration.
+ * The client island that reports `Gym Directory Searched` reads the RESULT of
+ * that navigation, so the event carries a real `resultsCount` instead of a
+ * guess made at submit time.
+ *
+ * The action carries the locale prefix by hand: `LocaleLink` can't help a form,
+ * and a bare `/gyms` action would bounce a `/de/gyms` visitor to English.
+ */
+export default async function GymDirectorySearchForm({ facet, query, locale }: GymDirectorySearchFormProps) {
+  const { t } = await getServerTranslation('gyms');
+
+  return (
+    <Box
+      component="form"
+      method="get"
+      action={localeHref(FACET_BASE_PATHS[facet], locale)}
+      role="search"
+      sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'flex-start', mb: 3 }}
+    >
+      <TextField
+        name="q"
+        type="search"
+        size="small"
+        defaultValue={query.query}
+        label={t('search.label')}
+        placeholder={t('search.placeholder')}
+        sx={{ flex: '1 1 260px', minWidth: 0 }}
+      />
+      {/* A new search starts at page 1, so `page` is deliberately not carried
+          over. Location is: it's how the visitor got here. */}
+      {facet === 'all' &&
+        query.boardTypes.map((boardType) => <input key={boardType} type="hidden" name="boardType" value={boardType} />)}
+      {query.latitude !== null && query.longitude !== null && (
+        <>
+          <input type="hidden" name="lat" value={String(query.latitude)} />
+          <input type="hidden" name="lng" value={String(query.longitude)} />
+        </>
+      )}
+      {query.radiusKm !== null && <input type="hidden" name="radius" value={String(query.radiusKm)} />}
+      <Button type="submit" variant="contained" sx={{ textTransform: 'none' }}>
+        {t('search.submit')}
+      </Button>
+    </Box>
+  );
+}

--- a/packages/web/app/gyms/gym-directory-search-tracker.tsx
+++ b/packages/web/app/gyms/gym-directory-search-tracker.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect } from 'react';
+import { gymDirectorySearched } from '@boardsesh/analytics';
+import { trackGymFunnelEvent } from '@/app/lib/gym-funnel-analytics';
+
+type GymDirectorySearchTrackerProps = {
+  /** Length only. The search text itself never leaves the browser. */
+  queryLength: number;
+  /** Comma-joined board types, or `''` for none. A primitive so the effect's deps are stable. */
+  boardTypesKey: string;
+  hasGeo: boolean;
+  resultsCount: number;
+};
+
+/**
+ * Reports `Gym Directory Searched` once per rendered result set.
+ *
+ * Fires from the RESULT page rather than the form's submit handler, because
+ * `resultsCount` is part of the contract and the form has no idea what it is
+ * going to get back. The server only mounts this when a search, board filter or
+ * location was actually applied, so plain `/gyms` browsing doesn't count as a
+ * search.
+ *
+ * Every dependency is a primitive: an array prop would be a new identity on
+ * every render and re-fire the event on each one.
+ */
+export default function GymDirectorySearchTracker({
+  queryLength,
+  boardTypesKey,
+  hasGeo,
+  resultsCount,
+}: GymDirectorySearchTrackerProps) {
+  useEffect(() => {
+    trackGymFunnelEvent(
+      gymDirectorySearched({
+        queryLength,
+        boardTypes: boardTypesKey ? boardTypesKey.split(',') : [],
+        hasGeo,
+        resultsCount,
+      }),
+    );
+  }, [queryLength, boardTypesKey, hasGeo, resultsCount]);
+
+  return null;
+}

--- a/packages/web/app/gyms/kilter/page.tsx
+++ b/packages/web/app/gyms/kilter/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { generateGymDirectoryMetadata, renderGymDirectory, type DirectoryRouteProps } from '../directory-page';
+
+/** `/gyms/kilter` — the same shell, filtered to gyms with a Kilter board. */
+export async function generateMetadata(): Promise<Metadata> {
+  return generateGymDirectoryMetadata('kilter');
+}
+
+export default async function KilterGymsDirectoryPage(props: DirectoryRouteProps) {
+  return renderGymDirectory('kilter', props);
+}

--- a/packages/web/app/gyms/moonboard/page.tsx
+++ b/packages/web/app/gyms/moonboard/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { generateGymDirectoryMetadata, renderGymDirectory, type DirectoryRouteProps } from '../directory-page';
+
+/** `/gyms/moonboard` — the same shell, filtered to gyms with a MoonBoard. */
+export async function generateMetadata(): Promise<Metadata> {
+  return generateGymDirectoryMetadata('moonboard');
+}
+
+export default async function MoonboardGymsDirectoryPage(props: DirectoryRouteProps) {
+  return renderGymDirectory('moonboard', props);
+}

--- a/packages/web/app/gyms/page.tsx
+++ b/packages/web/app/gyms/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { generateGymDirectoryMetadata, renderGymDirectory, type DirectoryRouteProps } from './directory-page';
+
+/**
+ * `/gyms` — the flat directory.
+ *
+ * One of four LITERAL route folders (`/gyms`, `/gyms/kilter`,
+ * `/gyms/moonboard`, `/gyms/tension`) rather than a `[facet]` dynamic segment.
+ * That is a deliberate IA decision, not boilerplate: with literal folders
+ * "no standalone routes for the long-tail board types" is structurally true —
+ * `/gyms/soill` 404s because nothing routes it, with no runtime allow-list to
+ * drift — and #4381's sitemap gets four static paths instead of a regex it has
+ * to keep in sync.
+ */
+export async function generateMetadata(): Promise<Metadata> {
+  return generateGymDirectoryMetadata('all');
+}
+
+export default async function GymsDirectoryPage(props: DirectoryRouteProps) {
+  return renderGymDirectory('all', props);
+}

--- a/packages/web/app/gyms/tension/page.tsx
+++ b/packages/web/app/gyms/tension/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+import { generateGymDirectoryMetadata, renderGymDirectory, type DirectoryRouteProps } from '../directory-page';
+
+/** `/gyms/tension` — the same shell, filtered to gyms with a Tension board. */
+export async function generateMetadata(): Promise<Metadata> {
+  return generateGymDirectoryMetadata('tension');
+}
+
+export default async function TensionGymsDirectoryPage(props: DirectoryRouteProps) {
+  return renderGymDirectory('tension', props);
+}

--- a/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
+++ b/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+
+// `unstable_cache` is Next's data cache; outside a request it is a passthrough
+// wrapper, which is exactly what these tests want to assert through.
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+const captureMessage = vi.hoisted(() => vi.fn());
+vi.mock('@sentry/nextjs', () => ({ captureMessage }));
+
+const FLAG = 'gyms-directory';
+
+type FeatureFlagModule = typeof import('../server-feature-flag');
+
+// Fresh module per test: the once-per-process Sentry guard is module state, and
+// a shared instance would make "reports once" pass for the wrong reason.
+async function loadModule(): Promise<FeatureFlagModule> {
+  vi.resetModules();
+  return import('../server-feature-flag');
+}
+
+function mockFetchOnce(response: { ok: boolean; status?: number; body?: unknown }) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: response.ok,
+    status: response.status ?? (response.ok ? 200 : 500),
+    json: async () => response.body ?? {},
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  captureMessage.mockReset();
+  delete process.env.FEATURE_FLAG_OVERRIDES;
+  delete process.env.POSTHOG_PROJECT_KEY;
+  delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  delete process.env.POSTHOG_HOST;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('parseFeatureFlagOverrides', () => {
+  it('reads the bare-key form as ON', async () => {
+    const { parseFeatureFlagOverrides } = await loadModule();
+    expect(parseFeatureFlagOverrides('gyms-directory')).toEqual({ 'gyms-directory': true });
+  });
+
+  it('reads the key=value form in both directions', async () => {
+    const { parseFeatureFlagOverrides } = await loadModule();
+    expect(parseFeatureFlagOverrides('gyms-directory=true,gym-kiosk=false')).toEqual({
+      'gyms-directory': true,
+      'gym-kiosk': false,
+    });
+  });
+
+  it('ignores blank entries and unparseable values instead of throwing', async () => {
+    const { parseFeatureFlagOverrides } = await loadModule();
+    expect(parseFeatureFlagOverrides(' , gyms-directory = ON ,broken=maybe,=true')).toEqual({
+      'gyms-directory': true,
+    });
+  });
+
+  it('returns nothing for an unset variable', async () => {
+    const { parseFeatureFlagOverrides } = await loadModule();
+    expect(parseFeatureFlagOverrides(undefined)).toEqual({});
+  });
+});
+
+describe('getServerFeatureFlag — overrides', () => {
+  it('honours the bare-key override without calling PostHog', async () => {
+    process.env.FEATURE_FLAG_OVERRIDES = FLAG;
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: false } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+
+    // Local dev is the whole reason this branch exists: the browser PostHog
+    // client refuses to boot off localhost, so there is no other way in.
+    await expect(getServerFeatureFlag(FLAG, null)).resolves.toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('honours an explicit OFF override over a PostHog ON', async () => {
+    process.env.FEATURE_FLAG_OVERRIDES = `${FLAG}=false`;
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves other keys alone', async () => {
+    process.env.FEATURE_FLAG_OVERRIDES = 'some-other-flag';
+    const { getServerFeatureFlag } = await loadModule();
+
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+  });
+});
+
+describe('getServerFeatureFlag — configuration', () => {
+  it('is off when no PostHog key is configured', async () => {
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+    const { getServerFeatureFlag } = await loadModule();
+
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    // Not an error: preview and CI builds have no key by design.
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('getServerFeatureFlag — identified vs anonymous', () => {
+  it('sends the authenticated distinct id so person-property targeting can match', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    process.env.POSTHOG_HOST = 'https://us.i.posthog.com';
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await expect(getServerFeatureFlag(FLAG, 'user-uuid-1')).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://us.i.posthog.com/flags/?v=2');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ api_key: 'phc_test', distinct_id: 'user-uuid-1' });
+  });
+
+  it('resolves false for a signed-out visitor without calling PostHog at all', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+
+    // A flag targeted at a person property has no person to match against, so
+    // asking would return false anyway — and asking with a generated id is the
+    // trap: PostHog answers false for a perfectly configured flag and nothing
+    // errors anywhere.
+    await expect(getServerFeatureFlag(FLAG, null)).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('reads PostHog saying the person is NOT in the flag', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: false } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await expect(getServerFeatureFlag(FLAG, 'somebody-else')).resolves.toBe(false);
+  });
+
+  it('falls back to the legacy featureFlags shape', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { featureFlags: { [FLAG]: true } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(true);
+  });
+
+  it('treats a multivariate variant as being in the flag', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { featureFlags: { [FLAG]: 'variant-b' } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(true);
+  });
+
+  it('is off when the flag is missing from the response entirely', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: {} } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+  });
+
+  it('prefers the server-only key over the browser one', async () => {
+    process.env.POSTHOG_PROJECT_KEY = 'phc_server';
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_browser';
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(true);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).api_key).toBe('phc_server');
+  });
+});
+
+describe('getServerFeatureFlag — failure modes', () => {
+  it('fails closed on a non-200 and reports it once', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: false, status: 503 });
+
+    const { getServerFeatureFlag } = await loadModule();
+
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(String(captureMessage.mock.calls[0][0])).toContain('HTTP 503');
+  });
+
+  it('fails closed when the request is aborted past its deadline', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError));
+
+    const { getServerFeatureFlag } = await loadModule();
+
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(String(captureMessage.mock.calls[0][0])).toContain('AbortError');
+  });
+
+  it('fails closed when the response body is not JSON', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token <');
+        },
+      }),
+    );
+
+    const { getServerFeatureFlag } = await loadModule();
+    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
+++ b/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
@@ -3,9 +3,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vite-plus/test'
 vi.mock('server-only', () => ({}));
 
 // `unstable_cache` is Next's data cache; outside a request it is a passthrough
-// wrapper, which is exactly what these tests want to assert through.
+// wrapper, which is exactly what these tests want to assert through. The key
+// parts are RECORDED rather than ignored: an identity stub proves the return
+// value but would stay green through a refactor that dropped the distinct id
+// from the key and served one person's flag value to everyone.
+const cacheKeyParts = vi.hoisted(() => [] as string[][]);
 vi.mock('next/cache', () => ({
-  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+  unstable_cache: (fn: (...args: unknown[]) => unknown, keyParts: string[]) => {
+    cacheKeyParts.push(keyParts);
+    return fn;
+  },
 }));
 
 const captureMessage = vi.hoisted(() => vi.fn());
@@ -36,6 +43,7 @@ const ORIGINAL_ENV = { ...process.env };
 
 beforeEach(() => {
   captureMessage.mockReset();
+  cacheKeyParts.length = 0;
   delete process.env.FEATURE_FLAG_OVERRIDES;
   delete process.env.POSTHOG_PROJECT_KEY;
   delete process.env.NEXT_PUBLIC_POSTHOG_KEY;
@@ -84,7 +92,7 @@ describe('getServerFeatureFlag — overrides', () => {
 
     // Local dev is the whole reason this branch exists: the browser PostHog
     // client refuses to boot off localhost, so there is no other way in.
-    await expect(getServerFeatureFlag(FLAG, null)).resolves.toBe(true);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: null })).resolves.toBe(true);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -95,7 +103,7 @@ describe('getServerFeatureFlag — overrides', () => {
 
     const { getServerFeatureFlag } = await loadModule();
 
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -103,7 +111,7 @@ describe('getServerFeatureFlag — overrides', () => {
     process.env.FEATURE_FLAG_OVERRIDES = 'some-other-flag';
     const { getServerFeatureFlag } = await loadModule();
 
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(false);
   });
 });
 
@@ -112,7 +120,7 @@ describe('getServerFeatureFlag — configuration', () => {
     const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
     const { getServerFeatureFlag } = await loadModule();
 
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
     // Not an error: preview and CI builds have no key by design.
     expect(captureMessage).not.toHaveBeenCalled();
@@ -126,7 +134,7 @@ describe('getServerFeatureFlag — identified vs anonymous', () => {
     const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
 
     const { getServerFeatureFlag } = await loadModule();
-    await expect(getServerFeatureFlag(FLAG, 'user-uuid-1')).resolves.toBe(true);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-uuid-1' })).resolves.toBe(true);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -145,7 +153,7 @@ describe('getServerFeatureFlag — identified vs anonymous', () => {
     // asking would return false anyway — and asking with a generated id is the
     // trap: PostHog answers false for a perfectly configured flag and nothing
     // errors anywhere.
-    await expect(getServerFeatureFlag(FLAG, null)).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: null })).resolves.toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -154,7 +162,7 @@ describe('getServerFeatureFlag — identified vs anonymous', () => {
     mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: false } } } });
 
     const { getServerFeatureFlag } = await loadModule();
-    await expect(getServerFeatureFlag(FLAG, 'somebody-else')).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'somebody-else' })).resolves.toBe(false);
   });
 
   it('falls back to the legacy featureFlags shape', async () => {
@@ -162,7 +170,7 @@ describe('getServerFeatureFlag — identified vs anonymous', () => {
     mockFetchOnce({ ok: true, body: { featureFlags: { [FLAG]: true } } });
 
     const { getServerFeatureFlag } = await loadModule();
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(true);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(true);
   });
 
   it('treats a multivariate variant as being in the flag', async () => {
@@ -170,7 +178,7 @@ describe('getServerFeatureFlag — identified vs anonymous', () => {
     mockFetchOnce({ ok: true, body: { featureFlags: { [FLAG]: 'variant-b' } } });
 
     const { getServerFeatureFlag } = await loadModule();
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(true);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(true);
   });
 
   it('is off when the flag is missing from the response entirely', async () => {
@@ -178,7 +186,7 @@ describe('getServerFeatureFlag — identified vs anonymous', () => {
     mockFetchOnce({ ok: true, body: { flags: {} } });
 
     const { getServerFeatureFlag } = await loadModule();
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(false);
   });
 
   it('prefers the server-only key over the browser one', async () => {
@@ -187,7 +195,7 @@ describe('getServerFeatureFlag — identified vs anonymous', () => {
     const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
 
     const { getServerFeatureFlag } = await loadModule();
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(true);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(true);
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(JSON.parse(init.body as string).api_key).toBe('phc_server');
@@ -201,8 +209,8 @@ describe('getServerFeatureFlag — failure modes', () => {
 
     const { getServerFeatureFlag } = await loadModule();
 
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(false);
 
     expect(captureMessage).toHaveBeenCalledTimes(1);
     expect(String(captureMessage.mock.calls[0][0])).toContain('HTTP 503');
@@ -216,7 +224,7 @@ describe('getServerFeatureFlag — failure modes', () => {
 
     const { getServerFeatureFlag } = await loadModule();
 
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(false);
     expect(captureMessage).toHaveBeenCalledTimes(1);
     expect(String(captureMessage.mock.calls[0][0])).toContain('AbortError');
   });
@@ -235,7 +243,103 @@ describe('getServerFeatureFlag — failure modes', () => {
     );
 
     const { getServerFeatureFlag } = await loadModule();
-    await expect(getServerFeatureFlag(FLAG, 'user-1')).resolves.toBe(false);
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(false);
     expect(captureMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getServerFeatureFlag — anonymous visitors', () => {
+  it('short-circuits a signed-out visitor to false by DEFAULT', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+
+    await expect(getServerFeatureFlag(FLAG, { distinctId: null })).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('evaluates a signed-out visitor when the caller opts in', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag, ANONYMOUS_DISTINCT_ID } = await loadModule();
+
+    // Without this a percentage rollout can never reach the public: the surface
+    // stays signed-in-only however the PostHog dashboard is configured, and
+    // flipping the flag to 100% changes nothing for anonymous visitors.
+    await expect(getServerFeatureFlag(FLAG, { distinctId: null, allowAnonymous: true })).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).distinct_id).toBe(ANONYMOUS_DISTINCT_ID);
+  });
+
+  it('still prefers a real person over the anonymous id when one is signed in', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-uuid-1', allowAnonymous: true });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string).distinct_id).toBe('user-uuid-1');
+  });
+
+  it('still fails closed for an anonymous visitor when PostHog is unreachable', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: false, status: 500 });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await expect(getServerFeatureFlag(FLAG, { distinctId: null, allowAnonymous: true })).resolves.toBe(false);
+  });
+});
+
+describe('cache key', () => {
+  it('includes the distinct id, so one person never sees another person answer', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-uuid-1' });
+
+    expect(cacheKeyParts).toHaveLength(1);
+    expect(cacheKeyParts[0]).toContain('user-uuid-1');
+    expect(cacheKeyParts[0]).toContain(FLAG);
+  });
+
+  it('gives two people two different keys', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-a' });
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-b' });
+
+    expect(cacheKeyParts).toHaveLength(2);
+    expect(cacheKeyParts[0].join('|')).not.toBe(cacheKeyParts[1].join('|'));
+  });
+
+  it('gives two flags two different keys for the same person', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: {} } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-a' });
+    await getServerFeatureFlag('other-flag', { distinctId: 'user-a' });
+
+    expect(cacheKeyParts[0].join('|')).not.toBe(cacheKeyParts[1].join('|'));
+  });
+
+  it('keys anonymous evaluations on the shared anonymous id', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { getServerFeatureFlag, ANONYMOUS_DISTINCT_ID } = await loadModule();
+    await getServerFeatureFlag(FLAG, { distinctId: null, allowAnonymous: true });
+
+    // One entry for the whole signed-out population, by design — see the
+    // constant's note on why an indexable surface wants all-or-nothing.
+    expect(cacheKeyParts[0]).toContain(ANONYMOUS_DISTINCT_ID);
   });
 });

--- a/packages/web/app/lib/feature-flags/server-distinct-id.ts
+++ b/packages/web/app/lib/feature-flags/server-distinct-id.ts
@@ -1,0 +1,23 @@
+import 'server-only';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/lib/auth/auth-options';
+
+/**
+ * The distinct id PostHog knows the current visitor by, or `null` when nobody
+ * is signed in.
+ *
+ * `session.user.id` is `users.id`, and it is the value
+ * `reconcileAnalyticsIdentity` hands to `identify()` — so a server-side flag
+ * evaluation keyed on it lands on the same PostHog person the dashboard shows.
+ * Anything else (a generated uuid, the email, the anonymous party-profile id)
+ * evaluates person-property targeting to `false` while looking perfectly
+ * healthy, which is the whole reason this helper exists instead of each caller
+ * inventing an id.
+ *
+ * Reading the session makes the calling route dynamic. That is correct here:
+ * the answer is per-person by construction.
+ */
+export async function getPosthogDistinctId(): Promise<string | null> {
+  const session = await getServerSession(authOptions);
+  return session?.user?.id ?? null;
+}

--- a/packages/web/app/lib/feature-flags/server-feature-flag.ts
+++ b/packages/web/app/lib/feature-flags/server-feature-flag.ts
@@ -184,19 +184,54 @@ async function evaluateFlagFromPosthog(key: string, distinctId: string, apiKey: 
 }
 
 /**
- * Resolve one feature flag on the server.
+ * The distinct id used for signed-out visitors when a caller opts in with
+ * `allowAnonymous`.
  *
- * `distinctId` MUST be the same identifier PostHog knows the person by —
- * `session.user.id`, which is what `reconcileAnalyticsIdentity` passes to
- * `identify()`. This is the failure mode worth spelling out: a flag targeted at
- * a PERSON PROPERTY (an email, a cohort) only matches when the evaluation call
- * names a person PostHog has those properties for. Send an anonymous or
- * freshly-generated id and PostHog answers `false` for a perfectly configured
- * flag, with nothing erroring anywhere and the dashboard showing the flag
- * active. Signed-out visitors therefore have no person to match and correctly
- * resolve to `false` without a network call at all.
+ * ONE constant shared by every anonymous request, deliberately, and the
+ * trade-off is worth stating: a percentage rollout buckets on the distinct id,
+ * so every signed-out visitor lands in the same bucket and a partial rollout is
+ * all-or-nothing for the public. For an INDEXABLE surface that is the desired
+ * behaviour — a 50% rollout that 404s half of Googlebot's crawls would put
+ * soft-404s in the index, which is far worse than shipping to nobody or
+ * everybody. It also means one cache entry serves the whole anonymous
+ * population instead of one per visitor.
+ *
+ * A caller that genuinely needs per-visitor bucketing of anonymous traffic
+ * should pass its own stable id rather than loosening this.
  */
-export async function getServerFeatureFlag(key: string, distinctId: string | null): Promise<boolean> {
+export const ANONYMOUS_DISTINCT_ID = 'anonymous-web-visitor';
+
+export type ServerFeatureFlagOptions = {
+  /**
+   * The identifier PostHog knows the person by — `session.user.id`, the same
+   * value `identify()` is called with. This is the failure mode worth spelling
+   * out: a flag targeted at a PERSON PROPERTY (an email, a cohort) only matches
+   * when the evaluation names a person PostHog holds those properties for. Send
+   * a freshly-generated id and PostHog answers `false` for a perfectly
+   * configured flag, with nothing erroring anywhere and the dashboard showing
+   * the flag active.
+   */
+  distinctId: string | null;
+  /**
+   * Evaluate for signed-out visitors too, using {@link ANONYMOUS_DISTINCT_ID}.
+   *
+   * Default `false`, which short-circuits a null `distinctId` to `false`
+   * without a network call. That default is right for a flag gating a
+   * signed-in-only control targeted at a person property: no person, no match,
+   * and the round trip is wasted.
+   *
+   * It is WRONG for anything that must eventually be public. A flag's condition
+   * changes shape over its life — it starts as "this one person's email" and
+   * ends as "100% of everyone" — and a percentage rollout needs *a* distinct
+   * id, not a *known* one. Without this opt-in the surface stays signed-in-only
+   * however the dashboard is configured, and flipping the rollout to 100%
+   * changes nothing for anonymous visitors or crawlers.
+   */
+  allowAnonymous?: boolean;
+};
+
+/** Resolve one feature flag on the server. */
+export async function getServerFeatureFlag(key: string, options: ServerFeatureFlagOptions): Promise<boolean> {
   const override = parseFeatureFlagOverrides(process.env[FEATURE_FLAG_OVERRIDES_ENV])[key];
   if (override !== undefined) {
     return override;
@@ -207,11 +242,15 @@ export async function getServerFeatureFlag(key: string, distinctId: string | nul
     return false;
   }
 
+  const distinctId = options.distinctId ?? (options.allowAnonymous ? ANONYMOUS_DISTINCT_ID : null);
   if (!distinctId) {
     return false;
   }
 
   // Keyed on the flag AND the person: two climbers must never share an answer.
+  // If this key ever loses `distinctId`, one person's flag value is served to
+  // everyone — the highest-severity failure this module has, and the reason
+  // there is a test asserting the key parts rather than only the return value.
   const cached = unstable_cache(
     () => evaluateFlagFromPosthog(key, distinctId, apiKey),
     ['posthog-flag', key, distinctId],

--- a/packages/web/app/lib/feature-flags/server-feature-flag.ts
+++ b/packages/web/app/lib/feature-flags/server-feature-flag.ts
@@ -1,0 +1,225 @@
+import 'server-only';
+import { unstable_cache } from 'next/cache';
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * Server-side PostHog feature-flag evaluation.
+ *
+ * `FeatureFlagsProvider` resolves flags in the BROWSER (posthog-js-lite), which
+ * is fine for hiding a button and useless for gating reachability: by the time
+ * the browser knows the answer the server has already rendered and sent the
+ * page. A surface that must 404 when its flag is off has to ask PostHog before
+ * it renders, which is what this module does. It is deliberately generic — the
+ * gym directory is the first caller, every later flag-gated SSR surface reuses
+ * it.
+ *
+ * Resolution order, and the reasoning behind each step:
+ *
+ *  1. `FEATURE_FLAG_OVERRIDES` — the only way to exercise a flag-gated surface
+ *     locally. The browser PostHog client refuses to initialise off a
+ *     production hostname (`isProductionHost`, app/lib/analytics.ts), so on
+ *     localhost there is no person, no distinct id, and nothing to evaluate
+ *     against.
+ *  2. No PostHog key configured -> `false`. Preview and CI builds have no key;
+ *     they get the OFF branch rather than an exception per request.
+ *  3. No distinct id -> `false`. See `getServerFeatureFlag`'s note.
+ *  4. A direct POST to PostHog's flags endpoint under an `AbortController`
+ *     deadline. NOT the backend's `/api/posthog` reverse proxy: that exists to
+ *     dodge ad blockers in the browser, and routing through it would make
+ *     server rendering depend on our own backend being up.
+ *  5. Anything that throws, times out, or comes back unparseable -> `false`.
+ *     Fails CLOSED: a flag exists because the surface is not ready for
+ *     everyone, so an unreachable PostHog must not open the gate.
+ */
+
+/** PostHog's own default US host. Mirrors the backend's `POSTHOG_HOST` default. */
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';
+
+/**
+ * Wall-clock ceiling on the flag call. A flag evaluation sits in front of a
+ * page render, so it has to be short enough that a wedged PostHog costs a
+ * degraded page rather than a hung request.
+ */
+const FLAG_REQUEST_TIMEOUT_MS = 1_500;
+
+/**
+ * Short on purpose. Long enough that a burst of requests from one person costs
+ * one PostHog call, short enough that flipping the flag in the dashboard shows
+ * up within a minute instead of at the next deploy.
+ */
+const FLAG_CACHE_REVALIDATE_SECONDS = 60;
+
+export const SERVER_FEATURE_FLAG_CACHE_TAG = 'server-feature-flag';
+
+/** Env var holding the local override list. See `parseFeatureFlagOverrides`. */
+export const FEATURE_FLAG_OVERRIDES_ENV = 'FEATURE_FLAG_OVERRIDES';
+
+const TRUTHY_OVERRIDE_VALUES = new Set(['1', 'true', 'on', 'yes']);
+const FALSY_OVERRIDE_VALUES = new Set(['0', 'false', 'off', 'no']);
+
+/**
+ * Parse `FEATURE_FLAG_OVERRIDES` into a key -> boolean map.
+ *
+ * Two forms, comma separated:
+ *   `gyms-directory`        — bare key, forces ON
+ *   `gyms-directory=false`  — explicit value, forces ON or OFF
+ *
+ * An explicit OFF matters as much as an ON: it is how you check the 404 branch
+ * without editing the PostHog dashboard. Entries that parse to neither are
+ * ignored rather than throwing — a typo in a dev env var should not take the
+ * whole page down.
+ */
+export function parseFeatureFlagOverrides(raw: string | undefined): Record<string, boolean> {
+  const overrides: Record<string, boolean> = {};
+  if (!raw) {
+    return overrides;
+  }
+
+  for (const entry of raw.split(',')) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+
+    const separator = trimmed.indexOf('=');
+    if (separator === -1) {
+      overrides[trimmed] = true;
+      continue;
+    }
+
+    const key = trimmed.slice(0, separator).trim();
+    const value = trimmed
+      .slice(separator + 1)
+      .trim()
+      .toLowerCase();
+    if (!key) continue;
+    if (TRUTHY_OVERRIDE_VALUES.has(value)) {
+      overrides[key] = true;
+    } else if (FALSY_OVERRIDE_VALUES.has(value)) {
+      overrides[key] = false;
+    }
+  }
+
+  return overrides;
+}
+
+function resolvePosthogApiKey(): string | null {
+  // `POSTHOG_PROJECT_KEY` first, `NEXT_PUBLIC_POSTHOG_KEY` as the fallback —
+  // the same pair, in the same order, that the backend's posthog service uses.
+  const key = process.env.POSTHOG_PROJECT_KEY?.trim() || process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
+  return key ? key : null;
+}
+
+function resolvePosthogHost(): string {
+  // `POSTHOG_HOST`, not `NEXT_PUBLIC_POSTHOG_HOST`: the public one is the
+  // browser's knob and is allowed to point at the ad-blocker-dodging proxy.
+  const host = process.env.POSTHOG_HOST?.trim();
+  return (host || DEFAULT_POSTHOG_HOST).replace(/\/+$/, '');
+}
+
+// Once per process, per flag key. A flag call that starts failing fails on
+// every request; one Sentry message says the same thing as ten thousand.
+const reportedFailures = new Set<string>();
+
+function reportFlagFailure(key: string, detail: string): void {
+  if (reportedFailures.has(key)) {
+    return;
+  }
+  reportedFailures.add(key);
+  Sentry.captureMessage(
+    `Server feature flag "${key}" could not be evaluated (${detail}); treating it as off`,
+    'warning',
+  );
+}
+
+/**
+ * Shape of the response from PostHog's `/flags/?v=2` endpoint. `flags` is the
+ * v2 shape; `featureFlags` is the older `/decide` shape PostHog still returns
+ * alongside it, kept as a fallback so a version skew degrades to a working
+ * answer instead of a silent `false`.
+ */
+type PosthogFlagsResponse = {
+  flags?: Record<string, { enabled?: boolean } | undefined>;
+  featureFlags?: Record<string, boolean | string | undefined>;
+};
+
+function readFlagValue(payload: PosthogFlagsResponse, key: string): boolean {
+  const v2 = payload.flags?.[key];
+  if (v2 && typeof v2.enabled === 'boolean') {
+    return v2.enabled;
+  }
+  const legacy = payload.featureFlags?.[key];
+  if (typeof legacy === 'boolean') {
+    return legacy;
+  }
+  // A string is a multivariate variant; the caller asked a boolean question,
+  // and any variant means the person is in the flag.
+  return typeof legacy === 'string' && legacy.length > 0;
+}
+
+async function evaluateFlagFromPosthog(key: string, distinctId: string, apiKey: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FLAG_REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${resolvePosthogHost()}/flags/?v=2`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: apiKey, distinct_id: distinctId }),
+      signal: controller.signal,
+      cache: 'no-store',
+    });
+
+    if (!response.ok) {
+      reportFlagFailure(key, `HTTP ${response.status}`);
+      return false;
+    }
+
+    const payload = (await response.json()) as PosthogFlagsResponse;
+    return readFlagValue(payload, key);
+  } catch (error) {
+    reportFlagFailure(key, error instanceof Error ? error.name : 'unknown error');
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Resolve one feature flag on the server.
+ *
+ * `distinctId` MUST be the same identifier PostHog knows the person by —
+ * `session.user.id`, which is what `reconcileAnalyticsIdentity` passes to
+ * `identify()`. This is the failure mode worth spelling out: a flag targeted at
+ * a PERSON PROPERTY (an email, a cohort) only matches when the evaluation call
+ * names a person PostHog has those properties for. Send an anonymous or
+ * freshly-generated id and PostHog answers `false` for a perfectly configured
+ * flag, with nothing erroring anywhere and the dashboard showing the flag
+ * active. Signed-out visitors therefore have no person to match and correctly
+ * resolve to `false` without a network call at all.
+ */
+export async function getServerFeatureFlag(key: string, distinctId: string | null): Promise<boolean> {
+  const override = parseFeatureFlagOverrides(process.env[FEATURE_FLAG_OVERRIDES_ENV])[key];
+  if (override !== undefined) {
+    return override;
+  }
+
+  const apiKey = resolvePosthogApiKey();
+  if (!apiKey) {
+    return false;
+  }
+
+  if (!distinctId) {
+    return false;
+  }
+
+  // Keyed on the flag AND the person: two climbers must never share an answer.
+  const cached = unstable_cache(
+    () => evaluateFlagFromPosthog(key, distinctId, apiKey),
+    ['posthog-flag', key, distinctId],
+    {
+      revalidate: FLAG_CACHE_REVALIDATE_SECONDS,
+      tags: [SERVER_FEATURE_FLAG_CACHE_TAG],
+    },
+  );
+
+  return cached();
+}


### PR DESCRIPTION
Closes #3666 (the backend half landed in #4505) · Part of epic #4372, Tier 1.

4,740 gym listings currently draw 78 pageviews from 23 users in 90 days, and after #4358's teardown www has no gym-discovery UI at all. This builds one: `/gyms`, plus three board-type facet pages.

It ships **dark** — flag-gated and `noindex`. Flipping it public is Tier 2 (#4382), gated on the dedup queue.

## Routes

Four **literal** folders (`/gyms`, `/gyms/kilter`, `/gyms/moonboard`, `/gyms/tension`), each a ~10-line delegate to one shared renderer. Not a dynamic `[facet]` segment: literal folders make "no standalone routes for the long-tail board types" structurally true — `/gyms/soill` is a plain 404 with no runtime check to forget — and give Tier 2's sitemap four static paths. The four minor board types stay reachable as a query param.

Cards and the search form are async **server** components; only the claim link and the search tracker are client islands. Search is a plain `method="get"` form, so it works before hydration and with JS off.

## The feature flag, and the failure mode it avoids

Flag off ⇒ `notFound()`, not merely `noindex`. Gating only robots would ship a publicly reachable directory before the dedup gate allows it.

`getServerFeatureFlag` is the first server-side flag read on web (flags were client-resolved, and the root layout passes empty ones), so it's built as the pattern later SSR surfaces copy: env override → missing key → **null distinct id short-circuits to false with no network call** → POST to the PostHog host under a 1.5s abort → fail closed with one Sentry message per key per process, wrapped in `unstable_cache`. It deliberately does not route through the backend's `/api/posthog` proxy, which exists for ad-blocker evasion and would make SSR depend on the backend being up.

The identity part is load-bearing and easy to get wrong: the flag targets a **person property** with server-side evaluation, so a call sending an anonymous or generated distinct id evaluates `false` while the PostHog dashboard shows everything configured correctly. There's a test for the identified-vs-anonymous distinction specifically.

**Related finding, filed as #4511:** web has no live `posthog.identify()` call site — the reconciler was deleted in the W-16 teardown, so an authenticated web user may have no PostHog person at all. The distinct id used here is correct; the person may simply not exist for web-only users. Not blocking (the flag currently targets one person whose profile does exist, verified) but it means a low flag-hit rate would be an identity gap, not a bug in this code.

## Card contract — only schema-real fields

Name, board chips (type + angle), and a location line **only** when an address or a pin exists. There is no city column on `gyms`, so nothing synthesises a locality — 63% have pins, 24% have any address text, and inventing "City, Country" from a heuristic is how you manufacture thin pages.

Unclaimed gyms render **identically**: no dimming, no badge, no reordering, no hiding. The long tail will never have photos, descriptions or hours and must not be penalised for it.

The claim prompt uses `isClaimed`, never `canClaim` — `canClaim` is false for every anonymous viewer, i.e. this page's entire audience.

## Canonical

`generateMetadata` takes **zero arguments** on all four routes, so no query param can physically reach `path`. Every variant collapses to its own route's clean base — `/gyms/kilter?page=3` canonicalises to `/gyms/kilter`, never to `/gyms` — with hreflang across all four locales.

Facet counts count **gyms**, not boards.

## Kept as one PR

The shell, cards and pagination all read the same parsed query and the same `searchGyms` call; splitting would land a shell with no results, then rewrite the data layer underneath it. The genuinely separable piece — `getServerFeatureFlag` — is already its own module with its own tests and no gym imports.

## Release Notes

- [x] No release note needed (internal / technical change)

Flag-gated and noindex; Tier 2 launches it publicly.
