### PR TITLE
fix(web): stop server feature flags failing silently when they fail closed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Read relevant `docs/` before working on the matching area; update docs when the 
 - `docs/ai-design-guidelines.md` — Velvet Send design system (mobile-canonical: palette, typography, tokens, Liquid Glass / Material variants; web now consumes it too via `@boardsesh/velvet-tokens` + the foreground/fill split — see the "Web (consuming Velvet Send)" section)
 - `docs/live-activity-push-testing.md` — APNs Live Activity push testing
 - `docs/db-migrations.md` — migration numbering, `when`-not-number apply order, the collision/renumber bot, and when it hands work back
+- `docs/feature-flags.md` — client vs server flags, why a server gate fails closed, the resolution reasons, the `/api/internal/feature-flags` diagnostic, and the `FEATURE_FLAG_OVERRIDES` kill switch
 - `docs/logging.md` — backend structured logger (winston)
 - `docs/db-connectivity.md` — Postgres connect retries (what is retried and why it can't double-execute a write), the retry budgets, and the `/health` vs `/health/db` split
 - `docs/og-climb.md` — backend-served climb OG share cards (`GET /og/climb`: caches, env vars, timings)

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -40,18 +40,21 @@ Ask production. Signed in as a global admin, open:
 https://www.boardsesh.com/api/internal/feature-flags
 ```
 
-It is a normal session-cookie-authenticated GET, so the browser you are already signed in with is enough. `?key=<flag>` narrows it to one flag; with no key it covers every server flag. Per flag it reports three answers:
+It is a normal session-cookie-authenticated GET, so the browser you are already signed in with is enough. `?key=<flag>` narrows it to one flag (any key, not only the registered ones — that is how you check whether the dashboard renamed it); with no key it covers every server flag.
 
-- `page` — the cached resolution, exactly what a gated route sees right now
-- `public` — an uncached probe as a signed-out visitor (what a crawler gets)
-- `viewer` — an uncached probe as you
+Per flag it reports a 2x2 — cached vs live, signed-out visitor vs you:
 
-Read it like this:
+- `cached.public` — the entry an anonymous request to the gated route used. **This is the one that 404'd the visitor.**
+- `cached.viewer` — the entry your own request to that route used
+- `live.public` — an uncached probe as a signed-out visitor (what a crawler gets)
+- `live.viewer` — an uncached probe as you
 
-- `page` off but `public` on → the 60s data cache has not caught up. Wait a minute and reload twice; the first request after expiry still serves the stale answer while it revalidates.
-- `public.reason` is `posthog-disabled` → PostHog really is saying no. The rollout is probably still person-targeted: a condition matching an email or a cohort cannot match `anonymous-web-visitor`, which is the single distinct id every signed-out visitor shares. A public launch needs the condition to be a plain percentage rollout, not 100% of a filtered set.
-- `public.reason` is `flag-missing` → the flag key and the project key disagree. Check `config.apiKeySource` and that the flag exists in PostHog project 412845 under exactly that name.
-- `public.reason` is `no-api-key` → the Vercel runtime env has no PostHog key. Every server flag is off, whatever the dashboard says.
+Both halves matter because the cache is keyed per flag **and** per person, so your answer says nothing about theirs. Read it like this:
+
+- `cached.public` off but `live.public` on → the 60s data cache has not caught up. Wait a minute and reload twice; the first request after expiry still serves the stale answer while it revalidates.
+- `live.public` off but `live.viewer` on → the rollout is still person-targeted. A condition matching an email or a cohort cannot match `anonymous-web-visitor`, the single distinct id every signed-out visitor shares. A public launch needs a plain percentage rollout, not 100% of a filtered set.
+- `live.public.reason` is `flag-missing` → the flag key and the project key disagree. Check `config.apiKeySource` and that the flag exists in PostHog project 412845 under exactly that name.
+- `live.public.reason` is `no-api-key` → the Vercel runtime env has no PostHog key. Every server flag is off, whatever the dashboard says.
 - `config.overrides` names the flag → an env override is deciding it, and the dashboard is not being consulted at all.
 
 ## The override lever

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -49,7 +49,9 @@ Per flag it reports a 2x2 — cached vs live, signed-out visitor vs you:
 - `live.public` — an uncached probe as a signed-out visitor (what a crawler gets)
 - `live.viewer` — an uncached probe as you
 
-Both halves matter because the cache is keyed per flag **and** per person, so your answer says nothing about theirs. Read it like this:
+Both halves matter because the cache is keyed per flag **and** per person, so your answer says nothing about theirs. The two `live` probes are uncached, so one request costs 2 PostHog calls per flag (each capped at 1.5s) — negligible for today's single server flag, worth a thought before `SERVER_FEATURE_FLAG_KEYS` grows long enough that an admin page load fans out dozens.
+
+Read it like this:
 
 - `cached.public` off but `live.public` on → the 60s data cache has not caught up. Wait a minute and reload twice; the first request after expiry still serves the stale answer while it revalidates.
 - `live.public` off but `live.viewer` on → the rollout is still person-targeted. A condition matching an email or a cohort cannot match `anonymous-web-visitor`, the single distinct id every signed-out visitor shares. A public launch needs a plain percentage rollout, not 100% of a filtered set.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,70 @@
+# Feature flags
+
+Two kinds, and they fail in different ways.
+
+**Client flags** (`FEATURE_FLAG_KEYS` in `packages/web/app/flags.ts`) resolve in the browser via `FeatureFlagsProvider`. They hide a control. If PostHog is slow or unreachable the control stays hidden and nothing else happens.
+
+**Server flags** (`SERVER_FEATURE_FLAG_KEYS`) resolve during SSR via `getServerFeatureFlag` and decide whether a route renders at all. `gyms-directory` is the only one today: with it off, `/gyms` and its three facet routes are a plain `notFound()`. A client-resolved flag could not do this — by the time the browser knows the answer the HTML has already shipped.
+
+## How a server flag resolves
+
+`packages/web/app/lib/feature-flags/server-feature-flag.ts`, in order:
+
+1. `FEATURE_FLAG_OVERRIDES` — wins over everything, including the dashboard.
+2. No PostHog project key in the environment → off.
+3. No distinct id (signed out, and the caller did not pass `allowAnonymous`) → off.
+4. `POST {POSTHOG_HOST}/flags/?v=2` under a 1.5s deadline, cached 60s per flag+person.
+5. Anything that throws, times out, or comes back unparseable → off.
+
+It fails **closed**: a flag exists because the surface is not ready for everyone, so an unreachable PostHog must not open the gate.
+
+Every step returns a `reason` alongside the boolean, because failing closed and failing silently are not the same thing:
+
+| reason                                 | what it means                                                                                                                                                              |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `override`                             | `FEATURE_FLAG_OVERRIDES` decided it, ON or OFF                                                                                                                             |
+| `no-api-key`                           | no `POSTHOG_PROJECT_KEY` / `NEXT_PUBLIC_POSTHOG_KEY` in the runtime env                                                                                                    |
+| `no-distinct-id`                       | nobody signed in and the caller did not pass `allowAnonymous`                                                                                                              |
+| `posthog-enabled` / `posthog-disabled` | PostHog evaluated the flag. The gate is working                                                                                                                            |
+| `flag-missing`                         | 200 OK, flag not in the payload — the key does not exist in the project this api key belongs to. A typo, a renamed or deleted flag, or a key pointing at the wrong project |
+| `quota-limited`                        | PostHog has stopped serving flags for the project                                                                                                                          |
+| `http-error` / `request-failed`        | non-2xx, timeout, or unparseable body                                                                                                                                      |
+
+The bottom four are "the gate is broken", not "the gate is closed", and each sends one Sentry warning per process per key.
+
+## The dashboard says 100% and the page still 404s
+
+Ask production. Signed in as a global admin, open:
+
+```
+https://www.boardsesh.com/api/internal/feature-flags
+```
+
+It is a normal session-cookie-authenticated GET, so the browser you are already signed in with is enough. `?key=<flag>` narrows it to one flag; with no key it covers every server flag. Per flag it reports three answers:
+
+- `page` — the cached resolution, exactly what a gated route sees right now
+- `public` — an uncached probe as a signed-out visitor (what a crawler gets)
+- `viewer` — an uncached probe as you
+
+Read it like this:
+
+- `page` off but `public` on → the 60s data cache has not caught up. Wait a minute and reload twice; the first request after expiry still serves the stale answer while it revalidates.
+- `public.reason` is `posthog-disabled` → PostHog really is saying no. The rollout is probably still person-targeted: a condition matching an email or a cohort cannot match `anonymous-web-visitor`, which is the single distinct id every signed-out visitor shares. A public launch needs the condition to be a plain percentage rollout, not 100% of a filtered set.
+- `public.reason` is `flag-missing` → the flag key and the project key disagree. Check `config.apiKeySource` and that the flag exists in PostHog project 412845 under exactly that name.
+- `public.reason` is `no-api-key` → the Vercel runtime env has no PostHog key. Every server flag is off, whatever the dashboard says.
+- `config.overrides` names the flag → an env override is deciding it, and the dashboard is not being consulted at all.
+
+## The override lever
+
+`FEATURE_FLAG_OVERRIDES` is a comma-separated list, `gyms-directory` (forces ON) or `gyms-directory=false` (forces OFF).
+
+Locally it is the only way in: the browser PostHog client refuses to initialise off a production hostname, so on localhost there is no person and nothing to evaluate against.
+
+In production it is the kill switch and the "I need this reachable now" lever — set it in the Vercel production environment and redeploy. It short-circuits before any network call, so it also keeps a flagged surface up during a PostHog outage. It outranks the dashboard silently, which is why the diagnostics endpoint always reports it.
+
+## Adding a server flag
+
+1. Export the key from `packages/web/app/flags.ts` and add it to `SERVER_FEATURE_FLAG_KEYS` (not `FEATURE_FLAG_KEYS` — the browser provider would fetch a flag no client component reads).
+2. Gate the route with `getServerFeatureFlag(KEY, { distinctId, allowAnonymous })`.
+3. Pass `allowAnonymous: true` for anything that must eventually be public. Without it a null distinct id short-circuits to off, so the surface stays signed-in-only however the dashboard is configured, and flipping the rollout to 100% changes nothing for visitors or crawlers.
+4. Ship `noindex` while the flag is on: a surface that 404s for half its visitors must not be in the index.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -30,7 +30,7 @@ Every step returns a `reason` alongside the boolean, because failing closed and 
 | `quota-limited`                        | PostHog has stopped serving flags for the project                                                                                                                          |
 | `http-error` / `request-failed`        | non-2xx, timeout, or unparseable body                                                                                                                                      |
 
-The bottom four are "the gate is broken", not "the gate is closed", and each sends one Sentry warning per process per key.
+The bottom four are "the gate is broken", not "the gate is closed", and each sends one Sentry warning per key per outage — a flag that starts failing fails on every request, so the key latches after the first message and re-arms as soon as PostHog answers again. Repeated warnings for one key therefore mean it recovered and broke again, not that it is noisy.
 
 ## The dashboard says 100% and the page still 404s
 

--- a/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const checkAdmin = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/admin/check-admin', () => ({ checkAdmin }));
+
+const getPosthogDistinctId = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinctId }));
+
+const getServerFeatureFlagResolution = vi.hoisted(() => vi.fn());
+const probeServerFeatureFlag = vi.hoisted(() => vi.fn());
+const describeServerFeatureFlagConfig = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({
+  ANONYMOUS_DISTINCT_ID: 'anonymous-web-visitor',
+  describeServerFeatureFlagConfig,
+  getServerFeatureFlagResolution,
+  probeServerFeatureFlag,
+}));
+
+import { GET } from '../route';
+
+const ADMIN = { authenticated: true as const, userId: 'admin-1', isAdmin: true, boardScopedOnly: false };
+
+function request(url = 'https://www.boardsesh.com/api/internal/feature-flags') {
+  return new Request(url);
+}
+
+beforeEach(() => {
+  checkAdmin.mockReset().mockResolvedValue(ADMIN);
+  getPosthogDistinctId.mockReset().mockResolvedValue('admin-1');
+  getServerFeatureFlagResolution.mockReset().mockResolvedValue({ enabled: false, reason: 'override', detail: null });
+  probeServerFeatureFlag.mockReset().mockResolvedValue({ enabled: true, reason: 'posthog-enabled', detail: null });
+  describeServerFeatureFlagConfig.mockReset().mockReturnValue({
+    apiKeySource: 'NEXT_PUBLIC_POSTHOG_KEY',
+    host: 'https://us.i.posthog.com',
+    overrides: {},
+  });
+});
+
+describe('GET /api/internal/feature-flags', () => {
+  it('turns a signed-out caller away', async () => {
+    checkAdmin.mockResolvedValue({ authenticated: false });
+    const response = await GET(request());
+    expect(response.status).toBe(401);
+    expect(getServerFeatureFlagResolution).not.toHaveBeenCalled();
+  });
+
+  it('turns a non-admin away', async () => {
+    checkAdmin.mockResolvedValue({ ...ADMIN, isAdmin: false, boardScopedOnly: true });
+    const response = await GET(request());
+    expect(response.status).toBe(403);
+    expect(probeServerFeatureFlag).not.toHaveBeenCalled();
+  });
+
+  it('reports the cached page answer alongside live public and viewer probes', async () => {
+    const response = await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=gyms-directory'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+
+    const body = await response.json();
+    expect(body.flags).toHaveLength(1);
+    expect(body.flags[0]).toEqual({
+      key: 'gyms-directory',
+      page: { enabled: false, reason: 'override', detail: null },
+      public: { enabled: true, reason: 'posthog-enabled', detail: null },
+      viewer: { enabled: true, reason: 'posthog-enabled', detail: null },
+    });
+
+    // The page answer has to be the gated route's own call — same distinct id,
+    // same allowAnonymous — or the diagnostic describes a different question
+    // than the one that 404'd.
+    expect(getServerFeatureFlagResolution).toHaveBeenCalledWith('gyms-directory', {
+      distinctId: 'admin-1',
+      allowAnonymous: true,
+    });
+    expect(probeServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', {
+      distinctId: null,
+      allowAnonymous: true,
+    });
+  });
+
+  it('covers every server flag when no key is given', async () => {
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(body.flags.map((flag: { key: string }) => flag.key)).toEqual(['gyms-directory']);
+    expect(body.config).toMatchObject({
+      apiKeySource: 'NEXT_PUBLIC_POSTHOG_KEY',
+      anonymousDistinctId: 'anonymous-web-visitor',
+    });
+  });
+
+  it('never returns the project key itself', async () => {
+    describeServerFeatureFlagConfig.mockReturnValue({
+      apiKeySource: 'POSTHOG_PROJECT_KEY',
+      host: 'https://us.i.posthog.com',
+      overrides: { 'gyms-directory': true },
+    });
+
+    const body = await (await GET(request())).text();
+    expect(body).not.toContain('phc_');
+  });
+
+  it('skips the viewer probe for a flag check with no signed-in person', async () => {
+    // checkAdmin can only pass with a session, so this is belt-and-braces —
+    // but a null distinct id must never be probed as if it were a person.
+    getPosthogDistinctId.mockResolvedValue(null);
+
+    const body = await (await GET(request())).json();
+    expect(body.flags[0].viewer).toBeNull();
+    expect(body.viewerDistinctId).toBeNull();
+    expect(probeServerFeatureFlag).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a key that is not a flag key', async () => {
+    const response = await GET(
+      request('https://www.boardsesh.com/api/internal/feature-flags?key=' + encodeURIComponent('../../etc/passwd')),
+    );
+    expect(response.status).toBe(400);
+    expect(probeServerFeatureFlag).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
@@ -145,7 +145,9 @@ describe('GET /api/internal/feature-flags', () => {
     expect(getServerFeatureFlagResolution).toHaveBeenCalledTimes(SERVER_FEATURE_FLAG_KEYS.length);
   });
 
-  it('rejects a key that is not a flag key', async () => {
+  // Shape, not membership: an unregistered key is answerable on purpose (see
+  // the `registered: false` test above), a path-traversal string is not.
+  it('rejects a key that is not shaped like a flag key', async () => {
     const response = await GET(
       request('https://www.boardsesh.com/api/internal/feature-flags?key=' + encodeURIComponent('../../etc/passwd')),
     );

--- a/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({
   probeServerFeatureFlag,
 }));
 
+import { SERVER_FEATURE_FLAG_KEYS } from '@/app/flags';
 import { GET } from '../route';
 
 const ADMIN = { authenticated: true as const, userId: 'admin-1', isAdmin: true, boardScopedOnly: false };
@@ -109,8 +110,11 @@ describe('GET /api/internal/feature-flags', () => {
     const response = await GET(request());
     const body = await response.json();
 
-    expect(body.flags.map((flag: { key: string }) => flag.key)).toEqual(['gyms-directory']);
-    expect(body.flags[0].registered).toBe(true);
+    // Derived from the registry rather than hardcoded: the behaviour under test
+    // is "covers every registered server flag", which a second flag must extend
+    // rather than break.
+    expect(body.flags.map((flag: { key: string }) => flag.key)).toEqual([...SERVER_FEATURE_FLAG_KEYS]);
+    expect(body.flags.every((flag: { registered: boolean }) => flag.registered)).toBe(true);
     expect(body.config).toMatchObject({
       apiKeySource: 'NEXT_PUBLIC_POSTHOG_KEY',
       anonymousDistinctId: 'anonymous-web-visitor',
@@ -137,8 +141,8 @@ describe('GET /api/internal/feature-flags', () => {
     expect(body.flags[0].cached.viewer).toBeNull();
     expect(body.flags[0].live.viewer).toBeNull();
     expect(body.viewerDistinctId).toBeNull();
-    expect(probeServerFeatureFlag).toHaveBeenCalledTimes(1);
-    expect(getServerFeatureFlagResolution).toHaveBeenCalledTimes(1);
+    expect(probeServerFeatureFlag).toHaveBeenCalledTimes(SERVER_FEATURE_FLAG_KEYS.length);
+    expect(getServerFeatureFlagResolution).toHaveBeenCalledTimes(SERVER_FEATURE_FLAG_KEYS.length);
   });
 
   it('rejects a key that is not a flag key', async () => {

--- a/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
@@ -145,8 +145,14 @@ describe('GET /api/internal/feature-flags', () => {
     expect(getServerFeatureFlagResolution).toHaveBeenCalledTimes(SERVER_FEATURE_FLAG_KEYS.length);
   });
 
+  it('accepts a dot-separated key, which PostHog allows', async () => {
+    const response = await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=gyms.directory.v2'));
+    expect(response.status).toBe(200);
+  });
+
   // Shape, not membership: an unregistered key is answerable on purpose (see
-  // the `registered: false` test above), a path-traversal string is not.
+  // the `registered: false` test above), a path-traversal string is not — the
+  // slashes are what disqualify it, dots on their own are fine.
   it('rejects a key that is not shaped like a flag key', async () => {
     const response = await GET(
       request('https://www.boardsesh.com/api/internal/feature-flags?key=' + encodeURIComponent('../../etc/passwd')),

--- a/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
@@ -51,7 +51,7 @@ describe('GET /api/internal/feature-flags', () => {
     expect(probeServerFeatureFlag).not.toHaveBeenCalled();
   });
 
-  it('reports the cached page answer alongside live public and viewer probes', async () => {
+  it('reports cached and live answers for both the visitor and the admin', async () => {
     const response = await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=gyms-directory'));
     expect(response.status).toBe(200);
     expect(response.headers.get('Cache-Control')).toBe('no-store');
@@ -60,14 +60,30 @@ describe('GET /api/internal/feature-flags', () => {
     expect(body.flags).toHaveLength(1);
     expect(body.flags[0]).toEqual({
       key: 'gyms-directory',
-      page: { enabled: false, reason: 'override', detail: null },
-      public: { enabled: true, reason: 'posthog-enabled', detail: null },
-      viewer: { enabled: true, reason: 'posthog-enabled', detail: null },
+      registered: true,
+      cached: {
+        public: { enabled: false, reason: 'override', detail: null },
+        viewer: { enabled: false, reason: 'override', detail: null },
+      },
+      live: {
+        public: { enabled: true, reason: 'posthog-enabled', detail: null },
+        viewer: { enabled: true, reason: 'posthog-enabled', detail: null },
+      },
     });
+  });
 
-    // The page answer has to be the gated route's own call — same distinct id,
-    // same allowAnonymous — or the diagnostic describes a different question
-    // than the one that 404'd.
+  it('reads the ANONYMOUS cache entry, which is the one that 404s a visitor', async () => {
+    await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=gyms-directory'));
+
+    // The data cache is keyed per flag AND per person, so the admin's entry says
+    // nothing about the entry a signed-out visitor's request used. Reading only
+    // the admin's would make "cached off, live on" mean either staleness or the
+    // admin being in a person-targeted rollout — the exact ambiguity this
+    // endpoint exists to remove.
+    expect(getServerFeatureFlagResolution).toHaveBeenCalledWith('gyms-directory', {
+      distinctId: null,
+      allowAnonymous: true,
+    });
     expect(getServerFeatureFlagResolution).toHaveBeenCalledWith('gyms-directory', {
       distinctId: 'admin-1',
       allowAnonymous: true,
@@ -78,11 +94,23 @@ describe('GET /api/internal/feature-flags', () => {
     });
   });
 
+  it('marks a key that is not a registered server flag', async () => {
+    const body = await (
+      await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=renamed-in-the-dashboard'))
+    ).json();
+
+    // Allowed on purpose: `flag-missing` is the answer to "did someone rename
+    // it?", which a membership check could never ask.
+    expect(body.flags[0].registered).toBe(false);
+    expect(body.flags[0].live.public).toMatchObject({ reason: 'posthog-enabled' });
+  });
+
   it('covers every server flag when no key is given', async () => {
     const response = await GET(request());
     const body = await response.json();
 
     expect(body.flags.map((flag: { key: string }) => flag.key)).toEqual(['gyms-directory']);
+    expect(body.flags[0].registered).toBe(true);
     expect(body.config).toMatchObject({
       apiKeySource: 'NEXT_PUBLIC_POSTHOG_KEY',
       anonymousDistinctId: 'anonymous-web-visitor',
@@ -100,15 +128,17 @@ describe('GET /api/internal/feature-flags', () => {
     expect(body).not.toContain('phc_');
   });
 
-  it('skips the viewer probe for a flag check with no signed-in person', async () => {
+  it('skips the viewer columns when there is no signed-in person', async () => {
     // checkAdmin can only pass with a session, so this is belt-and-braces —
     // but a null distinct id must never be probed as if it were a person.
     getPosthogDistinctId.mockResolvedValue(null);
 
     const body = await (await GET(request())).json();
-    expect(body.flags[0].viewer).toBeNull();
+    expect(body.flags[0].cached.viewer).toBeNull();
+    expect(body.flags[0].live.viewer).toBeNull();
     expect(body.viewerDistinctId).toBeNull();
     expect(probeServerFeatureFlag).toHaveBeenCalledTimes(1);
+    expect(getServerFeatureFlagResolution).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a key that is not a flag key', async () => {

--- a/packages/web/app/api/internal/feature-flags/route.ts
+++ b/packages/web/app/api/internal/feature-flags/route.ts
@@ -51,8 +51,13 @@ export const dynamic = 'force-dynamic';
  * `flag-missing` is precisely the answer to "did the dashboard rename it?" or
  * "does this project know that key at all?", and a membership check could only
  * ever answer keys we already know are fine.
+ *
+ * Dots are allowed because PostHog accepts dot-separated keys; `/` is not, so a
+ * traversal-shaped string is still rejected. The key never reaches a URL or a
+ * path — it is a JSON lookup and a cache-key part — so the shape check is about
+ * keeping the input recognisably a flag key, not about escaping.
  */
-const FLAG_KEY_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+const FLAG_KEY_PATTERN = /^[a-zA-Z0-9._-]{1,64}$/;
 
 /** One resolution per (cached | live) x (public | viewer). */
 export type FeatureFlagAudience = {

--- a/packages/web/app/api/internal/feature-flags/route.ts
+++ b/packages/web/app/api/internal/feature-flags/route.ts
@@ -23,25 +23,50 @@ import {
  * of those fail closed, by design — and used to fail closed identically, with no
  * way to tell them apart short of a Sentry message that four of them never sent.
  *
- * Reported per flag:
- *   `page`   — the cached resolution, exactly what a gated route sees right now
- *   `public` — an uncached probe as a signed-out visitor (what a crawler gets)
- *   `viewer` — an uncached probe as the calling admin, when signed in
+ * Reported per flag, as a 2x2 — cached vs live, signed-out visitor vs the
+ * calling admin:
+ *   `cached.public` — the entry an anonymous request to the gated route used
+ *   `cached.viewer` — the entry the admin's own request to that route used
+ *   `live.public`   — an uncached probe as a signed-out visitor (crawler's view)
+ *   `live.viewer`   — an uncached probe as the calling admin
  *
- * `page` disagreeing with `public` means the answer is cached and will catch up;
- * `public.reason` explains everything else. No secret is returned: the config
- * block names which env var held the key, never its value.
+ * Both halves of each pair matter because the data cache is keyed per flag AND
+ * per person: the admin's cached answer says nothing about the entry that 404'd
+ * a visitor. Split this way each comparison means exactly one thing —
+ * `cached.public` vs `live.public` is cache staleness, `live.public` vs
+ * `live.viewer` is a rollout still targeted at people rather than a percentage.
+ * Collapsing them into one "what the page sees" row makes those two
+ * indistinguishable, which is the confusion this endpoint exists to remove.
+ *
+ * No secret is returned: the config block names which env var held the project
+ * key, never its value.
  */
 export const dynamic = 'force-dynamic';
 
-/** Guards the free-text `?key=`, which is forwarded to PostHog verbatim. */
+/**
+ * Guards the free-text `?key=`, which is forwarded to PostHog verbatim.
+ *
+ * Deliberately a shape check rather than a `SERVER_FEATURE_FLAG_KEYS`
+ * membership check: an unregistered key is a legitimate question here, because
+ * `flag-missing` is precisely the answer to "did the dashboard rename it?" or
+ * "does this project know that key at all?", and a membership check could only
+ * ever answer keys we already know are fine.
+ */
 const FLAG_KEY_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+
+/** One resolution per (cached | live) x (public | viewer). */
+export type FeatureFlagAudience = {
+  public: ServerFeatureFlagResolution;
+  /** Null when nobody is signed in — never probed as if a person existed. */
+  viewer: ServerFeatureFlagResolution | null;
+};
 
 export type FeatureFlagDiagnostic = {
   key: string;
-  page: ServerFeatureFlagResolution;
-  public: ServerFeatureFlagResolution;
-  viewer: ServerFeatureFlagResolution | null;
+  /** Registered in `SERVER_FEATURE_FLAG_KEYS`, vs asked for ad hoc via `?key=`. */
+  registered: boolean;
+  cached: FeatureFlagAudience;
+  live: FeatureFlagAudience;
 };
 
 export type FeatureFlagDiagnosticsResponse = {
@@ -64,19 +89,29 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Invalid flag key' }, { status: 400 });
   }
 
-  const keys: string[] = requestedKey ? [requestedKey] : [...SERVER_FEATURE_FLAG_KEYS];
+  const registeredKeys: string[] = [...SERVER_FEATURE_FLAG_KEYS];
+  const keys = requestedKey ? [requestedKey] : registeredKeys;
   const viewerDistinctId = await getPosthogDistinctId();
 
   const flags = await Promise.all(
     keys.map(async (key): Promise<FeatureFlagDiagnostic> => {
-      const [page, publicResolution, viewer] = await Promise.all([
-        // Same arguments the gated routes pass, so this is their answer and not
-        // a re-derivation of it.
-        getServerFeatureFlagResolution(key, { distinctId: viewerDistinctId, allowAnonymous: true }),
+      const [cachedPublic, cachedViewer, livePublic, liveViewer] = await Promise.all([
+        // The arguments an ANONYMOUS request to a gated route passes, so this
+        // reads the very cache entry that served the visitor their 404 — not a
+        // re-derivation of it, and not the admin's separate entry.
+        getServerFeatureFlagResolution(key, { distinctId: null, allowAnonymous: true }),
+        viewerDistinctId
+          ? getServerFeatureFlagResolution(key, { distinctId: viewerDistinctId, allowAnonymous: true })
+          : Promise.resolve(null),
         probeServerFeatureFlag(key, { distinctId: null, allowAnonymous: true }),
         viewerDistinctId ? probeServerFeatureFlag(key, { distinctId: viewerDistinctId }) : Promise.resolve(null),
       ]);
-      return { key, page, public: publicResolution, viewer };
+      return {
+        key,
+        registered: registeredKeys.includes(key),
+        cached: { public: cachedPublic, viewer: cachedViewer },
+        live: { public: livePublic, viewer: liveViewer },
+      };
     }),
   );
 

--- a/packages/web/app/api/internal/feature-flags/route.ts
+++ b/packages/web/app/api/internal/feature-flags/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { checkAdmin } from '@/app/lib/admin/check-admin';
+import { SERVER_FEATURE_FLAG_KEYS } from '@/app/flags';
+import { getPosthogDistinctId } from '@/app/lib/feature-flags/server-distinct-id';
+import {
+  ANONYMOUS_DISTINCT_ID,
+  describeServerFeatureFlagConfig,
+  getServerFeatureFlagResolution,
+  probeServerFeatureFlag,
+  type ServerFeatureFlagConfig,
+  type ServerFeatureFlagResolution,
+} from '@/app/lib/feature-flags/server-feature-flag';
+
+/**
+ * Admin-only diagnostics for the SERVER-side feature flags — the ones that gate
+ * whether a route renders at all (`gyms-directory` today).
+ *
+ * It exists because "the dashboard says 100% and the page still 404s" has half a
+ * dozen causes that look identical from outside: no project key in the runtime
+ * env, a key pointing at another PostHog project, the flag renamed or deleted,
+ * the project quota-limited, PostHog timing out, `FEATURE_FLAG_OVERRIDES` set to
+ * OFF somewhere, or a stale `false` still inside the 60s data-cache window. All
+ * of those fail closed, by design — and used to fail closed identically, with no
+ * way to tell them apart short of a Sentry message that four of them never sent.
+ *
+ * Reported per flag:
+ *   `page`   — the cached resolution, exactly what a gated route sees right now
+ *   `public` — an uncached probe as a signed-out visitor (what a crawler gets)
+ *   `viewer` — an uncached probe as the calling admin, when signed in
+ *
+ * `page` disagreeing with `public` means the answer is cached and will catch up;
+ * `public.reason` explains everything else. No secret is returned: the config
+ * block names which env var held the key, never its value.
+ */
+export const dynamic = 'force-dynamic';
+
+/** Guards the free-text `?key=`, which is forwarded to PostHog verbatim. */
+const FLAG_KEY_PATTERN = /^[a-zA-Z0-9_-]{1,64}$/;
+
+export type FeatureFlagDiagnostic = {
+  key: string;
+  page: ServerFeatureFlagResolution;
+  public: ServerFeatureFlagResolution;
+  viewer: ServerFeatureFlagResolution | null;
+};
+
+export type FeatureFlagDiagnosticsResponse = {
+  config: ServerFeatureFlagConfig & { anonymousDistinctId: string };
+  viewerDistinctId: string | null;
+  flags: FeatureFlagDiagnostic[];
+};
+
+export async function GET(request: Request) {
+  const access = await checkAdmin();
+  if (!access.authenticated) {
+    return NextResponse.json({ error: 'Sign in required' }, { status: 401 });
+  }
+  if (!access.isAdmin) {
+    return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+  }
+
+  const requestedKey = new URL(request.url).searchParams.get('key');
+  if (requestedKey !== null && !FLAG_KEY_PATTERN.test(requestedKey)) {
+    return NextResponse.json({ error: 'Invalid flag key' }, { status: 400 });
+  }
+
+  const keys: string[] = requestedKey ? [requestedKey] : [...SERVER_FEATURE_FLAG_KEYS];
+  const viewerDistinctId = await getPosthogDistinctId();
+
+  const flags = await Promise.all(
+    keys.map(async (key): Promise<FeatureFlagDiagnostic> => {
+      const [page, publicResolution, viewer] = await Promise.all([
+        // Same arguments the gated routes pass, so this is their answer and not
+        // a re-derivation of it.
+        getServerFeatureFlagResolution(key, { distinctId: viewerDistinctId, allowAnonymous: true }),
+        probeServerFeatureFlag(key, { distinctId: null, allowAnonymous: true }),
+        viewerDistinctId ? probeServerFeatureFlag(key, { distinctId: viewerDistinctId }) : Promise.resolve(null),
+      ]);
+      return { key, page, public: publicResolution, viewer };
+    }),
+  );
+
+  const response: FeatureFlagDiagnosticsResponse = {
+    config: { ...describeServerFeatureFlagConfig(), anonymousDistinctId: ANONYMOUS_DISTINCT_ID },
+    viewerDistinctId,
+    flags,
+  };
+
+  return NextResponse.json(response, { headers: { 'Cache-Control': 'no-store' } });
+}

--- a/packages/web/app/api/internal/feature-flags/route.ts
+++ b/packages/web/app/api/internal/feature-flags/route.ts
@@ -104,7 +104,9 @@ export async function GET(request: Request) {
           ? getServerFeatureFlagResolution(key, { distinctId: viewerDistinctId, allowAnonymous: true })
           : Promise.resolve(null),
         probeServerFeatureFlag(key, { distinctId: null, allowAnonymous: true }),
-        viewerDistinctId ? probeServerFeatureFlag(key, { distinctId: viewerDistinctId }) : Promise.resolve(null),
+        viewerDistinctId
+          ? probeServerFeatureFlag(key, { distinctId: viewerDistinctId, allowAnonymous: true })
+          : Promise.resolve(null),
       ]);
       return {
         key,

--- a/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
+++ b/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
@@ -429,6 +429,24 @@ describe('probeServerFeatureFlag', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('never spends the once-per-process Sentry budget', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: {} } });
+
+    const { probeServerFeatureFlag, getServerFeatureFlag } = await loadModule();
+
+    // An admin opening the diagnostics endpoint while a flag is broken must not
+    // mark the key as already-reported: the next genuinely broken PAGE request
+    // in this worker would then fail silently, so the observability endpoint
+    // would be costing observability.
+    await probeServerFeatureFlag(FLAG, { distinctId: 'admin-1' });
+    expect(captureMessage).not.toHaveBeenCalled();
+
+    await getServerFeatureFlag(FLAG, { distinctId: null, allowAnonymous: true });
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(String(captureMessage.mock.calls[0][0])).toContain('flag-missing');
+  });
+
   it('honours the override and the missing-key short circuits too', async () => {
     process.env.FEATURE_FLAG_OVERRIDES = FLAG;
     const fetchMock = mockFetchOnce({ ok: true, body: { flags: {} } });

--- a/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
+++ b/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
@@ -345,10 +345,39 @@ describe('resolution reasons', () => {
     mockFetchOnce({ ok: true, body: { flags: {}, quotaLimited: ['feature_flags'] } });
 
     const { getServerFeatureFlagResolution } = await loadModule();
-    await expect(getServerFeatureFlagResolution(FLAG, { distinctId: 'user-1' })).resolves.toMatchObject({
+    await expect(getServerFeatureFlagResolution(FLAG, { distinctId: 'user-1' })).resolves.toEqual({
       enabled: false,
       reason: 'quota-limited',
+      detail: 'feature_flags',
     });
+  });
+
+  it('still reads quota-limited if PostHog renames the product string', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: {}, quotaLimited: ['feature-flags-v2'] } });
+
+    const { getServerFeatureFlagResolution } = await loadModule();
+
+    // Matching a hardcoded product name would degrade this to `flag-missing`,
+    // sending whoever is debugging to hunt a renamed flag during a billing
+    // outage. The names PostHog did send land in `detail`.
+    await expect(getServerFeatureFlagResolution(FLAG, { distinctId: 'user-1' })).resolves.toEqual({
+      enabled: false,
+      reason: 'quota-limited',
+      detail: 'feature-flags-v2',
+    });
+  });
+
+  it('ignores a quota limit on some other product when the flag resolved fine', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } }, quotaLimited: ['recordings'] } });
+
+    const { getServerFeatureFlagResolution } = await loadModule();
+    await expect(getServerFeatureFlagResolution(FLAG, { distinctId: 'user-1' })).resolves.toMatchObject({
+      enabled: true,
+      reason: 'posthog-enabled',
+    });
+    expect(captureMessage).not.toHaveBeenCalled();
   });
 
   it('carries the HTTP status and the error name as detail', async () => {

--- a/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
+++ b/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
@@ -399,6 +399,30 @@ describe('reporting', () => {
     expect(String(captureMessage.mock.calls[0][0])).toContain('quota-limited');
   });
 
+  it('re-arms after a recovery, so a second outage is not swallowed', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const responses = [
+      { ok: false, status: 503, json: async () => ({}) },
+      { ok: true, status: 200, json: async () => ({ flags: { [FLAG]: { enabled: true } } }) },
+      { ok: false, status: 503, json: async () => ({}) },
+    ];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() => Promise.resolve(responses.shift())),
+    );
+
+    const { getServerFeatureFlag } = await loadModule();
+
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-1' });
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+
+    // PostHog answered, so the outage is over and the key re-arms. Latching for
+    // the life of the process would make this second outage silent.
+    await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(true);
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-1' });
+    expect(captureMessage).toHaveBeenCalledTimes(2);
+  });
+
   it('stays quiet when the flag simply says no', async () => {
     process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
     mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: false } } } });

--- a/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
+++ b/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
@@ -213,7 +213,7 @@ describe('getServerFeatureFlag — failure modes', () => {
     await expect(getServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toBe(false);
 
     expect(captureMessage).toHaveBeenCalledTimes(1);
-    expect(String(captureMessage.mock.calls[0][0])).toContain('HTTP 503');
+    expect(String(captureMessage.mock.calls[0][0])).toContain('http-error: 503');
   });
 
   it('fails closed when the request is aborted past its deadline', async () => {
@@ -292,6 +292,185 @@ describe('getServerFeatureFlag — anonymous visitors', () => {
 
     const { getServerFeatureFlag } = await loadModule();
     await expect(getServerFeatureFlag(FLAG, { distinctId: null, allowAnonymous: true })).resolves.toBe(false);
+  });
+});
+
+describe('resolution reasons', () => {
+  it('names the override branch', async () => {
+    process.env.FEATURE_FLAG_OVERRIDES = `${FLAG}=false`;
+    const { getServerFeatureFlagResolution } = await loadModule();
+
+    await expect(getServerFeatureFlagResolution(FLAG, { distinctId: 'user-1' })).resolves.toEqual({
+      enabled: false,
+      reason: 'override',
+      detail: null,
+    });
+  });
+
+  it('separates a missing key from a missing person', async () => {
+    const { getServerFeatureFlagResolution } = await loadModule();
+    await expect(getServerFeatureFlagResolution(FLAG, { distinctId: 'user-1' })).resolves.toMatchObject({
+      reason: 'no-api-key',
+    });
+
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const { getServerFeatureFlagResolution: resolveWithKey } = await loadModule();
+    await expect(resolveWithKey(FLAG, { distinctId: null })).resolves.toMatchObject({ reason: 'no-distinct-id' });
+  });
+
+  it('separates PostHog saying no from PostHog never having heard of the flag', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: false } } } });
+    const { getServerFeatureFlagResolution } = await loadModule();
+    await expect(getServerFeatureFlagResolution(FLAG, { distinctId: 'user-1' })).resolves.toMatchObject({
+      enabled: false,
+      reason: 'posthog-disabled',
+    });
+
+    // The distinction this whole type exists for: `posthog-disabled` is the flag
+    // working, `flag-missing` is the key pointing at the wrong project (or a
+    // renamed flag) — same `false`, completely different fix.
+    mockFetchOnce({ ok: true, body: { flags: { 'some-other-flag': { enabled: true } } } });
+    const { getServerFeatureFlagResolution: resolveMissing } = await loadModule();
+    await expect(resolveMissing(FLAG, { distinctId: 'user-1' })).resolves.toMatchObject({
+      enabled: false,
+      reason: 'flag-missing',
+    });
+  });
+
+  it('reads a quota-limited project as broken, not as off', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    // PostHog answers 200 with an EMPTY flags map when the project is over its
+    // feature-flag quota, which is otherwise identical to a deleted flag.
+    mockFetchOnce({ ok: true, body: { flags: {}, quotaLimited: ['feature_flags'] } });
+
+    const { getServerFeatureFlagResolution } = await loadModule();
+    await expect(getServerFeatureFlagResolution(FLAG, { distinctId: 'user-1' })).resolves.toMatchObject({
+      enabled: false,
+      reason: 'quota-limited',
+    });
+  });
+
+  it('carries the HTTP status and the error name as detail', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: false, status: 401 });
+    const { getServerFeatureFlagResolution } = await loadModule();
+    await expect(getServerFeatureFlagResolution(FLAG, { distinctId: 'user-1' })).resolves.toEqual({
+      enabled: false,
+      reason: 'http-error',
+      detail: '401',
+    });
+
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError));
+    const { getServerFeatureFlagResolution: resolveAborted } = await loadModule();
+    await expect(resolveAborted(FLAG, { distinctId: 'user-1' })).resolves.toEqual({
+      enabled: false,
+      reason: 'request-failed',
+      detail: 'AbortError',
+    });
+  });
+});
+
+describe('reporting', () => {
+  it('reports a flag PostHog has never heard of', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: {} } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-1' });
+
+    // Used to be the silent branch: a 200 that simply didn't mention the flag
+    // returned false with nothing in Sentry, so a key pointing at the wrong
+    // project 404'd the page and left no trace anywhere.
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(String(captureMessage.mock.calls[0][0])).toContain('flag-missing');
+  });
+
+  it('reports a quota-limited project', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: {}, quotaLimited: ['feature_flags'] } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-1' });
+
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+    expect(String(captureMessage.mock.calls[0][0])).toContain('quota-limited');
+  });
+
+  it('stays quiet when the flag simply says no', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: false } } } });
+
+    const { getServerFeatureFlag } = await loadModule();
+    await getServerFeatureFlag(FLAG, { distinctId: 'user-1' });
+
+    // A closed gate is the point of a flag. Reporting it would bury the four
+    // reasons above in noise from every anonymous pageview.
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('probeServerFeatureFlag', () => {
+  it('asks PostHog without going through the data cache', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_test';
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: { [FLAG]: { enabled: true } } } });
+
+    const { probeServerFeatureFlag } = await loadModule();
+    await expect(probeServerFeatureFlag(FLAG, { distinctId: 'user-1' })).resolves.toMatchObject({
+      enabled: true,
+      reason: 'posthog-enabled',
+    });
+
+    // The whole point of the probe: a cached stale `false` and a live `false`
+    // are different problems, so it must not read (or write) the cache.
+    expect(cacheKeyParts).toHaveLength(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('honours the override and the missing-key short circuits too', async () => {
+    process.env.FEATURE_FLAG_OVERRIDES = FLAG;
+    const fetchMock = mockFetchOnce({ ok: true, body: { flags: {} } });
+
+    const { probeServerFeatureFlag } = await loadModule();
+    await expect(probeServerFeatureFlag(FLAG, { distinctId: null, allowAnonymous: true })).resolves.toMatchObject({
+      enabled: true,
+      reason: 'override',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('describeServerFeatureFlagConfig', () => {
+  it('names the env var holding the key, never the key itself', async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_browser';
+    const { describeServerFeatureFlagConfig } = await loadModule();
+
+    const config = describeServerFeatureFlagConfig();
+    expect(config.apiKeySource).toBe('NEXT_PUBLIC_POSTHOG_KEY');
+    expect(JSON.stringify(config)).not.toContain('phc_browser');
+    expect(config.host).toBe('https://us.i.posthog.com');
+  });
+
+  it('reports the server key, the host override and the parsed overrides', async () => {
+    process.env.POSTHOG_PROJECT_KEY = 'phc_server';
+    process.env.NEXT_PUBLIC_POSTHOG_KEY = 'phc_browser';
+    process.env.POSTHOG_HOST = 'https://eu.i.posthog.com/';
+    process.env.FEATURE_FLAG_OVERRIDES = `${FLAG}=false`;
+    const { describeServerFeatureFlagConfig } = await loadModule();
+
+    expect(describeServerFeatureFlagConfig()).toEqual({
+      apiKeySource: 'POSTHOG_PROJECT_KEY',
+      // Trailing slash stripped, matching the URL the evaluation builds.
+      host: 'https://eu.i.posthog.com',
+      overrides: { [FLAG]: false },
+    });
+  });
+
+  it('reports no key when the environment has none', async () => {
+    const { describeServerFeatureFlagConfig } = await loadModule();
+    expect(describeServerFeatureFlagConfig().apiKeySource).toBeNull();
   });
 });
 

--- a/packages/web/app/lib/feature-flags/server-feature-flag.ts
+++ b/packages/web/app/lib/feature-flags/server-feature-flag.ts
@@ -243,13 +243,28 @@ function readFlagResolution(payload: PosthogFlagsResponse, key: string): ServerF
   return { enabled: false, reason: 'flag-missing', detail: null };
 }
 
+/**
+ * `report: false` for the diagnostic probe. The Sentry guard is once per
+ * process per key, so a reporting probe would spend that budget and silence the
+ * warning the next genuinely broken PAGE request in the same worker would have
+ * sent — an observability endpoint quietly costing observability. The probe's
+ * caller reads the reason off the return value and needs no side effect.
+ */
 async function evaluateFlagFromPosthog(
   key: string,
   distinctId: string,
   apiKey: string,
+  { report }: { report: boolean },
 ): Promise<ServerFeatureFlagResolution> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FLAG_REQUEST_TIMEOUT_MS);
+
+  const finish = (resolution: ServerFeatureFlagResolution): ServerFeatureFlagResolution => {
+    if (report) {
+      reportUnevaluableFlag(key, resolution);
+    }
+    return resolution;
+  };
 
   try {
     const response = await fetch(`${resolvePosthogHost()}/flags/?v=2`, {
@@ -261,22 +276,17 @@ async function evaluateFlagFromPosthog(
     });
 
     if (!response.ok) {
-      return withReport(key, { enabled: false, reason: 'http-error', detail: String(response.status) });
+      return finish({ enabled: false, reason: 'http-error', detail: String(response.status) });
     }
 
     const payload = (await response.json()) as PosthogFlagsResponse;
-    return withReport(key, readFlagResolution(payload, key));
+    return finish(readFlagResolution(payload, key));
   } catch (error) {
     const detail = error instanceof Error ? error.name : 'unknown error';
-    return withReport(key, { enabled: false, reason: 'request-failed', detail });
+    return finish({ enabled: false, reason: 'request-failed', detail });
   } finally {
     clearTimeout(timer);
   }
-}
-
-function withReport(key: string, resolution: ServerFeatureFlagResolution): ServerFeatureFlagResolution {
-  reportUnevaluableFlag(key, resolution);
-  return resolution;
 }
 
 /**
@@ -370,7 +380,7 @@ export async function getServerFeatureFlagResolution(
   // everyone — the highest-severity failure this module has, and the reason
   // there is a test asserting the key parts rather than only the return value.
   const cached = unstable_cache(
-    () => evaluateFlagFromPosthog(key, distinctId, apiKey),
+    () => evaluateFlagFromPosthog(key, distinctId, apiKey, { report: true }),
     ['posthog-flag', key, distinctId],
     {
       revalidate: FLAG_CACHE_REVALIDATE_SECONDS,
@@ -396,6 +406,8 @@ export async function getServerFeatureFlag(key: string, options: ServerFeatureFl
  * dashboard — so `/api/internal/feature-flags` reports the cached answer and
  * this one side by side. Never call it from a page: it is an uncached network
  * round trip in front of a render.
+ *
+ * Deliberately does not report to Sentry — see `evaluateFlagFromPosthog`.
  */
 export async function probeServerFeatureFlag(
   key: string,
@@ -405,7 +417,7 @@ export async function probeServerFeatureFlag(
   if ('resolution' in early) {
     return early.resolution;
   }
-  return evaluateFlagFromPosthog(key, early.distinctId, early.apiKey);
+  return evaluateFlagFromPosthog(key, early.distinctId, early.apiKey, { report: false });
 }
 
 export type ServerFeatureFlagConfig = {

--- a/packages/web/app/lib/feature-flags/server-feature-flag.ts
+++ b/packages/web/app/lib/feature-flags/server-feature-flag.ts
@@ -189,12 +189,21 @@ const BROKEN_REASONS: ReadonlySet<ServerFeatureFlagReason> = new Set([
   'request-failed',
 ]);
 
-// Once per process, per flag key. A flag call that starts failing fails on
-// every request; one Sentry message says the same thing as ten thousand.
+// Once per flag key per OUTAGE, not per process. A flag call that starts
+// failing fails on every request, so one Sentry message says the same thing as
+// ten thousand — but a key that stays latched for the life of the process turns
+// a broken → recovered → broken again cycle into a silent second outage, which
+// is the failure this module exists to make visible. A successful evaluation
+// re-arms the key, so each distinct outage costs exactly one message.
 const reportedFailures = new Set<string>();
 
 function reportUnevaluableFlag(key: string, resolution: ServerFeatureFlagResolution): void {
-  if (!BROKEN_REASONS.has(resolution.reason) || reportedFailures.has(key)) {
+  if (!BROKEN_REASONS.has(resolution.reason)) {
+    // PostHog answered, so whatever was wrong is over. Re-arm.
+    reportedFailures.delete(key);
+    return;
+  }
+  if (reportedFailures.has(key)) {
     return;
   }
   reportedFailures.add(key);

--- a/packages/web/app/lib/feature-flags/server-feature-flag.ts
+++ b/packages/web/app/lib/feature-flags/server-feature-flag.ts
@@ -228,12 +228,6 @@ type PosthogFlagsResponse = {
 };
 
 function readFlagResolution(payload: PosthogFlagsResponse, key: string): ServerFeatureFlagResolution {
-  // Checked before the flag maps: a quota-limited project answers 200 with an
-  // EMPTY `flags`, which is otherwise indistinguishable from a deleted flag.
-  if (payload.quotaLimited?.includes('feature_flags')) {
-    return { enabled: false, reason: 'quota-limited', detail: null };
-  }
-
   const v2 = payload.flags?.[key];
   if (v2 && typeof v2.enabled === 'boolean') {
     return { enabled: v2.enabled, reason: v2.enabled ? 'posthog-enabled' : 'posthog-disabled', detail: null };
@@ -247,6 +241,22 @@ function readFlagResolution(payload: PosthogFlagsResponse, key: string): ServerF
   // and any variant means the person is in the flag.
   if (typeof legacy === 'string' && legacy.length > 0) {
     return { enabled: true, reason: 'posthog-enabled', detail: null };
+  }
+
+  // The flag is absent, which needs explaining. A quota-limited project answers
+  // 200 with an EMPTY `flags` map, so that is one explanation and a deleted or
+  // renamed flag is the other.
+  //
+  // Tested AFTER the lookup and on ANY quota limitation rather than on the
+  // `feature_flags` product string: checking a hardcoded product name first
+  // would call a project that is only quota-limited on, say, recordings
+  // `quota-limited` while its flags resolve perfectly, and would silently
+  // degrade to `flag-missing` the day PostHog renames the string — sending
+  // whoever is debugging to look for a renamed flag during a billing outage,
+  // which is exactly the confusion this reason vocabulary exists to prevent.
+  const quotaLimited = payload.quotaLimited?.filter((product) => product.trim().length > 0) ?? [];
+  if (quotaLimited.length > 0) {
+    return { enabled: false, reason: 'quota-limited', detail: quotaLimited.join(', ') };
   }
 
   return { enabled: false, reason: 'flag-missing', detail: null };

--- a/packages/web/app/lib/feature-flags/server-feature-flag.ts
+++ b/packages/web/app/lib/feature-flags/server-feature-flag.ts
@@ -30,6 +30,14 @@ import * as Sentry from '@sentry/nextjs';
  *  5. Anything that throws, times out, or comes back unparseable -> `false`.
  *     Fails CLOSED: a flag exists because the surface is not ready for
  *     everyone, so an unreachable PostHog must not open the gate.
+ *
+ * Every step resolves to a {@link ServerFeatureFlagResolution} — a value AND
+ * the reason for it — because failing closed and failing silently are not the
+ * same thing. "PostHog says this person is not in the flag" and "PostHog has
+ * never heard of this flag key" are the same `false` to a caller and completely
+ * different problems to whoever flipped the flag in the dashboard and is
+ * staring at a 404. The reason is what `/api/internal/feature-flags` reports
+ * and what decides whether a resolution is worth a Sentry message.
  */
 
 /** PostHog's own default US host. Mirrors the backend's `POSTHOG_HOST` default. */
@@ -101,11 +109,21 @@ export function parseFeatureFlagOverrides(raw: string | undefined): Record<strin
   return overrides;
 }
 
-function resolvePosthogApiKey(): string | null {
+/** Env var names holding the PostHog project key, in resolution order. */
+const API_KEY_ENV_NAMES = ['POSTHOG_PROJECT_KEY', 'NEXT_PUBLIC_POSTHOG_KEY'] as const;
+
+export type PosthogApiKeySource = (typeof API_KEY_ENV_NAMES)[number];
+
+function resolvePosthogApiKey(): { key: string; source: PosthogApiKeySource } | null {
   // `POSTHOG_PROJECT_KEY` first, `NEXT_PUBLIC_POSTHOG_KEY` as the fallback —
   // the same pair, in the same order, that the backend's posthog service uses.
-  const key = process.env.POSTHOG_PROJECT_KEY?.trim() || process.env.NEXT_PUBLIC_POSTHOG_KEY?.trim();
-  return key ? key : null;
+  for (const source of API_KEY_ENV_NAMES) {
+    const key = process.env[source]?.trim();
+    if (key) {
+      return { key, source };
+    }
+  }
+  return null;
 }
 
 function resolvePosthogHost(): string {
@@ -115,15 +133,72 @@ function resolvePosthogHost(): string {
   return (host || DEFAULT_POSTHOG_HOST).replace(/\/+$/, '');
 }
 
+/**
+ * Why a flag resolved the way it did.
+ *
+ * The ones that mean "the gate is broken, not closed" — `flag-missing`,
+ * `quota-limited`, `http-error`, `request-failed` — are each a `false` that has
+ * nothing to do with the rollout the dashboard is showing. See BROKEN_REASONS.
+ */
+export type ServerFeatureFlagReason =
+  /** `FEATURE_FLAG_OVERRIDES` decided it, ON or OFF. PostHog was not asked. */
+  | 'override'
+  /** No project key in the environment — preview and CI builds by design. */
+  | 'no-api-key'
+  /** Nobody signed in and the caller did not pass `allowAnonymous`. */
+  | 'no-distinct-id'
+  /** PostHog evaluated the flag and this person is in it. */
+  | 'posthog-enabled'
+  /** PostHog evaluated the flag and this person is NOT in it. */
+  | 'posthog-disabled'
+  /**
+   * PostHog answered 200 without mentioning the flag at all. NOT "you're not in
+   * the rollout" — PostHog returns those with `enabled: false`. It means the key
+   * does not exist in the project the api key belongs to: a typo, a flag deleted
+   * or renamed in the dashboard, or a key pointing at the wrong project.
+   */
+  | 'flag-missing'
+  /** PostHog stopped serving flags for the project (billing/quota). */
+  | 'quota-limited'
+  /** PostHog answered non-2xx. */
+  | 'http-error'
+  /** The request threw, timed out, or came back unparseable. */
+  | 'request-failed';
+
+export type ServerFeatureFlagResolution = {
+  enabled: boolean;
+  reason: ServerFeatureFlagReason;
+  /** HTTP status for `http-error`, the error name for `request-failed`. */
+  detail: string | null;
+};
+
+/**
+ * Reasons that mean the gate could not be evaluated, rather than that it
+ * evaluated to closed. Only these are worth a Sentry message — a healthy
+ * `posthog-disabled` is the entire point of a flag and must stay quiet.
+ *
+ * `flag-missing` and `quota-limited` are in here deliberately: both are 200 OK
+ * responses that used to fall through to a bare `false`, so a key pointing at
+ * the wrong PostHog project produced a 404'd page and not one line of telemetry
+ * anywhere.
+ */
+const BROKEN_REASONS: ReadonlySet<ServerFeatureFlagReason> = new Set([
+  'flag-missing',
+  'quota-limited',
+  'http-error',
+  'request-failed',
+]);
+
 // Once per process, per flag key. A flag call that starts failing fails on
 // every request; one Sentry message says the same thing as ten thousand.
 const reportedFailures = new Set<string>();
 
-function reportFlagFailure(key: string, detail: string): void {
-  if (reportedFailures.has(key)) {
+function reportUnevaluableFlag(key: string, resolution: ServerFeatureFlagResolution): void {
+  if (!BROKEN_REASONS.has(resolution.reason) || reportedFailures.has(key)) {
     return;
   }
   reportedFailures.add(key);
+  const detail = resolution.detail ? `${resolution.reason}: ${resolution.detail}` : resolution.reason;
   Sentry.captureMessage(
     `Server feature flag "${key}" could not be evaluated (${detail}); treating it as off`,
     'warning',
@@ -134,28 +209,45 @@ function reportFlagFailure(key: string, detail: string): void {
  * Shape of the response from PostHog's `/flags/?v=2` endpoint. `flags` is the
  * v2 shape; `featureFlags` is the older `/decide` shape PostHog still returns
  * alongside it, kept as a fallback so a version skew degrades to a working
- * answer instead of a silent `false`.
+ * answer instead of a silent `false`. `quotaLimited` names the products PostHog
+ * has stopped serving for the project.
  */
 type PosthogFlagsResponse = {
   flags?: Record<string, { enabled?: boolean } | undefined>;
   featureFlags?: Record<string, boolean | string | undefined>;
+  quotaLimited?: string[];
 };
 
-function readFlagValue(payload: PosthogFlagsResponse, key: string): boolean {
+function readFlagResolution(payload: PosthogFlagsResponse, key: string): ServerFeatureFlagResolution {
+  // Checked before the flag maps: a quota-limited project answers 200 with an
+  // EMPTY `flags`, which is otherwise indistinguishable from a deleted flag.
+  if (payload.quotaLimited?.includes('feature_flags')) {
+    return { enabled: false, reason: 'quota-limited', detail: null };
+  }
+
   const v2 = payload.flags?.[key];
   if (v2 && typeof v2.enabled === 'boolean') {
-    return v2.enabled;
+    return { enabled: v2.enabled, reason: v2.enabled ? 'posthog-enabled' : 'posthog-disabled', detail: null };
   }
+
   const legacy = payload.featureFlags?.[key];
   if (typeof legacy === 'boolean') {
-    return legacy;
+    return { enabled: legacy, reason: legacy ? 'posthog-enabled' : 'posthog-disabled', detail: null };
   }
   // A string is a multivariate variant; the caller asked a boolean question,
   // and any variant means the person is in the flag.
-  return typeof legacy === 'string' && legacy.length > 0;
+  if (typeof legacy === 'string' && legacy.length > 0) {
+    return { enabled: true, reason: 'posthog-enabled', detail: null };
+  }
+
+  return { enabled: false, reason: 'flag-missing', detail: null };
 }
 
-async function evaluateFlagFromPosthog(key: string, distinctId: string, apiKey: string): Promise<boolean> {
+async function evaluateFlagFromPosthog(
+  key: string,
+  distinctId: string,
+  apiKey: string,
+): Promise<ServerFeatureFlagResolution> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FLAG_REQUEST_TIMEOUT_MS);
 
@@ -169,18 +261,22 @@ async function evaluateFlagFromPosthog(key: string, distinctId: string, apiKey: 
     });
 
     if (!response.ok) {
-      reportFlagFailure(key, `HTTP ${response.status}`);
-      return false;
+      return withReport(key, { enabled: false, reason: 'http-error', detail: String(response.status) });
     }
 
     const payload = (await response.json()) as PosthogFlagsResponse;
-    return readFlagValue(payload, key);
+    return withReport(key, readFlagResolution(payload, key));
   } catch (error) {
-    reportFlagFailure(key, error instanceof Error ? error.name : 'unknown error');
-    return false;
+    const detail = error instanceof Error ? error.name : 'unknown error';
+    return withReport(key, { enabled: false, reason: 'request-failed', detail });
   } finally {
     clearTimeout(timer);
   }
+}
+
+function withReport(key: string, resolution: ServerFeatureFlagResolution): ServerFeatureFlagResolution {
+  reportUnevaluableFlag(key, resolution);
+  return resolution;
 }
 
 /**
@@ -230,22 +326,44 @@ export type ServerFeatureFlagOptions = {
   allowAnonymous?: boolean;
 };
 
-/** Resolve one feature flag on the server. */
-export async function getServerFeatureFlag(key: string, options: ServerFeatureFlagOptions): Promise<boolean> {
+/** The steps that resolve without asking PostHog, shared by cached and probe. */
+function resolveWithoutPosthog(
+  key: string,
+  options: ServerFeatureFlagOptions,
+): { resolution: ServerFeatureFlagResolution } | { apiKey: string; distinctId: string } {
   const override = parseFeatureFlagOverrides(process.env[FEATURE_FLAG_OVERRIDES_ENV])[key];
   if (override !== undefined) {
-    return override;
+    return { resolution: { enabled: override, reason: 'override', detail: null } };
   }
 
   const apiKey = resolvePosthogApiKey();
   if (!apiKey) {
-    return false;
+    return { resolution: { enabled: false, reason: 'no-api-key', detail: null } };
   }
 
   const distinctId = options.distinctId ?? (options.allowAnonymous ? ANONYMOUS_DISTINCT_ID : null);
   if (!distinctId) {
-    return false;
+    return { resolution: { enabled: false, reason: 'no-distinct-id', detail: null } };
   }
+
+  return { apiKey: apiKey.key, distinctId };
+}
+
+/**
+ * Resolve one feature flag on the server, with the reason behind the answer.
+ *
+ * This is what a page gate should call when it wants to log or expose WHY it
+ * closed; {@link getServerFeatureFlag} is the boolean-only wrapper.
+ */
+export async function getServerFeatureFlagResolution(
+  key: string,
+  options: ServerFeatureFlagOptions,
+): Promise<ServerFeatureFlagResolution> {
+  const early = resolveWithoutPosthog(key, options);
+  if ('resolution' in early) {
+    return early.resolution;
+  }
+  const { apiKey, distinctId } = early;
 
   // Keyed on the flag AND the person: two climbers must never share an answer.
   // If this key ever loses `distinctId`, one person's flag value is served to
@@ -261,4 +379,52 @@ export async function getServerFeatureFlag(key: string, options: ServerFeatureFl
   );
 
   return cached();
+}
+
+/** Resolve one feature flag on the server. */
+export async function getServerFeatureFlag(key: string, options: ServerFeatureFlagOptions): Promise<boolean> {
+  const { enabled } = await getServerFeatureFlagResolution(key, options);
+  return enabled;
+}
+
+/**
+ * The same resolution, skipping the data cache.
+ *
+ * For diagnostics ONLY. A gate that is 404ing because a stale `false` is still
+ * inside its 60s window looks identical to one that is 404ing because PostHog
+ * says no, and the difference decides whether you wait a minute or go fix the
+ * dashboard — so `/api/internal/feature-flags` reports the cached answer and
+ * this one side by side. Never call it from a page: it is an uncached network
+ * round trip in front of a render.
+ */
+export async function probeServerFeatureFlag(
+  key: string,
+  options: ServerFeatureFlagOptions,
+): Promise<ServerFeatureFlagResolution> {
+  const early = resolveWithoutPosthog(key, options);
+  if ('resolution' in early) {
+    return early.resolution;
+  }
+  return evaluateFlagFromPosthog(key, early.distinctId, early.apiKey);
+}
+
+export type ServerFeatureFlagConfig = {
+  /** Which env var supplied the project key, or null when none is set. */
+  apiKeySource: PosthogApiKeySource | null;
+  /** The PostHog host being asked. Not a secret; a wrong one is a real cause. */
+  host: string;
+  /** Parsed `FEATURE_FLAG_OVERRIDES`, which silently outranks the dashboard. */
+  overrides: Record<string, boolean>;
+};
+
+/**
+ * The environment this module is resolving flags against — never the key
+ * itself, only which variable it came from.
+ */
+export function describeServerFeatureFlagConfig(): ServerFeatureFlagConfig {
+  return {
+    apiKeySource: resolvePosthogApiKey()?.source ?? null,
+    host: resolvePosthogHost(),
+    overrides: parseFeatureFlagOverrides(process.env[FEATURE_FLAG_OVERRIDES_ENV]),
+  };
 }


### PR DESCRIPTION
## Summary

`www.boardsesh.com/gyms` 404s with the `gyms-directory` flag at 100% in PostHog, and there is currently no way to find out why.

Confirmed first that the route is deployed and dynamic — the production build table lists `ƒ /gyms`, `ƒ /gyms/kilter`, `ƒ /gyms/moonboard`, `ƒ /gyms/tension` (server-rendered on demand, so it is not a build-time-baked 404), and the web deploy is aliasing to `www.boardsesh.com` on every run. The 404 is the `getServerFeatureFlag` gate in `renderGymDirectory`.

That gate fails closed by design, but until now every way of resolving `false` looked identical from outside: no PostHog key in the runtime env, a key pointing at another project, the flag renamed or deleted, the project quota-limited, PostHog timing out, `FEATURE_FLAG_OVERRIDES` forcing OFF, or a stale answer still inside the 60s data-cache window. Two of those — a 200 that doesn't mention the flag, and a quota-limited project — returned `false` with **no Sentry message at all**, so a misconfigured gate produced a 404'd page and no telemetry anywhere.

- Server flags now resolve to a value **and** a reason (`override`, `no-api-key`, `no-distinct-id`, `posthog-enabled`, `posthog-disabled`, `flag-missing`, `quota-limited`, `http-error`, `request-failed`).
- The four that mean "could not be evaluated" each send one Sentry warning per key **per outage** — the key latches after the first message and re-arms once PostHog answers again, so a broken → recovered → broken cycle is not swallowed. A healthy `posthog-disabled` stays quiet: a closed gate is the point of a flag, and reporting it would bury the real ones under every anonymous pageview.
- `quotaLimited` is now read explicitly, and only to explain an **absent** flag: PostHog answers 200 with an empty `flags` map when a project is over quota, which is otherwise indistinguishable from a deleted flag. Matched on any non-empty quota list rather than a hardcoded product name, so a rename can't degrade a billing outage into `flag-missing`, and a project limited on some other product isn't mislabelled while its flags resolve fine.
- New admin-only `GET /api/internal/feature-flags` reports a 2x2 per server flag — cached vs live, signed-out visitor vs calling admin. The cache is keyed per flag **and** per person, so `cached.public` is the entry that actually 404'd the visitor. `cached.public` vs `live.public` is cache staleness; `live.public` vs `live.viewer` is a rollout still targeted at people rather than a percentage; `live.public.reason` explains the rest. It returns which env var held the project key, never the key itself. The uncached probes deliberately don't report to Sentry — the guard is once per key, and a diagnostic read spending it would silence the next genuinely broken page request.
- `docs/feature-flags.md` covers client vs server flags, the resolution order, how to read the diagnostic, and the `FEATURE_FLAG_OVERRIDES` lever (which forces a flagged surface reachable from the Vercel production env without touching PostHog — the immediate unblock for this, and the kill switch #4382 asks to document).

No change to how any gate decides: `getServerFeatureFlag` returns the same booleans it did before.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project web` — 356 files, 3925 tests pass. 53 of those are in the two feature-flag files (26 new): per-reason resolutions, quota-limited including a renamed product string and a limit on an unrelated product, Sentry reporting for the previously silent branches, re-arming across a 503 → 200 → 503 cycle, the uncached probe leaving the Sentry budget intact for the page request behind it, the config description never leaking the key, and for the route the 401/403 guards, the 2x2 shape, reading the anonymous cache entry, key-shape validation, and no key in the body.
- `tsc --noEmit -p packages/web` — clean.
- `vp check` — no findings in the touched files.
- Not exercised against production PostHog from this environment (egress to `boardsesh.com` and `us.i.posthog.com` is blocked here); the endpoint's value is in reading it from prod once deployed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2jn8htdUxoENBFmQ6X1Eg)_