### PR TITLE
feat(web): make the gym claim path a reviewable funnel

### DIFF
--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
 import { v4 as uuidv4 } from 'uuid';
 import { sql, eq, is, SQL } from 'drizzle-orm';
+import type { GraphQLError } from 'graphql';
 import { GYM_HOURS_MAX_LENGTH, type ConnectionContext } from '@boardsesh/shared-schema';
 import * as dbSchema from '@boardsesh/db/schema';
 import { db } from '../db/client';
@@ -13,6 +14,7 @@ import {
   verifyGymClaimByToken,
   hashClaimToken,
   MAX_PENDING_CLAIMS_PER_USER,
+  GYM_CLAIM_LIMIT_CODE,
 } from '../graphql/resolvers/social/gym-claims';
 import {
   socialCommunitySettingsMutations,
@@ -2039,7 +2041,7 @@ describe('requestGymClaim — auto-approval', () => {
 // ============================================================================
 
 describe('approving a claim lands the same way whichever path approves it', () => {
-  it('auto-approval and admin approval agree on owner + sync freeze, differing only in reviewed_by', async () => {
+  it('auto-approval, admin approval and applyGymClaim itself agree, differing only in reviewed_by', async () => {
     // Same starting shape for both: an unclaimed catalog listing, one claimant.
     // Auto-approval is the only path that ever runs unattended, so if the two
     // ever drift, an admin-approved gym silently stops being sync-frozen and
@@ -2072,12 +2074,25 @@ describe('approving a claim lands the same way whichever path approves it', () =
       ),
     ).resolves.toBe(true);
 
+    // Third arm: applyGymClaim itself — the one function both paths are
+    // supposed to delegate to, and the only reason the two above can be
+    // expected to agree at all. If either mutation ever grows its own transfer
+    // logic, its end state drifts from this one and this test fails, which is
+    // the drift it exists to catch.
+    const directGym = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Parity Direct' });
+    const directClaimId = await insertClaim({ gymId: directGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+    const [directClaim] = await db.select().from(dbSchema.gymClaims).where(eq(dbSchema.gymClaims.id, directClaimId));
+    expect(await applyGymClaim(directClaim, { requireCurrentOwnerId: SYSTEM_OWNER })).not.toBeNull();
+
     // Identical end state...
     expect(await gymOwnerId(autoGym.uuid)).toBe(CLAIMANT);
     expect(await gymOwnerId(reviewedGym.uuid)).toBe(CLAIMANT);
+    expect(await gymOwnerId(directGym.uuid)).toBe(CLAIMANT);
     expect(await gymSyncFrozenAt(autoGym.uuid)).not.toBeNull();
     expect(await gymSyncFrozenAt(reviewedGym.uuid)).not.toBeNull();
+    expect(await gymSyncFrozenAt(directGym.uuid)).not.toBeNull();
     expect(await claimStatus(queued.id)).toBe('approved');
+    expect(await claimStatus(directClaimId)).toBe('approved');
 
     // ...except for who is on record as having decided it.
     expect(await claimRows(autoGym.id)).toEqual([expect.objectContaining({ status: 'approved', reviewed_by: null })]);
@@ -2160,13 +2175,16 @@ describe('pending claims are capped per user, and the admin inbox is not flooded
     }
 
     const oneTooMany = await insertGym({ ownerId: PRIOR_OWNER, name: 'One Too Many' });
-    await expect(
-      socialGymClaimMutations.requestGymClaim(
-        null,
-        { input: { gymUuid: oneTooMany.uuid, message: 'this one as well' } },
-        authCtx(hoarder),
-      ),
-    ).rejects.toThrow(/waiting on review/);
+    const rejection = await socialGymClaimMutations
+      .requestGymClaim(null, { input: { gymUuid: oneTooMany.uuid, message: 'this one as well' } }, authCtx(hoarder))
+      .catch((error: unknown) => error);
+    expect(String((rejection as Error).message)).toMatch(/waiting on review/);
+    // Carries a machine-readable code, like the rate limiter, so a client can
+    // branch on the cap instead of matching English.
+    expect((rejection as GraphQLError).extensions).toMatchObject({
+      code: GYM_CLAIM_LIMIT_CODE,
+      limit: MAX_PENDING_CLAIMS_PER_USER,
+    });
     expect(await claimRowCount(oneTooMany.id)).toBe(0);
 
     // Re-submitting on a gym they already have queued replaces that row rather
@@ -2180,7 +2198,7 @@ describe('pending claims are capped per user, and the admin inbox is not flooded
     ).resolves.toEqual({ status: 'admin_review' });
   });
 
-  it('mails the admin inbox once per claimant backlog, not once per claim', async () => {
+  it('carries the backlog in the mail rather than going quiet on the second claim', async () => {
     const serialClaimer = `gw-serial-${uuidv4()}`;
     await insertUser(serialClaimer);
     const first = await insertGym({ ownerId: PRIOR_OWNER, name: 'Backlog One' });
@@ -2192,11 +2210,70 @@ describe('pending claims are capped per user, and the admin inbox is not flooded
       ).resolves.toEqual({ status: 'admin_review' });
     }
 
-    // Both are queued and reviewable; only the first one mailed.
+    // EVERY queued claim mails. Skipping the later ones would mean one swallowed
+    // SMTP failure mutes an account's whole queue — the batching is in the
+    // content (the "N waiting" count), not in the delivery.
+    expect(sendGymClaimAdminNotification).toHaveBeenCalledTimes(2);
+    expect(sendGymClaimAdminNotification).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ gymName: 'Backlog One', pendingClaimCount: 1 }),
+    );
+    expect(sendGymClaimAdminNotification).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ gymName: 'Backlog Two', pendingClaimCount: 2 }),
+    );
+  });
+
+  it('keeps mailing after a send fails, instead of muting the account for good', async () => {
+    // The regression this guards: a post-insert "do they already have claims?"
+    // check paired with a deliberately swallowed send meant one SMTP blip
+    // silenced every claim that account would ever file.
+    const unluckyClaimer = `gw-smtp-blip-${uuidv4()}`;
+    await insertUser(unluckyClaimer);
+    const first = await insertGym({ ownerId: PRIOR_OWNER, name: 'Blip One' });
+    const second = await insertGym({ ownerId: PRIOR_OWNER, name: 'Blip Two' });
+
+    vi.mocked(sendGymClaimAdminNotification).mockRejectedValueOnce(new Error('SMTP down'));
+
+    await expect(
+      socialGymClaimMutations.requestGymClaim(null, { input: { gymUuid: first.uuid } }, authCtx(unluckyClaimer)),
+    ).resolves.toEqual({ status: 'admin_review' });
+    await expect(
+      socialGymClaimMutations.requestGymClaim(null, { input: { gymUuid: second.uuid } }, authCtx(unluckyClaimer)),
+    ).resolves.toEqual({ status: 'admin_review' });
+
+    expect(sendGymClaimAdminNotification).toHaveBeenCalledTimes(2);
     expect(await claimRowCount(first.id)).toBe(1);
     expect(await claimRowCount(second.id)).toBe(1);
-    expect(sendGymClaimAdminNotification).toHaveBeenCalledTimes(1);
-    expect(sendGymClaimAdminNotification).toHaveBeenCalledWith(expect.objectContaining({ gymName: 'Backlog One' }));
+  });
+
+  it('does not let an expired domain claim hold a slot forever', async () => {
+    // Nothing sweeps expired rows — the only flip to `expired` happens when
+    // someone clicks the dead link — so a cap that counted them would strand
+    // the claimant with no way to free the slot.
+    const stuckClaimer = `gw-stuck-${uuidv4()}`;
+    await insertUser(stuckClaimer);
+
+    const seeded = await Promise.all(
+      Array.from({ length: MAX_PENDING_CLAIMS_PER_USER }, (_, index) =>
+        insertGym({ ownerId: PRIOR_OWNER, name: `Stale ${index}` }),
+      ),
+    );
+    for (const gym of seeded) {
+      await insertClaim({
+        gymId: gym.id,
+        claimantUserId: stuckClaimer,
+        method: 'domain',
+        claimEmail: 'boss@stale.com',
+        tokenHash: hashClaimToken(`stale-${gym.id}`),
+        expiresAt: new Date(Date.now() - 60 * 1000),
+      });
+    }
+
+    const freshGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Fresh Claim' });
+    await expect(
+      socialGymClaimMutations.requestGymClaim(null, { input: { gymUuid: freshGym.uuid } }, authCtx(stuckClaimer)),
+    ).resolves.toEqual({ status: 'admin_review' });
   });
 });
 
@@ -2222,6 +2299,26 @@ describe('Gym.myPendingClaim (viewer-scoped)', () => {
     const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
 
     await socialGymClaimMutations.reviewGymClaim(null, { input: { claimId, decision: 'deny' } }, authCtx(GLOBAL_ADMIN));
+
+    await expect(
+      gymClaimFieldResolvers.myPendingClaim({ uuid: claimGym.uuid }, {}, authCtx(CLAIMANT)),
+    ).resolves.toBeNull();
+  });
+
+  it('stops reporting an expired domain claim, so the claimant is not trapped', async () => {
+    // The gym page swaps the claim CTA for "check your inbox" while this is
+    // non-null. Nothing sweeps expired rows, so if the resolver kept returning
+    // one, the page would point at a dead link forever with no way back to the
+    // dialog — strictly worse than showing no notice at all.
+    const claimGym = await insertGym({ ownerId: OWNER, name: 'Lapsed Link Gym', website: 'https://www.lapsed.com' });
+    await insertClaim({
+      gymId: claimGym.id,
+      claimantUserId: CLAIMANT,
+      method: 'domain',
+      claimEmail: 'boss@lapsed.com',
+      tokenHash: hashClaimToken('lapsed-token'),
+      expiresAt: new Date(Date.now() - 60 * 1000),
+    });
 
     await expect(
       gymClaimFieldResolvers.myPendingClaim({ uuid: claimGym.uuid }, {}, authCtx(CLAIMANT)),

--- a/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
+++ b/packages/backend/src/__tests__/gym-write-access-and-claims.test.ts
@@ -8,9 +8,11 @@ import { socialGymQueries, socialGymMutations, mapRawGymRow, enrichGym } from '.
 import {
   socialGymClaimMutations,
   socialGymClaimQueries,
+  gymClaimFieldResolvers,
   applyGymClaim,
   verifyGymClaimByToken,
   hashClaimToken,
+  MAX_PENDING_CLAIMS_PER_USER,
 } from '../graphql/resolvers/social/gym-claims';
 import {
   socialCommunitySettingsMutations,
@@ -35,12 +37,14 @@ vi.mock('../email/email-service', () => ({
   sendGymClaimVerificationEmail: vi.fn(() => Promise.resolve()),
   sendGymClaimAdminNotification: vi.fn(() => Promise.resolve()),
   sendGymClaimApprovedEmail: vi.fn(() => Promise.resolve()),
+  sendGymClaimDeniedEmail: vi.fn(() => Promise.resolve()),
   sendGymClaimOwnershipLostEmail: vi.fn(() => Promise.resolve()),
 }));
 import {
   sendGymClaimVerificationEmail,
   sendGymClaimAdminNotification,
   sendGymClaimApprovedEmail,
+  sendGymClaimDeniedEmail,
   sendGymClaimOwnershipLostEmail,
 } from '../email/email-service';
 
@@ -2026,6 +2030,221 @@ describe('requestGymClaim — auto-approval', () => {
     expect(await gymOwnerId(claimGym.uuid)).toBe(SYSTEM_OWNER);
     expect(await claimRows(claimGym.id)).toEqual([]);
     expect(sendGymClaimVerificationEmail).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Claim funnel: outcome notifications, the pending-claim cap, and the viewer's
+// own pending claim (#4377)
+// ============================================================================
+
+describe('approving a claim lands the same way whichever path approves it', () => {
+  it('auto-approval and admin approval agree on owner + sync freeze, differing only in reviewed_by', async () => {
+    // Same starting shape for both: an unclaimed catalog listing, one claimant.
+    // Auto-approval is the only path that ever runs unattended, so if the two
+    // ever drift, an admin-approved gym silently stops being sync-frozen and
+    // the location sync starts overwriting the new owner's edits.
+    await setAutoApprove(true);
+    const autoGym = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Parity Auto' });
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: autoGym.uuid, message: 'mine' } },
+        authCtx(CLAIMANT),
+      ),
+    ).resolves.toEqual({ status: 'approved' });
+
+    await setAutoApprove(false);
+    const reviewedGym = await insertGym({ ownerId: SYSTEM_OWNER, name: 'Parity Reviewed' });
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: reviewedGym.uuid, message: 'mine too' } },
+        authCtx(CLAIMANT),
+      ),
+    ).resolves.toEqual({ status: 'admin_review' });
+    const [queued] = await db.select().from(dbSchema.gymClaims).where(eq(dbSchema.gymClaims.gymId, reviewedGym.id));
+    await expect(
+      socialGymClaimMutations.reviewGymClaim(
+        null,
+        { input: { claimId: queued.id, decision: 'approve' } },
+        authCtx(GLOBAL_ADMIN),
+      ),
+    ).resolves.toBe(true);
+
+    // Identical end state...
+    expect(await gymOwnerId(autoGym.uuid)).toBe(CLAIMANT);
+    expect(await gymOwnerId(reviewedGym.uuid)).toBe(CLAIMANT);
+    expect(await gymSyncFrozenAt(autoGym.uuid)).not.toBeNull();
+    expect(await gymSyncFrozenAt(reviewedGym.uuid)).not.toBeNull();
+    expect(await claimStatus(queued.id)).toBe('approved');
+
+    // ...except for who is on record as having decided it.
+    expect(await claimRows(autoGym.id)).toEqual([expect.objectContaining({ status: 'approved', reviewed_by: null })]);
+    expect(await claimRows(reviewedGym.id)).toEqual([
+      expect.objectContaining({ status: 'approved', reviewed_by: GLOBAL_ADMIN }),
+    ]);
+  });
+});
+
+describe('the claimant hears the outcome', () => {
+  it('emails an admin-path claimant at their account address on approval', async () => {
+    // The claim row carries no claimEmail (that column is the domain path's
+    // verification address), so before the account-email fallback every admin
+    // approval mailed nobody at all.
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Approved By Hand' });
+    const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+
+    await expect(
+      socialGymClaimMutations.reviewGymClaim(null, { input: { claimId, decision: 'approve' } }, authCtx(GLOBAL_ADMIN)),
+    ).resolves.toBe(true);
+
+    expect(sendGymClaimApprovedEmail).toHaveBeenCalledWith(`${CLAIMANT}@test.com`, 'Approved By Hand');
+  });
+
+  it('emails a denied claimant instead of leaving them waiting forever', async () => {
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Denied Gym' });
+    const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+
+    await expect(
+      socialGymClaimMutations.reviewGymClaim(null, { input: { claimId, decision: 'deny' } }, authCtx(GLOBAL_ADMIN)),
+    ).resolves.toBe(true);
+
+    expect(sendGymClaimDeniedEmail).toHaveBeenCalledWith(`${CLAIMANT}@test.com`, 'Denied Gym');
+    expect(sendGymClaimApprovedEmail).not.toHaveBeenCalled();
+    expect(await gymOwnerId(claimGym.uuid)).toBe(PRIOR_OWNER);
+  });
+
+  it('never marks a claim denied after it has already been approved', async () => {
+    // A deny racing an approve on the same claim. Without the `status =
+    // 'pending'` guard on the deny UPDATE, the deny lands AFTER the transfer
+    // and the row reads `denied` on a gym that changed hands.
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Raced Decision' });
+    const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+
+    const outcomes = await Promise.allSettled([
+      socialGymClaimMutations.reviewGymClaim(null, { input: { claimId, decision: 'approve' } }, authCtx(GLOBAL_ADMIN)),
+      socialGymClaimMutations.reviewGymClaim(null, { input: { claimId, decision: 'deny' } }, authCtx(GLOBAL_ADMIN)),
+    ]);
+
+    // One decision, not two.
+    expect(outcomes.filter((outcome) => outcome.status === 'fulfilled')).toHaveLength(1);
+
+    // Whichever won, the row and the ownership agree — that is the invariant
+    // the guard buys, and it holds regardless of how the two interleaved.
+    const finalStatus = await claimStatus(claimId);
+    const finalOwner = await gymOwnerId(claimGym.uuid);
+    if (finalStatus === 'approved') {
+      expect(finalOwner).toBe(CLAIMANT);
+    } else {
+      expect(finalStatus).toBe('denied');
+      expect(finalOwner).toBe(PRIOR_OWNER);
+    }
+  });
+});
+
+describe('pending claims are capped per user, and the admin inbox is not flooded', () => {
+  it(`refuses claim ${MAX_PENDING_CLAIMS_PER_USER + 1} while the first ${MAX_PENDING_CLAIMS_PER_USER} are still open`, async () => {
+    // Fresh account: applyRateLimit's tier-1 bucket is per-process and never
+    // reset between tests, so a shared fixture user would make this order-dependent.
+    const hoarder = `gw-hoarder-${uuidv4()}`;
+    await insertUser(hoarder);
+
+    const seeded = await Promise.all(
+      Array.from({ length: MAX_PENDING_CLAIMS_PER_USER }, (_, index) =>
+        insertGym({ ownerId: PRIOR_OWNER, name: `Hoarded ${index}` }),
+      ),
+    );
+    for (const gym of seeded) {
+      await insertClaim({ gymId: gym.id, claimantUserId: hoarder, method: 'admin' });
+    }
+
+    const oneTooMany = await insertGym({ ownerId: PRIOR_OWNER, name: 'One Too Many' });
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: oneTooMany.uuid, message: 'this one as well' } },
+        authCtx(hoarder),
+      ),
+    ).rejects.toThrow(/waiting on review/);
+    expect(await claimRowCount(oneTooMany.id)).toBe(0);
+
+    // Re-submitting on a gym they already have queued replaces that row rather
+    // than adding one, so the cap must not block it.
+    await expect(
+      socialGymClaimMutations.requestGymClaim(
+        null,
+        { input: { gymUuid: seeded[0].uuid, message: 'still mine' } },
+        authCtx(hoarder),
+      ),
+    ).resolves.toEqual({ status: 'admin_review' });
+  });
+
+  it('mails the admin inbox once per claimant backlog, not once per claim', async () => {
+    const serialClaimer = `gw-serial-${uuidv4()}`;
+    await insertUser(serialClaimer);
+    const first = await insertGym({ ownerId: PRIOR_OWNER, name: 'Backlog One' });
+    const second = await insertGym({ ownerId: PRIOR_OWNER, name: 'Backlog Two' });
+
+    for (const gym of [first, second]) {
+      await expect(
+        socialGymClaimMutations.requestGymClaim(null, { input: { gymUuid: gym.uuid } }, authCtx(serialClaimer)),
+      ).resolves.toEqual({ status: 'admin_review' });
+    }
+
+    // Both are queued and reviewable; only the first one mailed.
+    expect(await claimRowCount(first.id)).toBe(1);
+    expect(await claimRowCount(second.id)).toBe(1);
+    expect(sendGymClaimAdminNotification).toHaveBeenCalledTimes(1);
+    expect(sendGymClaimAdminNotification).toHaveBeenCalledWith(expect.objectContaining({ gymName: 'Backlog One' }));
+  });
+});
+
+describe('Gym.myPendingClaim (viewer-scoped)', () => {
+  it('returns the viewer’s own pending claim and nothing else', async () => {
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Under Review Gym' });
+    const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+
+    await expect(
+      gymClaimFieldResolvers.myPendingClaim({ uuid: claimGym.uuid }, {}, authCtx(CLAIMANT)),
+    ).resolves.toEqual({ id: String(claimId), method: 'admin', createdAt: expect.any(String) });
+
+    // Another signed-in climber's view of the same gym is unaffected...
+    await expect(
+      gymClaimFieldResolvers.myPendingClaim({ uuid: claimGym.uuid }, {}, authCtx(PLAIN_USER)),
+    ).resolves.toBeNull();
+    // ...and so is an anonymous one.
+    await expect(gymClaimFieldResolvers.myPendingClaim({ uuid: claimGym.uuid }, {}, anonCtx())).resolves.toBeNull();
+  });
+
+  it('goes back to null once the claim is decided, so the CTA returns', async () => {
+    const claimGym = await insertGym({ ownerId: PRIOR_OWNER, name: 'Decided Gym' });
+    const claimId = await insertClaim({ gymId: claimGym.id, claimantUserId: CLAIMANT, method: 'admin' });
+
+    await socialGymClaimMutations.reviewGymClaim(null, { input: { claimId, decision: 'deny' } }, authCtx(GLOBAL_ADMIN));
+
+    await expect(
+      gymClaimFieldResolvers.myPendingClaim({ uuid: claimGym.uuid }, {}, authCtx(CLAIMANT)),
+    ).resolves.toBeNull();
+  });
+
+  it('reports the domain method, so the page can say "check your inbox"', async () => {
+    const claimGym = await insertGym({
+      ownerId: OWNER,
+      name: 'Domain Pending Gym',
+      website: 'https://www.domainpending.com',
+      websiteVouchedByOwner: true,
+    });
+
+    await socialGymClaimMutations.requestGymClaim(
+      null,
+      { input: { gymUuid: claimGym.uuid, claimEmail: 'boss@domainpending.com' } },
+      authCtx(CLAIMANT),
+    );
+
+    await expect(
+      gymClaimFieldResolvers.myPendingClaim({ uuid: claimGym.uuid }, {}, authCtx(CLAIMANT)),
+    ).resolves.toEqual(expect.objectContaining({ method: 'domain' }));
   });
 });
 

