### PR TITLE
fix(mobile): show sync spinner on Android app-bar bulb

### DIFF
--- a/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
+++ b/packages/mobile/src/components/chrome/MaterialBoardActions.tsx
@@ -18,6 +18,8 @@ import { useTheme } from '../../providers/theme-provider';
 import { hapticLight } from '../../lib/haptics';
 import { useLightbulbControl } from '../ble/use-lightbulb-control';
 import { useBleControlSheet } from '../../providers/ble-control-sheet-provider';
+import { useBluetoothWriteInProgress } from '../../providers/bluetooth-write-activity';
+import { ActivityIndicator } from '../ActivityIndicator';
 import { Text } from '../Text';
 import { iconMap } from '../icon-map';
 import { AngleSelectorSheet } from '../play-drawer/AngleSelectorSheet';
@@ -62,11 +64,21 @@ export function MaterialLightbulbAction() {
   const { bluetooth, lit, localConnected, onPress, onLongPress } = useLightbulbControl({
     onOpenControls: openControls,
   });
+  // Re-lighting the wall (a "Re-light board" tap in the BLE controls sheet, or
+  // any other write) leaves this icon as the only feedback in the app bar —
+  // the controls sheet closes immediately on tap. Swap in a spinner so the
+  // write isn't silent.
+  const isWriting = useBluetoothWriteInProgress();
 
   const handlePress = useCallback(() => {
     hapticLight();
     onPress();
   }, [onPress]);
+
+  const writingIcon = useCallback(
+    () => <ActivityIndicator size="small" color={brandColors.warning} />,
+    [brandColors.warning],
+  );
 
   if (!bluetooth) return null;
 
@@ -75,7 +87,7 @@ export function MaterialLightbulbAction() {
 
   return (
     <Appbar.Action
-      icon={iconName}
+      icon={isWriting ? writingIcon : iconName}
       color={iconColor as string}
       onPress={handlePress}
       // Short press connects/disconnects; long press (connected) opens the
@@ -84,6 +96,7 @@ export function MaterialLightbulbAction() {
       // The label reflects what tapping does (this device's link), not the fill —
       // the bulb can read lit because a session peer holds the wall.
       accessibilityLabel={localConnected ? tCommon('lightControl.disconnect') : tSettings('ble.connectBoard')}
+      accessibilityState={{ busy: isWriting }}
     />
   );
 }

--- a/packages/mobile/src/components/chrome/__tests__/MaterialBoardActions.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/MaterialBoardActions.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { act, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+type AppbarActionMockProps = {
+  icon: string | (() => ReactNode);
+  onPress?: () => void;
+  onLongPress?: () => void;
+  accessibilityLabel?: string;
+  accessibilityState?: { busy?: boolean };
+};
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+}));
+
+vi.mock('react-native-paper', () => ({
+  Appbar: {
+    Action: ({ icon, onPress, onLongPress, accessibilityLabel, accessibilityState }: AppbarActionMockProps) =>
+      createElement(
+        'button',
+        {
+          onClick: onPress,
+          onDoubleClick: onLongPress,
+          'data-label': accessibilityLabel,
+          'data-busy': String(accessibilityState?.busy ?? false),
+        },
+        typeof icon === 'function' ? icon() : createElement('span', { 'data-icon': icon }),
+      ),
+  },
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticLight: vi.fn() }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { label: '#000000' },
+    brandColors: { warning: '#ffcc00' },
+  }),
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: ({ color }: { color?: string }) =>
+    createElement('span', { 'data-spinner': 'true', 'data-color': color }),
+}));
+vi.mock('../../Text', () => ({ Text: () => null }));
+vi.mock('../../play-drawer/AngleSelectorSheet', () => ({ AngleSelectorSheet: () => null }));
+vi.mock('../use-material-angle-control', () => ({ useMaterialAngleControl: () => ({}) }));
+vi.mock('../../../providers/ble-control-sheet-provider', () => ({
+  useBleControlSheet: () => ({ open: vi.fn(), close: vi.fn() }),
+}));
+
+const lightbulbControl = vi.hoisted(() => ({
+  bluetooth: { connected: true },
+  lit: true,
+  localConnected: true,
+  onPress: vi.fn(),
+  onLongPress: vi.fn(),
+}));
+vi.mock('../../ble/use-lightbulb-control', () => ({
+  useLightbulbControl: () => lightbulbControl,
+}));
+
+import { createBleWriteActivityStore } from '../../../lib/ble/write-activity-store';
+import { BluetoothWriteActivityProvider } from '../../../providers/bluetooth-write-activity';
+import { MaterialLightbulbAction } from '../MaterialBoardActions';
+
+describe('MaterialLightbulbAction write activity', () => {
+  it('swaps the app-bar icon for a spinner while a BLE write is in flight', () => {
+    const store = createBleWriteActivityStore();
+    const view = render(
+      createElement(BluetoothWriteActivityProvider, { store }, createElement(MaterialLightbulbAction)),
+    );
+
+    // Idle: renders the lightbulb glyph, not busy.
+    expect(view.container.querySelector('[data-spinner="true"]')).toBeNull();
+    expect(view.container.querySelector('[data-icon]')).toBeTruthy();
+    expect(view.getByRole('button').getAttribute('data-busy')).toBe('false');
+
+    let release = () => {};
+    act(() => {
+      release = store.begin();
+    });
+
+    // Writing (e.g. a "Re-light board" tap): spinner replaces the glyph and the
+    // button reports busy, so the app-bar icon is never silent about the write.
+    expect(view.container.querySelector('[data-spinner="true"]')).toBeTruthy();
+    expect(view.container.querySelector('[data-icon]')).toBeNull();
+    expect(view.getByRole('button').getAttribute('data-busy')).toBe('true');
+
+    act(() => release());
+    expect(view.container.querySelector('[data-spinner="true"]')).toBeNull();
+    expect(view.container.querySelector('[data-icon]')).toBeTruthy();
+    expect(view.getByRole('button').getAttribute('data-busy')).toBe('false');
+  });
+});

