### PR TITLE
fix(ci): get main's full-repo lint back to green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,10 +226,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Install Expo web lint dependencies
-        # Widened alongside the job gate above: lint now also runs for
-        # sharedDeps-only changes, and the expo-web runtime has to be present
-        # whenever we lint mobile sources.
-        if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.sharedDeps == 'true'
+        # Unconditional: the push-to-main step below lints the WHOLE repo, so
+        # packages/mobile/src/web-shims/bottom-sheet.tsx is always in scope and
+        # its `@gorhom/bottom-sheet` types only resolve through the isolated
+        # web-runtime install (packages/mobile/tsconfig.json maps the path
+        # there). Gating this on the mobile/sharedDeps change filters made every
+        # main push that touched neither fail with two TS2307s that no PR run
+        # could reproduce. ~0.5s to install, so there is nothing to gate on.
         run: vp run mobile:web-runtime:install
       # The nine `check:mobile-*` guards below used to run in mobile-bundle, in
       # front of Metro — ~24s of the critical path (18s of it the fingerprint

--- a/scripts/__tests__/cleanup-merged-worktrees.test.ts
+++ b/scripts/__tests__/cleanup-merged-worktrees.test.ts
@@ -29,7 +29,12 @@ type PullRequest = {
   url: string;
 };
 