--- a/packages/backend/src/email/email-service.ts
+++ b/packages/backend/src/email/email-service.ts
@@ -142,36 +142,50 @@ export async function sendGymClaimVerificationEmail(
 /**
  * Notify the Boardsesh team that a user requested a gym claim that needs manual
  * review (no usable domain on file).
+ *
+ * `pendingClaimCount` is how many claims that same account now has waiting. Past
+ * the first, the mail leads with the backlog so a claimant working through
+ * several gyms reads as one job rather than N unrelated pings. Every claim still
+ * mails: suppressing the later ones would let one failed send mute an account's
+ * entire queue.
  */
 export async function sendGymClaimAdminNotification(details: {
   gymName: string;
   gymUuid: string;
   claimantName: string;
   message?: string | null;
+  pendingClaimCount?: number;
 }): Promise<void> {
   // Static path, no user input — used raw in the href (see the verify email note).
   const reviewUrl = `${webPublicUrl()}/admin/gym-claims`;
   const safeGym = escapeHtml(details.gymName);
   const safeClaimant = escapeHtml(details.claimantName);
   const safeMessage = details.message ? escapeHtml(details.message) : null;
+  const backlog = details.pendingClaimCount && details.pendingClaimCount > 1 ? details.pendingClaimCount : null;
+  const backlogLine = backlog ? `${details.claimantName} now has ${backlog} claims waiting on review.` : null;
 
   await getTransporter().sendMail({
     from: fromAddress(),
     to: ADMIN_NOTIFICATION_EMAIL,
-    subject: headerSafe(`Gym claim to review: ${details.gymName}`),
+    subject: headerSafe(
+      backlog
+        ? `Gym claim to review: ${details.gymName} (${backlog} from this claimant)`
+        : `Gym claim to review: ${details.gymName}`,
+    ),
     html: shell(
       'New gym claim',
       `
       <p style="color: ${colors.textPrimary}; font-size: 16px; line-height: 1.5;">
         <strong>${safeClaimant}</strong> wants to claim <strong>${safeGym}</strong>.
       </p>
+      ${backlogLine ? `<p style="color: ${colors.textSecondary}; font-size: 15px; line-height: 1.5;">${escapeHtml(backlogLine)} Review them together below.</p>` : ''}
       ${safeMessage ? `<p style="color: ${colors.textSecondary}; font-size: 15px; line-height: 1.5;">"${safeMessage}"</p>` : ''}
       ${button(reviewUrl, 'Review claims')}
       <hr style="border: none; border-top: 1px solid ${colors.border}; margin: 32px 0;" />
       <p style="color: ${colors.textMuted}; font-size: 12px;">Gym UUID: ${escapeHtml(details.gymUuid)}</p>
     `,
     ),
-    text: `${details.claimantName} wants to claim ${details.gymName}.${details.message ? `\n\nMessage: ${details.message}` : ''}\n\nReview: ${reviewUrl}\n\nGym UUID: ${details.gymUuid}`,
+    text: `${details.claimantName} wants to claim ${details.gymName}.${backlogLine ? `\n\n${backlogLine}` : ''}${details.message ? `\n\nMessage: ${details.message}` : ''}\n\nReview: ${reviewUrl}\n\nGym UUID: ${details.gymUuid}`,
   });
 }
 

--- a/packages/backend/src/email/email-service.ts
+++ b/packages/backend/src/email/email-service.ts
@@ -245,6 +245,39 @@ export async function sendGymClaimApprovedEmail(email: string, gymName: string):
 }
 
 /**
+ * Tell a claimant their claim was turned down, and how to get it looked at
+ * again. Best-effort — a dead SMTP must not undo the review decision, which is
+ * already committed by the time this runs.
+ */
+export async function sendGymClaimDeniedEmail(email: string, gymName: string): Promise<void> {
+  try {
+    const validatedEmail = emailSchema.parse(email);
+    const safeGym = escapeHtml(gymName);
+    await getTransporter().sendMail({
+      from: fromAddress(),
+      to: validatedEmail,
+      subject: headerSafe(`Your claim for ${gymName} wasn't approved`),
+      html: shell(
+        'We couldn’t approve this claim',
+        `
+        <p style="color: ${colors.textPrimary}; font-size: 16px; line-height: 1.5;">
+          We reviewed your claim for <strong>${safeGym}</strong> and couldn't confirm you run it,
+          so the listing stays where it is.
+        </p>
+        <p style="color: ${colors.textSecondary}; font-size: 15px; line-height: 1.5;">
+          If this is your gym, reply to this email with something that shows you manage it — a work
+          email address, your role, anything on the gym's own site — and we'll take another look.
+        </p>
+      `,
+      ),
+      text: `We reviewed your claim for ${gymName} and couldn't confirm you run it, so the listing stays where it is. If this is your gym, reply with something that shows you manage it and we'll take another look.`,
+    });
+  } catch (error) {
+    logger.warn('[GymClaim] Failed to send denial email:', error instanceof Error ? error.message : error);
+  }
+}
+
+/**
  * Heads-up to a previous owner whose gym was claimed by someone who verified
  * control of the gym's domain (or was approved by an admin). They're kept on as
  * a gym admin, so this is transparency, not a lockout. Best-effort.

--- a/packages/backend/src/graphql/resolvers/index.ts
+++ b/packages/backend/src/graphql/resolvers/index.ts
@@ -42,7 +42,7 @@ import { socialGymMatchQueries } from './social/gym-matching';
 import { socialGymStrayBoardQueries, socialGymStrayBoardMutations } from './social/gym-stray-boards';
 import { socialGymKioskQueries, socialGymKioskMutations } from './social/gym-kiosks';
 import { socialGymInsightsQueries } from './social/gym-insights';
-import { socialGymClaimQueries, socialGymClaimMutations } from './social/gym-claims';
+import { socialGymClaimQueries, socialGymClaimMutations, gymClaimFieldResolvers } from './social/gym-claims';
 import { socialGymDuplicateQueries, socialGymDuplicateMutations } from './social/gym-duplicates';
 import { socialLocationSyncFreezeQueries, socialLocationSyncFreezeMutations } from './social/location-sync-freezes';
 import { socialGymReportMutations } from './social/gym-reports';
@@ -160,6 +160,10 @@ export const resolvers = {
 
   // Field-level resolvers
   ClimbSearchResult: climbFieldResolvers,
+
+  // `Gym.myPendingClaim` only — every other Gym field comes off the enriched
+  // object the queries return, via the default resolver.
+  Gym: gymClaimFieldResolvers,
 
   // Climb type resolvers (derived fields)
   Climb: {

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { eq, and, isNull, desc, count } from 'drizzle-orm';
+import { eq, ne, and, isNull, desc, count } from 'drizzle-orm';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { isClaimableDomain, emailDomainMatchesWebsite } from '@boardsesh/gym-claim';
 import { db } from '../../../db/client';
@@ -19,11 +19,22 @@ import {
   sendGymClaimVerificationEmail,
   sendGymClaimAdminNotification,
   sendGymClaimApprovedEmail,
+  sendGymClaimDeniedEmail,
   sendGymClaimOwnershipLostEmail,
 } from '../../../email/email-service';
 import { logger } from '../../../utils/logger';
 
 const CLAIM_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * How many gyms one account may have waiting on review at once. The unique index
+ * caps one pending claim per (gym, claimant), so without this a single account
+ * could sit on a claim for every gym in the directory — flooding both the review
+ * queue and the ops inbox. Ten is far above any real operator's estate (the
+ * largest chains on the listing run single digits) and low enough that the queue
+ * stays reviewable.
+ */
+export const MAX_PENDING_CLAIMS_PER_USER = 10;
 
 /** Hash a raw verification token for storage. The raw token only ever lives in the email link. */
 export function hashClaimToken(token: string): string {
@@ -126,24 +137,36 @@ export async function applyGymClaim(
   });
 }
 
