### PR TITLE
fix(web): stop the sitemap index dropping the boards shard on a cold start

### DIFF
--- a/packages/web/app/lib/__tests__/server-popular-configs.test.ts
+++ b/packages/web/app/lib/__tests__/server-popular-configs.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, it, vi } from 'vite-plus/test';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import type { PopularBoardConfig } from '@boardsesh/shared-schema';
 
 vi.mock('server-only', () => ({}));
+// The Next Data Cache is a pass-through here: `unstable_cache` memoises across
+// requests in production, and the layer under test is the in-process one in
+// front of it.
 vi.mock('next/cache', () => ({
   unstable_cache: (fn: (...args: never[]) => unknown) => fn,
 }));
 
-const backend = vi.hoisted(() => ({ hasMore: false, totalCount: 51 }));
+const backend = vi.hoisted(() => ({ hasMore: false, totalCount: 51, gate: null as null | Promise<void> }));
 
 const CONFIG: PopularBoardConfig = {
   boardType: 'kilter',
@@ -28,6 +31,10 @@ const requestedInputs: unknown[] = [];
 vi.mock('@/app/lib/graphql/server-cached-client', () => ({
   executeGraphQLInternal: async (_document: unknown, variables: { input: unknown }) => {
     requestedInputs.push(variables.input);
+    // A real await point, so two concurrent callers genuinely overlap and the
+    // single-flight promise is observable rather than an accident of timing.
+    await Promise.resolve();
+    if (backend.gate) await backend.gate;
     return {
       popularBoardConfigs: {
         configs: [CONFIG],
@@ -38,11 +45,20 @@ vi.mock('@/app/lib/graphql/server-cached-client', () => ({
   },
 }));
 
-const { getAllBoardConfigsOrThrow } = await import('../server-popular-configs');
+const { getAllBoardConfigsOrThrow, resetBoardConfigCacheForTests } = await import('../server-popular-configs');
 
 describe('getAllBoardConfigsOrThrow', () => {
-  it('asks for the API cap in one page', () => {
+  beforeEach(() => {
+    // The in-process TTL outlives a test, so without this every case after the
+    // first would assert against the previous one's cached answer.
+    resetBoardConfigCacheForTests();
     requestedInputs.length = 0;
+    backend.hasMore = false;
+    backend.totalCount = 51;
+    backend.gate = null;
+  });
+
+  it('asks for the API cap in one page', () => {
     return getAllBoardConfigsOrThrow().then((configs) => {
       expect(configs).toEqual([CONFIG]);
       expect(requestedInputs[0]).toEqual({ limit: 100, offset: 0 });
@@ -56,12 +72,44 @@ describe('getAllBoardConfigsOrThrow', () => {
     // 503 doctrine exists to prevent, so this must surface as a throw.
     backend.hasMore = true;
     backend.totalCount = 137;
-    try {
-      await expect(getAllBoardConfigsOrThrow()).rejects.toThrow(/truncated/);
-      await expect(getAllBoardConfigsOrThrow()).rejects.toThrow(/137/);
-    } finally {
-      backend.hasMore = false;
-      backend.totalCount = 51;
+    await expect(getAllBoardConfigsOrThrow()).rejects.toThrow(/truncated/);
+    await expect(getAllBoardConfigsOrThrow()).rejects.toThrow(/137/);
+  });
+
+  it('serves a second call from cache instead of re-running the fetch', async () => {
+    // #4519: uncached, this ran live on every `/sitemap.xml` miss at ~10s cold
+    // and blew the index's 3s per-shard deadline, publishing an index with no
+    // boards shard at all.
+    await getAllBoardConfigsOrThrow();
+    await getAllBoardConfigsOrThrow();
+    expect(requestedInputs).toHaveLength(1);
+  });
+
+  it('collapses concurrent misses into one fetch', async () => {
+    // `unstable_cache` does not deduplicate concurrent misses, and one cold
+    // `/sitemap.xml` already calls this twice in parallel — the boards shard and
+    // the climbs summary — before a crawl burst piles on.
+    let release: () => void = () => {};
+    backend.gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const inFlight = [getAllBoardConfigsOrThrow(), getAllBoardConfigsOrThrow(), getAllBoardConfigsOrThrow()];
+    release();
+    const results = await Promise.all(inFlight);
+
+    expect(requestedInputs).toHaveLength(1);
+    for (const configs of results) {
+      expect(configs).toEqual([CONFIG]);
     }
+  });
+
+  it('does not cache a failure — a poisoned hour of empty sitemaps is worse than a retry', async () => {
+    backend.hasMore = true;
+    await expect(getAllBoardConfigsOrThrow()).rejects.toThrow(/truncated/);
+
+    backend.hasMore = false;
+    await expect(getAllBoardConfigsOrThrow()).resolves.toEqual([CONFIG]);
+    expect(requestedInputs).toHaveLength(2);
   });
 });

--- a/packages/web/app/lib/__tests__/server-popular-configs.test.ts
+++ b/packages/web/app/lib/__tests__/server-popular-configs.test.ts
@@ -104,7 +104,11 @@ describe('getAllBoardConfigsOrThrow', () => {
     }
   });
 
-  it('does not cache a failure — a poisoned hour of empty sitemaps is worse than a retry', async () => {
+  it('stores nothing in the in-process layer on a failure, so the next call retries', async () => {
+    // Scoped to the in-process layer deliberately: `unstable_cache` is a
+    // pass-through in this file, so this proves nothing about whether the Data
+    // Cache memoises a rejection. A poisoned hour of empty sitemaps would be far
+    // worse than a retry, and this is the half we own and can pin.
     backend.hasMore = true;
     await expect(getAllBoardConfigsOrThrow()).rejects.toThrow(/truncated/);
 

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -385,13 +385,15 @@ export async function pagedShardRouteHandler(id: PagedShardId, rawPage: string):
  * Cheap to be wrong, so be impatient. W-23 (#4483) settled on the same value for
  * its paged summary, so fixed and paged work intentionally share one constant.
  *
- * Not a claim that the builders are cached: `getAllBoardConfigsOrThrow` is a bare
- * `executeGraphQLInternal` call (the `unstable_cache` wrapper in that file is
- * `fetchPopularBoardConfigs`, the limit=12 homepage variant), and `/sitemap.xml`
- * is `force-dynamic`, so every CDN miss re-runs it live. Caching the per-shard
- * summaries is the follow-up; the short degraded window is what makes missing it
- * survivable in the meantime. The climb summary is already cached at two levels,
- * but the scan behind a cold miss is still expensive enough to need this bound.
+ * Two of the three data-backed builders are now cached at two levels — a Next
+ * Data Cache entry plus an in-process TTL and single-flight
+ * (`getAllBoardConfigsOrThrow`, `fetchTier2Summary`) — because `/sitemap.xml` is
+ * `force-dynamic` and every CDN miss otherwise re-ran them live: the uncached
+ * boards fetch took ~10 s cold and deterministically lost its shard on the first
+ * request after a deploy (#4519). Caching does not make the deadline redundant.
+ * It makes it *reachable*: the first miss after a cold start still pays full
+ * price, and the scan behind a cold climbs summary is expensive enough to need
+ * the bound regardless. `fetchPlaylistSitemapRows` remains uncached.
  */
 export const SHARD_DEADLINE_MS = 3_000;
 

--- a/packages/web/app/lib/server-popular-configs.ts
+++ b/packages/web/app/lib/server-popular-configs.ts
@@ -45,34 +45,104 @@ const SITEMAP_LIMIT = 100;
 const SITEMAP_FETCH_TIMEOUT_MS = 10_000;
 
 /**
- * Every listed board config, for the boards sitemap shard.
+ * One hour, matching the `s-maxage=3600` the boards shard route serves under, so
+ * the Data Cache and the CDN expire on the same clock rather than one of them
+ * pinning stale entries the other already dropped. The board catalogue moves on
+ * the order of a merge — a new layout or vendor — never on the order of minutes,
+ * so an hour is generous freshness for a file crawlers refetch in days.
+ */
+const SITEMAP_REVALIDATE_SECONDS = 3_600;
+const SITEMAP_CACHE_TAG = 'sitemap-board-configs';
+/** Same window in front of the Data Cache (which does not dedupe misses). */
+const SITEMAP_TTL_MS = SITEMAP_REVALIDATE_SECONDS * 1_000;
+
+/**
+ * Every listed board config, for the sitemap.
  *
  * Deliberately **not** the swallow-and-return-`[]` wrapper above: a sitemap that
  * silently loses its URLs tells Google those pages were deleted. The shard route
  * turns a throw into a 503 so the crawler retries and keeps the last good copy.
+ * `unstable_cache` does not memoise a rejection, so a failing fetch stays a
+ * failing fetch rather than a poisoned hour of empty sitemaps.
  *
  * `hasMore` is the same rule applied to the API cap. The listed-config count grows
  * with the board catalogue — a new vendor is one merge away — and 100 is the
  * schema ceiling, so the fix when this fires is paging (`offset`), not a bigger
  * constant. Throwing turns "quietly dropped the tail with a 200" into a 503.
  */
-export async function getAllBoardConfigsOrThrow(): Promise<PopularBoardConfig[]> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), SITEMAP_FETCH_TIMEOUT_MS);
-  try {
-    const result = await executeGraphQLInternal<GetPopularBoardConfigsQueryResponse>(
-      GET_POPULAR_BOARD_CONFIGS,
-      { input: { limit: SITEMAP_LIMIT, offset: 0 } },
-      controller.signal,
-    );
-    const { configs, hasMore, totalCount } = result.popularBoardConfigs;
-    if (hasMore) {
-      throw new Error(
-        `[sitemap] boards shard truncated: ${configs.length} of ${totalCount} listed configs came back at the ${SITEMAP_LIMIT}-config API cap — page it with offset instead of raising the limit.`,
+const fetchAllBoardConfigs = unstable_cache(
+  async (): Promise<PopularBoardConfig[]> => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), SITEMAP_FETCH_TIMEOUT_MS);
+    try {
+      const result = await executeGraphQLInternal<GetPopularBoardConfigsQueryResponse>(
+        GET_POPULAR_BOARD_CONFIGS,
+        { input: { limit: SITEMAP_LIMIT, offset: 0 } },
+        controller.signal,
       );
+      const { configs, hasMore, totalCount } = result.popularBoardConfigs;
+      if (hasMore) {
+        throw new Error(
+          `[sitemap] boards shard truncated: ${configs.length} of ${totalCount} listed configs came back at the ${SITEMAP_LIMIT}-config API cap — page it with offset instead of raising the limit.`,
+        );
+      }
+      return configs;
+    } finally {
+      clearTimeout(timer);
     }
-    return configs;
-  } finally {
-    clearTimeout(timer);
+  },
+  ['all-board-configs'],
+  { revalidate: SITEMAP_REVALIDATE_SECONDS, tags: [SITEMAP_CACHE_TAG] },
+);
+
+let cachedAllConfigs: { builtAt: number; configs: PopularBoardConfig[] } | null = null;
+let allConfigsInFlight: Promise<PopularBoardConfig[]> | null = null;
+
+/**
+ * The listed board configs, behind the Next Data Cache plus an in-process TTL and
+ * single-flight — the same two-layer shape `fetchTier2Summary` uses, for the same
+ * reason.
+ *
+ * Uncached, this was a bare `executeGraphQLInternal` call measured at ~10 s cold
+ * in production, and `/sitemap.xml` is `force-dynamic`, so every CDN miss re-ran
+ * it live and blew the index's `SHARD_DEADLINE_MS` — publishing an index with no
+ * boards shard at all (#4519). The Data Cache is what makes the deadline
+ * reachable across instances.
+ *
+ * The in-process layer is not redundant with it. `unstable_cache` does not
+ * deduplicate concurrent misses, and a single cold `/sitemap.xml` already calls
+ * this twice in parallel — once for the boards shard and once through the climbs
+ * summary — before a crawl burst adds `/sitemaps/boards.xml` and every climbs
+ * page on top. Sharing one in-flight promise turns that into one fetch.
+ *
+ * A miss still degrades rather than hangs: the fetch keeps its own 10 s abort and
+ * the index stops waiting after `SHARD_DEADLINE_MS`, so the worst a cold start
+ * costs is one minute of degraded index while the abandoned fetch populates both
+ * layers for the next request.
+ */
+export async function getAllBoardConfigsOrThrow(): Promise<PopularBoardConfig[]> {
+  if (cachedAllConfigs && Date.now() - cachedAllConfigs.builtAt < SITEMAP_TTL_MS) {
+    return cachedAllConfigs.configs;
   }
+  if (allConfigsInFlight) {
+    return allConfigsInFlight;
+  }
+
+  const build = fetchAllBoardConfigs().then((configs) => {
+    cachedAllConfigs = { builtAt: Date.now(), configs };
+    return configs;
+  });
+  allConfigsInFlight = build;
+
+  try {
+    return await build;
+  } finally {
+    allConfigsInFlight = null;
+  }
+}
+
+/** Test seam: drops the in-process TTL cache and any in-flight fetch. */
+export function resetBoardConfigCacheForTests(): void {
+  cachedAllConfigs = null;
+  allConfigsInFlight = null;
 }

--- a/packages/web/app/lib/server-popular-configs.ts
+++ b/packages/web/app/lib/server-popular-configs.ts
@@ -45,13 +45,20 @@ const SITEMAP_LIMIT = 100;
 const SITEMAP_FETCH_TIMEOUT_MS = 10_000;
 
 /**
- * One hour, matching the `s-maxage=3600` the boards shard route serves under, so
- * the Data Cache and the CDN expire on the same clock rather than one of them
- * pinning stale entries the other already dropped. The board catalogue moves on
- * the order of a merge — a new layout or vendor — never on the order of minutes,
- * so an hour is generous freshness for a file crawlers refetch in days.
+ * One hour — the same number as the `s-maxage=3600` the boards shard route serves
+ * under, but not a claim that the two expire together: that route's header
+ * carries a day of `stale-while-revalidate` on top, so the CDN can hand out a body
+ * up to 25 hours old whatever this entry does. It is one window picked for one
+ * reason on both layers. The board catalogue moves on the order of a merge — a new
+ * layout or vendor — never on the order of minutes, so an hour is generous
+ * freshness for a file crawlers refetch in days.
  */
 const SITEMAP_REVALIDATE_SECONDS = 3_600;
+/**
+ * Decorative today: nothing calls `revalidateTag` on it, so the entry only ever
+ * expires on the clock above. Named anyway so a future catalogue write has one
+ * thing to invalidate instead of inventing a key.
+ */
 const SITEMAP_CACHE_TAG = 'sitemap-board-configs';
 /** Same window in front of the Data Cache (which does not dedupe misses). */
 const SITEMAP_TTL_MS = SITEMAP_REVALIDATE_SECONDS * 1_000;
@@ -62,8 +69,11 @@ const SITEMAP_TTL_MS = SITEMAP_REVALIDATE_SECONDS * 1_000;
  * Deliberately **not** the swallow-and-return-`[]` wrapper above: a sitemap that
  * silently loses its URLs tells Google those pages were deleted. The shard route
  * turns a throw into a 503 so the crawler retries and keeps the last good copy.
- * `unstable_cache` does not memoise a rejection, so a failing fetch stays a
- * failing fetch rather than a poisoned hour of empty sitemaps.
+ * The in-process layer below stores nothing on a rejection, so a failing fetch
+ * stays a failing fetch rather than a poisoned hour of empty sitemaps — that is
+ * the half a test pins. Whether the Data Cache also declines to memoise the
+ * rejection is unverified here (the test mocks `unstable_cache` to a
+ * pass-through), so do not lean on it.
  *
  * `hasMore` is the same rule applied to the API cap. The listed-config count grows
  * with the board catalogue — a new vendor is one merge away — and 100 is the

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import { describe, expect, it } from 'vitest';
-import { FIXTURE_PATHS, WWW_CHECKS, parseBaseUrl, type SmokeResponse } from './production-smoke';
+import { FIXTURE_PATHS, WWW_CHECKS, finalVerdict, parseBaseUrl, type SmokeResponse } from './production-smoke';
 
 // The assertions are the whole product here: the runner is a retry loop, but
 // the check table is what decides whether a broken deploy is caught. These
@@ -37,8 +37,28 @@ describe('www production smoke checks', () => {
   it('covers the surfaces other systems depend on', () => {
     const paths = WWW_CHECKS.filter((check) => !check.fixtureEnvVar).map((check) => check.path);
     expect(paths).toEqual(
-      expect.arrayContaining(['/', '/robots.txt', '/sitemap.xml', '/api/auth/session', '/api/internal/ws-auth']),
+      expect.arrayContaining([
+        '/',
+        '/robots.txt',
+        '/sitemap.xml',
+        // Both `expectsUrls` shard routes get a check of their own. `boards.xml`
+        // in particular is the only hard signal left on the boards surface once
+        // the index check can excuse a declared degradation.
+        '/sitemaps/static.xml',
+        '/sitemaps/boards.xml',
+        '/api/auth/session',
+        '/api/internal/ws-auth',
+      ]),
     );
+  });
+
+  it('keeps the warning channel on the index alone', () => {
+    // `degradation` is the only thing in this file that can end a run green on a
+    // response that is not fully healthy. It is safe exactly where the server
+    // declares the degradation on the response, and nowhere else — a check that
+    // grew one by copy-paste would be silently unable to go red.
+    const withDegradation = WWW_CHECKS.filter((check) => check.degradation).map((check) => check.path);
+    expect(withDegradation).toEqual(['/sitemap.xml']);
   });
 
   it('rejects a homepage that 200s with a spinner-only shell', () => {
@@ -114,7 +134,7 @@ describe('www production smoke checks', () => {
     // Names the shards, so the annotation is actionable without opening the site.
     expect(check.degradation?.(withoutBoards)).toMatch(/boards/);
     expect(check.degradation?.(withoutBoards)).toMatch(/playlists/);
-    expect(check.degradation?.(withoutBoards)).toMatch(/mandatory boards/);
+    expect(check.degradation?.(withoutBoards)).toMatch(/required boards/);
 
     // A shard the header does NOT name is still missing silently — the header
     // must not become a blanket amnesty for anything absent from the body.
@@ -137,7 +157,7 @@ describe('www production smoke checks', () => {
     });
     expect(check.assert(optionalOnly)).toBeNull();
     expect(check.degradation?.(optionalOnly)).toMatch(/playlists, climbs/);
-    expect(check.degradation?.(optionalOnly)).not.toMatch(/mandatory/);
+    expect(check.degradation?.(optionalOnly)).not.toMatch(/required/);
 
     // The header can never rescue a genuinely broken index: a non-200, a body
     // that is not a `<sitemapindex>`, or one that resolved nothing at all.
@@ -154,9 +174,16 @@ describe('www production smoke checks', () => {
         }),
       ),
     ).toMatch(/sitemapindex/);
-    expect(check.assert(response({ contentType: 'application/xml', body: '<sitemapindex></sitemapindex>' }))).toMatch(
-      /shard/,
-    );
+    // The one that would otherwise slip through: an index that resolved NOTHING,
+    // with a header naming every shard, is structurally a `<sitemapindex>` and has
+    // an excuse for everything in it. `static` is deliberately not excusable so
+    // this stays red — `buildStaticEntries` is hardcoded and pure, so its absence
+    // is never a transient degradation.
+    expect(
+      check.assert(
+        response({ contentType: 'application/xml', body: '<sitemapindex></sitemapindex>', headers: degradedHeader }),
+      ),
+    ).toMatch(/static/);
 
     // A healthy index carries no header and must not warn.
     const healthy = response({
@@ -176,6 +203,28 @@ describe('www production smoke checks', () => {
       check.assert(response({ contentType: 'application/xml', body: '<urlset><url><loc>x</loc></url></urlset>' })),
     ).toBeNull();
     expect(check.assert(response({ contentType: 'application/xml', body: '<urlset></urlset>' }))).toMatch(/loc/);
+  });
+
+  it('keeps a hard signal on the boards shard, which the index check can no longer give', () => {
+    // Every way boards drops out of the index puts its id in `degradedShards`, so
+    // the index check now WARNs on all of them. Without this check the suite could
+    // never go red on boards again while `/sitemaps/boards.xml` 503s — and the
+    // `hasMore` truncation throw is a permanent, not transient, way to get there
+    // once the catalogue passes the 100-config API cap.
+    const check = checkNamed('boards sitemap shard');
+    expect(
+      check.assert(response({ contentType: 'application/xml', body: '<urlset><url><loc>x</loc></url></urlset>' })),
+    ).toBeNull();
+    // The shard route's own failure mode: fail-closed 503, no body worth parsing.
+    expect(check.assert(response({ status: 503, contentType: 'text/plain', body: 'unavailable' }))).toMatch(/503/);
+    expect(check.assert(response({ contentType: 'application/xml', body: '<urlset></urlset>' }))).toMatch(/loc/);
+    // No degradation channel: a shard route is fail-closed and declares nothing,
+    // so a header on this response must not buy it a green.
+    expect(
+      check.degradation?.(
+        response({ status: 503, contentType: 'text/plain', body: '', headers: { 'x-sitemap-degraded': 'boards' } }),
+      ) ?? null,
+    ).toBeNull();
   });
 
   it('rejects a session endpoint that 200s with an error payload', () => {
@@ -233,6 +282,29 @@ describe('www production smoke checks', () => {
   it('builds fixture paths from the configured value', () => {
     expect(FIXTURE_PATHS.SMOKE_KIOSK_GYM_SLUG('movement-lu')).toBe('/kiosk/movement-lu');
     expect(FIXTURE_PATHS.SMOKE_EMBED_BOARD_UUID('abc-123')).toBe('/embed/board/abc-123');
+  });
+});
+
+describe('finalVerdict', () => {
+  it('warns only when every attempt was a clean, self-declared degradation', () => {
+    expect(finalVerdict(['degraded'])).toBe('warn');
+    expect(finalVerdict(['degraded', 'degraded', 'degraded'])).toBe('warn');
+  });
+
+  it('fails a run that flapped, even when it recovered into a degradation', () => {
+    // The trap a "last attempt wins" rule falls into: two 503s and a degraded
+    // third is a real outage that happened to recover, and reporting it green
+    // hides the outage behind its own recovery.
+    expect(finalVerdict(['fail', 'fail', 'degraded'])).toBe('fail');
+    expect(finalVerdict(['degraded', 'fail', 'degraded'])).toBe('fail');
+    expect(finalVerdict(['degraded', 'degraded', 'fail'])).toBe('fail');
+    expect(finalVerdict(['fail'])).toBe('fail');
+  });
+
+  it('never warns on an empty run', () => {
+    // Unreachable today (ATTEMPTS is 3), but "no evidence" must not read as
+    // "warning" if the loop ever changes shape.
+    expect(finalVerdict([])).toBe('fail');
   });
 });
 

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -10,7 +10,13 @@ import { FIXTURE_PATHS, WWW_CHECKS, parseBaseUrl, type SmokeResponse } from './p
 // healthy response.
 
 function response(overrides: Partial<SmokeResponse> = {}): SmokeResponse {
-  return { status: 200, contentType: 'text/html; charset=utf-8', body: '<h1>Boardsesh</h1>', ...overrides };
+  return {
+    status: 200,
+    contentType: 'text/html; charset=utf-8',
+    body: '<h1>Boardsesh</h1>',
+    headers: {},
+    ...overrides,
+  };
 }
 
 /**
@@ -71,6 +77,9 @@ describe('www production smoke checks', () => {
     // ships a 200 that quietly lost ~2,600 URLs. `static` is hardcoded and cannot
     // fail, so an "any one shard <loc>" assertion would be green on every
     // possible outage — the detector that found the bug would never fire again.
+    //
+    // Silent is the operative word: with no `X-Sitemap-Degraded` header there is
+    // nothing to say the omission was deliberate, so it stays a hard failure.
     const degradedIndex =
       '<sitemapindex><sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap></sitemapindex>';
     expect(check.assert(response({ contentType: 'application/xml', body: degradedIndex }))).toMatch(/boards/);
@@ -87,6 +96,78 @@ describe('www production smoke checks', () => {
     expect(check.assert(response({ contentType: 'application/xml', body: '<sitemapindex></sitemapindex>' }))).toMatch(
       /shard/,
     );
+  });
+
+  it('warns instead of failing when the index declares which shard it dropped', () => {
+    // #4519: `/sitemap.xml` is force-dynamic, so the first request after a deploy
+    // rebuilds every shard live and the boards builder can miss the index's 3s
+    // deadline. The handler publishes without it under a 60s window and names it
+    // in `X-Sitemap-Degraded` — a self-healing state, not a broken deploy. The
+    // smoke ran in exactly that window and went red on every single deploy.
+    const check = checkNamed('sitemap index');
+    const withoutBoards = response({
+      contentType: 'application/xml',
+      body: '<sitemapindex><sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap></sitemapindex>',
+      headers: { 'x-sitemap-degraded': 'boards,playlists' },
+    });
+    expect(check.assert(withoutBoards)).toBeNull();
+    // Names the shards, so the annotation is actionable without opening the site.
+    expect(check.degradation?.(withoutBoards)).toMatch(/boards/);
+    expect(check.degradation?.(withoutBoards)).toMatch(/playlists/);
+    expect(check.degradation?.(withoutBoards)).toMatch(/mandatory boards/);
+
+    // A shard the header does NOT name is still missing silently — the header
+    // must not become a blanket amnesty for anything absent from the body.
+    const wrongShardDeclared = response({
+      contentType: 'application/xml',
+      body: '<sitemapindex><sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap></sitemapindex>',
+      headers: { 'x-sitemap-degraded': 'playlists' },
+    });
+    expect(check.assert(wrongShardDeclared)).toMatch(/boards/);
+
+    // Optional shards degrading is worth a warning but is not a missing mandatory.
+    const optionalOnly = response({
+      contentType: 'application/xml',
+      body:
+        '<sitemapindex>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
+        '</sitemapindex>',
+      headers: { 'x-sitemap-degraded': 'playlists,climbs' },
+    });
+    expect(check.assert(optionalOnly)).toBeNull();
+    expect(check.degradation?.(optionalOnly)).toMatch(/playlists, climbs/);
+    expect(check.degradation?.(optionalOnly)).not.toMatch(/mandatory/);
+
+    // The header can never rescue a genuinely broken index: a non-200, a body
+    // that is not a `<sitemapindex>`, or one that resolved nothing at all.
+    const degradedHeader = { 'x-sitemap-degraded': 'boards,playlists,climbs' };
+    expect(
+      check.assert(response({ status: 503, contentType: 'application/xml', body: '', headers: degradedHeader })),
+    ).toMatch(/503/);
+    expect(
+      check.assert(
+        response({
+          contentType: 'application/xml',
+          body: '<urlset><url><loc>https://x/</loc></url></urlset>',
+          headers: degradedHeader,
+        }),
+      ),
+    ).toMatch(/sitemapindex/);
+    expect(check.assert(response({ contentType: 'application/xml', body: '<sitemapindex></sitemapindex>' }))).toMatch(
+      /shard/,
+    );
+
+    // A healthy index carries no header and must not warn.
+    const healthy = response({
+      contentType: 'application/xml',
+      body:
+        '<sitemapindex>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
+        '</sitemapindex>',
+    });
+    expect(check.degradation?.(healthy) ?? null).toBeNull();
   });
 
   it('rejects an empty static sitemap shard', () => {

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -68,11 +68,18 @@ export type SmokeCheck = {
    * than it should have". Returns null when the response is fully healthy, or a
    * reason string describing the degradation.
    *
-   * A degradation is retried like a failure — the retry is what gives a cold
-   * cache time to warm — but on the last attempt it reports as a WARNING and
-   * leaves the job green, where `assert` reports as a failure and turns it red.
-   * The distinction only belongs on a surface whose degradation is *declared*
-   * by the server; anything we merely infer from the body is an assertion.
+   * A degradation reports as a WARNING and leaves the job green, where `assert`
+   * reports as a failure and turns it red. The distinction only belongs on a
+   * surface whose degradation is *declared* by the server; anything we merely
+   * infer from the body is an assertion.
+   *
+   * It is retried like a failure, but do not read the retry as a warm-up: the
+   * WARN is the mechanism, not a last resort. Vercel's edge ignores this
+   * script's `Cache-Control: no-cache` request header and caches the degraded
+   * index for 60s — longer than all three attempts put together (~10s), so the
+   * retries return the same cached body. Measured: attempt 1 MISS 3.35s,
+   * attempt 2 HIT 0.09s, both carrying an identical `x-sitemap-degraded`. Once
+   * the window opens the WARN is guaranteed; the retry only covers an edge blip.
    */
   degradation?: (response: SmokeResponse) => string | null;
   /**
@@ -143,18 +150,34 @@ const MIN_RENDERED_PAGE_CHARS = 4_000;
 const SITEMAP_DEGRADED_HEADER = 'x-sitemap-degraded';
 
 /**
- * Shards the index must always list. Both are the ones the registry marks
- * `expectsUrls`; `gyms`, `setters` and `playlists` are legitimately empty and a
- * missing entry there proves nothing.
+ * Shards the index must always list.
+ *
+ * `gyms`, `setters` and `playlists` are legitimately empty, so a missing entry
+ * there proves nothing. `climbs` is NOT in that category — the registry marks it
+ * `expectsUrls: true` exactly like these two — but its summary cannot meet
+ * `SHARD_DEADLINE_MS` today, so production serves it degraded on every request
+ * and asserting it here would be a permanently red check rather than a detector.
+ * That is a real ~52,000-URL hole tracked separately, not a property of this
+ * list.
+ *
+ * `degradable` is what `X-Sitemap-Degraded` may excuse. `boards` is genuinely
+ * transient — a cold cache, a slow backend — and self-heals under the 60s window.
+ * `static` is not: `buildStaticEntries` is hardcoded and pure, with no fetch, no
+ * query and nothing to time out, so it can only go missing if the index resolved
+ * essentially nothing. Excusing it via the header would buy no real coverage and
+ * would let an empty `<sitemapindex></sitemapindex>` pass as long as the handler
+ * named every shard in the header.
  *
  * The `<loc>` values are absolute and hardcoded on purpose: the index renders
  * them from the configured site base, not from the request host, so they stay
  * `www.boardsesh.com` even when the smoke runs against a preview `--base`.
  */
-const MANDATORY_SITEMAP_SHARDS = [
-  { id: 'static', loc: 'https://www.boardsesh.com/sitemaps/static.xml' },
-  { id: 'boards', loc: 'https://www.boardsesh.com/sitemaps/boards.xml' },
+const REQUIRED_SITEMAP_SHARDS = [
+  { id: 'static', loc: 'https://www.boardsesh.com/sitemaps/static.xml', degradable: false },
+  { id: 'boards', loc: 'https://www.boardsesh.com/sitemaps/boards.xml', degradable: true },
 ] as const;
+
+type RequiredSitemapShard = (typeof REQUIRED_SITEMAP_SHARDS)[number];
 
 /** Shard ids the response declared it dropped, in header order. */
 function declaredDegradedShards(response: SmokeResponse): string[] {
@@ -164,10 +187,8 @@ function declaredDegradedShards(response: SmokeResponse): string[] {
     .filter((shard) => shard.length > 0);
 }
 
-function missingMandatoryShards(response: SmokeResponse): string[] {
-  return MANDATORY_SITEMAP_SHARDS.filter((shard) => !response.body.includes(`<loc>${shard.loc}`)).map(
-    (shard) => shard.id,
-  );
+function missingRequiredShards(response: SmokeResponse): RequiredSitemapShard[] {
+  return REQUIRED_SITEMAP_SHARDS.filter((shard) => !response.body.includes(`<loc>${shard.loc}`));
 }
 
 function renderedHtmlPage(response: SmokeResponse): string | null {
@@ -214,14 +235,18 @@ export const WWW_CHECKS: SmokeCheck[] = [
     // `static.xml`, which is a pure hardcoded builder that cannot fail, so this
     // check could never have gone red again.
     //
-    // What splits fail from warn is `X-Sitemap-Degraded`, not the body. A shard
-    // that is missing AND named in that header is the subsystem working as
+    // What splits fail from warn on a *degradable* shard is `X-Sitemap-Degraded`,
+    // not the body. Missing AND named in that header is the subsystem working as
     // designed: the handler logged it, dropped the CDN window to sixty seconds so
-    // it self-heals, and told us which shard it was. That is a warning. A shard
-    // missing WITHOUT the header is the silent loss this check exists to catch,
-    // and stays a failure — as do a non-200, a non-XML body, and anything that
-    // is not a `<sitemapindex>`. Degradation is not free: this deploy is serving
-    // an incomplete sitemap and somebody should look at why.
+    // it self-heals, and told us which shard it was. That is a warning. Missing
+    // WITHOUT the header is the silent loss this check exists to catch, and stays
+    // a failure — as do a non-200, a non-XML body, anything that is not a
+    // `<sitemapindex>`, and a missing `static` under any header at all.
+    //
+    // Softening boards to a warning here removes this check's only view of the
+    // boards surface, so `/sitemaps/boards.xml` gets a check of its own below.
+    // Together they draw the line where it belongs: a transient index degradation
+    // WARNs, a boards outage that actually breaks the shard URL stays FAIL.
     name: 'sitemap.xml serves a sitemap index pointing at shards',
     path: '/sitemap.xml',
     assert: (response) => {
@@ -233,22 +258,52 @@ export const WWW_CHECKS: SmokeCheck[] = [
       if (structural) return structural;
 
       const declared = declaredDegradedShards(response);
-      const silentlyMissing = missingMandatoryShards(response).filter((shard) => !declared.includes(shard));
-      return silentlyMissing.length === 0
+      const unexcused = missingRequiredShards(response).filter(
+        (shard) => !shard.degradable || !declared.includes(shard.id),
+      );
+      return unexcused.length === 0
         ? null
-        : `response body has no ${silentlyMissing.join(', ')} shard <loc> entry, and no ${SITEMAP_DEGRADED_HEADER} header declaring it`;
+        : `response body has no ${unexcused.map((shard) => shard.id).join(', ')} shard <loc> entry that the ${SITEMAP_DEGRADED_HEADER} header excuses`;
     },
     degradation: (response) => {
       const declared = declaredDegradedShards(response);
       if (declared.length === 0) return null;
-      const missing = missingMandatoryShards(response);
-      const mandatoryNote = missing.length > 0 ? ` — including the mandatory ${missing.join(', ')}` : '';
-      return `index published WITHOUT ${declared.join(', ')}${mandatoryNote} (${SITEMAP_DEGRADED_HEADER}: ${declared.join(',')})`;
+      const missing = missingRequiredShards(response).map((shard) => shard.id);
+      const requiredNote = missing.length > 0 ? ` — including the required ${missing.join(', ')}` : '';
+      return `index published WITHOUT ${declared.join(', ')}${requiredNote} (${SITEMAP_DEGRADED_HEADER}: ${declared.join(',')})`;
     },
   },
   {
     name: 'the static sitemap shard serves URLs',
     path: '/sitemaps/static.xml',
+    assert: (response) =>
+      firstFailure(
+        expectStatus(response, 200),
+        expectContentType(response, 'xml'),
+        expectBodyContains(response, '<urlset', '<urlset> root element'),
+        expectBodyContains(response, '<loc>', '<loc> entry'),
+      ),
+  },
+  {
+    // The boards surface's only remaining hard signal, and the reason the index
+    // check above can afford to WARN. Every way `boards` goes missing from the
+    // index puts its id in `degradedShards` — a rejecting builder, a missed
+    // deadline, an unexpectedly empty build, an over-budget URL count — so once
+    // the header excuses it there, nothing else in this suite would ever go red
+    // on boards while `/sitemaps/boards.xml` sat there 503ing.
+    //
+    // Not a hypothetical failure mode: `getAllBoardConfigsOrThrow` throws on
+    // `hasMore`, and 100 is the schema's hard cap on a catalogue its own comment
+    // calls "one merge away" from outgrowing. That throw is permanent by
+    // construction — every request, indefinitely, until someone pages the query —
+    // and the shard route turns it into a 503 that this check catches on the
+    // first deploy after it starts.
+    //
+    // No `degradation` channel on purpose: a shard route is fail-closed by
+    // doctrine and has nothing to declare. Measured against production at 2,760
+    // `<loc>` entries in 0.98s, comfortably inside REQUEST_TIMEOUT_MS.
+    name: 'the boards sitemap shard serves URLs',
+    path: '/sitemaps/boards.xml',
     assert: (response) =>
       firstFailure(
         expectStatus(response, 200),
@@ -348,6 +403,22 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 type CheckOutcome = { name: string; state: 'pass' | 'warn' | 'fail' | 'skip'; detail: string };
 
+/** What one non-passing attempt ended as. A passing attempt returns immediately. */
+export type AttemptState = 'fail' | 'degraded';
+
+/**
+ * The verdict for a check whose every attempt was used up.
+ *
+ * WARN is reserved for a run where *no* attempt failed outright — every one was a
+ * clean 200 that simply declared itself incomplete. A surface that 503s twice and
+ * recovers into a merely-degraded third attempt is flapping, and flapping is an
+ * outage: reporting that green would hide a real one behind its own recovery.
+ * Taking only the last attempt's state is the bug this exists to avoid.
+ */
+export function finalVerdict(attempts: readonly AttemptState[]): 'warn' | 'fail' {
+  return attempts.length > 0 && attempts.every((attempt) => attempt === 'degraded') ? 'warn' : 'fail';
+}
+
 async function runCheck(check: SmokeCheck, baseUrl: string, env: NodeJS.ProcessEnv): Promise<CheckOutcome> {
   const path = resolvePath(check, env);
   if (path === null) {
@@ -355,39 +426,40 @@ async function runCheck(check: SmokeCheck, baseUrl: string, env: NodeJS.ProcessE
   }
 
   const url = `${baseUrl}${path}`;
-  let lastDetail = '';
-  // Set only when every assertion passed and the response merely declared itself
-  // degraded, so a later attempt that fails outright cannot be reported as a warning.
-  let degraded = false;
+  const attempts: AttemptState[] = [];
+  let lastFailure = '';
+  let lastDegradation = '';
 
   for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    let detail: string;
     try {
       const response = await fetchOnce(url);
       const failure = check.assert(response);
       if (failure === null) {
         const degradation = check.degradation?.(response) ?? null;
         if (degradation === null) return { name: check.name, state: 'pass', detail: path };
-        // Retried like a failure: the whole point of the retry loop here is to
-        // give a cold cache the two extra requests it needs to warm up, which
-        // turns a transient post-deploy degradation into a clean pass.
-        lastDetail = degradation;
-        degraded = true;
+        lastDegradation = degradation;
+        attempts.push('degraded');
+        detail = degradation;
       } else {
-        lastDetail = failure;
-        degraded = false;
+        lastFailure = failure;
+        attempts.push('fail');
+        detail = failure;
       }
     } catch (error) {
-      lastDetail = `request failed: ${error instanceof Error ? error.message : String(error)}`;
-      degraded = false;
+      lastFailure = `request failed: ${error instanceof Error ? error.message : String(error)}`;
+      attempts.push('fail');
+      detail = lastFailure;
     }
     if (attempt < ATTEMPTS) {
-      const label = degraded ? 'degraded' : 'failed';
-      console.log(`  ${check.name}: attempt ${attempt} ${label} (${lastDetail}); retrying in 5s...`);
+      const label = attempts[attempts.length - 1] === 'degraded' ? 'degraded' : 'failed';
+      console.log(`  ${check.name}: attempt ${attempt} ${label} (${detail}); retrying in 5s...`);
       await delay(RETRY_DELAY_MS);
     }
   }
 
-  return { name: check.name, state: degraded ? 'warn' : 'fail', detail: `${path} — ${lastDetail}` };
+  const state = finalVerdict(attempts);
+  return { name: check.name, state, detail: `${path} — ${state === 'warn' ? lastDegradation : lastFailure}` };
 }
 
 /** `--base` is the only override — one documented way to point this elsewhere. */

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -15,6 +15,11 @@
  * a session, a mutation, or seeded data belongs in e2e, not here — this runs
  * against production and must stay read-only.
  *
+ * Outcomes are pass / WARN / FAIL / skip. WARN exists for a surface that answers
+ * correctly but tells us, on the response itself, that it served less than it
+ * should have — today only the degrading sitemap index. It annotates the job and
+ * leaves it green; only FAIL exits non-zero.
+ *
  *   vp run smoke:production                    # www.boardsesh.com
  *   vp run smoke:production -- --base <url>    # a preview deployment
  *
@@ -40,6 +45,8 @@ export type SmokeResponse = {
   status: number;
   contentType: string;
   body: string;
+  /** Response headers, keys lowercased. Only read by checks that need one. */
+  headers: Record<string, string>;
 };
 
 export type SmokeCheck = {
@@ -56,6 +63,18 @@ export type SmokeCheck = {
    * rather than an assertion failure, which reads very differently on-call.
    */
   assert: (response: SmokeResponse) => string | null;
+  /**
+   * Optional second channel for "served, but the server told us it served less
+   * than it should have". Returns null when the response is fully healthy, or a
+   * reason string describing the degradation.
+   *
+   * A degradation is retried like a failure — the retry is what gives a cold
+   * cache time to warm — but on the last attempt it reports as a WARNING and
+   * leaves the job green, where `assert` reports as a failure and turns it red.
+   * The distinction only belongs on a surface whose degradation is *declared*
+   * by the server; anything we merely infer from the body is an assertion.
+   */
+  degradation?: (response: SmokeResponse) => string | null;
   /**
    * Env var holding the fixture this check needs. When set on the check and
    * absent from the environment, the check is skipped rather than failed.
@@ -113,6 +132,44 @@ function firstFailure(...reasons: (string | null)[]): string | null {
  */
 const MIN_RENDERED_PAGE_CHARS = 4_000;
 
+/**
+ * The header `sitemapIndexRouteHandler` sets when it published an index without
+ * one of its shards. It exists precisely so the degradation is legible from the
+ * outside instead of only in a `console.error` nobody reads, and reading it here
+ * is what lets this check tell "the index dropped a shard and said so" apart
+ * from "the shard vanished silently", which are the same body and very
+ * different bugs.
+ */
+const SITEMAP_DEGRADED_HEADER = 'x-sitemap-degraded';
+
+/**
+ * Shards the index must always list. Both are the ones the registry marks
+ * `expectsUrls`; `gyms`, `setters` and `playlists` are legitimately empty and a
+ * missing entry there proves nothing.
+ *
+ * The `<loc>` values are absolute and hardcoded on purpose: the index renders
+ * them from the configured site base, not from the request host, so they stay
+ * `www.boardsesh.com` even when the smoke runs against a preview `--base`.
+ */
+const MANDATORY_SITEMAP_SHARDS = [
+  { id: 'static', loc: 'https://www.boardsesh.com/sitemaps/static.xml' },
+  { id: 'boards', loc: 'https://www.boardsesh.com/sitemaps/boards.xml' },
+] as const;
+
+/** Shard ids the response declared it dropped, in header order. */
+function declaredDegradedShards(response: SmokeResponse): string[] {
+  return (response.headers[SITEMAP_DEGRADED_HEADER] ?? '')
+    .split(',')
+    .map((shard) => shard.trim())
+    .filter((shard) => shard.length > 0);
+}
+
+function missingMandatoryShards(response: SmokeResponse): string[] {
+  return MANDATORY_SITEMAP_SHARDS.filter((shard) => !response.body.includes(`<loc>${shard.loc}`)).map(
+    (shard) => shard.id,
+  );
+}
+
 function renderedHtmlPage(response: SmokeResponse): string | null {
   return firstFailure(
     expectStatus(response, 200),
@@ -155,19 +212,39 @@ export const WWW_CHECKS: SmokeCheck[] = [
     // That is the right behaviour for crawlers and the wrong behaviour for a
     // detector — the original wording passes on an index that lost everything but
     // `static.xml`, which is a pure hardcoded builder that cannot fail, so this
-    // check could never have gone red again. `static` and `boards` are exactly
-    // the shards the registry marks `expectsUrls`, so both must always be there;
-    // `gyms`, `setters` and `playlists` are legitimately empty and stay out of it.
+    // check could never have gone red again.
+    //
+    // What splits fail from warn is `X-Sitemap-Degraded`, not the body. A shard
+    // that is missing AND named in that header is the subsystem working as
+    // designed: the handler logged it, dropped the CDN window to sixty seconds so
+    // it self-heals, and told us which shard it was. That is a warning. A shard
+    // missing WITHOUT the header is the silent loss this check exists to catch,
+    // and stays a failure — as do a non-200, a non-XML body, and anything that
+    // is not a `<sitemapindex>`. Degradation is not free: this deploy is serving
+    // an incomplete sitemap and somebody should look at why.
     name: 'sitemap.xml serves a sitemap index pointing at shards',
     path: '/sitemap.xml',
-    assert: (response) =>
-      firstFailure(
+    assert: (response) => {
+      const structural = firstFailure(
         expectStatus(response, 200),
         expectContentType(response, 'xml'),
         expectBodyContains(response, '<sitemapindex', '<sitemapindex> root element'),
-        expectBodyContains(response, '<loc>https://www.boardsesh.com/sitemaps/static.xml', 'static shard <loc> entry'),
-        expectBodyContains(response, '<loc>https://www.boardsesh.com/sitemaps/boards.xml', 'boards shard <loc> entry'),
-      ),
+      );
+      if (structural) return structural;
+
+      const declared = declaredDegradedShards(response);
+      const silentlyMissing = missingMandatoryShards(response).filter((shard) => !declared.includes(shard));
+      return silentlyMissing.length === 0
+        ? null
+        : `response body has no ${silentlyMissing.join(', ')} shard <loc> entry, and no ${SITEMAP_DEGRADED_HEADER} header declaring it`;
+    },
+    degradation: (response) => {
+      const declared = declaredDegradedShards(response);
+      if (declared.length === 0) return null;
+      const missing = missingMandatoryShards(response);
+      const mandatoryNote = missing.length > 0 ? ` — including the mandatory ${missing.join(', ')}` : '';
+      return `index published WITHOUT ${declared.join(', ')}${mandatoryNote} (${SITEMAP_DEGRADED_HEADER}: ${declared.join(',')})`;
+    },
   },
   {
     name: 'the static sitemap shard serves URLs',
@@ -252,10 +329,15 @@ async function fetchOnce(url: string): Promise<SmokeResponse> {
         'Cache-Control': 'no-cache',
       },
     });
+    const headers: Record<string, string> = {};
+    response.headers.forEach((value, name) => {
+      headers[name.toLowerCase()] = value;
+    });
     return {
       status: response.status,
       contentType: response.headers.get('content-type') ?? '',
       body: await response.text(),
+      headers,
     };
   } finally {
     clearTimeout(timer);
@@ -264,7 +346,7 @@ async function fetchOnce(url: string): Promise<SmokeResponse> {
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-type CheckOutcome = { name: string; state: 'pass' | 'fail' | 'skip'; detail: string };
+type CheckOutcome = { name: string; state: 'pass' | 'warn' | 'fail' | 'skip'; detail: string };
 
 async function runCheck(check: SmokeCheck, baseUrl: string, env: NodeJS.ProcessEnv): Promise<CheckOutcome> {
   const path = resolvePath(check, env);
@@ -274,23 +356,38 @@ async function runCheck(check: SmokeCheck, baseUrl: string, env: NodeJS.ProcessE
 
   const url = `${baseUrl}${path}`;
   let lastDetail = '';
+  // Set only when every assertion passed and the response merely declared itself
+  // degraded, so a later attempt that fails outright cannot be reported as a warning.
+  let degraded = false;
 
   for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
     try {
       const response = await fetchOnce(url);
       const failure = check.assert(response);
-      if (failure === null) return { name: check.name, state: 'pass', detail: path };
-      lastDetail = failure;
+      if (failure === null) {
+        const degradation = check.degradation?.(response) ?? null;
+        if (degradation === null) return { name: check.name, state: 'pass', detail: path };
+        // Retried like a failure: the whole point of the retry loop here is to
+        // give a cold cache the two extra requests it needs to warm up, which
+        // turns a transient post-deploy degradation into a clean pass.
+        lastDetail = degradation;
+        degraded = true;
+      } else {
+        lastDetail = failure;
+        degraded = false;
+      }
     } catch (error) {
       lastDetail = `request failed: ${error instanceof Error ? error.message : String(error)}`;
+      degraded = false;
     }
     if (attempt < ATTEMPTS) {
-      console.log(`  ${check.name}: attempt ${attempt} failed (${lastDetail}); retrying in 5s...`);
+      const label = degraded ? 'degraded' : 'failed';
+      console.log(`  ${check.name}: attempt ${attempt} ${label} (${lastDetail}); retrying in 5s...`);
       await delay(RETRY_DELAY_MS);
     }
   }
 
-  return { name: check.name, state: 'fail', detail: `${path} — ${lastDetail}` };
+  return { name: check.name, state: degraded ? 'warn' : 'fail', detail: `${path} — ${lastDetail}` };
 }
 
 /** `--base` is the only override — one documented way to point this elsewhere. */
@@ -313,20 +410,31 @@ async function main(): Promise<void> {
   const baseUrl = parseBaseUrl(process.argv.slice(2));
   console.log(`Production smoke against ${baseUrl}\n`);
 
+  const MARKERS: Record<CheckOutcome['state'], string> = { pass: 'ok', warn: 'WARN', fail: 'FAIL', skip: '--' };
+
   const outcomes: CheckOutcome[] = [];
   for (const check of WWW_CHECKS) {
     const outcome = await runCheck(check, baseUrl, process.env);
     outcomes.push(outcome);
-    const marker = outcome.state === 'pass' ? 'ok' : outcome.state === 'skip' ? '--' : 'FAIL';
-    console.log(`${marker.padEnd(4)} ${outcome.name}${outcome.state === 'pass' ? '' : ` (${outcome.detail})`}`);
+    console.log(
+      `${MARKERS[outcome.state].padEnd(4)} ${outcome.name}${outcome.state === 'pass' ? '' : ` (${outcome.detail})`}`,
+    );
   }
 
   const failures = outcomes.filter((outcome) => outcome.state === 'fail');
+  const warnings = outcomes.filter((outcome) => outcome.state === 'warn');
   const skipped = outcomes.filter((outcome) => outcome.state === 'skip');
   console.log(
-    `\n${outcomes.length - failures.length - skipped.length} passed, ${failures.length} failed, ${skipped.length} skipped`,
+    `\n${outcomes.length - failures.length - warnings.length - skipped.length} passed, ${failures.length} failed, ${warnings.length} degraded, ${skipped.length} skipped`,
   );
 
+  // A degraded surface is real news, so it gets a GitHub annotation of its own —
+  // but not a red deploy: the server declared the degradation, serves it under a
+  // sixty-second window, and self-heals. Only a silent or structural break is a
+  // failure.
+  for (const warning of warnings) {
+    console.log(`::warning::production smoke degraded: ${warning.name} — ${warning.detail}`);
+  }
   for (const failure of failures) {
     console.log(`::error::production smoke failed: ${failure.name} — ${failure.detail}`);
   }


### PR DESCRIPTION
`Production Deploy` has been red on every commit since `a5795a08e`, failing the post-deploy smoke on *"sitemap.xml serves a sitemap index pointing at shards — no boards shard `<loc>` entry"*.

It isn't flaky and the shard isn't broken. It's a cold-start race, and the real cost isn't the red deploy — it's that **Google intermittently sees a sitemap index containing no board pages at all**.

## What's happening

The index gives each shard `SHARD_DEADLINE_MS` (3s). `getAllBoardConfigsOrThrow` is uncached and takes ~10s cold, so the index publishes without boards — and the post-deploy smoke runs in exactly that window.

Measured against production:

| | result |
|---|---|
| `/sitemaps/boards.xml` cold | **503 after 10.35s** |
| `/sitemaps/boards.xml` warm | 200, 2.6 MB, 0.33s |
| `/sitemap.xml` right after deploy | lists only `static.xml` |
| `/sitemap.xml` warm | lists `boards.xml`, header `X-Sitemap-Degraded: playlists,climbs` |

Sampling it warm is why this reads as flaky: an hour after a deploy it always looks fine.

## Also found: the cold index fetched the board catalogue twice

`buildIndexEntry(boards)` and `buildPagedIndexEntries(climbs) → fetchTier2Summary` both call `getAllBoardConfigsOrThrow`, in parallel, on every cold index build. That's two live 10-second GraphQL fetches per miss. Now one.

## The fix, both halves

**Cache the fetch.** `unstable_cache` at `revalidate: 3600`, the same number as the `s-maxage=3600` the boards shard route already serves under — one window picked for one reason on both layers, not a claim that they expire together (that route's `stale-while-revalidate` tail can still hand out a body up to 25h old). In front of it, an in-process TTL with single-flight. Those aren't redundant: `unstable_cache` doesn't dedupe concurrent misses, which is what the double-fetch above needs. The in-process layer stores nothing on a rejection, so a truncation can't poison an hour of empty sitemaps — whether the Data Cache also declines to memoise it is unverified, and the code says so. The 10s abort stays inside the cached function and `withDeadline` still gives up at 3s, so a miss degrades rather than hanging.

**Teach the smoke to tell degraded from broken.** It now reads `X-Sitemap-Degraded`. A *degradable* shard missing **and** named in that header retries, then warns and exits 0. A shard missing **without** the header is still a hard failure — the header is not a blanket amnesty, and there's a test where it names `playlists` while `boards` is what's absent. Non-200, non-XML, and anything that isn't a `<sitemapindex>` all still fail.

Three things keep that from becoming a permanent amnesty:

- **`/sitemaps/boards.xml` gets a check of its own**, alongside the static one. Softening the index check removed the suite's only view of the boards surface, and *every* way boards drops out of the index records its id in `degradedShards` — so without this the smoke could never go red on boards again while the shard URL sat there 503ing. The `hasMore` truncation throw makes that concrete: it's permanent by construction once the catalogue passes the 100-config API cap, and its only loud signal was the check being softened. Measured at 2,676 KB in 0.14s, well inside the 30s timeout.
- **`static` is not excusable by the header.** `buildStaticEntries` is hardcoded and pure, so its absence is never transient — and excusing it would have let an empty `<sitemapindex></sitemapindex>` pass whenever the handler named every shard in the header.
- **A run that flapped reports FAIL, not WARN.** The verdict is an exported `finalVerdict(attempts)`: WARN requires *every* attempt to have been a clean 200 that declared itself incomplete, so 503/503/degraded no longer reads green off the last attempt alone.

The retry is not a warm-up, and the comment no longer claims it is: Vercel's edge ignores the smoke's `Cache-Control: no-cache` request header and holds the degraded index for 60s — longer than all three attempts (~10s). Measured: attempt 1 MISS 3.35s, attempt 2 HIT 0.09s, identical `x-sitemap-degraded`. Once the window opens the WARN is guaranteed; the retry only covers an edge blip.

Neither half is redundant. The cache is the actual bug fix, but it has a first-deploy race — the abandoned fetch has to complete to populate the Data Cache, and the smoke's retries span about the length of one cold fetch. The smoke change stops that being a red deploy. The smoke change alone would leave the index genuinely shipping without boards for 60s after every cold start.

## Three comments in the registry were asserting the opposite

`shard-registry.ts` claimed in two places that the builders are uncached, and named caching them as "the follow-up". A third, inherited into the smoke, said the two required shards are "the ones the registry marks `expectsUrls`" — `climbs` is `expectsUrls: true` as well, and is excluded because its summary can't meet the deadline, not because it's optional. All now describe what the code does.

## playlists and climbs: same class, different fixes — deliberately untouched

- **playlists** has *no* cache at all and hits Postgres on every force-dynamic index hit. Not the same one-line fix: Dates don't survive the Data Cache, so it needs rehydration, and its deadline doesn't cancel the query so a wrapper alone won't bound pool load. Degraded on 100% of the samples taken while preparing this PR.
- **climbs** is already cached at two levels — its degradation is an intrinsically expensive miss (~18 sequential `DISTINCT ON` groups, 9.2s cold for the largest alone) that can never meet 3s. When it degrades, ~52,000 climb URLs leave the index. This PR removes up to 10s from its cold path as a side effect but doesn't close that gap. Tracked separately in #4523.

Worth a follow-up issue: on Vercel the index can't reliably warm its own caches, because work abandoned at 3s must outlive the response to write the Data Cache. A `waitUntil` around the abandoned builder would make degradation genuinely self-healing on the first miss instead of probabilistically.

## A test that would have gone red

The existing registry coverage mocks `server-popular-configs` wholesale, so it was structurally blind to this. `server-popular-configs.test.ts` was not: once caching existed, its truncation case would have read the *first* case's cached value instead of throwing, and gone **red** — noisy rather than silent, but still a false signal about the wrong thing. It now resets between cases, plus four new ones: single fetch on repeat, concurrent misses collapsing to one fetch, no in-process storage on failure, and the one-page request shape unchanged.

## Release Notes

- [x] No release note needed (internal / technical change)

Sitemap caching and post-deploy smoke; no user-facing change.