--- a/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/collapsing-top-chrome.test.tsx
@@ -37,6 +37,8 @@ vi.mock('react-native', () => ({
       },
       children,
     ),
+  ActivityIndicator: () => createElement('span', { 'data-spinner': 'true' }),
+  Platform: { OS: 'android' },
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
 }));
 

--- a/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
+++ b/packages/mobile/src/components/chrome/__tests__/discover-top-chrome.test.tsx
@@ -37,6 +37,8 @@ vi.mock('react-native', () => ({
       },
       children,
     ),
+  ActivityIndicator: () => createElement('span', { 'data-spinner': 'true' }),
+  Platform: { OS: 'android' },
   StyleSheet: { create: (styles: Record<string, unknown>) => styles, absoluteFill: {}, hairlineWidth: 1 },
 }));
 


### PR DESCRIPTION
## Summary

On Android, tapping the app-bar lightbulb (or "Re-light board" in the BLE controls sheet reached by long-pressing it) pushes the current climb's LEDs to the wall over Bluetooth, but gave zero visual feedback while the write was in flight — the controls sheet closes immediately on tap. The play-drawer lightbulb already swaps to a spinner during a write via `useBluetoothWriteInProgress`; the Android app-bar bulb (`MaterialLightbulbAction`) never read that state.

- Swap the app-bar icon for a small `ActivityIndicator` while `isWriting` is true.
- Set `accessibilityState={{ busy: isWriting }}` to match the play-drawer bulb's a11y behaviour.
- Two pre-existing chrome tests (`collapsing-top-chrome.test.tsx`, `discover-top-chrome.test.tsx`) mock `react-native` locally without `Platform`; the new `ActivityIndicator` import pulls in `theme/colors.ts`, which reads `Platform.OS` at module-eval time. Added `Platform: { OS: 'android' }` (+ an `ActivityIndicator` stub) to both mocks.

## Release Notes

- The wall-sync bulb now spins while your climb is being sent to the board, so you're never left wondering if the tap registered.

## Test plan

- [x] `vp test run --project mobile` — 681 files / 6518 tests pass
- [x] `vp run typecheck:mobile`
- [x] `vp check`
- [x] `vp run check:mobile-bundle`
- [x] New `MaterialBoardActions.test.tsx` covers idle → writing → idle icon/`busy` transitions via the real `write-activity-store`