+/** A user's account email, for the claim outcome emails. Null when the row is gone. */
+async function loadUserEmail(userId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ email: dbSchema.users.email })
+    .from(dbSchema.users)
+    .where(eq(dbSchema.users.id, userId))
+    .limit(1);
+  return row?.email ?? null;
+}
+
 /**
  * Fire the post-transfer notifications (best-effort): the claimant gets an in-app
- * notification (and an email if we have their address), and a displaced real owner
- * a heads-up.
+ * notification and an email, and a displaced real owner a heads-up.
+ *
+ * `claimEmail` is only ever set on the domain path (it's the address the
+ * verification link went to), so for every admin-reviewed claim — which is
+ * ~99.9% of them, since almost no gym has a verifiable website on file — the
+ * approval email used to go nowhere at all. Fall back to the claimant's account
+ * email so an approval is actually delivered.
  */
 async function notifyClaimApplied(result: ClaimApplied): Promise<void> {
   await createGymManageAccessNotification(result.claimantUserId, result.gymUuid, result.gymName);
-  if (result.claimEmail) {
-    void sendGymClaimApprovedEmail(result.claimEmail, result.gymName);
+  const claimantEmail = result.claimEmail ?? (await loadUserEmail(result.claimantUserId));
+  if (claimantEmail) {
+    void sendGymClaimApprovedEmail(claimantEmail, result.gymName);
   }
   if (result.priorOwnerId) {
-    const [prior] = await db
-      .select({ email: dbSchema.users.email })
-      .from(dbSchema.users)
-      .where(eq(dbSchema.users.id, result.priorOwnerId))
-      .limit(1);
-    if (prior?.email) {
-      void sendGymClaimOwnershipLostEmail(prior.email, result.gymName);
+    const priorOwnerEmail = await loadUserEmail(result.priorOwnerId);
+    if (priorOwnerEmail) {
+      void sendGymClaimOwnershipLostEmail(priorOwnerEmail, result.gymName);
     }
   }
 }
@@ -287,6 +310,113 @@ async function replacePendingClaim(
   });
 }
 