-function run(command: string, args: string[], cwd: string, extraEnvironment: NodeJS.ProcessEnv = {}) {
+// An override bag layered over process.env, not a complete environment — typing
+// it as NodeJS.ProcessEnv would demand the NODE_ENV the repo's Next global.d.ts
+// makes required, which no caller here wants to set.
+type EnvironmentOverrides = Record<string, string | undefined>;
+
+function run(command: string, args: string[], cwd: string, extraEnvironment: EnvironmentOverrides = {}) {
   return spawnSync(command, args, {
     cwd,
     encoding: 'utf8',
@@ -42,7 +47,7 @@ function run(command: string, args: string[], cwd: string, extraEnvironment: Nod
   });
 }
 
-function runGit(args: string[], cwd: string, extraEnvironment: NodeJS.ProcessEnv = {}): string {
+function runGit(args: string[], cwd: string, extraEnvironment: EnvironmentOverrides = {}): string {
   const result = run('git', args, cwd, extraEnvironment);
   if (result.status !== 0) {
     throw new Error(`git ${args.join(' ')} failed:\n${result.stderr}`);
@@ -168,7 +173,7 @@ function runCleanup(
   fixture: Fixture,
   pullRequests: PullRequest[],
   args: string[] = [],
-  extraEnvironment: NodeJS.ProcessEnv = {},
+  extraEnvironment: EnvironmentOverrides = {},
 ) {
   return run('bash', [fixture.scriptPath, ...args], fixture.primaryWorktree, {
     GH_PR_JSON: JSON.stringify(pullRequests),

--- a/scripts/__tests__/configure-git-hooks.test.ts
+++ b/scripts/__tests__/configure-git-hooks.test.ts
@@ -19,7 +19,12 @@ type Fixture = {
   vpLogPath: string;
 };
 
-function run(command: string, args: string[], cwd: string, extraEnvironment: NodeJS.ProcessEnv = {}) {
+// An override bag layered over process.env, not a complete environment — typing
+// it as NodeJS.ProcessEnv would demand the NODE_ENV the repo's Next global.d.ts
+// makes required, which no caller here wants to set.
+type EnvironmentOverrides = Record<string, string | undefined>;
+
+function run(command: string, args: string[], cwd: string, extraEnvironment: EnvironmentOverrides = {}) {
   return spawnSync(command, args, {
     cwd,
     encoding: 'utf8',

--- a/scripts/lib/mobile-publish-retry.test.ts
+++ b/scripts/lib/mobile-publish-retry.test.ts
@@ -14,6 +14,11 @@ import {
   type TextOutput,
 } from './mobile-publish-retry';
 
+// The repo's Next global.d.ts augments NodeJS.ProcessEnv to require NODE_ENV, so
+// a bare `{}` literal isn't assignable. These cases never read the child
+// environment, so an empty one is the honest fixture.
+const emptyChildEnvironment = {} as NodeJS.ProcessEnv;
+
 function outputCollector(): { output: TextOutput; read: () => string } {
   const chunks: string[] = [];
   return {
@@ -111,7 +116,7 @@ describe('self-hosted publish retries', () => {
     const stderr = outputCollector();
 
     const outcome = await publishSelfHostedPlatformWithRetry(
-      { platform: 'ios', command: 'bunx', args: ['eoas', 'publish'], cwd: '/repo', env: {} },
+      { platform: 'ios', command: 'bunx', args: ['eoas', 'publish'], cwd: '/repo', env: emptyChildEnvironment },
       { runner, sleeper, stdout: stdout.output, stderr: stderr.output },
     );
 
@@ -135,7 +140,7 @@ describe('self-hosted publish retries', () => {
     const stderr = outputCollector();
 
     const outcome = await publishSelfHostedPlatformWithRetry(
-      { platform: 'android', command: 'bunx', args: [], cwd: '/repo', env: {} },
+      { platform: 'android', command: 'bunx', args: [], cwd: '/repo', env: emptyChildEnvironment },
       { runner, sleeper, stdout: outputCollector().output, stderr: stderr.output },
     );
 
@@ -155,7 +160,7 @@ describe('self-hosted publish retries', () => {
     const stderr = outputCollector();
 
     const outcome = await publishSelfHostedPlatformWithRetry(
-      { platform: 'ios', command: 'bunx', args: [], cwd: '/repo', env: {} },
+      { platform: 'ios', command: 'bunx', args: [], cwd: '/repo', env: emptyChildEnvironment },
       { runner, sleeper, stdout: outputCollector().output, stderr: stderr.output },
     );
 
@@ -176,7 +181,7 @@ describe('self-hosted publish retries', () => {
     const stderr = outputCollector();
 
     await publishSelfHostedPlatformWithRetry(
-      { platform: 'ios', command: 'bunx', args: [], cwd: '/repo', env: {} },
+      { platform: 'ios', command: 'bunx', args: [], cwd: '/repo', env: emptyChildEnvironment },
       { runner, stdout: outputCollector().output, stderr: stderr.output },
     );
 

--- a/scripts/mobile-dsyms.test.ts
+++ b/scripts/mobile-dsyms.test.ts
@@ -137,8 +137,15 @@ describe('sentry-cli upload output', () => {
   });
 });
 
+// The repo's Next global.d.ts augments NodeJS.ProcessEnv to require NODE_ENV, so
+// the partial env fixtures below need the assertion to be assignable.
+function processEnv(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return values as NodeJS.ProcessEnv;
+}
+
 describe('uploadArchiveDsyms', () => {
-  const environment = { SENTRY_AUTH_TOKEN: 'test-token' };
+  const environment = processEnv({ SENTRY_AUTH_TOKEN: 'test-token' });
+  const emptyEnvironment = processEnv({});
 
   it('invokes sentry-cli against the archive dSYMs with the boardsesh Sentry env', () => {
     const fixture = createArchiveFixture(['Boardsesh.app.dSYM', 'BoardseshBeta.appex.dSYM']);
@@ -285,14 +292,22 @@ describe('uploadArchiveDsyms', () => {
   it('validates the archive before requiring an auth token', () => {
     const fixture = createArchiveFixture(['BoardseshWidgets.appex.dSYM']);
     expect(() =>
-      uploadArchiveDsyms({ archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment: {} }),
+      uploadArchiveDsyms({
+        archivePath: fixture.archivePath,
+        mobileDir: fixture.mobileDir,
+        environment: emptyEnvironment,
+      }),
     ).toThrow('No *.app.dSYM');
   });
 
   it('requires an auth token once the archive checks out', () => {
     const fixture = createArchiveFixture();
     expect(() =>
-      uploadArchiveDsyms({ archivePath: fixture.archivePath, mobileDir: fixture.mobileDir, environment: {} }),
+      uploadArchiveDsyms({
+        archivePath: fixture.archivePath,
+        mobileDir: fixture.mobileDir,
+        environment: emptyEnvironment,
+      }),
     ).toThrow('SENTRY_AUTH_TOKEN is required');
   });
 });

--- a/scripts/mobile-sourcemaps.test.ts
+++ b/scripts/mobile-sourcemaps.test.ts
@@ -28,6 +28,12 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const VALID_DEBUG_ID = '12345678-1234-4abc-9def-1234567890ab';
 const createdDirectories: string[] = [];
 
+// The repo's Next global.d.ts augments NodeJS.ProcessEnv to require NODE_ENV, so
+// the partial env fixtures below need the assertion to be assignable.
+function processEnv(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return values as NodeJS.ProcessEnv;
+}
+
 interface MobileFixture {
   mobileDir: string;
   outputDir: string;
@@ -436,15 +442,17 @@ describe('official Sentry uploader invocation', () => {
   });
 
   it('fixes org/project/url and removes release, dist, and CLI overrides', () => {
-    const environment = createSentryUploadEnvironment({
-      SENTRY_AUTH_TOKEN: ' token ',
-      SENTRY_ORG: 'wrong',
-      SENTRY_PROJECT: 'wrong',
-      SENTRY_URL: 'https://wrong.invalid/',
-      SENTRY_RELEASE: 'synthetic-release',
-      SENTRY_DIST: 'synthetic-dist',
-      SENTRY_CLI_EXECUTABLE: '/tmp/untrusted-cli',
-    });
+    const environment = createSentryUploadEnvironment(
+      processEnv({
+        SENTRY_AUTH_TOKEN: ' token ',
+        SENTRY_ORG: 'wrong',
+        SENTRY_PROJECT: 'wrong',
+        SENTRY_URL: 'https://wrong.invalid/',
+        SENTRY_RELEASE: 'synthetic-release',
+        SENTRY_DIST: 'synthetic-dist',
+        SENTRY_CLI_EXECUTABLE: '/tmp/untrusted-cli',
+      }),
+    );
     expect(environment).toMatchObject({
       SENTRY_AUTH_TOKEN: 'token',
       SENTRY_ORG: 'boardsesh',
@@ -457,7 +465,7 @@ describe('official Sentry uploader invocation', () => {
   });
 
   it('requires the auth token before starting the uploader', () => {
-    expect(() => createSentryUploadEnvironment({})).toThrow('SENTRY_AUTH_TOKEN is required');
+    expect(() => createSentryUploadEnvironment(processEnv({}))).toThrow('SENTRY_AUTH_TOKEN is required');
   });
 
   it('fails validation before resolving or starting the official uploader', () => {
@@ -472,7 +480,7 @@ describe('official Sentry uploader invocation', () => {
           platform: 'ios',
           mobileDir: fixture.mobileDir,
           outputDir: fixture.outputDir,
-          environment: { SENTRY_AUTH_TOKEN: 'secret-token' },
+          environment: processEnv({ SENTRY_AUTH_TOKEN: 'secret-token' }),
         },
         {
           resolveUploader: () => {
@@ -501,7 +509,7 @@ describe('official Sentry uploader invocation', () => {
           platform: 'ios',
           mobileDir: fixture.mobileDir,
           outputDir: fixture.outputDir,
-          environment: { SENTRY_AUTH_TOKEN: 'secret-token' },
+          environment: processEnv({ SENTRY_AUTH_TOKEN: 'secret-token' }),
         },
         {
           resolveUploader: () => join(fixture.mobileDir, 'fake-uploader.js'),
@@ -528,7 +536,7 @@ describe('official Sentry uploader invocation', () => {
           platform: 'android',
           mobileDir: fixture.mobileDir,
           outputDir: fixture.outputDir,
-          environment: { SENTRY_AUTH_TOKEN: 'secret-token' },
+          environment: processEnv({ SENTRY_AUTH_TOKEN: 'secret-token' }),
         },
         {
           resolveUploader: () => join(fixture.mobileDir, 'fake-uploader.js'),
@@ -581,11 +589,11 @@ describe('official Sentry uploader invocation', () => {
         platform: 'android',
         mobileDir: fixture.mobileDir,
         outputDir: fixture.outputDir,
-        environment: {
+        environment: processEnv({
           SENTRY_AUTH_TOKEN: 'secret-token',
           SENTRY_RELEASE: 'remove-me',
           SENTRY_DIST: 'remove-me-too',
-        },
+        }),
       },
       {
         resolveUploader: () => fakeUploaderPath,


### PR DESCRIPTION
`main`'s CI `lint` job has been failing on every commit for at least several days. Nobody noticed because **PR CI lints only changed files while the push-to-main job lints the whole repo** — so every PR goes green and main stays red, which means a genuine regression on main is currently camouflaged. That's the real cost, not the errors themselves.

`vp check` now exits 0.

## Two causes, neither a code defect

**1. A CI wiring bug that no PR run could ever reproduce.** The lint job's "Install Expo web lint dependencies" step was gated on the mobile/sharedDeps changes filter. But `packages/mobile/src/web-shims/bottom-sheet.tsx` resolves `@gorhom/bottom-sheet` types only through the isolated `packages/mobile/web-runtime` install, and the **push-to-main** run lints the whole repo, where that file is always in scope. So any push to main touching neither filter failed with two `TS2307`s — and a PR touching mobile would install the deps and pass, hiding it. The step is now unconditional; it costs about half a second.

**2. A type-model artifact, 33 errors, all one thing.** `next/types/global.d.ts` augments `NodeJS.ProcessEnv` with a **required** `NODE_ENV`. `vp check` runs a single program over the whole repo, so that global leaks into root `scripts/`, and every partial `{ ... }` env fixture in those tests stops being assignable. 29 × `TS2741`, 4 × `TS2345`, across five test files.

## No genuine bugs

I expected floating promises — a test whose assertion was never awaited would have been the interesting outcome. That isn't what these were: `no-floating-promises` findings here are *warnings*, not errors. All 35 build-failing diagnostics are type-model noise. No test was silently passing, no assertion unawaited, no runtime behaviour wrong. The 944 tests in the `scripts` project pass identically before and after.

## Fix shape

Where the parameter is an **override bag** layered over `process.env`, it's retyped `Record<string, string | undefined>` — that's the honest type, and it cleared 13 errors with no call-site churn. Where the value really is a whole environment, a local helper carries the assertion, following the precedent already documented in `scripts/__tests__/mobile-screenshots.test.ts`. No `oxlint-disable`, no `any`, and the 323 warnings are deliberately untouched.

6 files, +71/−30.

## Still open

The deeper problem stands: root `scripts/` is type-checked by the lint program against Next's globals, while `typecheck:scripts` uses a narrow `scripts/tsconfig.json` whose `include` covers six files. Those two disagree, so **the next partial-env fixture added under `scripts/` will fail main again the same invisible way**. Fixing it properly means widening that tsconfig and scoping the lint program — bigger than this PR.

Also worth knowing before someone tries the obvious shortcut: `{ SENTRY_AUTH_TOKEN: 'x' } as NodeJS.ProcessEnv` is rejected outright with `TS2352` for insufficient overlap. The assertion only works through a `Record<string, string | undefined>` parameter.

## Release Notes

- [x] No release note needed (internal / technical change)

CI and test-fixture typing only.
