### PR TITLE
fix(mobile): stop the create-climb action bar pushing Save off-screen

### DIFF
--- a/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
+++ b/packages/mobile/src/components/create-climb/CreateDrawerActionBar.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from 'react';
-import { View, Pressable, StyleSheet } from 'react-native';
+import { View, Pressable, ScrollView, StyleSheet } from 'react-native';
 import type { BoardName } from '@boardsesh/shared-schema';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
@@ -48,7 +48,8 @@ type CreateDrawerActionBarProps = {
  * The create-drawer two-row action bar, built on the shared drawer-action-bar
  * grammar. Row 1 (where the Play Drawer's play controls sit) is the five brush
  * chips; Row 2 is the other actions: undo / redo / clear, then set-active and
- * the save state-machine button.
+ * the save state-machine button. Row 2's editing actions scroll horizontally so
+ * set-active and save stay pinned no matter how wide that cluster grows.
  */
 export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
   boardName,
@@ -135,61 +136,72 @@ export const CreateDrawerActionBar = memo(function CreateDrawerActionBar({
       </View>
 
       <View style={drawerActionBarStyles.rowSecondary}>
-        <ActionButton
-          size="sm"
-          iconName="undo"
-          onPress={onUndo}
-          disabled={!canUndo}
-          accessibilityLabel={t('mobile.create.actions.undo')}
-        />
-        <ActionButton
-          size="sm"
-          iconName="redo"
-          onPress={onRedo}
-          disabled={!canRedo}
-          accessibilityLabel={t('mobile.create.actions.redo')}
-        />
-        <ActionButton
-          size="sm"
-          iconName="delete"
-          onPress={onClear}
-          accessibilityLabel={t('mobile.create.actions.clear')}
-        />
-        <ActionButton
-          size="sm"
-          iconName="copy"
-          onPress={onDuplicateFrame}
-          accessibilityLabel={t('mobile.create.frames.duplicate')}
-        />
-        {frameCount > 1 && (
-          <>
-            <ActionButton
-              size="sm"
-              iconName="skip.previous"
-              onPress={onPrevFrame}
-              disabled={currentFrameIndex === 0}
-              accessibilityLabel={t('mobile.create.frames.prev')}
-            />
-            <Text variant="caption1" style={styles.frameCounter} numberOfLines={1}>
-              {t('mobile.create.frames.counter', { index: currentFrameIndex + 1, total: frameCount })}
-            </Text>
-            <ActionButton
-              size="sm"
-              iconName="skip.next"
-              onPress={onNextFrame}
-              disabled={currentFrameIndex >= frameCount - 1}
-              accessibilityLabel={t('mobile.create.frames.next')}
-            />
-            <ActionButton
-              size="sm"
-              iconName="frame.remove"
-              onPress={onDeleteFrame}
-              accessibilityLabel={t('mobile.create.frames.delete')}
-            />
-          </>
-        )}
-
-        <View style={drawerActionBarStyles.spacer} />
+        {/* The editing cluster grows by four controls once a climb has a second
+            frame, and RN views don't shrink — with no wrap and no scroll it used
+            to push Save clean off the right edge. The scroller takes the row's
+            leftover width in place of the shared `spacer`, so Set Active and Save
+            hold the same position whether or not the stepper is showing. */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+          style={styles.actionScroll}
+          contentContainerStyle={styles.actionScrollContent}
+        >
+          <ActionButton
+            size="sm"
+            iconName="undo"
+            onPress={onUndo}
+            disabled={!canUndo}
+            accessibilityLabel={t('mobile.create.actions.undo')}
+          />
+          <ActionButton
+            size="sm"
+            iconName="redo"
+            onPress={onRedo}
+            disabled={!canRedo}
+            accessibilityLabel={t('mobile.create.actions.redo')}
+          />
+          <ActionButton
+            size="sm"
+            iconName="delete"
+            onPress={onClear}
+            accessibilityLabel={t('mobile.create.actions.clear')}
+          />
+          <ActionButton
+            size="sm"
+            iconName="copy"
+            onPress={onDuplicateFrame}
+            accessibilityLabel={t('mobile.create.frames.duplicate')}
+          />
+          {frameCount > 1 && (
+            <>
+              <ActionButton
+                size="sm"
+                iconName="skip.previous"
+                onPress={onPrevFrame}
+                disabled={currentFrameIndex === 0}
+                accessibilityLabel={t('mobile.create.frames.prev')}
+              />
+              <Text variant="caption1" style={styles.frameCounter} numberOfLines={1}>
+                {t('mobile.create.frames.counter', { index: currentFrameIndex + 1, total: frameCount })}
+              </Text>
+              <ActionButton
+                size="sm"
+                iconName="skip.next"
+                onPress={onNextFrame}
+                disabled={currentFrameIndex >= frameCount - 1}
+                accessibilityLabel={t('mobile.create.frames.next')}
+              />
+              <ActionButton
+                size="sm"
+                iconName="frame.remove"
+                onPress={onDeleteFrame}
+                accessibilityLabel={t('mobile.create.frames.delete')}
+              />
+            </>
+          )}
+        </ScrollView>
 
         <ActionButton
           size="sm"
@@ -257,5 +269,14 @@ const styles = StyleSheet.create({
   frameCounter: {
     minWidth: 44,
     textAlign: 'center',
+  },
+  actionScroll: {
+    // Claims the row's leftover width so the trailing Set Active + Save pair is
+    // pinned; anything that doesn't fit scrolls inside here, not off-screen.
+    flex: 1,
+  },
+  actionScrollContent: {
+    alignItems: 'center',
+    gap: spacing[2],
   },
 });

--- a/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/create-climb/__tests__/create-drawer-action-bar.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+// Minimal RN surface. The horizontal ScrollView renders as a tagged div so the
+// tests can assert which controls ride the scroller and which stay pinned
+// outside it — the whole point of the row's layout.
+type PressMockProps = { children?: ReactNode; onPress?: () => void; accessibilityLabel?: string };
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress, accessibilityLabel }: PressMockProps) =>
+    createElement('button', { onClick: onPress, 'data-label': accessibilityLabel }, children),
+  ScrollView: ({ children, horizontal }: { children?: ReactNode; horizontal?: boolean }) =>
+    createElement('div', { 'data-scroll': 'true', 'data-horizontal': horizontal ? 'true' : 'false' }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+// Paths are relative to THIS file (one level under the source in __tests__), so
+// they carry an extra `../`.
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name?: string }) => createElement('span', { 'data-icon': name }) }));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Button', () => ({
+  Button: ({ title, disabled }: { title?: string; disabled?: boolean }) =>
+    createElement('button', { 'data-save-button': 'true', 'data-title': title, disabled }),
+}));
+vi.mock('../../Button.surface', () => ({
+  ButtonSurfaceProvider: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('../../drawer-action-bar/DrawerActionBar', () => ({
+  ActionButton: ({ iconName, accessibilityLabel }: { iconName?: string; accessibilityLabel?: string }) =>
+    createElement('button', { 'data-action': iconName, 'data-label': accessibilityLabel }),
+  drawerActionBarStyles: { container: {}, rowSecondary: {}, spacer: {} },
+}));
+vi.mock('../brush-roles', () => ({
+  brushRoleColor: () => '#00FF00',
+  getPaintRoles: () => ['STARTING', 'HAND', 'FINISH', 'FOOT'],
+  useBrushRoleLabels: () => ({ STARTING: 'Start', HAND: 'Hand', FINISH: 'Finish', FOOT: 'Foot' }),
+}));
+vi.mock('../../../lib/haptics', () => ({ hapticSelection: vi.fn() }));
+vi.mock('../../../lib/hold-color-overrides', () => ({ useHoldColorOverrides: () => ({ overrides: {} }) }));
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { fill: '#EFEFF0', label: '#000000' } }),
+}));
+vi.mock('../../../theme/colors', () => ({ brandColors: { primary: '#6D28D9', success: '#047857' } }));
+vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12, 4: 16 }, borderRadius: { md: 8 } }));
+
+import { CreateDrawerActionBar } from '../CreateDrawerActionBar';
+
+const baseProps = {
+  boardName: 'kilter' as const,
+  selectedBrush: 'HAND' as const,
+  onSelectBrush: vi.fn(),
+  canUndo: true,
+  canRedo: true,
+  onUndo: vi.fn(),
+  onRedo: vi.fn(),
+  onClear: vi.fn(),
+  frameCount: 1,
+  currentFrameIndex: 0,
+  onDuplicateFrame: vi.fn(),
+  onDeleteFrame: vi.fn(),
+  onPrevFrame: vi.fn(),
+  onNextFrame: vi.fn(),
+  canSetActive: true,
+  onSetActive: vi.fn(),
+  saveState: 'ready' as const,
+  onSave: vi.fn(),
+};
+
+function renderBar(frameCount: number) {
+  const { container } = render(createElement(CreateDrawerActionBar, { ...baseProps, frameCount }));
+  return {
+    scroller: container.querySelector('[data-scroll="true"]') as HTMLElement,
+    setActive: container.querySelector('[data-action="play.circle"]') as HTMLElement,
+    save: container.querySelector('[data-save-button="true"]') as HTMLElement,
+  };
+}
+
+describe('CreateDrawerActionBar', () => {
+  it('pins Set Active and Save outside the scrolling editing cluster', () => {
+    const { scroller, setActive, save } = renderBar(1);
+
+    expect(scroller.getAttribute('data-horizontal')).toBe('true');
+    expect(setActive).toBeTruthy();
+    expect(save).toBeTruthy();
+    expect(scroller.contains(setActive)).toBe(false);
+    expect(scroller.contains(save)).toBe(false);
+    // The editing actions are the part allowed to scroll.
+    expect(scroller.querySelector('[data-action="undo"]')).toBeTruthy();
+    expect(scroller.querySelector('[data-action="copy"]')).toBeTruthy();
+  });
+
+  it('puts the multi-frame stepper in the scroller rather than pushing Save off the row', () => {
+    const { scroller, setActive, save } = renderBar(3);
+
+    // The four extra controls a multi-frame climb adds...
+    expect(scroller.querySelector('[data-action="skip.previous"]')).toBeTruthy();
+    expect(scroller.querySelector('[data-action="skip.next"]')).toBeTruthy();
+    expect(scroller.querySelector('[data-action="frame.remove"]')).toBeTruthy();
+    // ...all land inside it, so the pinned pair is still reachable.
+    expect(scroller.contains(setActive)).toBe(false);
+    expect(scroller.contains(save)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- The create-climb editor's second action row (undo/redo/clear/duplicate, then — once a route has more than one frame — the prev/counter/next/delete-frame stepper, then Set Active + Save) has no wrap and no scroll. React Native views default to `flexShrink: 0`, so once the frame stepper's four extra controls appear, the row's total width can exceed the screen and the trailing Set Active/Save buttons get pushed off-screen and become unreachable. Reported on Android; the bug is in shared RN code so it affects iOS too.
- Move undo/redo/clear/duplicate and the frame stepper into a horizontal `ScrollView`; keep Set Active and Save pinned outside it so they're always visible and tappable regardless of frame count. The shared `drawerActionBarStyles` in `DrawerActionBar.tsx` (also used by the Play Drawer) are untouched — this is a `CreateDrawerActionBar`-local fix.
- Board-agnostic: applies to any board that can reach a multi-frame route (Aurora boards today; MoonBoard once #TBD lands).

## Release Notes

- Fixed the Save button getting pushed off-screen when editing a multi-frame route/circuit in the climb editor

## Test plan

- `vp run typecheck:mobile` — pass
- `vp test run --project mobile` — 6520/6527 pass; the 7 failures are pre-existing timezone-dependent flakes (`logbook-tab-grouped.test.tsx`, `feed-time-buckets.test.ts`), confirmed present on a clean `main`, unrelated to this change
- New test `create-drawer-action-bar.test.tsx` — Set Active/Save stay outside the scrolling cluster at both `frameCount === 1` and `frameCount > 1`
- `vp run check:mobile-bundle` — pass
- `vp check` — clean (0 errors)
- Manually verified via Metro dev server + QA notes: duplicate a frame, confirm Set Active/Save don't move and stay tappable, confirm the left cluster scrolls