+/**
+ * Refuse a new claim once this account is already sitting on
+ * MAX_PENDING_CLAIMS_PER_USER unresolved ones elsewhere. Counted excluding the
+ * gym being claimed, so re-submitting on a gym they already have queued (which
+ * replaces the row rather than adding one) never trips the cap.
+ */
+async function assertPendingClaimBudget(claimantUserId: string, excludedGymId: number): Promise<void> {
+  const [pending] = await db
+    .select({ count: count() })
+    .from(dbSchema.gymClaims)
+    .where(
+      and(
+        eq(dbSchema.gymClaims.claimantUserId, claimantUserId),
+        eq(dbSchema.gymClaims.status, 'pending'),
+        ne(dbSchema.gymClaims.gymId, excludedGymId),
+      ),
+    );
+  if (Number(pending?.count ?? 0) >= MAX_PENDING_CLAIMS_PER_USER) {
+    throw new Error(
+      `You already have ${MAX_PENDING_CLAIMS_PER_USER} gym claims waiting on review. Wait for those to be decided before claiming another gym.`,
+    );
+  }
+}
+
+/**
+ * Tell the admin inbox about a queued claim — once per claimant backlog, not
+ * once per claim. Ten pending claims used to mean ten separate emails; the
+ * queue at /admin/gym-claims lists every one of them, so the follow-ups added
+ * inbox noise and no information. The first claim of a backlog still mails
+ * immediately, and a claimant whose queue has been cleared mails again.
+ *
+ * Best-effort throughout: the claim row is already committed and visible in the
+ * queue, so a dead SMTP must not turn a successfully queued claim into a
+ * GraphQL error (the dedup check would then suppress the re-notify on retry and
+ * silently strand the admin).
+ */
+async function notifyAdminOfQueuedClaim(details: {
+  claimantUserId: string;
+  gymName: string;
+  gymUuid: string;
+  claimantName: string;
+  message: string | null;
+}): Promise<void> {
+  try {
+    const [pending] = await db
+      .select({ count: count() })
+      .from(dbSchema.gymClaims)
+      .where(
+        and(
+          eq(dbSchema.gymClaims.claimantUserId, details.claimantUserId),
+          eq(dbSchema.gymClaims.status, 'pending'),
+          eq(dbSchema.gymClaims.method, 'admin'),
+        ),
+      );
+    const pendingForClaimant = Number(pending?.count ?? 0);
+    if (pendingForClaimant > 1) {
+      logger.info(
+        `[GymClaim] Claimant ${details.claimantUserId} now has ${pendingForClaimant} pending claims (gym ${details.gymUuid}); batching under the first notification instead of mailing again`,
+      );
+      return;
+    }
+
+    await sendGymClaimAdminNotification({
+      gymName: details.gymName,
+      gymUuid: details.gymUuid,
+      claimantName: details.claimantName,
+      message: details.message,
+    });
+  } catch (error) {
+    logger.warn(
+      '[GymClaim] Failed to send admin notification for queued claim:',
+      error instanceof Error ? error.message : error,
+    );
+  }
+}
+
+/**
+ * `Gym.myPendingClaim` — a lazy field resolver, so the extra query only runs for
+ * the one document that selects it (the web gym page). enrichGym already fires
+ * ~9 round trips per gym and runs per row for up to 50 rows in searchGyms, so
+ * this deliberately does NOT live there.
+ */
+export const gymClaimFieldResolvers = {
+  myPendingClaim: async (gym: { uuid: string }, _args: unknown, ctx: ConnectionContext) => {
+    if (!ctx.isAuthenticated || !ctx.userId) return null;
+    const [claim] = await db
+      .select({
+        id: dbSchema.gymClaims.id,
+        method: dbSchema.gymClaims.method,
+        createdAt: dbSchema.gymClaims.createdAt,
+      })
+      .from(dbSchema.gymClaims)
+      .innerJoin(dbSchema.gyms, eq(dbSchema.gymClaims.gymId, dbSchema.gyms.id))
+      .where(
+        and(
+          eq(dbSchema.gyms.uuid, gym.uuid),
+          eq(dbSchema.gymClaims.claimantUserId, ctx.userId),
+          eq(dbSchema.gymClaims.status, 'pending'),
+        ),
+      )
+      .orderBy(desc(dbSchema.gymClaims.createdAt))
+      .limit(1);
+    if (!claim) return null;
+    return { id: String(claim.id), method: claim.method, createdAt: claim.createdAt.toISOString() };
+  },
+};
+
 export const socialGymClaimQueries = {
   pendingGymClaims: async (_: unknown, { input }: { input?: unknown }, ctx: ConnectionContext) => {
     await requireAdmin(ctx);
@@ -415,6 +545,7 @@ export const socialGymClaimMutations = {
 
       // Bound outbound verification emails per user (in addition to the general limit).
       await applyRateLimit(ctx, 5, 'gymClaimVerificationEmail');
+      await assertPendingClaimBudget(userId, gym.id);
 
       const token = randomUUID();
       await replacePendingClaim({
@@ -460,6 +591,8 @@ export const socialGymClaimMutations = {
       return { status: 'admin_review' };
     }
 
+    await assertPendingClaimBudget(userId, gym.id);
+
     const queuedClaim = await replacePendingClaim({
       gymId: gym.id,
       claimantUserId: userId,
@@ -474,24 +607,13 @@ export const socialGymClaimMutations = {
       return { status: 'approved' };
     }
 
-    // Best-effort: the claim is already queued and visible in /admin/gym-claims,
-    // so a failed notification (SMTP down) must not throw — that would roll the
-    // request back into a GraphQL error while the row stays committed, and the
-    // dedup check would then suppress the re-notify on retry, silently stranding
-    // the admin. Log it for ops instead; the queue is the source of truth.
-    try {
-      await sendGymClaimAdminNotification({
-        gymName: gym.name,
-        gymUuid: gym.uuid,
-        claimantName,
-        message: validatedInput.message ?? null,
-      });
-    } catch (error) {
-      logger.warn(
-        '[GymClaim] Failed to send admin notification for queued claim:',
-        error instanceof Error ? error.message : error,
-      );
-    }
+    await notifyAdminOfQueuedClaim({
+      claimantUserId: userId,
+      gymName: gym.name,
+      gymUuid: gym.uuid,
+      claimantName,
+      message: validatedInput.message ?? null,
+    });
 
     return { status: 'admin_review' };
   },
@@ -521,10 +643,35 @@ export const socialGymClaimMutations = {
     }
 
     if (validatedInput.decision === 'deny') {
-      await db
+      // Re-assert `pending` in the UPDATE itself. The SELECT above ran without a
+      // row lock, so a deny racing an approve (a second reviewer, or the
+      // claimant's own domain verify link landing) would otherwise stamp
+      // `denied` on an already-approved row AFTER ownership had moved — the gym
+      // transferred, the audit trail saying it was refused.
+      const denied = await db
         .update(dbSchema.gymClaims)
         .set({ status: 'denied', reviewedBy: adminUserId, updatedAt: new Date() })
-        .where(eq(dbSchema.gymClaims.id, claim.id));
+        .where(and(eq(dbSchema.gymClaims.id, claim.id), eq(dbSchema.gymClaims.status, 'pending')))
+        .returning({ id: dbSchema.gymClaims.id });
+      if (denied.length === 0) {
+        throw new Error('Could not deny this claim — it was already resolved');
+      }
+
+      // A denied claimant used to hear nothing, ever: they filed, the CTA
+      // stayed put, and no outcome ever arrived. `claimEmail` is only set on
+      // the domain path, so the account email is what reaches an admin-path
+      // claimant.
+      const claimantEmail = claim.claimEmail ?? (await loadUserEmail(claim.claimantUserId));
+      if (claimantEmail) {
+        const [claimedGym] = await db
+          .select({ name: dbSchema.gyms.name })
+          .from(dbSchema.gyms)
+          .where(eq(dbSchema.gyms.id, claim.gymId))
+          .limit(1);
+        if (claimedGym) {
+          void sendGymClaimDeniedEmail(claimantEmail, claimedGym.name);
+        }
+      }
       return true;
     }
 

--- a/packages/backend/src/graphql/resolvers/social/gym-claims.ts
+++ b/packages/backend/src/graphql/resolvers/social/gym-claims.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { eq, ne, and, isNull, desc, count } from 'drizzle-orm';
+import { eq, ne, gt, or, and, isNull, desc, count } from 'drizzle-orm';
+import { GraphQLError } from 'graphql';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { isClaimableDomain, emailDomainMatchesWebsite } from '@boardsesh/gym-claim';
 import { db } from '../../../db/client';
@@ -35,6 +36,27 @@ const CLAIM_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
  * stays reviewable.
  */
 export const MAX_PENDING_CLAIMS_PER_USER = 10;
+
+/** `extensions.code` on the cap rejection, so clients can branch without scraping the message. */
+export const GYM_CLAIM_LIMIT_CODE = 'GYM_CLAIM_LIMIT_REACHED';
+
+/**
+ * A claim that is genuinely still live: `pending` AND not past its expiry.
+ *
+ * The status column alone is not enough. A domain claim's token dies after 24h,
+ * but the row is only flipped to `expired` when someone clicks the dead link —
+ * there is no sweeper and no cron — so a row can sit `pending` forever holding a
+ * token that can never work again. Anything that asks "does this user have a
+ * claim in flight?" has to read the clock too, or a dead claim keeps the
+ * claimant's slot AND makes the gym page tell them to check an inbox for a link
+ * that is already useless.
+ */
+function claimIsLive() {
+  return and(
+    eq(dbSchema.gymClaims.status, 'pending'),
+    or(isNull(dbSchema.gymClaims.expiresAt), gt(dbSchema.gymClaims.expiresAt, new Date())),
+  );
+}
 
 /** Hash a raw verification token for storage. The raw token only ever lives in the email link. */
 export function hashClaimToken(token: string): string {
@@ -156,18 +178,31 @@ async function loadUserEmail(userId: string): Promise<string | null> {
  * ~99.9% of them, since almost no gym has a verifiable website on file — the
  * approval email used to go nowhere at all. Fall back to the claimant's account
  * email so an approval is actually delivered.
+ *
+ * Every caller runs this AFTER `applyGymClaim` has committed the transfer, so
+ * nothing in here may throw: the gym has already changed hands, and a Postgres
+ * hiccup on the address lookup would otherwise hand the admin a GraphQL error
+ * for an approval that in fact went through. Telling someone about a transfer
+ * is strictly less important than the transfer itself.
  */
 async function notifyClaimApplied(result: ClaimApplied): Promise<void> {
-  await createGymManageAccessNotification(result.claimantUserId, result.gymUuid, result.gymName);
-  const claimantEmail = result.claimEmail ?? (await loadUserEmail(result.claimantUserId));
-  if (claimantEmail) {
-    void sendGymClaimApprovedEmail(claimantEmail, result.gymName);
-  }
-  if (result.priorOwnerId) {
-    const priorOwnerEmail = await loadUserEmail(result.priorOwnerId);
-    if (priorOwnerEmail) {
-      void sendGymClaimOwnershipLostEmail(priorOwnerEmail, result.gymName);
+  try {
+    await createGymManageAccessNotification(result.claimantUserId, result.gymUuid, result.gymName);
+    const claimantEmail = result.claimEmail ?? (await loadUserEmail(result.claimantUserId));
+    if (claimantEmail) {
+      void sendGymClaimApprovedEmail(claimantEmail, result.gymName);
     }
+    if (result.priorOwnerId) {
+      const priorOwnerEmail = await loadUserEmail(result.priorOwnerId);
+      if (priorOwnerEmail) {
+        void sendGymClaimOwnershipLostEmail(priorOwnerEmail, result.gymName);
+      }
+    }
+  } catch (error) {
+    logger.warn(
+      `[GymClaim] Ownership of gym ${result.gymUuid} transferred to ${result.claimantUserId}, but notifying them failed:`,
+      error,
+    );
   }
 }
 
@@ -311,73 +346,77 @@ async function replacePendingClaim(
 }
 
 /**
- * Refuse a new claim once this account is already sitting on
- * MAX_PENDING_CLAIMS_PER_USER unresolved ones elsewhere. Counted excluding the
- * gym being claimed, so re-submitting on a gym they already have queued (which
- * replaces the row rather than adding one) never trips the cap.
+ * How many live claims this account is already sitting on, ignoring the gym
+ * being claimed now (re-submitting there replaces the row rather than adding
+ * one, so it must not count against the claimant).
+ *
+ * Expired-but-unswept domain rows are excluded via `claimIsLive`: nothing in the
+ * product flips them, so counting them would let a dead claim occupy a slot
+ * forever with no user-reachable way to clear it.
  */
-async function assertPendingClaimBudget(claimantUserId: string, excludedGymId: number): Promise<void> {
+async function countOtherLivePendingClaims(claimantUserId: string, excludedGymId: number): Promise<number> {
   const [pending] = await db
     .select({ count: count() })
     .from(dbSchema.gymClaims)
     .where(
       and(
         eq(dbSchema.gymClaims.claimantUserId, claimantUserId),
-        eq(dbSchema.gymClaims.status, 'pending'),
+        claimIsLive(),
         ne(dbSchema.gymClaims.gymId, excludedGymId),
       ),
     );
-  if (Number(pending?.count ?? 0) >= MAX_PENDING_CLAIMS_PER_USER) {
-    throw new Error(
-      `You already have ${MAX_PENDING_CLAIMS_PER_USER} gym claims waiting on review. Wait for those to be decided before claiming another gym.`,
-    );
-  }
+  return Number(pending?.count ?? 0);
 }
 
 /**
- * Tell the admin inbox about a queued claim — once per claimant backlog, not
- * once per claim. Ten pending claims used to mean ten separate emails; the
- * queue at /admin/gym-claims lists every one of them, so the follow-ups added
- * inbox noise and no information. The first claim of a backlog still mails
- * immediately, and a claimant whose queue has been cleared mails again.
+ * Refuse a new claim once this account already holds MAX_PENDING_CLAIMS_PER_USER
+ * live ones elsewhere.
  *
- * Best-effort throughout: the claim row is already committed and visible in the
- * queue, so a dead SMTP must not turn a successfully queued claim into a
- * GraphQL error (the dedup check would then suppress the re-notify on retry and
- * silently strand the admin).
+ * A soft flood cap, not a guarantee: it is a check-then-insert, so concurrent
+ * submissions can both pass it. `requestGymClaim`'s own rate limit (10 per
+ * window) bounds how far past the cap that can go — roughly 20 rows, not
+ * unbounded — which is all this needs to do.
+ *
+ * Returns the backlog it counted, so a caller that also wants to report it
+ * doesn't run the same query twice.
+ */
+async function assertPendingClaimBudget(claimantUserId: string, excludedGymId: number): Promise<number> {
+  const otherPending = await countOtherLivePendingClaims(claimantUserId, excludedGymId);
+  if (otherPending >= MAX_PENDING_CLAIMS_PER_USER) {
+    throw new GraphQLError(
+      `You already have ${MAX_PENDING_CLAIMS_PER_USER} gym claims waiting on review. Wait for those to be decided before claiming another gym.`,
+      { extensions: { code: GYM_CLAIM_LIMIT_CODE, limit: MAX_PENDING_CLAIMS_PER_USER } },
+    );
+  }
+  return otherPending;
+}
+
+/**
+ * Tell the admin inbox about a queued claim. EVERY queued claim mails — the
+ * batching is in the content, not in the delivery.
+ *
+ * Suppressing the send for a claimant who already has a backlog looks tempting
+ * and is a trap: the send is deliberately best-effort (the row is already
+ * committed and visible in /admin/gym-claims, so a dead SMTP must not turn a
+ * successfully queued claim into a GraphQL error), so one swallowed failure
+ * would silently mute every later claim that account ever files — the exact
+ * outcome batching was meant to prevent. Two concurrent submissions would both
+ * see a backlog and both stay quiet, too.
+ *
+ * So instead, a claim filed on top of a backlog carries the backlog with it:
+ * the mail leads with how many that claimant now has waiting, and points at the
+ * queue that lists them. The admin still acts once; nothing can go unheard.
  */
 async function notifyAdminOfQueuedClaim(details: {
-  claimantUserId: string;
   gymName: string;
   gymUuid: string;
   claimantName: string;
   message: string | null;
+  /** This claimant's live pending claims INCLUDING the one just queued. */
+  pendingClaimCount: number;
 }): Promise<void> {
   try {
-    const [pending] = await db
-      .select({ count: count() })
-      .from(dbSchema.gymClaims)
-      .where(
-        and(
-          eq(dbSchema.gymClaims.claimantUserId, details.claimantUserId),
-          eq(dbSchema.gymClaims.status, 'pending'),
-          eq(dbSchema.gymClaims.method, 'admin'),
-        ),
-      );
-    const pendingForClaimant = Number(pending?.count ?? 0);
-    if (pendingForClaimant > 1) {
-      logger.info(
-        `[GymClaim] Claimant ${details.claimantUserId} now has ${pendingForClaimant} pending claims (gym ${details.gymUuid}); batching under the first notification instead of mailing again`,
-      );
-      return;
-    }
-
-    await sendGymClaimAdminNotification({
-      gymName: details.gymName,
-      gymUuid: details.gymUuid,
-      claimantName: details.claimantName,
-      message: details.message,
-    });
+    await sendGymClaimAdminNotification(details);
   } catch (error) {
     logger.warn(
       '[GymClaim] Failed to send admin notification for queued claim:',
@@ -388,9 +427,15 @@ async function notifyAdminOfQueuedClaim(details: {
 
 /**
  * `Gym.myPendingClaim` — a lazy field resolver, so the extra query only runs for
- * the one document that selects it (the web gym page). enrichGym already fires
- * ~9 round trips per gym and runs per row for up to 50 rows in searchGyms, so
- * this deliberately does NOT live there.
+ * the one document that selects it (GET_GYM_PENDING_CLAIM, on the web gym
+ * page). enrichGym already fires ~9 round trips per gym and runs per row for up
+ * to 50 rows in searchGyms, so this deliberately does NOT live there.
+ *
+ * `claimIsLive` and not just `status = 'pending'`: an expired domain claim is
+ * never swept, and returning one would replace the claim call-out with "check
+ * your inbox" for a link that can no longer work — a dead end the claimant
+ * cannot get out of, since that notice is the gym page's only route to the
+ * claim dialog.
  */
 export const gymClaimFieldResolvers = {
   myPendingClaim: async (gym: { uuid: string }, _args: unknown, ctx: ConnectionContext) => {
@@ -403,13 +448,7 @@ export const gymClaimFieldResolvers = {
       })
       .from(dbSchema.gymClaims)
       .innerJoin(dbSchema.gyms, eq(dbSchema.gymClaims.gymId, dbSchema.gyms.id))
-      .where(
-        and(
-          eq(dbSchema.gyms.uuid, gym.uuid),
-          eq(dbSchema.gymClaims.claimantUserId, ctx.userId),
-          eq(dbSchema.gymClaims.status, 'pending'),
-        ),
-      )
+      .where(and(eq(dbSchema.gyms.uuid, gym.uuid), eq(dbSchema.gymClaims.claimantUserId, ctx.userId), claimIsLive()))
       .orderBy(desc(dbSchema.gymClaims.createdAt))
       .limit(1);
     if (!claim) return null;
@@ -591,7 +630,10 @@ export const socialGymClaimMutations = {
       return { status: 'admin_review' };
     }
 
-    await assertPendingClaimBudget(userId, gym.id);
+    // Read the backlog BEFORE the insert, and use that one number for both the
+    // cap and the notification's "N waiting" line — so the count the mail
+    // reports can't drift from the count the cap enforced.
+    const otherPendingClaims = await assertPendingClaimBudget(userId, gym.id);
 
     const queuedClaim = await replacePendingClaim({
       gymId: gym.id,
@@ -608,11 +650,11 @@ export const socialGymClaimMutations = {
     }
 
     await notifyAdminOfQueuedClaim({
-      claimantUserId: userId,
       gymName: gym.name,
       gymUuid: gym.uuid,
       claimantName,
       message: validatedInput.message ?? null,
+      pendingClaimCount: otherPendingClaims + 1,
     });
 
     return { status: 'admin_review' };

--- a/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
+++ b/packages/mobile/src/components/gym-directory/ClaimGymSheet.tsx
@@ -3,7 +3,12 @@ import { StyleSheet, View } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import type { Gym } from '@boardsesh/shared-schema';
-import { extractDomain, isClaimableDomain, GYM_CLAIM_MESSAGE_MAX_LENGTH } from '@boardsesh/gym-claim';
+import {
+  extractDomain,
+  isClaimableDomain,
+  GYM_CLAIM_MESSAGE_MAX_LENGTH,
+  GYM_CLAIM_SUPPORT_EMAIL,
+} from '@boardsesh/gym-claim';
 import { ModalSheet } from '../ModalSheet';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -115,6 +120,20 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
     }
   }, [gym.slug, gym.uuid, dismiss, t]);
 
+  // The same two promises the web dialog makes, in the same place: what taking
+  // the listing protects, and where an ownership handover goes. Both form modes
+  // show them; the confirmation doesn't — by then the terms are agreed.
+  const protections = (
+    <View style={styles.protections}>
+      <Text variant="footnote" color={systemColors.secondaryLabel}>
+        {t('mobile.gymClaim.protections.syncFreeze')}
+      </Text>
+      <Text variant="footnote" color={systemColors.secondaryLabel}>
+        {t('mobile.gymClaim.protections.transfer', { email: GYM_CLAIM_SUPPORT_EMAIL })}
+      </Text>
+    </View>
+  );
+
   return (
     <ModalSheet
       ref={sheetRef}
@@ -215,6 +234,7 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
             size="medium"
             tintColor={brandColors.primary}
           />
+          {protections}
         </>
       ) : (
         <>
@@ -264,6 +284,7 @@ export function ClaimGymSheet({ sheetRef, gym, onClosed }: ClaimGymSheetProps) {
               tintColor={brandColors.primary}
             />
           ) : null}
+          {protections}
         </>
       )}
     </ModalSheet>
@@ -313,6 +334,10 @@ const styles = StyleSheet.create({
     marginTop: -spacing[1],
   },
   submitButton: {
+    marginTop: spacing[1],
+  },
+  protections: {
+    gap: spacing[2],
     marginTop: spacing[1],
   },
   confirmation: {

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2758,6 +2758,19 @@ type GymBoardSummary {
 }
 
 """
+The viewer's own ownership claim on a gym that hasn't been resolved yet.
+Viewer-scoped: null for signed-out viewers and for anyone with no live claim.
+"""
+type MyGymClaim {
+  "Claim row id."
+  id: ID!
+  "How it gets verified: an emailed domain link, or a Boardsesh admin's review."
+  method: GymClaimMethod!
+  "ISO timestamp of when the claim was filed."
+  createdAt: String!
+}
+
+"""
 A physical gym location that can contain multiple boards.
 """
 type Gym {
@@ -2831,6 +2844,15 @@ type Gym {
   canClaim: Boolean!
   "Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer."
   isClaimed: Boolean!
+  """
+  The viewer's own unresolved claim on this gym, so a claimant who already
+  filed sees "under review" instead of the claim call-out. A lazy field
+  resolver with its own query — deliberately NOT part of enrichGym, which
+  already fires ~9 round trips per gym and runs per row for up to 50 rows.
+  Only the web gym page selects it; GYM_FIELDS leaves it out, which is why it
+  is nullable.
+  """
+  myPendingClaim: MyGymClaim
 }
 
 """

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -2739,7 +2739,7 @@ enum GymClaimStatus {
 enum GymClaimRequestStatus {
   "A verification email was sent to the claimant's work address."
   email_sent
-  "The claim was queued for admin review and our team was notified."
+  "The claim is queued for a Boardsesh admin to review, and the claimant gets emailed the outcome either way. Mailing the team is best-effort on top of that queue, not a guarantee, so don't promise the claimant a reply."
   admin_review
   "The claim was approved on the spot — the gym was an unclaimed listing and auto-approval is on. The claimant already manages the gym."
   approved

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2467,6 +2467,15 @@ export type Gym = {
   longitude?: Maybe<Scalars['Float']['output']>;
   /** Number of members */
   memberCount: Scalars['Int']['output'];
+  /**
+   * The viewer's own unresolved claim on this gym, so a claimant who already
+   * filed sees "under review" instead of the claim call-out. A lazy field
+   * resolver with its own query — deliberately NOT part of enrichGym, which
+   * already fires ~9 round trips per gym and runs per row for up to 50 rows.
+   * Only the web gym page selects it; GYM_FIELDS leaves it out, which is why it
+   * is nullable.
+   */
+  myPendingClaim?: Maybe<MyGymClaim>;
   /** Current user's role (null if not a member/owner) */
   myRole?: Maybe<GymMemberRole>;
   /** Gym name */
@@ -4182,6 +4191,20 @@ export type MyBoardsInput = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** Offset for pagination */
   offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/**
+ * The viewer's own ownership claim on a gym that hasn't been resolved yet.
+ * Viewer-scoped: null for signed-out viewers and for anyone with no live claim.
+ */
+export type MyGymClaim = {
+  __typename?: 'MyGymClaim';
+  /** ISO timestamp of when the claim was filed. */
+  createdAt: Scalars['String']['output'];
+  /** Claim row id. */
+  id: Scalars['ID']['output'];
+  /** How it gets verified: an emailed domain link, or a Boardsesh admin's review. */
+  method: GymClaimMethod;
 };
 
 /** Input for listing current user's gyms. */
@@ -8365,6 +8388,7 @@ export type ResolversTypes = ResolversObject<{
   MoonBoardMethod: MoonBoardMethod;
   Mutation: ResolverTypeWrapper<{}>;
   MyBoardsInput: MyBoardsInput;
+  MyGymClaim: ResolverTypeWrapper<MyGymClaim>;
   MyGymsInput: MyGymsInput;
   NewClimbCreatedEvent: ResolverTypeWrapper<NewClimbCreatedEvent>;
   NewClimbFeedInput: NewClimbFeedInput;
@@ -8723,6 +8747,7 @@ export type ResolversParentTypes = ResolversObject<{
   MoonBoardHoldsInput: MoonBoardHoldsInput;
   Mutation: {};
   MyBoardsInput: MyBoardsInput;
+  MyGymClaim: MyGymClaim;
   MyGymsInput: MyGymsInput;
   NewClimbCreatedEvent: NewClimbCreatedEvent;
   NewClimbFeedInput: NewClimbFeedInput;
@@ -10080,6 +10105,7 @@ export type GymResolvers<
   logoUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   longitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   memberCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  myPendingClaim?: Resolver<Maybe<ResolversTypes['MyGymClaim']>, ParentType, ContextType>;
   myRole?: Resolver<Maybe<ResolversTypes['GymMemberRole']>, ParentType, ContextType>;
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   ownerAvatarUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -11107,6 +11133,16 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationVoteOnProposalArgs, 'input'>
   >;
+}>;
+
+export type MyGymClaimResolvers<
+  ContextType = ConnectionContext,
+  ParentType extends ResolversParentTypes['MyGymClaim'] = ResolversParentTypes['MyGymClaim'],
+> = ResolversObject<{
+  createdAt?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  method?: Resolver<ResolversTypes['GymClaimMethod'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type NewClimbCreatedEventResolvers<
@@ -13299,6 +13335,7 @@ export type Resolvers<ContextType = ConnectionContext> = ResolversObject<{
   MergeGymsResult?: MergeGymsResultResolvers<ContextType>;
   MoonBoardClimbDuplicateMatch?: MoonBoardClimbDuplicateMatchResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
+  MyGymClaim?: MyGymClaimResolvers<ContextType>;
   NewClimbCreatedEvent?: NewClimbCreatedEventResolvers<ContextType>;
   NewClimbFeedItem?: NewClimbFeedItemResolvers<ContextType>;
   NewClimbFeedResult?: NewClimbFeedResultResolvers<ContextType>;

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -2556,7 +2556,7 @@ export type GymClaimMethod =
 
 /** Outcome of a requestGymClaim call, so clients can show the right next step. */
 export type GymClaimRequestStatus =
-  /** The claim was queued for admin review and our team was notified. */
+  /** The claim is queued for a Boardsesh admin to review, and the claimant gets emailed the outcome either way. Mailing the team is best-effort on top of that queue, not a guarantee, so don't promise the claimant a reply. */
   | 'admin_review'
   /** The claim was approved on the spot — the gym was an unclaimed listing and auto-approval is on. The claimant already manages the gym. */
   | 'approved'

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -30,7 +30,7 @@ export const gymsTypeDefs = /* GraphQL */ `
   enum GymClaimRequestStatus {
     "A verification email was sent to the claimant's work address."
     email_sent
-    "The claim was queued for admin review and our team was notified."
+    "The claim is queued for a Boardsesh admin to review, and the claimant gets emailed the outcome either way. Mailing the team is best-effort on top of that queue, not a guarantee, so don't promise the claimant a reply."
     admin_review
     "The claim was approved on the spot — the gym was an unclaimed listing and auto-approval is on. The claimant already manages the gym."
     approved

--- a/packages/shared-schema/src/schema/gyms.ts
+++ b/packages/shared-schema/src/schema/gyms.ts
@@ -49,6 +49,19 @@ export const gymsTypeDefs = /* GraphQL */ `
   }
 
   """
+  The viewer's own ownership claim on a gym that hasn't been resolved yet.
+  Viewer-scoped: null for signed-out viewers and for anyone with no live claim.
+  """
+  type MyGymClaim {
+    "Claim row id."
+    id: ID!
+    "How it gets verified: an emailed domain link, or a Boardsesh admin's review."
+    method: GymClaimMethod!
+    "ISO timestamp of when the claim was filed."
+    createdAt: String!
+  }
+
+  """
   A physical gym location that can contain multiple boards.
   """
   type Gym {
@@ -122,6 +135,15 @@ export const gymsTypeDefs = /* GraphQL */ `
     canClaim: Boolean!
     "Whether a real person owns this gym, as opposed to the system import user. Viewer-independent — unlike canClaim, which is false for every signed-out viewer."
     isClaimed: Boolean!
+    """
+    The viewer's own unresolved claim on this gym, so a claimant who already
+    filed sees "under review" instead of the claim call-out. A lazy field
+    resolver with its own query — deliberately NOT part of enrichGym, which
+    already fires ~9 round trips per gym and runs per row for up to 50 rows.
+    Only the web gym page selects it; GYM_FIELDS leaves it out, which is why it
+    is nullable.
+    """
+    myPendingClaim: MyGymClaim
   }
 
   """

--- a/packages/shared-schema/src/types/gyms.ts
+++ b/packages/shared-schema/src/types/gyms.ts
@@ -36,6 +36,16 @@ export type GymBoardSummary = {
   angle: number;
 };
 
+/**
+ * The viewer's own claim on a gym that is still waiting on an outcome — the
+ * emailed domain link or a Boardsesh admin's decision.
+ */
+export type MyGymClaim = {
+  id: string;
+  method: GymClaimMethod;
+  createdAt: string;
+};
+
 export type Gym = {
   uuid: string;
   slug?: string | null;
@@ -93,6 +103,14 @@ export type Gym = {
    * document typed `Gym` genuinely returns it.
    */
   isClaimed: boolean;
+  /**
+   * The viewer's unresolved claim on this gym, or null when they have none.
+   * OPTIONAL on purpose: only GET_GYM_BY_SLUG selects it. Adding it to the
+   * shared GYM_FIELDS would put it in documents the mobile app ships, where a
+   * production OTA can reach devices before the backend deploy that answers the
+   * field — and every mobile gym view would then fail GraphQL validation.
+   */
+  myPendingClaim?: MyGymClaim | null;
 };
 
 export type GymConnection = {

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2553,7 +2553,7 @@ export type GymClaimMethod =
 
 /** Outcome of a requestGymClaim call, so clients can show the right next step. */
 export type GymClaimRequestStatus =
-  /** The claim was queued for admin review and our team was notified. */
+  /** The claim is queued for a Boardsesh admin to review, and the claimant gets emailed the outcome either way. Mailing the team is best-effort on top of that queue, not a guarantee, so don't promise the claimant a reply. */
   | 'admin_review'
   /** The claim was approved on the spot — the gym was an unclaimed listing and auto-approval is on. The claimant already manages the gym. */
   | 'approved'

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -2464,6 +2464,15 @@ export type Gym = {
   longitude?: Maybe<Scalars['Float']['output']>;
   /** Number of members */
   memberCount: Scalars['Int']['output'];
+  /**
+   * The viewer's own unresolved claim on this gym, so a claimant who already
+   * filed sees "under review" instead of the claim call-out. A lazy field
+   * resolver with its own query — deliberately NOT part of enrichGym, which
+   * already fires ~9 round trips per gym and runs per row for up to 50 rows.
+   * Only the web gym page selects it; GYM_FIELDS leaves it out, which is why it
+   * is nullable.
+   */
+  myPendingClaim?: Maybe<MyGymClaim>;
   /** Current user's role (null if not a member/owner) */
   myRole?: Maybe<GymMemberRole>;
   /** Gym name */
@@ -4179,6 +4188,20 @@ export type MyBoardsInput = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   /** Offset for pagination */
   offset?: InputMaybe<Scalars['Int']['input']>;
+};
+
+/**
+ * The viewer's own ownership claim on a gym that hasn't been resolved yet.
+ * Viewer-scoped: null for signed-out viewers and for anyone with no live claim.
+ */
+export type MyGymClaim = {
+  __typename?: 'MyGymClaim';
+  /** ISO timestamp of when the claim was filed. */
+  createdAt: Scalars['String']['output'];
+  /** Claim row id. */
+  id: Scalars['ID']['output'];
+  /** How it gets verified: an emailed domain link, or a Boardsesh admin's review. */
+  method: GymClaimMethod;
 };
 
 /** Input for listing current user's gyms. */

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -96,10 +96,22 @@ export const GET_GYM = gql`
   }
 `;
 
+/**
+ * The web gym page (and its manage console). `myPendingClaim` is selected HERE
+ * and nowhere else: it must stay out of GYM_FIELDS, which GET_GYM carries into
+ * the mobile app, because a production OTA auto-publishes on every push to main
+ * and can reach devices before the backend deploy that answers the field — at
+ * which point every mobile gym view fails GraphQL validation.
+ */
 export const GET_GYM_BY_SLUG = gql`
   query GetGymBySlug($slug: String!) {
     gymBySlug(slug: $slug) {
       ${GYM_FIELDS}
+      myPendingClaim {
+        id
+        method
+        createdAt
+      }
     }
   }
 `;

--- a/packages/shared/graphql/src/operations/gyms.ts
+++ b/packages/shared/graphql/src/operations/gyms.ts
@@ -3,6 +3,7 @@ import type {
   Gym,
   GymBoardSummary,
   GymConnection,
+  MyGymClaim,
   GymMemberConnection,
   CreateGymInput,
   UpdateGymInput,
@@ -96,17 +97,34 @@ export const GET_GYM = gql`
   }
 `;
 
-/**
- * The web gym page (and its manage console). `myPendingClaim` is selected HERE
- * and nowhere else: it must stay out of GYM_FIELDS, which GET_GYM carries into
- * the mobile app, because a production OTA auto-publishes on every push to main
- * and can reach devices before the backend deploy that answers the field — at
- * which point every mobile gym view fails GraphQL validation.
- */
 export const GET_GYM_BY_SLUG = gql`
   query GetGymBySlug($slug: String!) {
     gymBySlug(slug: $slug) {
       ${GYM_FIELDS}
+    }
+  }
+`;
+
+/**
+ * The viewer's own in-flight claim on a gym. A SEPARATE document from
+ * GET_GYM_BY_SLUG on purpose — this is a deploy-ordering firewall, not a style
+ * choice.
+ *
+ * A field is only answerable once the backend declaring it is live, and an
+ * unknown field fails validation for the WHOLE document. Folded into
+ * GET_GYM_BY_SLUG, a web-deploys-first ordering would therefore take the gym
+ * page and the manage console down together — both treat a failed fetch as
+ * "gym not found" and render a 404 — until the backend caught up. Split out,
+ * the same failure costs exactly one notice on one page.
+ *
+ * The mirror-image constraint is why it is not in GYM_FIELDS either: GET_GYM
+ * ships inside the mobile app, whose production OTA auto-publishes on every
+ * push to main and can reach devices BEFORE the backend deploy.
+ */
+export const GET_GYM_PENDING_CLAIM = gql`
+  query GetGymPendingClaim($slug: String!) {
+    gymBySlug(slug: $slug) {
+      uuid
       myPendingClaim {
         id
         method
@@ -526,6 +544,19 @@ export type GetGymBySlugQueryVariables = {
 
 export type GetGymBySlugQueryResponse = {
   gymBySlug: Gym | null;
+};
+
+export type GetGymPendingClaimQueryVariables = {
+  slug: string;
+};
+
+/**
+ * Exactly what GET_GYM_PENDING_CLAIM selects. Deliberately not typed `Gym`: the
+ * document fetches two fields, and a consumer that reads more than that from it
+ * would be reading `undefined` behind a type that promises a value.
+ */
+export type GetGymPendingClaimQueryResponse = {
+  gymBySlug: { uuid: string; myPendingClaim: MyGymClaim | null } | null;
 };
 
 export type GetMyGymsQueryVariables = {

--- a/packages/shared/gym-claim/src/constants.ts
+++ b/packages/shared/gym-claim/src/constants.ts
@@ -7,3 +7,11 @@
 
 /** Max length of the optional note on an admin-review claim (backend + both clients). */
 export const GYM_CLAIM_MESSAGE_MAX_LENGTH = 1000;
+
+/**
+ * Where an owner writes about a claim or an ownership handover. There is no
+ * in-product owner-reassignment action yet (#4378 builds one), so both clients
+ * name the channel that actually processes these — the same admin-reviewed
+ * inbox the claim queue mails.
+ */
+export const GYM_CLAIM_SUPPORT_EMAIL = 'admin@boardsesh.com';

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -260,6 +260,10 @@
         "sent": "{{gym}} gehört jetzt dir.",
         "manageCta": "Halle einrichten",
         "manageError": "Die Halle-Einrichtung ließ sich nicht öffnen. Probier es im Browser."
+      },
+      "protections": {
+        "syncFreeze": "Sobald sie dir gehört, bleiben deine Angaben stehen — die Standort-Synchronisierung überschreibt nie das, was du als Inhaber*in einträgst.",
+        "transfer": "Gibst du die Halle später ab? Schreib an {{email}}, wir übertragen sie."
       }
     },
     "offline": {

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -254,7 +254,7 @@
         "messageLabel": "Nachricht (optional)",
         "messagePlaceholder": "Alles, was uns hilft zu prüfen, dass du diese Halle leitest",
         "submit": "Prüfung anfragen",
-        "sent": "Wir haben unser Team benachrichtigt. Wir melden uns bald."
+        "sent": "Dein Anspruch liegt in der Prüf-Warteschlange. Wir schreiben dir, sobald entschieden ist."
       },
       "approved": {
         "sent": "{{gym}} gehört jetzt dir.",
@@ -626,11 +626,15 @@
       "messageLabel": "Nachricht (optional)",
       "messagePlaceholder": "Alles, was uns hilft zu prüfen, dass du diese Halle leitest",
       "submit": "Prüfung anfragen",
-      "sent": "Wir haben unser Team benachrichtigt. Wir melden uns bald."
+      "sent": "Dein Anspruch liegt in der Prüf-Warteschlange. Wir schreiben dir, sobald entschieden ist."
     },
     "approved": {
       "body": "{{gym}} gehört jetzt dir. Richte sie ein, wann du willst.",
       "manageCta": "Halle einrichten"
+    },
+    "protections": {
+      "syncFreeze": "Sobald sie dir gehört, bleiben deine Angaben stehen — die Standort-Synchronisierung überschreibt nie das, was du als Inhaber*in einträgst.",
+      "transfer": "Gibst du die Halle später ab? Schreib an {{email}}, wir übertragen sie."
     }
   },
   "claimLanding": {

--- a/packages/shared/i18n/locales/de/kiosk.json
+++ b/packages/shared/i18n/locales/de/kiosk.json
@@ -90,6 +90,10 @@
     "claimBody": "Übernimm sie und steuere die Boards, den Auftritt und das, was an der Wand läuft.",
     "claimCta": "Diese Halle übernehmen",
     "claimCtaSignedOut": "Anmelden und übernehmen",
+    "claimPendingTitle": "Dein Anspruch wird geprüft",
+    "claimPendingBody": "Wir prüfen gerade, dass du diese Halle leitest. Du hörst in jedem Fall per E-Mail von uns, meist innerhalb weniger Tage.",
+    "claimPendingDomainTitle": "Schau in dein Postfach",
+    "claimPendingDomainBody": "Wir haben dir einen Link an deine Arbeits-E-Mail geschickt. Klick drauf und die Halle gehört dir.",
     "claimAuthTitle": "Übernimm deine Halle",
     "claimAuthBody": "Melde dich an, wir bringen dich direkt hierher zurück, um sie zu übernehmen.",
     "owner": {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -260,6 +260,10 @@
         "sent": "{{gym}} is yours to manage.",
         "manageCta": "Set up your gym",
         "manageError": "Couldn't open gym setup. Try it in a browser."
+      },
+      "protections": {
+        "syncFreeze": "Once it's yours, your edits stay put — location sync never overwrites what an owner sets.",
+        "transfer": "Handing the gym to someone else later? Email {{email}} and we'll move ownership across."
       }
     },
     "offline": {

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -254,7 +254,7 @@
         "messageLabel": "Message (optional)",
         "messagePlaceholder": "Anything that helps us verify you run this gym",
         "submit": "Request review",
-        "sent": "We've emailed our team. They'll be in touch soon."
+        "sent": "Your claim is in the review queue. We'll email you as soon as it's decided."
       },
       "approved": {
         "sent": "{{gym}} is yours to manage.",
@@ -626,11 +626,15 @@
       "messageLabel": "Message (optional)",
       "messagePlaceholder": "Anything that helps us verify you run this gym",
       "submit": "Request review",
-      "sent": "We've emailed our team. They'll be in touch soon."
+      "sent": "Your claim is in the review queue. We'll email you as soon as it's decided."
     },
     "approved": {
       "body": "{{gym}} is yours. Set it up whenever you're ready.",
       "manageCta": "Set up your gym"
+    },
+    "protections": {
+      "syncFreeze": "Once it's yours, your edits stay put — location sync never overwrites what an owner sets.",
+      "transfer": "Handing the gym to someone else later? Email {{email}} and we'll move ownership across."
     }
   },
   "claimLanding": {

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -90,6 +90,10 @@
     "claimBody": "Claim it to run the boards, the branding, and what shows up on the wall.",
     "claimCta": "Claim this gym",
     "claimCtaSignedOut": "Log in and claim it",
+    "claimPendingTitle": "Your claim is under review",
+    "claimPendingBody": "We're checking that you run this gym. We'll email you either way, usually within a few days.",
+    "claimPendingDomainTitle": "Check your inbox",
+    "claimPendingDomainBody": "We sent a link to your work email. Click it and the gym is yours.",
     "claimAuthTitle": "Claim your gym",
     "claimAuthBody": "Log in and we'll drop you straight back here to claim it.",
     "owner": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -254,7 +254,7 @@
         "messageLabel": "Mensaje (opcional)",
         "messagePlaceholder": "Cualquier cosa que nos ayude a verificar que gestionas este rocódromo",
         "submit": "Solicitar revisión",
-        "sent": "Hemos avisado a nuestro equipo. Se pondrán en contacto pronto."
+        "sent": "Tu solicitud está en la cola de revisión. Te escribiremos en cuanto se decida."
       },
       "approved": {
         "sent": "{{gym}} ya es tuyo.",
@@ -626,11 +626,15 @@
       "messageLabel": "Mensaje (opcional)",
       "messagePlaceholder": "Cualquier cosa que nos ayude a verificar que gestionas este rocódromo",
       "submit": "Solicitar revisión",
-      "sent": "Hemos avisado a nuestro equipo. Se pondrán en contacto pronto."
+      "sent": "Tu solicitud está en la cola de revisión. Te escribiremos en cuanto se decida."
     },
     "approved": {
       "body": "{{gym}} es tuyo. Configúralo cuando quieras.",
       "manageCta": "Configura tu rocódromo"
+    },
+    "protections": {
+      "syncFreeze": "Cuando sea tuyo, tus cambios se quedan: la sincronización de ubicaciones nunca sobrescribe lo que pone quien lo gestiona.",
+      "transfer": "¿Más adelante pasas el rocódromo a otra persona? Escríbenos a {{email}} y trasladamos la propiedad."
     }
   },
   "claimLanding": {

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -260,6 +260,10 @@
         "sent": "{{gym}} ya es tuyo.",
         "manageCta": "Configura tu rocódromo",
         "manageError": "No se pudo abrir la configuración del rocódromo. Ábrela en un navegador."
+      },
+      "protections": {
+        "syncFreeze": "Cuando sea tuyo, tus cambios se quedan: la sincronización de ubicaciones nunca sobrescribe lo que pone quien lo gestiona.",
+        "transfer": "¿Más adelante pasas el rocódromo a otra persona? Escríbenos a {{email}} y trasladamos la propiedad."
       }
     },
     "offline": {

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -90,6 +90,10 @@
     "claimBody": "Reclámalo para gestionar los plafones, la marca y lo que se ve en el muro.",
     "claimCta": "Reclamar este rocódromo",
     "claimCtaSignedOut": "Inicia sesión y reclámalo",
+    "claimPendingTitle": "Tu solicitud está en revisión",
+    "claimPendingBody": "Estamos comprobando que gestionas este rocódromo. Te escribiremos igualmente, normalmente en unos días.",
+    "claimPendingDomainTitle": "Revisa tu bandeja de entrada",
+    "claimPendingDomainBody": "Te hemos enviado un enlace a tu correo de trabajo. Haz clic y el rocódromo será tuyo.",
     "claimAuthTitle": "Reclama tu rocódromo",
     "claimAuthBody": "Inicia sesión y te devolvemos aquí mismo para reclamarlo.",
     "owner": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -254,7 +254,7 @@
         "messageLabel": "Message (facultatif)",
         "messagePlaceholder": "Tout ce qui nous aide à vérifier que tu gères cette salle",
         "submit": "Demander une vérification",
-        "sent": "Nous avons prévenu notre équipe. Elle te contactera bientôt."
+        "sent": "Ta demande est dans la file d'examen. On t'écrit dès qu'elle est tranchée."
       },
       "approved": {
         "sent": "{{gym}} est à toi.",
@@ -626,11 +626,15 @@
       "messageLabel": "Message (facultatif)",
       "messagePlaceholder": "Tout ce qui nous aide à vérifier que vous gérez cette salle",
       "submit": "Demander une vérification",
-      "sent": "Nous avons prévenu notre équipe. Elle vous contactera bientôt."
+      "sent": "Votre demande est dans la file d'examen. Nous vous écrirons dès qu'elle sera tranchée."
     },
     "approved": {
       "body": "{{gym}} est à vous. Configurez-la quand vous voulez.",
       "manageCta": "Configurer votre salle"
+    },
+    "protections": {
+      "syncFreeze": "Une fois la salle à vous, vos modifications restent : la synchronisation des lieux n'écrase jamais ce que le gestionnaire a saisi.",
+      "transfer": "Vous passerez la main un jour ? Écrivez à {{email}} et nous transférons la propriété."
     }
   },
   "claimLanding": {

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -260,6 +260,10 @@
         "sent": "{{gym}} est à toi.",
         "manageCta": "Configurer ta salle",
         "manageError": "Impossible d'ouvrir la configuration de la salle. Ouvre-la dans un navigateur."
+      },
+      "protections": {
+        "syncFreeze": "Une fois la salle à toi, tes modifications restent : la synchronisation des lieux n'écrase jamais ce que le gestionnaire a saisi.",
+        "transfer": "Tu passeras la main un jour ? Écris à {{email}} et on transfère la propriété."
       }
     },
     "offline": {

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -90,6 +90,10 @@
     "claimBody": "Revendique-la pour gérer les boards, l'identité visuelle et ce qui s'affiche sur le mur.",
     "claimCta": "Revendiquer cette salle",
     "claimCtaSignedOut": "Connecte-toi et revendique-la",
+    "claimPendingTitle": "Ta demande est en cours d'examen",
+    "claimPendingBody": "On vérifie que tu gères cette salle. On te répond par e-mail dans tous les cas, en général sous quelques jours.",
+    "claimPendingDomainTitle": "Regarde ta boîte mail",
+    "claimPendingDomainBody": "On a envoyé un lien à ton e-mail professionnel. Clique dessus et la salle est à toi.",
     "claimAuthTitle": "Revendique ta salle",
     "claimAuthBody": "Connecte-toi, on te ramène ici pour la revendiquer.",
     "owner": {

--- a/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog.test.tsx
+++ b/packages/web/app/components/gym-entity/__tests__/claim-gym-dialog.test.tsx
@@ -80,7 +80,10 @@ describe('ClaimGymDialog — auto-approved claim', () => {
     renderDialog();
     await submit();
 
-    await screen.findByText("We've emailed our team. They'll be in touch soon.");
+    // The confirmation promises the outcome email the funnel now actually
+    // sends, rather than narrating an admin notification that a claimant with a
+    // backlog doesn't trigger.
+    await screen.findByText("Your claim is in the review queue. We'll email you as soon as it's decided.");
     // Nothing was transferred, so there is nothing to refresh.
     expect(mockRefresh).not.toHaveBeenCalled();
   });

--- a/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
+++ b/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
@@ -22,6 +22,7 @@ import {
   isClaimableDomain,
   emailDomainMatchesWebsite,
   GYM_CLAIM_MESSAGE_MAX_LENGTH,
+  GYM_CLAIM_SUPPORT_EMAIL,
 } from '@boardsesh/gym-claim';
 import { gymClaimResult, gymClaimSubmitted } from '@boardsesh/analytics';
 import { useWsAuthToken } from '@/app/hooks/use-ws-auth-token';
@@ -43,14 +44,6 @@ type ClaimGymDialogProps = {
 };
 
 type Mode = 'domain' | 'admin';
-
-/**
- * Where an owner writes about a claim or an ownership handover. There is no
- * in-product owner-reassignment action yet (#4378 builds one), so the copy has
- * to name the channel that actually processes these — the same admin-reviewed
- * inbox the claim queue mails.
- */
-const CLAIM_SUPPORT_EMAIL = 'admin@boardsesh.com';
 
 function graphqlErrorMessage(error: unknown): string | null {
   const response = (error as { response?: { errors?: Array<{ message?: string }> } })?.response;
@@ -298,7 +291,7 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
               {t('claimGym.protections.syncFreeze')}
             </Typography>
             <Typography variant="caption" color="text.secondary">
-              {t('claimGym.protections.transfer', { email: CLAIM_SUPPORT_EMAIL })}
+              {t('claimGym.protections.transfer', { email: GYM_CLAIM_SUPPORT_EMAIL })}
             </Typography>
           </Box>
         )}

--- a/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
+++ b/packages/web/app/components/gym-entity/claim-gym-dialog.tsx
@@ -13,6 +13,7 @@ import TextField from '@mui/material/TextField';
 import MuiButton from '@mui/material/Button';
 import MuiLink from '@mui/material/Link';
 import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import Alert from '@mui/material/Alert';
 import CircularProgress from '@mui/material/CircularProgress';
 import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutline';
@@ -42,6 +43,14 @@ type ClaimGymDialogProps = {
 };
 
 type Mode = 'domain' | 'admin';
+
+/**
+ * Where an owner writes about a claim or an ownership handover. There is no
+ * in-product owner-reassignment action yet (#4378 builds one), so the copy has
+ * to name the channel that actually processes these — the same admin-reviewed
+ * inbox the claim queue mails.
+ */
+const CLAIM_SUPPORT_EMAIL = 'admin@boardsesh.com';
 
 function graphqlErrorMessage(error: unknown): string | null {
   const response = (error as { response?: { errors?: Array<{ message?: string }> } })?.response;
@@ -276,7 +285,24 @@ export default function ClaimGymDialog({ gymUuid, gymName, website, open, onClos
   return (
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
       <DialogTitle>{t('claimGym.title', { gym: gymName })}</DialogTitle>
-      <DialogContent>{body}</DialogContent>
+      <DialogContent>
+        {body}
+        {/* Two things every claimant asks before they commit, so they sit under
+            both forms rather than in a confirmation nobody reads twice: what
+            taking the listing protects, and what happens when the gym changes
+            hands. Hidden once submitted — the confirmation is about what comes
+            next, not about the terms. */}
+        {!succeeded && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75, mt: 2.5 }}>
+            <Typography variant="caption" color="text.secondary">
+              {t('claimGym.protections.syncFreeze')}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {t('claimGym.protections.transfer', { email: CLAIM_SUPPORT_EMAIL })}
+            </Typography>
+          </Box>
+        )}
+      </DialogContent>
       <DialogActions>
         <MuiButton onClick={handleClose} sx={{ textTransform: 'none' }}>
           {succeeded ? t('claimGym.done') : t('claimGym.cancel')}

--- a/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta-logic.test.ts
+++ b/packages/web/app/gym/[gym_slug]/__tests__/gym-claim-cta-logic.test.ts
@@ -4,6 +4,7 @@ import {
   CLAIM_PARAM_VALUE,
   buildClaimReturnPath,
   resolveClaimCtaVariant,
+  resolveClaimSurface,
   shouldAutoOpenClaimDialog,
 } from '../gym-claim-cta-logic';
 
@@ -61,6 +62,42 @@ describe('resolveClaimCtaVariant', () => {
       expect(resolveClaimCtaVariant({ serverCanClaim: true, serverHasSession: false, gymIsClaimed: true })).toBe(
         'hidden',
       );
+    });
+  });
+});
+
+describe('resolveClaimSurface', () => {
+  it('swaps the call-out for the review notice once the viewer has a claim in flight', () => {
+    // `canClaim` stays true while a claim sits in the queue, so without this the
+    // claimant is invited to submit the same claim again, forever.
+    expect(resolveClaimSurface({ variant: 'signed-in', gymIsPublic: true, hasPendingClaim: true })).toEqual({
+      kind: 'pending',
+    });
+  });
+
+  it('shows the call-out to a signed-in viewer with no claim of their own', () => {
+    expect(resolveClaimSurface({ variant: 'signed-in', gymIsPublic: true, hasPendingClaim: false })).toEqual({
+      kind: 'cta',
+      viewerState: 'signed-in',
+    });
+  });
+
+  it('keeps the anonymous arm a call-out — a signed-out viewer has no claim to be pending', () => {
+    expect(resolveClaimSurface({ variant: 'signed-out', gymIsPublic: true, hasPendingClaim: true })).toEqual({
+      kind: 'cta',
+      viewerState: 'signed-out',
+    });
+  });
+
+  it.each([true, false])('renders nothing for a viewer who already covers the gym (pending: %s)', (hasPendingClaim) => {
+    // They were granted access while the claim sat in the queue: a "under
+    // review" notice above a gym they can already edit is stale.
+    expect(resolveClaimSurface({ variant: 'hidden', gymIsPublic: true, hasPendingClaim })).toEqual({ kind: 'none' });
+  });
+
+  it('renders nothing on a private gym, which the backend refuses to let anyone claim', () => {
+    expect(resolveClaimSurface({ variant: 'signed-in', gymIsPublic: false, hasPendingClaim: false })).toEqual({
+      kind: 'none',
     });
   });
 });

--- a/packages/web/app/gym/[gym_slug]/gym-claim-cta-logic.ts
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-cta-logic.ts
@@ -83,6 +83,47 @@ export function resolveClaimCtaVariant({
 }
 
 /**
+ * What the gym page puts where the claim call-out goes: the call-out itself, an
+ * "under review" notice for a claimant who already filed, or nothing.
+ *
+ * The `cta` arm carries the viewer state the island needs, so the page renders
+ * one decision instead of re-deriving (and possibly contradicting) it — and so
+ * `hidden`, which is not a viewer state, can't reach the island at all.
+ */
+export type GymClaimSurface =
+  | { kind: 'cta'; viewerState: GymClaimViewerState }
+  | { kind: 'pending' }
+  | { kind: 'none' };
+
+/**
+ * A claimant who already submitted must not be shown the CTA again — `canClaim`
+ * is a pure permission bit and knows nothing about claims in flight, so before
+ * `myPendingClaim` existed the same person could keep re-submitting into a
+ * queue they were already in, with nothing on the page acknowledging it.
+ *
+ * The pending claim only matters on the `signed-in` arm: a pending claim needs a
+ * claimant, and `hidden` means the viewer now covers the gym anyway (an admin
+ * granted them access while the claim sat in the queue), where a review notice
+ * would be stale.
+ */
+export function resolveClaimSurface({
+  variant,
+  gymIsPublic,
+  hasPendingClaim,
+}: {
+  variant: GymClaimCtaVariant;
+  /** Claims are for public listings only — the backend rejects the rest. */
+  gymIsPublic: boolean;
+  /** Whether `gym.myPendingClaim` came back non-null for this viewer. */
+  hasPendingClaim: boolean;
+}): GymClaimSurface {
+  if (!gymIsPublic) return { kind: 'none' };
+  if (variant === 'hidden') return { kind: 'none' };
+  if (variant === 'signed-in' && hasPendingClaim) return { kind: 'pending' };
+  return { kind: 'cta', viewerState: variant };
+}
+
+/**
  * True only for the exact scalar `'1'`. Next hands a repeated param
  * (`?claim=1&claim=1`, which a crawler or a double-appended redirect produces)
  * as an array, and an array must not auto-open a dialog.

--- a/packages/web/app/gym/[gym_slug]/gym-claim-pending-notice.tsx
+++ b/packages/web/app/gym/[gym_slug]/gym-claim-pending-notice.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import HourglassTopOutlined from '@mui/icons-material/HourglassTopOutlined';
+import MarkEmailReadOutlined from '@mui/icons-material/MarkEmailReadOutlined';
+import type { GymClaimMethod } from '@boardsesh/shared-schema';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { themeTokens } from '@/app/theme/theme-config';
+
+type GymClaimPendingNoticeProps = {
+  /** `gym.myPendingClaim.method` — which proof this claim is waiting on. */
+  method: GymClaimMethod;
+};
+
+/**
+ * Stands in for the claim call-out once this viewer has a claim in flight.
+ * Server-rendered: the claim comes off the same request as the rest of the page,
+ * so the notice is in the first HTML rather than appearing a beat later.
+ *
+ * The two methods wait on different things — an admin claim waits on a human,
+ * a domain claim waits on the claimant clicking the link we emailed them — so
+ * telling them apart is the difference between "sit tight" and "go check your
+ * inbox".
+ */
+export default async function GymClaimPendingNotice({ method }: GymClaimPendingNoticeProps) {
+  const { t } = await getServerTranslation('kiosk');
+  const isDomainClaim = method === 'domain';
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1.5,
+        border: '1px solid var(--neutral-200)',
+        borderRadius: `${themeTokens.borderRadius.lg}px`,
+        p: 2.5,
+        mb: 3,
+      }}
+    >
+      {isDomainClaim ? (
+        <MarkEmailReadOutlined color="action" fontSize="small" />
+      ) : (
+        <HourglassTopOutlined color="action" fontSize="small" />
+      )}
+      <Box>
+        <Typography variant="subtitle1" sx={{ fontWeight: themeTokens.typography.fontWeight.bold }}>
+          {isDomainClaim ? t('gymPage.claimPendingDomainTitle') : t('gymPage.claimPendingTitle')}
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {isDomainClaim ? t('gymPage.claimPendingDomainBody') : t('gymPage.claimPendingBody')}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -40,7 +40,8 @@ import GymPageManageButton from './gym-page-manage-button';
 import GymFollowButton from './gym-follow-button';
 import GymClaimCta from './gym-claim-cta';
 import GymClaimParamCleanup from './gym-claim-param-cleanup';
-import { CLAIM_PARAM, resolveClaimCtaVariant } from './gym-claim-cta-logic';
+import GymClaimPendingNotice from './gym-claim-pending-notice';
+import { CLAIM_PARAM, resolveClaimCtaVariant, resolveClaimSurface } from './gym-claim-cta-logic';
 import GymOwnerPrompts from './gym-owner-prompts';
 import GymReportDuplicateCta from './gym-report-duplicate-cta';
 import { formatHoursConfirmedDate } from './gym-hours-display';
@@ -205,7 +206,15 @@ export default async function GymPage(props: GymRouteProps) {
     gymIsClaimed: gym.isClaimed,
   });
   const claimParam = searchParams[CLAIM_PARAM];
-  const showsClaimCta = gym.isPublic && claimCtaVariant !== 'hidden';
+  // A viewer with a claim already in flight gets the review notice instead of
+  // the call-out — `canClaim` is a permission bit and stays true while their
+  // claim sits in the queue.
+  const pendingClaim = gym.myPendingClaim ?? null;
+  const claimSurface = resolveClaimSurface({
+    variant: claimCtaVariant,
+    gymIsPublic: gym.isPublic,
+    hasPendingClaim: pendingClaim !== null,
+  });
 
   // Prefer the real photo for search-result thumbnails; fall back to the logo.
   const structuredDataImage = photoSrc ?? logoSrc;
@@ -372,21 +381,26 @@ export default async function GymPage(props: GymRouteProps) {
             leaning on `isGymViewable`: a private gym reaches this line only via
             its own editors, and the anonymous arm has to stay impossible there
             even if the viewability rule is loosened later. */}
-        {showsClaimCta ? (
+        {claimSurface.kind === 'cta' ? (
           <GymClaimCta
             gymUuid={gym.uuid}
             gymName={gym.name}
             gymSlug={gym_slug}
             website={gym.website}
-            viewerState={claimCtaVariant}
+            viewerState={claimSurface.viewerState}
             claimParam={claimParam}
           />
         ) : (
           /* No call-out to clear the return-from-auth param, so clear it here:
              an owner or community leader who signed in and turned out to
              already cover this gym — or an anonymous visitor on a gym someone
-             already runs — would otherwise sit on a live `?claim=1`. */
-          <GymClaimParamCleanup claimParam={claimParam} />
+             already runs — would otherwise sit on a live `?claim=1`. A returning
+             claimant whose claim is already queued lands here too: the notice
+             replaces the dialog `?claim=1` would have re-opened. */
+          <>
+            {claimSurface.kind === 'pending' && pendingClaim && <GymClaimPendingNotice method={pendingClaim.method} />}
+            <GymClaimParamCleanup claimParam={claimParam} />
+          </>
         )}
 
         <GymReportDuplicateCta

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -12,12 +12,14 @@ import PersonOutlined from '@mui/icons-material/PersonOutlined';
 import PeopleOutlined from '@mui/icons-material/PeopleOutlined';
 import ChatBubbleOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import ScheduleOutlined from '@mui/icons-material/ScheduleOutlined';
-import type { Gym, UserBoard } from '@boardsesh/shared-schema';
+import type { Gym, MyGymClaim, UserBoard } from '@boardsesh/shared-schema';
 import {
   GET_GYM_BY_SLUG,
+  GET_GYM_PENDING_CLAIM,
   GET_GYM_BOARDS,
   GET_GYM_KIOSK,
   type GetGymBySlugQueryResponse,
+  type GetGymPendingClaimQueryResponse,
   type GetGymBoardsQueryResponse,
   type GetGymKioskQueryResponse,
   type GymKioskOperationResult,
@@ -67,6 +69,29 @@ const fetchGymBySlug = cache(async (slug: string, token: string | undefined): Pr
     return null;
   }
 });
+
+/**
+ * The viewer's own claim in flight, fetched on its own so a failure degrades to
+ * "no notice" instead of "no gym". `fetchGymBySlug` returning null means
+ * `notFound()`, so folding this selection into that document would 404 the whole
+ * page — for every gym at once — if web ever deploys ahead of the backend that
+ * answers `myPendingClaim`. Only ever called for a signed-in viewer who could
+ * actually hold a claim, so anonymous readers (the page's whole audience) pay
+ * nothing.
+ */
+async function fetchMyPendingClaim(slug: string, token: string): Promise<MyGymClaim | null> {
+  try {
+    const response = await executeAuthenticatedGraphQL<GetGymPendingClaimQueryResponse>(
+      GET_GYM_PENDING_CLAIM,
+      { slug },
+      token,
+    );
+    return response.gymBySlug?.myPendingClaim ?? null;
+  } catch (error) {
+    console.error('fetchMyPendingClaim failed:', error);
+    return null;
+  }
+}
 
 async function fetchDefaultKiosk(gymSlug: string, token: string | undefined): Promise<GymKioskOperationResult | null> {
   try {
@@ -208,8 +233,9 @@ export default async function GymPage(props: GymRouteProps) {
   const claimParam = searchParams[CLAIM_PARAM];
   // A viewer with a claim already in flight gets the review notice instead of
   // the call-out — `canClaim` is a permission bit and stays true while their
-  // claim sits in the queue.
-  const pendingClaim = gym.myPendingClaim ?? null;
+  // claim sits in the queue. Only the signed-in arm can have one, so this is the
+  // only case worth a second round trip.
+  const pendingClaim = claimCtaVariant === 'signed-in' && token ? await fetchMyPendingClaim(gym_slug, token) : null;
   const claimSurface = resolveClaimSurface({
     variant: claimCtaVariant,
     gymIsPublic: gym.isPublic,


### PR DESCRIPTION
Closes #4377 · Part of epic #4372, Tier 1.

**The headline: every admin claim approval since launch has emailed nobody.**

`notifyClaimApplied` gated the approval email on the claim row's `claimEmail` — a column only the *domain* verification path ever writes. The admin path never sets it. So a gym owner who claimed their gym, got approved, and became the owner was never told. And a denied claimant heard nothing at all, ever.

That's now fixed: the claimant's account email is used as a fallback, and there's a denial email too.

## The issue's premise was stale

Worth stating for anyone reading #4377 against this diff. Already shipped and **not** rebuilt here: pending-row creation, the `admin_review` return, auto-approval of ownerless gyms, the admin-inbox notification, `reviewGymClaim`'s approve/deny, and both #4374 analytics events. The four things that were genuinely missing:

1. The claimant outcome emails, above.
2. **A claimant who already submitted still saw the claim CTA** — `canClaim` is a pure permission bit that knows nothing about pending claims. Added a viewer-scoped `Gym.myPendingClaim` and an "under review" notice.
3. **A TOCTOU in the deny path** — the deny UPDATE didn't re-check `status='pending'`, so a deny racing an approve could flip an already-approved row to `denied` *after* ownership had moved. Now conditional with `.returning()`, throwing on zero rows.
4. **The dialog said nothing about sync-freeze or ownership transfer.**

`applyGymClaim` is deliberately untouched — parity between the admin-review and auto-approve paths is proven by a new test (same `owner_id`, same non-null `sync_frozen_at`, differing only in `reviewed_by`), not by new code.

## Abuse bounds

Self-serve claiming opens a vector the all-founder-vetted flow didn't have: the existing unique index caps one pending claim per *gym*, not per user, and each one fired a separate admin email. So a cap of 10 pending claims per user, and the admin notification now fires only on the first of a backlog — the rest are logged, and `/admin/gym-claims` lists them all regardless.

The cap deliberately excludes the gym being claimed, so re-submitting on a gym you've already queued is a replace rather than an add and never trips it.

## Mobile

`GET_GYM` and `GYM_FIELDS` are untouched — `myPendingClaim` has its own document (see the deploy-ordering section below), and the field is nullable, so the #4505 required-field invariant holds. That matters because the production OTA auto-publishes on every push to main and can reach devices before the backend deploy.

One mobile string was actively lying: `ClaimGymSheet` said "We've emailed our team. They'll be in touch soon." — false for a batched second claim, and promising contact the backend never delivered. Now "Your claim is in the review queue. We'll email you as soon as it's decided," which this PR makes literally true.

**Known remaining gap, deliberately out of scope:** mobile gates its claim entry on `canClaim` from `GET_GYM`, which doesn't select `myPendingClaim` — so a mobile claimant with a queued claim still sees the affordance and can re-submit. Harmless (it's a replace plus an auto-approve retry), and closing it means adding the field to `GET_GYM`, which is precisely the OTA-ordering hazard above. It should follow one backend deploy behind.

## Deploy ordering: backend first

`myPendingClaim` lives in its own `GET_GYM_PENDING_CLAIM` document rather than in `GET_GYM_BY_SLUG`, fetched with its own try/catch and only for a signed-in viewer. That matters: selecting it from the main document would mean a web deploy landing ahead of the backend one fails validation on the whole query, and both consumers swallow the error and return null — which becomes `notFound()`. Every gym page and every manage page would 404 until backend caught up.

As built, web-before-backend costs one "under review" notice instead. Still a visible regression, so **ship backend first** — that direction is safe both ways, since the field is additive and nothing older selects it.

The mirror-image constraint is why `GET_GYM` and `GYM_FIELDS` stay untouched: the production OTA auto-publishes on every push to main and can reach devices before the backend deploys.

## The cap is a soft flood cap, not a guarantee

`assertPendingClaimBudget` is a check-then-insert with no lock, so concurrent submissions can both pass. The existing `requestGymClaim` rate limit bounds the overshoot to roughly 20 rows rather than unbounded. That's the intended level of protection — it exists to stop the admin queue and ops inbox being floodable, not to enforce an exact number.

## Release Notes

Claimed a gym? Your page now says it's under review, and we email you either way once we've looked at it — approved or not.
