### PR TITLE
feat(web): print-ready QR poster per gym

### DIFF
--- a/packages/shared/i18n/locales/de/kiosk.json
+++ b/packages/shared/i18n/locales/de/kiosk.json
@@ -124,7 +124,18 @@
         "body": "Füg Logo und Farben hinzu, damit die Seite nach dir aussieht."
       }
     },
-    "photoAlt": "Die Kletterwand von {{gymName}}"
+    "photoAlt": "Die Kletterwand von {{gymName}}",
+    "poster": {
+      "metaTitle": "QR-Poster für {{gymName}}",
+      "metaDescription": "Ein druckfertiger Code zum Scannen direkt an der Wand.",
+      "heading": "Code scannen, Wand beleuchten",
+      "pitch": "Hol dir Boardsesh, such dir einen Boulder aus, und die Griffe leuchten am Board vor dir auf. Jede Begehung landet gleich im Logbuch.",
+      "typedUrlLabel": "Keine Kamera? Tipp das ein:",
+      "compatibility": "Funktioniert mit Kilter, Tension und MoonBoard.",
+      "independence": "Boardsesh ist eine unabhängige App. Sie ist weder mit Aurora Climbing, Moon Climbing noch einem anderen Board-Hersteller verbunden noch wird sie von ihnen unterstützt.",
+      "printAction": "Poster drucken",
+      "backToGym": "Zurück zur Halle"
+    }
   },
   "manage": {
     "welcome": {
@@ -367,6 +378,7 @@
       "quickLinksHeading": "Deine Halle steuern",
       "viewPublicPage": "Öffentliche Seite ansehen",
       "embedAction": "Auf deiner Website einbetten",
+      "printPoster": "Poster drucken",
       "stats": {
         "boards": "Boards",
         "members": "Mitglieder",

--- a/packages/shared/i18n/locales/de/kiosk.json
+++ b/packages/shared/i18n/locales/de/kiosk.json
@@ -132,7 +132,7 @@
       "pitch": "Hol dir Boardsesh, such dir einen Boulder aus, und die Griffe leuchten am Board vor dir auf. Jede Begehung landet gleich im Logbuch.",
       "typedUrlLabel": "Keine Kamera? Tipp das ein:",
       "compatibility": "Funktioniert mit Kilter, Tension und MoonBoard.",
-      "independence": "Boardsesh ist eine unabhängige App. Sie ist weder mit Aurora Climbing, Moon Climbing noch einem anderen Board-Hersteller verbunden noch wird sie von ihnen unterstützt.",
+      "independence": "Boardsesh ist eine unabhängige App. Sie ist weder mit Aurora Climbing, Moon Climbing oder einem anderen Board-Hersteller verbunden noch wird sie von ihnen unterstützt.",
       "printAction": "Poster drucken",
       "backToGym": "Zurück zur Halle"
     }

--- a/packages/shared/i18n/locales/en-US/kiosk.json
+++ b/packages/shared/i18n/locales/en-US/kiosk.json
@@ -124,7 +124,18 @@
         "body": "Add your logo and colors so your page looks like you."
       }
     },
-    "photoAlt": "The climbing wall at {{gymName}}"
+    "photoAlt": "The climbing wall at {{gymName}}",
+    "poster": {
+      "metaTitle": "QR poster for {{gymName}}",
+      "metaDescription": "A print-ready code climbers can scan at the wall.",
+      "heading": "Scan the code, light up the wall",
+      "pitch": "Get Boardsesh, pick a climb, and the holds light up on the board in front of you. Log every send while you're at it.",
+      "typedUrlLabel": "No camera? Type this in:",
+      "compatibility": "Works with Kilter, Tension and MoonBoard.",
+      "independence": "Boardsesh is an independent app. It is not affiliated with or endorsed by Aurora Climbing, Moon Climbing, or any board manufacturer.",
+      "printAction": "Print this poster",
+      "backToGym": "Back to the gym page"
+    }
   },
   "manage": {
     "welcome": {
@@ -367,6 +378,7 @@
       "quickLinksHeading": "Run your gym",
       "viewPublicPage": "View public page",
       "embedAction": "Embed on your website",
+      "printPoster": "Print your poster",
       "stats": {
         "boards": "boards",
         "members": "members",

--- a/packages/shared/i18n/locales/es/kiosk.json
+++ b/packages/shared/i18n/locales/es/kiosk.json
@@ -124,7 +124,18 @@
         "body": "Añade tu logo y tus colores para que la página sea tuya."
       }
     },
-    "photoAlt": "El muro de escalada de {{gymName}}"
+    "photoAlt": "El muro de escalada de {{gymName}}",
+    "poster": {
+      "metaTitle": "Póster QR de {{gymName}}",
+      "metaDescription": "Un código listo para imprimir que los escaladores escanean en el muro.",
+      "heading": "Escanea el código y enciende el muro",
+      "pitch": "Consigue Boardsesh, elige un bloque y las presas se encienden en el plafón que tienes delante. Y de paso registra cada encadene.",
+      "typedUrlLabel": "¿Sin cámara? Escribe esto:",
+      "compatibility": "Compatible con Kilter, Tension y MoonBoard.",
+      "independence": "Boardsesh es una app independiente. No está afiliada ni respaldada por Aurora Climbing, Moon Climbing ni ningún fabricante de plafones.",
+      "printAction": "Imprimir este póster",
+      "backToGym": "Volver al rocódromo"
+    }
   },
   "manage": {
     "welcome": {
@@ -367,6 +378,7 @@
       "quickLinksHeading": "Gestiona tu rocódromo",
       "viewPublicPage": "Ver la página pública",
       "embedAction": "Insertar en tu sitio web",
+      "printPoster": "Imprime tu póster",
       "stats": {
         "boards": "plafones",
         "members": "miembros",

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -132,7 +132,7 @@
       "pitch": "Prends Boardsesh, choisis un bloc et les prises s'allument sur la board devant toi. Et fais la croix dans la foulée.",
       "typedUrlLabel": "Pas d'appareil photo ? Tape ceci :",
       "compatibility": "Compatible avec Kilter, Tension et MoonBoard.",
-      "independence": "Boardsesh est une appli indépendante. Elle n'est ni affiliée à Aurora Climbing, Moon Climbing ou un fabricant de boards, ni approuvée par eux.",
+      "independence": "Boardsesh est une appli indépendante. Elle n'est ni affiliée à Aurora Climbing, à Moon Climbing ou à un fabricant de boards, ni approuvée par eux.",
       "printAction": "Imprimer cette affiche",
       "backToGym": "Retour à la salle"
     }

--- a/packages/shared/i18n/locales/fr/kiosk.json
+++ b/packages/shared/i18n/locales/fr/kiosk.json
@@ -124,7 +124,18 @@
         "body": "Ajoute ton logo et tes couleurs pour que la page te ressemble."
       }
     },
-    "photoAlt": "Le mur d'escalade de {{gymName}}"
+    "photoAlt": "Le mur d'escalade de {{gymName}}",
+    "poster": {
+      "metaTitle": "Affiche QR pour {{gymName}}",
+      "metaDescription": "Un code prêt à imprimer que les grimpeurs scannent au pied du mur.",
+      "heading": "Scanne le code, allume le mur",
+      "pitch": "Prends Boardsesh, choisis un bloc et les prises s'allument sur la board devant toi. Et fais la croix dans la foulée.",
+      "typedUrlLabel": "Pas d'appareil photo ? Tape ceci :",
+      "compatibility": "Compatible avec Kilter, Tension et MoonBoard.",
+      "independence": "Boardsesh est une appli indépendante. Elle n'est ni affiliée à Aurora Climbing, Moon Climbing ou un fabricant de boards, ni approuvée par eux.",
+      "printAction": "Imprimer cette affiche",
+      "backToGym": "Retour à la salle"
+    }
   },
   "manage": {
     "welcome": {
@@ -367,6 +378,7 @@
       "quickLinksHeading": "Gère ta salle",
       "viewPublicPage": "Voir la page publique",
       "embedAction": "Intégrer à ton site web",
+      "printPoster": "Imprime ton affiche",
       "stats": {
         "boards": "boards",
         "members": "membres",

--- a/packages/web/app/components/gym-entity/manage/__tests__/overview-tab.test.tsx
+++ b/packages/web/app/components/gym-entity/manage/__tests__/overview-tab.test.tsx
@@ -91,6 +91,18 @@ describe('OverviewTab', () => {
     expect(link.getAttribute('href')).toBe('/gym/test-gym');
   });
 
+  it('links to the printable QR poster', async () => {
+    renderTab(makeGym());
+    const link = await screen.findByRole('link', { name: /print your poster/i });
+    expect(link.getAttribute('href')).toBe('/gym/test-gym/poster');
+  });
+
+  it('hides the poster link for a slug-less gym — the printed code encodes the slug', async () => {
+    renderTab(makeGym({ slug: null }));
+    await screen.findByRole('link', { name: /put it on the tv/i });
+    expect(screen.queryByRole('link', { name: /print your poster/i })).toBeNull();
+  });
+
   it('shows the follower/member/board counts from the gym and the kiosk count from the query', async () => {
     renderTab(makeGym());
 

--- a/packages/web/app/components/gym-entity/manage/overview-tab.tsx
+++ b/packages/web/app/components/gym-entity/manage/overview-tab.tsx
@@ -27,6 +27,7 @@ import BadgeOutlined from '@mui/icons-material/BadgeOutlined';
 import ArrowForwardOutlined from '@mui/icons-material/ArrowForwardOutlined';
 import LaunchOutlined from '@mui/icons-material/LaunchOutlined';
 import CodeOutlined from '@mui/icons-material/CodeOutlined';
+import PrintOutlined from '@mui/icons-material/PrintOutlined';
 import type { Gym } from '@boardsesh/shared-schema';
 import {
   GET_GYM_KIOSKS,
@@ -223,6 +224,22 @@ export default function OverviewTab({ gym }: { gym: Gym }) {
             sx={{ textTransform: 'none' }}
           >
             {t('manage.overview.viewPublicPage')}
+          </Button>
+        )}
+        {/* Slug-gated, like the public-page link above it: the poster route is
+            addressed by slug only (a slug-less legacy gym reaches this console
+            by UUID), and the printed code has to encode the canonical slug —
+            there is no poster to print until the gym has one. */}
+        {gym.slug && (
+          <Button
+            component={LocaleLink}
+            href={`/gym/${gym.slug}/poster`}
+            variant="outlined"
+            size="small"
+            startIcon={<PrintOutlined />}
+            sx={{ textTransform: 'none' }}
+          >
+            {t('manage.overview.printPoster')}
           </Button>
         )}
         <Button

--- a/packages/web/app/gym/[gym_slug]/fetch-gym-by-slug.ts
+++ b/packages/web/app/gym/[gym_slug]/fetch-gym-by-slug.ts
@@ -1,0 +1,36 @@
+// The one slug → gym lookup every public gym surface uses, plus the
+// viewability rule that goes with it.
+//
+// Extracted from `page.tsx` when `/gym/[gym_slug]/poster` landed (#4379): the
+// poster is the same gym under a second URL, and the two must agree on what
+// exists, what 404s, and what an owner can see before going public. A second
+// copy of `isGymViewable` is how a private-preview rule drifts into a private
+// gym leaking from one route and not the other.
+
+import { cache } from 'react';
+import type { Gym } from '@boardsesh/shared-schema';
+import { GET_GYM_BY_SLUG, type GetGymBySlugQueryResponse } from '@boardsesh/graphql/operations';
+import { executeAuthenticatedGraphQL } from '@/app/lib/graphql/server-graphql';
+
+/**
+ * Request-deduped: `generateMetadata` and the page body of the same route each
+ * call it, and React's `cache()` collapses that into one round-trip.
+ */
+export const fetchGymBySlug = cache(async (slug: string, token: string | undefined): Promise<Gym | null> => {
+  try {
+    const response = await executeAuthenticatedGraphQL<GetGymBySlugQueryResponse>(GET_GYM_BY_SLUG, { slug }, token);
+    return response.gymBySlug ?? null;
+  } catch (error) {
+    console.error('fetchGymBySlug failed:', error);
+    return null;
+  }
+});
+
+/**
+ * A gym is viewable when it's public, or the viewer can edit it (private
+ * preview) — an owner can lay out and print a poster before the listing goes
+ * public.
+ */
+export function isGymViewable(gym: Gym | null): gym is Gym {
+  return gym !== null && (gym.isPublic || gym.canEdit);
+}

--- a/packages/web/app/gym/[gym_slug]/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/page.tsx
@@ -1,4 +1,4 @@
-import React, { cache } from 'react';
+import React from 'react';
 import type { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
 import Container from '@mui/material/Container';
@@ -14,11 +14,9 @@ import ChatBubbleOutlined from '@mui/icons-material/ChatBubbleOutlineOutlined';
 import ScheduleOutlined from '@mui/icons-material/ScheduleOutlined';
 import type { Gym, MyGymClaim, UserBoard } from '@boardsesh/shared-schema';
 import {
-  GET_GYM_BY_SLUG,
   GET_GYM_PENDING_CLAIM,
   GET_GYM_BOARDS,
   GET_GYM_KIOSK,
-  type GetGymBySlugQueryResponse,
   type GetGymPendingClaimQueryResponse,
   type GetGymBoardsQueryResponse,
   type GetGymKioskQueryResponse,
@@ -51,6 +49,7 @@ import { formatHoursConfirmedDate } from './gym-hours-display';
 import GymPageCtaLink from './gym-page-cta-link';
 import GymInstallCta from './gym-install-cta';
 import GymQrLandingTracker from './gym-qr-landing-tracker';
+import { fetchGymBySlug, isGymViewable } from './fetch-gym-by-slug';
 import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 import { resolveGymLogoDisplayUrl, resolveGymPhotoDisplayUrl } from '@/app/lib/gym-logo-display-url';
 
@@ -61,16 +60,6 @@ type GymRouteProps = {
   // epic read their own params from it.
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
-
-const fetchGymBySlug = cache(async (slug: string, token: string | undefined): Promise<Gym | null> => {
-  try {
-    const response = await executeAuthenticatedGraphQL<GetGymBySlugQueryResponse>(GET_GYM_BY_SLUG, { slug }, token);
-    return response.gymBySlug ?? null;
-  } catch (error) {
-    console.error('fetchGymBySlug failed:', error);
-    return null;
-  }
-});
 
 /**
  * The viewer's own claim in flight, fetched on its own so a failure degrades to
@@ -117,11 +106,6 @@ async function fetchGymBoards(gymUuid: string, token: string | undefined): Promi
     console.error('fetchGymBoards failed:', error);
     return [];
   }
-}
-
-/** A gym is viewable when it's public, or the viewer can edit it (private preview). */
-function isGymViewable(gym: Gym | null): gym is Gym {
-  return gym !== null && (gym.isPublic || gym.canEdit);
 }
 
 /**

--- a/packages/web/app/gym/[gym_slug]/poster/__tests__/gym-poster-print-bar.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/poster/__tests__/gym-poster-print-bar.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import GymPosterPrintBar from '../gym-poster-print-bar';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en-US' } }),
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('GymPosterPrintBar', () => {
+  it('opens the browser print dialog', () => {
+    // jsdom has no print implementation, so it is stubbed rather than spied on.
+    const print = vi.fn();
+    vi.stubGlobal('print', print);
+
+    render(<GymPosterPrintBar gymHref="/gym/test-gym" printLabel="Print this poster" backLabel="Back to the gym" />);
+    fireEvent.click(screen.getByRole('button', { name: 'Print this poster' }));
+
+    expect(print).toHaveBeenCalledTimes(1);
+    vi.unstubAllGlobals();
+  });
+
+  it('links back to the gym page with the href it was handed', () => {
+    render(<GymPosterPrintBar gymHref="/gym/test-gym" printLabel="Print this poster" backLabel="Back to the gym" />);
+    // A real anchor, not a click handler: the way back has to survive a page
+    // printed from a browser with JS blocked, and be middle-clickable.
+    expect(screen.getByRole('link', { name: 'Back to the gym' }).getAttribute('href')).toBe('/gym/test-gym');
+  });
+
+  it('carries a percent-encoded slug through untouched', () => {
+    render(<GymPosterPrintBar gymHref="/gym/boulder%231" printLabel="Print" backLabel="Back" />);
+    expect(screen.getByRole('link', { name: 'Back' }).getAttribute('href')).toBe('/gym/boulder%231');
+  });
+
+  it('renders the labels the server passed rather than translating in the island', () => {
+    // The i18n mock echoes keys, so a label rendered from a key would show the
+    // key. Seeing the passed strings proves the island stays off client i18n.
+    render(<GymPosterPrintBar gymHref="/gym/test-gym" printLabel="Imprimer" backLabel="Retour" />);
+    expect(screen.getByRole('button', { name: 'Imprimer' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Retour' })).toBeTruthy();
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/poster/__tests__/gym-poster-qr.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/poster/__tests__/gym-poster-qr.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vite-plus/test';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { SITE_URL } from '@/app/lib/seo/base-url';
+import GymPosterQr from '../gym-poster-qr';
+
+// Capture the QRCodeSVG props so the encoded target and the print-critical
+// colour/quiet-zone settings are assertable without decoding the matrix — the
+// same trick the kiosk's install-QR test uses.
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: (props: { value: string; fgColor?: string; bgColor?: string; marginSize?: number; level?: string }) => (
+    <svg
+      data-testid="qr"
+      data-value={props.value}
+      data-fg={props.fgColor}
+      data-bg={props.bgColor}
+      data-margin={String(props.marginSize)}
+      data-level={props.level}
+    />
+  ),
+}));
+
+describe('GymPosterQr', () => {
+  it('encodes the canonical gym URL with the poster attribution params', () => {
+    render(<GymPosterQr gymSlug="boulderwelt-ost" />);
+    // Spelled out rather than round-tripped through gymQrUrl: this string is
+    // printed and laminated, so the test states the exact bytes a phone will
+    // resolve. Derived from SITE_URL so it tracks the base URL, not the host.
+    expect(screen.getByTestId('qr').getAttribute('data-value')).toBe(
+      `${SITE_URL}/gym/boulderwelt-ost?src=qr&medium=poster`,
+    );
+  });
+
+  it('percent-encodes a slug so a printed URL is never malformed', () => {
+    render(<GymPosterQr gymSlug="boulder#1" />);
+    expect(screen.getByTestId('qr').getAttribute('data-value')).toBe(
+      `${SITE_URL}/gym/boulder%231?src=qr&medium=poster`,
+    );
+  });
+
+  it('sets black-on-white as SVG props, not CSS', () => {
+    // Browsers drop background graphics when printing by default, so a CSS
+    // quiet zone prints away and a dark-mode page yields a dark-on-dark code.
+    // As props they are page content and always print.
+    render(<GymPosterQr gymSlug="boulderwelt-ost" />);
+    const qr = screen.getByTestId('qr');
+    expect(qr.getAttribute('data-fg')).toBe('#000000');
+    expect(qr.getAttribute('data-bg')).toBe('#ffffff');
+  });
+
+  it('uses the spec 4-module quiet zone, not the kiosk margin', () => {
+    render(<GymPosterQr gymSlug="boulderwelt-ost" />);
+    expect(screen.getByTestId('qr').getAttribute('data-margin')).toBe('4');
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/poster/__tests__/poster-page.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/poster/__tests__/poster-page.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import React from 'react';
 import type { Gym } from '@boardsesh/shared-schema';
 
 vi.mock('server-only', () => ({}));
@@ -106,6 +107,78 @@ describe('gym poster route', () => {
       return;
     }
     throw new Error('expected a redirect');
+  });
+});
+
+describe('poster sheet structure', () => {
+  // The single-page guarantee is a per-block height budget (see the comment on
+  // `.sheet`), and that budget is verified by a static print harness that
+  // mirrors this markup. Pin the block sequence so the two cannot drift apart
+  // silently — and so the block that spills first, the trademark disclaimer,
+  // stays visibly last.
+  function sheetChildren(tree: React.ReactElement): React.ReactElement[] {
+    const found: React.ReactElement[] = [];
+    const walk = (node: React.ReactNode): void => {
+      if (!React.isValidElement(node)) return;
+      const props = node.props as { children?: React.ReactNode };
+      if (node.type === 'main') {
+        React.Children.forEach(props.children, (child) => {
+          if (React.isValidElement(child)) found.push(child);
+        });
+        return;
+      }
+      React.Children.forEach(props.children, walk);
+    };
+    walk(tree);
+    return found;
+  }
+
+  it('renders the blocks in the order the print budget assumes, disclaimer last', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gymFixture({ slug: 'poster-structure' }) });
+    const tree = (await renderPoster('poster-structure')) as React.ReactElement;
+
+    const kinds = sheetChildren(tree).map((child) =>
+      typeof child.type === 'string' ? child.type : ((child.type as { name?: string }).name ?? 'component'),
+    );
+    // The fixture has no logo, so: name, heading, pitch, QR, typed-URL block,
+    // footer block. A gym with a logo adds an <img> in front — the harness
+    // measures that case too, since the logo is 18 mm of the height budget.
+    expect(kinds).toEqual(['h1', 'p', 'p', 'GymPosterQr', 'div', 'div']);
+  });
+
+  it('prints a clean, percent-encoded typed URL — no attribution params on the human line', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gymFixture({ slug: 'boulder#1' }) });
+    const tree = (await renderPoster('boulder#1')) as React.ReactElement;
+
+    const typedBlock = sheetChildren(tree).at(-2) as React.ReactElement;
+    const lines: string[] = [];
+    React.Children.forEach((typedBlock.props as { children?: React.ReactNode }).children, (child) => {
+      if (!React.isValidElement(child)) return;
+      const text = (child.props as { children?: unknown }).children;
+      if (typeof text === 'string') lines.push(text);
+    });
+
+    // Encoded the same way `gymQrUrl` encodes: the code and the line are
+    // printed centimetres apart and must not disagree. Scheme stripped, and no
+    // `?src=qr&medium=poster` — someone typing a URL off a wall is not a scan.
+    expect(lines).toContain('www.boardsesh.com/gym/boulder%231');
+    expect(lines.some((line) => line.includes('src=qr'))).toBe(false);
+  });
+
+  it('keeps the compatibility line and the non-affiliation line inside the last block', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gymFixture({ slug: 'poster-footer' }) });
+    const tree = (await renderPoster('poster-footer')) as React.ReactElement;
+
+    const lastBlock = sheetChildren(tree).at(-1) as React.ReactElement;
+    const lines: string[] = [];
+    React.Children.forEach((lastBlock.props as { children?: React.ReactNode }).children, (child) => {
+      if (!React.isValidElement(child)) return;
+      const text = (child.props as { children?: unknown }).children;
+      if (typeof text === 'string') lines.push(text);
+    });
+    // The i18n mock echoes keys, so these are the catalog paths.
+    expect(lines).toContain('gymPage.poster.compatibility');
+    expect(lines).toContain('gymPage.poster.independence');
   });
 });
 

--- a/packages/web/app/gym/[gym_slug]/poster/__tests__/poster-page.test.tsx
+++ b/packages/web/app/gym/[gym_slug]/poster/__tests__/poster-page.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import type { Gym } from '@boardsesh/shared-schema';
+
+vi.mock('server-only', () => ({}));
+
+// Next's real navigation helpers throw and stop the render; sentinels keep the
+// control flow honest instead of letting the page fall through.
+class RedirectSignal extends Error {
+  constructor(readonly target: string) {
+    super(`permanentRedirect:${target}`);
+  }
+}
+class NotFoundSignal extends Error {}
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new NotFoundSignal('notFound');
+  },
+  permanentRedirect: (target: string) => {
+    throw new RedirectSignal(target);
+  },
+}));
+
+vi.mock('@/app/lib/i18n/server', () => ({
+  getServerTranslation: vi.fn(async () => ({
+    t: (key: string) => key,
+    locale: 'en-US',
+  })),
+}));
+
+const getServerAuthToken = vi.hoisted(() => vi.fn(async () => undefined as string | undefined));
+vi.mock('@/app/lib/auth/server-auth', () => ({ getServerAuthToken }));
+
+const executeAuthenticatedGraphQL = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/graphql/server-graphql', () => ({ executeAuthenticatedGraphQL }));
+
+const posterModule = await import('../page');
+const GymPosterPage = posterModule.default;
+const { generateMetadata } = posterModule;
+
+function gymFixture(overrides: Partial<Gym>): Gym {
+  return {
+    uuid: 'uuid-1',
+    slug: 'boulderwelt-ost',
+    name: 'Boulderwelt Ost',
+    isPublic: true,
+    canEdit: false,
+    ...overrides,
+  } as unknown as Gym;
+}
+
+// `fetchGymBySlug` is wrapped in React's `cache()`, so every test addresses a
+// slug of its own rather than relying on the mock being re-read.
+async function renderPoster(slug: string) {
+  return GymPosterPage({ params: Promise.resolve({ gym_slug: slug }) });
+}
+
+beforeEach(() => {
+  executeAuthenticatedGraphQL.mockReset();
+  getServerAuthToken.mockReset();
+  getServerAuthToken.mockResolvedValue(undefined);
+});
+
+describe('gym poster route', () => {
+  it('renders for a public gym', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gymFixture({ slug: 'poster-public' }) });
+    await expect(renderPoster('poster-public')).resolves.toBeTruthy();
+  });
+
+  it('renders for a private gym the viewer can edit, so an owner can print before going public', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({
+      gymBySlug: gymFixture({ slug: 'poster-private', isPublic: false, canEdit: true }),
+    });
+    await expect(renderPoster('poster-private')).resolves.toBeTruthy();
+  });
+
+  it('404s a private gym the viewer cannot edit — the poster must not leak its existence', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({
+      gymBySlug: gymFixture({ slug: 'poster-hidden', isPublic: false, canEdit: false }),
+    });
+    await expect(renderPoster('poster-hidden')).rejects.toBeInstanceOf(NotFoundSignal);
+  });
+
+  it('404s a missing gym', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: null });
+    await expect(renderPoster('poster-nope')).rejects.toBeInstanceOf(NotFoundSignal);
+  });
+
+  it('308s a merged twin onto the canonical slug, keeping /poster', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gymFixture({ slug: 'poster-canonical' }) });
+    try {
+      await renderPoster('poster-old-twin');
+    } catch (error) {
+      expect(error).toBeInstanceOf(RedirectSignal);
+      expect((error as RedirectSignal).target).toBe('/gym/poster-canonical/poster');
+      return;
+    }
+    throw new Error('expected a redirect');
+  });
+
+  it('percent-encodes the canonical slug in the redirect', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gymFixture({ slug: 'boulder#1' }) });
+    try {
+      await renderPoster('poster-old-hash');
+    } catch (error) {
+      expect((error as RedirectSignal).target).toBe('/gym/boulder%231/poster');
+      return;
+    }
+    throw new Error('expected a redirect');
+  });
+});
+
+describe('gym poster metadata', () => {
+  it('is noindex and emits no canonical or hreflang — a utility surface has nothing to canonicalise', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({ gymBySlug: gymFixture({ slug: 'poster-meta' }) });
+    const metadata = await generateMetadata({ params: Promise.resolve({ gym_slug: 'poster-meta' }) });
+
+    expect(metadata.robots).toEqual({ index: false, follow: true });
+    // No `path` is passed, so `createPageMetadata` builds no alternates at all.
+    // hreflang is only honoured between mutually indexable pages, and a
+    // canonical beside a noindex directive is a contradictory pair.
+    expect(metadata.alternates).toBeUndefined();
+  });
+
+  it('does not name a gym the viewer cannot see', async () => {
+    executeAuthenticatedGraphQL.mockResolvedValue({
+      gymBySlug: gymFixture({ slug: 'poster-meta-hidden', name: 'Secret Gym', isPublic: false, canEdit: false }),
+    });
+    const metadata = await generateMetadata({ params: Promise.resolve({ gym_slug: 'poster-meta-hidden' }) });
+
+    expect(JSON.stringify(metadata)).not.toContain('Secret Gym');
+  });
+});

--- a/packages/web/app/gym/[gym_slug]/poster/gym-poster-print-bar.tsx
+++ b/packages/web/app/gym/[gym_slug]/poster/gym-poster-print-bar.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+// Screen-only bar under the poster: open the print dialog, or go back to the
+// gym page. `@media print` in the stylesheet removes it, so nothing here ends
+// up on paper.
+
+import React from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import PrintOutlined from '@mui/icons-material/PrintOutlined';
+import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined';
+import LocaleLink from '@/app/components/i18n/locale-link';
+import styles from './gym-poster.module.css';
+
+type GymPosterPrintBarProps = {
+  gymHref: string;
+  /**
+   * Already translated by the server component that renders this island — the
+   * same arrangement `GymInstallCta` uses, so a static poster page doesn't drag
+   * the client i18n bundle along for two button labels.
+   */
+  printLabel: string;
+  backLabel: string;
+};
+
+export default function GymPosterPrintBar({ gymHref, printLabel, backLabel }: GymPosterPrintBarProps) {
+  return (
+    <Box className={styles.noPrint}>
+      <Button
+        variant="contained"
+        startIcon={<PrintOutlined />}
+        onClick={() => window.print()}
+        sx={{ textTransform: 'none' }}
+      >
+        {printLabel}
+      </Button>
+      <Button
+        component={LocaleLink}
+        href={gymHref}
+        variant="outlined"
+        startIcon={<ArrowBackOutlined />}
+        sx={{ textTransform: 'none' }}
+      >
+        {backLabel}
+      </Button>
+    </Box>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/poster/gym-poster-qr.tsx
+++ b/packages/web/app/gym/[gym_slug]/poster/gym-poster-qr.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+// The printed code itself (#4379).
+//
+// A client island because `qrcode.react` calls hooks — the rest of the poster
+// is server-rendered.
+
+import React from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+import { gymQrUrl } from '@/app/lib/gym-attribution';
+import styles from './gym-poster.module.css';
+
+// COLOURS ARE COMPONENT PROPS, NOT CSS, AND THAT IS THE WHOLE POINT.
+//
+// Browsers strip background graphics when printing unless the reader ticks the
+// box, so a white quiet zone painted as a CSS background disappears on paper
+// and a dark-mode page prints a dark code on dark — unscannable, and only
+// discovered after someone laminates it. As SVG fills they are page content:
+// they print by default, in every theme, on every browser.
+const POSTER_QR_FOREGROUND = '#000000';
+const POSTER_QR_BACKGROUND = '#ffffff';
+
+export default function GymPosterQr({ gymSlug }: { gymSlug: string }) {
+  // `gymQrUrl` — never a hand-built string. The printed code and every counter
+  // that reads `?src=qr&medium=poster` have to come out of one function, because
+  // a disagreement between them is only discovered after the poster is on a wall.
+  const posterUrl = gymQrUrl(gymSlug, 'poster');
+
+  return (
+    <QRCodeSVG
+      className={styles.qr}
+      value={posterUrl}
+      // Internal resolution only; the CSS sizes the SVG in millimetres.
+      size={512}
+      fgColor={POSTER_QR_FOREGROUND}
+      bgColor={POSTER_QR_BACKGROUND}
+      // Error correction Q (25%) rather than the kiosk's M. A kiosk QR lives on
+      // a clean backlit screen; this one gets taped to a wall, scuffed and
+      // fingerprinted. The extra modules cost nothing at 76 mm.
+      level="Q"
+      // The spec quiet zone is 4 modules. The kiosk uses 1, which is fine
+      // against its own white tile and wrong on paper next to printed text.
+      marginSize={4}
+      // The typed-URL line below the code is the accessible equivalent, so the
+      // matrix itself is decoration to a screen reader.
+      aria-hidden
+    />
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/poster/gym-poster.module.css
+++ b/packages/web/app/gym/[gym_slug]/poster/gym-poster.module.css
@@ -34,8 +34,23 @@
 .sheet {
   /* A4 is the narrower paper (210 mm) and US Letter the shorter (279.4 mm), so
    * the printable box common to both, at the 12 mm @page margin above, is
-   * 186 mm × 255.4 mm. Bounding the sheet to that is what makes "one sheet"
-   * true on both without a second, paper-specific layout. */
+   * 186 mm × 255.4 mm.
+   *
+   * WIDTH is enforced here by `max-width`. HEIGHT cannot be — a `max-height`
+   * would clip, and clipping the last block is worse than a second page: the
+   * last block is the trademark footer, so a laminated poster would lose its
+   * disclaimer while the QR above it still scanned, and nobody would notice.
+   * The height is instead held by BOUNDING EVERY BLOCK, so the worst case is
+   * computable rather than hoped for. With every element at its maximum wrap:
+   *
+   *   logo 18 + name 29.7 (3 lines, clamped) + heading 13.2 (2 lines)
+   *   + pitch 23.5 (4 lines) + QR 76 + typed URL 23.7 (3 lines)
+   *   + footer 30 (6 lines) + 6 gaps at 6 = 36        →  250.1 mm
+   *
+   * That leaves ~5 mm against the 255.4 mm ceiling. Any new block, or any
+   * loosened clamp, has to be subtracted from that budget — and checked with
+   * the 100-character-name fixture, which is what a `gyms.name` at its
+   * server-side cap actually produces. */
   box-sizing: border-box;
   width: 100%;
   max-width: 186mm;
@@ -43,7 +58,7 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  gap: 8mm;
+  gap: 6mm;
   padding: 10mm;
   background: #ffffff;
   color: #111111;
@@ -53,23 +68,33 @@
 
 .logo {
   max-width: 40mm;
-  max-height: 22mm;
+  max-height: 18mm;
   object-fit: contain;
 }
 
 .gymName {
   margin: 0;
-  font-size: 11mm;
-  line-height: 1.15;
+  font-size: 9mm;
+  line-height: 1.1;
   font-weight: 700;
   /* Long gym names wrap rather than run off the sheet; a 30-character German
    * compound gets broken instead of clipped. */
   overflow-wrap: anywhere;
+  /* HARD LINE CLAMP, and it is load-bearing. `gyms.name` is capped at 100
+   * characters server-side, which is four-plus lines here — enough to push the
+   * trademark footer onto a second sheet that nobody prints. Three lines fits
+   * every real gym name; the rare 100-character outlier is ellipsised, which
+   * is the right trade against silently dropping the disclaimer. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow: hidden;
 }
 
 .heading {
   margin: 0;
-  font-size: 6mm;
+  font-size: 5.5mm;
   line-height: 1.2;
   font-weight: 700;
 }
@@ -77,7 +102,7 @@
 .pitch {
   margin: 0;
   max-width: 140mm;
-  font-size: 4.4mm;
+  font-size: 4.2mm;
   line-height: 1.4;
 }
 
@@ -161,8 +186,10 @@
      * ~6 mm wider than the A4-derived bound the layout is built to. */
     margin: 0 auto;
     padding: 0;
-    /* Guarantees the single sheet even if a locale's copy runs long: nothing
-     * inside is allowed to split across a page. */
+    /* Keeps the sheet from being split mid-block when it fits. It is NOT the
+     * single-page guarantee — a box taller than the page fragments regardless
+     * of this property. The guarantee is the per-block height budget on
+     * `.sheet` above. */
     break-inside: avoid;
     page-break-inside: avoid;
   }

--- a/packages/web/app/gym/[gym_slug]/poster/gym-poster.module.css
+++ b/packages/web/app/gym/[gym_slug]/poster/gym-poster.module.css
@@ -1,0 +1,173 @@
+/* Print sheet for the per-gym QR poster (#4379).
+ *
+ * WHY A STYLESHEET AND NOT `sx`: `@page` is a top-level at-rule — it cannot be
+ * expressed through MUI's `sx`, and the print rules below have to sit next to
+ * the screen rules they override or the two drift. Same call the kiosk made for
+ * its install-QR tile.
+ *
+ * HARDCODED COLOURS ARE THE DOCUMENTED PRINT EXCEPTION (the theme-token rule
+ * says colours come from theme-config). This sheet is ALWAYS black on white,
+ * light theme or dark, screen or paper: the reader is a phone camera pointed at
+ * a laminated page, and a themed sheet would print a dark-on-dark code that
+ * does not scan. `board-install-qr.module.css` hardcodes #ffffff/#111111 for
+ * the same reason. What you see on screen is what comes out of the printer.
+ */
+
+/* `auto`, deliberately NOT `A4`. A fixed `size: A4` clips on US Letter (216 mm
+ * wide, so the driver shrinks or crops), and a fixed `size: letter` letterboxes
+ * A4. `auto` prints on whatever paper is loaded; the sheet below is bounded to
+ * the INTERSECTION of the two sizes so the identical layout fits either. */
+@page {
+  size: auto;
+  margin: 12mm;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-4);
+  padding: var(--spacing-6) var(--spacing-4);
+  min-height: 100dvh;
+}
+
+.sheet {
+  /* A4 is the narrower paper (210 mm) and US Letter the shorter (279.4 mm), so
+   * the printable box common to both, at the 12 mm @page margin above, is
+   * 186 mm × 255.4 mm. Bounding the sheet to that is what makes "one sheet"
+   * true on both without a second, paper-specific layout. */
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 186mm;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8mm;
+  padding: 10mm;
+  background: #ffffff;
+  color: #111111;
+  border-radius: var(--border-radius-lg);
+  box-shadow: 0 2px 16px var(--overlay-dark);
+}
+
+.logo {
+  max-width: 40mm;
+  max-height: 22mm;
+  object-fit: contain;
+}
+
+.gymName {
+  margin: 0;
+  font-size: 11mm;
+  line-height: 1.15;
+  font-weight: 700;
+  /* Long gym names wrap rather than run off the sheet; a 30-character German
+   * compound gets broken instead of clipped. */
+  overflow-wrap: anywhere;
+}
+
+.heading {
+  margin: 0;
+  font-size: 6mm;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+.pitch {
+  margin: 0;
+  max-width: 140mm;
+  font-size: 4.4mm;
+  line-height: 1.4;
+}
+
+.qr {
+  display: block;
+  /* ~72 mm of code plus the SVG's own 4-module quiet zone. At a typical 41
+   * modules that is ~1.6 mm per module — an order of magnitude over what a
+   * phone camera needs from a metre away, with room to spare for a scuffed
+   * laminate. */
+  width: 76mm;
+  height: 76mm;
+}
+
+.typedUrlLabel {
+  margin: 0 0 1mm;
+  font-size: 3.6mm;
+  line-height: 1.3;
+}
+
+.typedUrl {
+  margin: 0;
+  font-size: 5mm;
+  line-height: 1.2;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.footer {
+  margin: 0;
+  font-size: 3.4mm;
+  line-height: 1.4;
+  /* Deliberately not a neutral token: this has to stay legible in ink on paper,
+   * and a themed grey is picked for a backlit screen. */
+  color: #444444;
+}
+
+.wordmark {
+  margin: 0;
+  font-size: 5mm;
+  line-height: 1.2;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+/* The screen-only bar: the print button that opens the browser dialog, and the
+ * way back to the gym page. Neither means anything on paper — @media print
+ * below removes it. */
+.noPrint {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--spacing-2);
+}
+
+@media print {
+  .page {
+    display: block;
+    padding: 0;
+    min-height: 0;
+    background: #ffffff;
+  }
+
+  .noPrint {
+    display: none;
+  }
+
+  .sheet {
+    /* Force the ink even where the browser would inherit a dark theme, and keep
+     * the paper white when "background graphics" is off (its default) — the QR
+     * itself does not depend on this, because its colours are SVG fills passed
+     * as component props rather than CSS backgrounds. */
+    background: #ffffff;
+    color: #111111;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+    box-shadow: none;
+    border-radius: 0;
+    /* @page already supplies the 12 mm paper margin; a second inner margin
+     * here is what pushes a nearly-full sheet onto page two. `auto` on the
+     * sides keeps the sheet centred on US Letter, whose printable box is
+     * ~6 mm wider than the A4-derived bound the layout is built to. */
+    margin: 0 auto;
+    padding: 0;
+    /* Guarantees the single sheet even if a locale's copy runs long: nothing
+     * inside is allowed to split across a page. */
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .footer {
+    color: #444444;
+  }
+}

--- a/packages/web/app/gym/[gym_slug]/poster/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/poster/page.tsx
@@ -1,0 +1,133 @@
+// Print-ready QR poster for one gym (#4379).
+//
+// The physical asset every gym-owner persona committed to: a laminated code by
+// the board. It is deliberately its own URL rather than a print stylesheet on
+// the gym page — an owner prints this, tapes it to the wall, and the page they
+// printed from stays a normal web page.
+//
+// Chrome-less by construction: `/gym/<slug>/poster` is listed in
+// `CHROME_LESS_ROUTE_PATTERNS`, because the root layout's fixed header would
+// print over the sheet and the footer would push it onto page two. A nested
+// layout cannot take that chrome away.
+
+import React from 'react';
+import type { Metadata } from 'next';
+import { notFound, permanentRedirect } from 'next/navigation';
+import { getServerAuthToken } from '@/app/lib/auth/server-auth';
+import { getServerTranslation } from '@/app/lib/i18n/server';
+import { createNoIndexMetadata, absoluteUrl } from '@/app/lib/seo/metadata';
+import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
+import { resolveGymLogoDisplayUrl } from '@/app/lib/gym-logo-display-url';
+import { fetchGymBySlug, isGymViewable } from '../fetch-gym-by-slug';
+import GymPosterQr from './gym-poster-qr';
+import GymPosterPrintBar from './gym-poster-print-bar';
+import styles from './gym-poster.module.css';
+
+type GymPosterRouteProps = {
+  params: Promise<{ gym_slug: string }>;
+};
+
+/**
+ * The line a human types when the code won't scan: `www.boardsesh.com/gym/x`,
+ * clean — no `?src=qr&medium=poster`. Someone typing a URL off a wall is not a
+ * scan, and asking them to key in two query params would guarantee a typo and
+ * mislabel them as a scan if they got it right.
+ *
+ * Built from `absoluteUrl` so the host tracks the canonical site URL, then
+ * stripped of its scheme: `https://` is noise on a printed line, and every
+ * browser and phone keyboard adds it back.
+ */
+function typedFallbackUrl(gymSlug: string): string {
+  return absoluteUrl(`/gym/${gymSlug}`).replace(/^https?:\/\//, '');
+}
+
+export async function generateMetadata(props: GymPosterRouteProps): Promise<Metadata> {
+  const { gym_slug } = await props.params;
+  const token = await getServerAuthToken();
+  const [gym, { t, locale }] = await Promise.all([fetchGymBySlug(gym_slug, token), getServerTranslation('kiosk')]);
+
+  // NO `path`, deliberately — and this is where the poster parts company with
+  // the manage route, which does pass one. `path` is what makes
+  // `createPageMetadata` emit `alternates.canonical`, an hreflang `languages`
+  // map for all four locales, and `og:url`. All three are indexing signals, and
+  // this page is `robots: noindex`: hreflang is only honoured between mutually
+  // indexable pages, and a canonical sitting beside a noindex directive is the
+  // classic conflicting-signal pair. The gym's indexable surface is
+  // `/gym/<slug>`, which carries its own canonical. Omitting `path` yields
+  // `alternates: undefined` — nothing to contradict.
+  const title = isGymViewable(gym) ? t('gymPage.poster.metaTitle', { gymName: gym.name }) : t('metadata.fallbackTitle');
+  return createNoIndexMetadata({
+    title,
+    description: t('gymPage.poster.metaDescription'),
+    locale,
+  });
+}
+
+export default async function GymPosterPage(props: GymPosterRouteProps) {
+  const { gym_slug } = await props.params;
+  const token = await getServerAuthToken();
+  const gym = await fetchGymBySlug(gym_slug, token);
+
+  // Same viewability contract as the public page: public, or the viewer can
+  // edit it. An owner lays the poster out and prints it before the listing goes
+  // live; everyone else gets the same 404 a missing gym returns, so a private
+  // gym's existence doesn't leak through this route.
+  if (!isGymViewable(gym)) {
+    notFound();
+  }
+
+  // The requested slug belonged to a merged twin — send the poster URL to the
+  // canonical one, exactly as the public page does. No attribution query to
+  // carry here: this is the page an owner prints from, not a page a scan lands
+  // on. Percent-encoded for the same reason `gymQrUrl` encodes.
+  if (gym.slug && gym.slug !== gym_slug) {
+    permanentRedirect(`/gym/${encodeURIComponent(gym.slug)}/poster`);
+  }
+
+  const { t } = await getServerTranslation('kiosk');
+  const logoSrc = resolveGymLogoDisplayUrl(gym.logoUrl ?? null, getPublicBackendHttpUrl());
+
+  // The canonical slug, not the one in the address bar: a merged twin 308s onto
+  // `gym.slug` above, and a slug-less legacy gym has no canonical to fall back
+  // to. `||` rather than `??` — the redirect guard above is a truthiness check,
+  // so an empty-string slug reaches here having skipped it.
+  const posterSlug = gym.slug || gym_slug;
+
+  // Plain elements and a stylesheet rather than MUI Typography: every Typography
+  // variant carries a themed colour, and this sheet is black-on-white in both
+  // themes because it is read off paper by a phone camera. The screen-only
+  // action bar below is normal MUI.
+  return (
+    <div className={styles.page}>
+      <main className={styles.sheet}>
+        {logoSrc && <img className={styles.logo} src={logoSrc} alt={gym.name} />}
+        <h1 className={styles.gymName}>{gym.name}</h1>
+        <p className={styles.heading}>{t('gymPage.poster.heading')}</p>
+        <p className={styles.pitch}>{t('gymPage.poster.pitch')}</p>
+        <GymPosterQr gymSlug={posterSlug} />
+        <div>
+          <p className={styles.typedUrlLabel}>{t('gymPage.poster.typedUrlLabel')}</p>
+          <p className={styles.typedUrl}>{typedFallbackUrl(posterSlug)}</p>
+        </div>
+        <div>
+          {/* Brand name — never translated, per the i18n rules. */}
+          {/* i18n-ignore-next-line */}
+          <p className={styles.wordmark}>Boardsesh</p>
+          {/* Compatibility, not endorsement — and this one goes on a physical
+              wall, so the wording matters more here than anywhere else. Board
+              names describe which hardware the app talks to; the second line
+              says plainly that nobody endorsed us. No manufacturer logos,
+              no manufacturer colours, no borrowed branding. */}
+          <p className={styles.footer}>{t('gymPage.poster.compatibility')}</p>
+          <p className={styles.footer}>{t('gymPage.poster.independence')}</p>
+        </div>
+      </main>
+
+      <GymPosterPrintBar
+        gymHref={`/gym/${posterSlug}`}
+        printLabel={t('gymPage.poster.printAction')}
+        backLabel={t('gymPage.poster.backToGym')}
+      />
+    </div>
+  );
+}

--- a/packages/web/app/gym/[gym_slug]/poster/page.tsx
+++ b/packages/web/app/gym/[gym_slug]/poster/page.tsx
@@ -36,9 +36,20 @@ type GymPosterRouteProps = {
  * Built from `absoluteUrl` so the host tracks the canonical site URL, then
  * stripped of its scheme: `https://` is noise on a printed line, and every
  * browser and phone keyboard adds it back.
+ *
+ * The slug is percent-encoded because `gymQrUrl` percent-encodes it, and these
+ * two strings are printed centimetres apart on the same sheet. No slug the
+ * backend generates today can differ between the two forms — but "the printed
+ * code and the printed line are built by two code paths that could disagree"
+ * is the exact failure this file exists to prevent, and the fix is one call.
  */
 function typedFallbackUrl(gymSlug: string): string {
-  return absoluteUrl(`/gym/${gymSlug}`).replace(/^https?:\/\//, '');
+  return absoluteUrl(gymPosterPath(gymSlug)).replace(/^https?:\/\//, '');
+}
+
+/** The gym's own page, encoded the same way — the back link and the typed line. */
+function gymPosterPath(gymSlug: string): string {
+  return `/gym/${encodeURIComponent(gymSlug)}`;
 }
 
 export async function generateMetadata(props: GymPosterRouteProps): Promise<Metadata> {
@@ -100,7 +111,11 @@ export default async function GymPosterPage(props: GymPosterRouteProps) {
   return (
     <div className={styles.page}>
       <main className={styles.sheet}>
-        {logoSrc && <img className={styles.logo} src={logoSrc} alt={gym.name} />}
+        {/* `alt=""`, deliberately: the gym's name is the <h1> immediately below,
+            so a described logo makes a screen reader announce the name twice.
+            Decorative here, in the strict sense — it carries no information the
+            next element doesn't. */}
+        {logoSrc && <img className={styles.logo} src={logoSrc} alt="" />}
         <h1 className={styles.gymName}>{gym.name}</h1>
         <p className={styles.heading}>{t('gymPage.poster.heading')}</p>
         <p className={styles.pitch}>{t('gymPage.poster.pitch')}</p>
@@ -124,7 +139,7 @@ export default async function GymPosterPage(props: GymPosterRouteProps) {
       </main>
 
       <GymPosterPrintBar
-        gymHref={`/gym/${posterSlug}`}
+        gymHref={gymPosterPath(posterSlug)}
         printLabel={t('gymPage.poster.printAction')}
         backLabel={t('gymPage.poster.backToGym')}
       />

--- a/packages/web/app/lib/__tests__/chrome-less-routes.test.ts
+++ b/packages/web/app/lib/__tests__/chrome-less-routes.test.ts
@@ -13,6 +13,16 @@ describe('isChromeLessPath', () => {
     expect(isChromeLessPath('/embed/board/abc-123')).toBe(true);
   });
 
+  it('matches the printable gym poster, and only that leaf', () => {
+    // The fixed header prints on top of the sheet and the footer pushes it onto
+    // page two, so this one is functional rather than cosmetic (#4379).
+    expect(isChromeLessPath('/gym/boulderwelt-ost/poster')).toBe(true);
+    expect(isChromeLessPath('/gym/boulderwelt-ost')).toBe(false);
+    expect(isChromeLessPath('/gym/boulderwelt-ost/manage')).toBe(false);
+    expect(isChromeLessPath('/gym/boulderwelt-ost/poster/extra')).toBe(false);
+    expect(isChromeLessPath('/gym/poster')).toBe(false);
+  });
+
   it('does not match lookalike prefixes', () => {
     expect(isChromeLessPath('/kiosks')).toBe(false);
     expect(isChromeLessPath('/embedded')).toBe(false);

--- a/packages/web/app/lib/chrome-less-routes.ts
+++ b/packages/web/app/lib/chrome-less-routes.ts
@@ -11,12 +11,25 @@
 
 export const CHROME_LESS_ROUTE_PREFIXES = ['/kiosk', '/embed'] as const;
 
+// Chrome-less surfaces that are NOT a whole route subtree, so a prefix cannot
+// express them.
+//
+// - /gym/<slug>/poster — the printable QR poster (#4379). It sits inside the
+//   very much chromed /gym tree, and the chrome removal is functional rather
+//   than cosmetic: the header is `position: fixed`, so it prints on top of the
+//   poster, and the footer's link columns push the sheet onto a second page.
+//   Anchored at both ends — nothing below /poster matches, and neither does
+//   /gym/<slug> itself.
+export const CHROME_LESS_ROUTE_PATTERNS = [/^\/gym\/[^/]+\/poster$/] as const;
+
 /**
  * Whether a locale-stripped pathname belongs to a chrome-less surface.
  * Boundary-aware prefix match: '/kiosk' and '/kiosk/…' match, '/kiosks' does not.
  */
 export function isChromeLessPath(pathnameWithoutLocale: string): boolean {
-  return CHROME_LESS_ROUTE_PREFIXES.some(
-    (prefix) => pathnameWithoutLocale === prefix || pathnameWithoutLocale.startsWith(`${prefix}/`),
+  return (
+    CHROME_LESS_ROUTE_PREFIXES.some(
+      (prefix) => pathnameWithoutLocale === prefix || pathnameWithoutLocale.startsWith(`${prefix}/`),
+    ) || CHROME_LESS_ROUTE_PATTERNS.some((pattern) => pattern.test(pathnameWithoutLocale))
   );
 }


### PR DESCRIPTION
Closes #4379 (part 2 — the attribution plumbing merged as #4510) · Part of epic #4372, Tier 1.

All four gym-owner personas named a printed QR by the board as their one committed physical asset — conditional on it never 404ing, and on a scan count existing. Both of those now exist, so this is the asset: `/gym/<slug>/poster`, one sheet, print it and laminate it.

## Why the details matter more than usual

This output goes on a wall and cannot be patched afterwards, so a few things are deliberate rather than incidental:

**The QR comes from `gymQrUrl()`** — the same builder #4510 added and the same string every counter reads. If the printed code and the tracked code were built by two code paths they would eventually disagree, and a printed disagreement is permanent.

**QR colours are SVG props, not CSS.** Browsers drop background graphics when printing by default, so a CSS quiet zone prints away — and on a dark-mode page that yields an unscannable dark-on-dark code. Quiet zone is the spec's 4 modules rather than the kiosk's tighter margin, which is fine on a lit screen and wrong on paper. Error correction is **Q** rather than the kiosk's M: a wall poster gets scuffed, and at ~1.6 mm modules the density costs nothing.

**`@page { size: auto }`, not `size: A4`** — a fixed size clips on US Letter and vice versa. Content is bounded to the intersection of both.

**The route joins the chrome-less list**, which was required rather than cosmetic: the root layout's fixed header prints over the sheet and the footer pushes it to a second page, and a nested layout cannot remove either. The existing mechanism was prefix-only and couldn't express a leaf inside `/gym`, so it gained an anchored-pattern sibling.

## Metadata: no `path`

Deliberate, and a divergence from the manage route. `createNoIndexMetadata` forwards to `createPageMetadata`, where `path` is the only thing producing `alternates.canonical`, the four-locale hreflang map and `og:url`. A canonical sitting next to a `noindex` directive is the classic contradictory pair, and hreflang is only honoured between mutually indexable pages. The gym's indexable surface is `/gym/<slug>`, which carries its own canonical. Verified in the rendered HTML: `noindex, follow`, no canonical, no hreflang.

## Print QA

Executed, with one gap stated plainly: **no physical phone scan** — this environment has no camera.

Print-to-PDF through headless Brave with background graphics **off** (the browser default):

| check | result |
|---|---|
| A4 × 4 locales × light/dark | one page each, 8/8 |
| US Letter, same matrix | one page each, 8/8 |
| German + a 49-character gym name, A4 | one page |
| header/footer elements on the route | 0 / 0 |
| sheet computed style in print media | white background, near-black text — identical under dark scheme |
| `.noPrint` bar in print media | not rendered |
| printed QR | 76 mm, every locale |

For QR content, since a camera scan wasn't possible: the module matrix was parsed out of the SVG the browser actually painted and compared against an independent encoder for the same URL — **byte-identical**, version 7, level Q, mask 4. A control with `medium=kiosk` matched on none of the eight masks. That's decode-equivalence, not a physical scan, and a real phone scan of a printed sheet is still owed before anyone laminates one.

Also verified live: the merged-slug 308 redirects `/gym/<old>/poster` → `/gym/<canonical>/poster`, an unknown slug 404s, and the es/fr/de copy renders correctly.

## Release Notes

Print a QR poster for your gym straight from the manage console — one page, A4 or Letter, in English, Spanish, French or German.
