### PR TITLE
feat: extend multi-frame route/circuit creation to MoonBoard

### DIFF
--- a/docs/ui/08-create-climb.md
+++ b/docs/ui/08-create-climb.md
@@ -40,6 +40,7 @@
 - **Center section:** Name input, description input (when settings open)
 - **Right section:**
   - Heatmap toggle (fire icon, Aurora only)
+  - Duplicate-frame button, plus a frame counter, prev/next stepper and delete-frame button once the climb has more than one frame (every board)
   - Settings gear (opens settings drawer)
   - Clear/delete button (resets all holds)
   - Save button (context-dependent icon):
@@ -57,7 +58,9 @@
 - Draft toggle (`Switch`): When ON, climb is saved as draft (not publicly visible). Default ON.
 - MoonBoard-specific: Grade select, Benchmark toggle, Angle select
 
-**Autosave:** Form state (holds, name, description, isDraft) is debounced (500ms) and persisted to IndexedDB via `saveAutosave()`. Restored on mount if not forking. Cleared on successful save or manual clear.
+**Autosave:** Form state (the whole frame sequence, name, description, isDraft) is debounced (500ms) and persisted to IndexedDB via `saveAutosave()`. Restored on mount if not forking. Cleared on successful save or manual clear.
+
+**Multi-frame routes/circuits:** Any board can build a climb out of a sequence of frames. How that sequence is written to `frames` is per-board (`FRAME_ENCODING` in `@boardsesh/board-constants`): Aurora delta-encodes (frame 0 absolute, later frames a `"`-prefixed diff), MoonBoard writes every frame as a full absolute snapshot joined by commas. Both decode through the same parser. MoonBoard saves send the frames string alongside `holds`, which carries the union of every frame for the hold rows and the duplicate check; the duplicate check itself is skipped for multi-frame climbs on both boards.
 
 **Save flow:**
 
@@ -95,8 +98,7 @@
 - `SAVE_MOONBOARD_CLIMB_MUTATION` GraphQL mutation (MoonBoard)
 - `CHECK_MOONBOARD_CLIMB_DUPLICATES_QUERY` for MoonBoard duplicate detection
 - `SEARCH_CLIMBS_COUNT` for drafts count badge
-- `useCreateClimb()` hook managing hold state, frame string generation
-- `useMoonBoardCreateClimb()` hook for MoonBoard-specific hold management
+- `useCreateClimb()` hook managing hold state, the frame sequence, and frame string generation — one hook for every board, including MoonBoard
 - `useBoardBluetooth()` for BLE connection and frame sending
 
 **User actions:**

--- a/packages/backend/src/__tests__/climb-mutations.test.ts
+++ b/packages/backend/src/__tests__/climb-mutations.test.ts
@@ -303,6 +303,122 @@ describe('climb mutations', () => {
     });
   });
 
+  it('stores a MoonBoard route with its own absolute frames string and real frame count', async () => {
+    mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockDb.select
+      .mockReturnValueOnce(
+        createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+      )
+      .mockReturnValueOnce(createMockChain([{ difficulty: 17 }]));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveMoonBoardClimb(
+      {},
+      {
+        input: {
+          boardType: 'moonboard',
+          layoutId: 3,
+          name: 'MoonBoard Circuit',
+          description: '',
+          // The union of every frame — what the hold rows and the dedupe read.
+          holds: { start: ['A1'], hand: ['B2'], finish: ['C3'] },
+          // Three absolute snapshots, no delta markers.
+          frames: 'p1r42,p1r42p13r43,p13r43p25r44',
+          angle: 40,
+          isDraft: false,
+          userGrade: '6A+',
+          isBenchmark: false,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls[0].values).toMatchObject({
+      frames: 'p1r42,p1r42p13r43,p13r43p25r44',
+      framesCount: 3,
+    });
+  });
+
+  it('writes MoonBoard hold rows from the frames string, matching what an edit would rewrite', async () => {
+    mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockDb.select
+      .mockReturnValueOnce(
+        createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+      )
+      .mockReturnValueOnce(createMockChain([{ difficulty: 17 }]));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    // Hold 1 (A1) is the start in frames 0-1 and a hand in frame 2. The `holds`
+    // union the client also sends collapses it to HAND (last frame wins), so a
+    // seed built from `holds` would disagree with the rows updateClimb writes
+    // the next time this route is edited (first frame wins, via the hold-id PK).
+    await climbMutations.saveMoonBoardClimb(
+      {},
+      {
+        input: {
+          boardType: 'moonboard',
+          layoutId: 3,
+          name: 'MoonBoard Circuit',
+          description: '',
+          holds: { start: [], hand: ['A1', 'B2'], finish: ['C3'] },
+          frames: 'p1r42,p1r42p13r43,p1r43p25r44',
+          angle: 40,
+          isDraft: false,
+          userGrade: '6A+',
+          isBenchmark: false,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls[1].values).toEqual([
+      expect.objectContaining({ holdId: 1, frameNumber: 0, holdState: 'STARTING' }),
+      expect.objectContaining({ holdId: 1, frameNumber: 1, holdState: 'STARTING' }),
+      expect.objectContaining({ holdId: 13, frameNumber: 1, holdState: 'HAND' }),
+      expect.objectContaining({ holdId: 1, frameNumber: 2, holdState: 'HAND' }),
+      expect.objectContaining({ holdId: 25, frameNumber: 2, holdState: 'FINISH' }),
+    ]);
+  });
+
+  it('encodes holds itself when a MoonBoard save sends no frames string', async () => {
+    mockDb.execute.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    mockDb.select
+      .mockReturnValueOnce(
+        createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+      )
+      .mockReturnValueOnce(createMockChain([{ difficulty: 17 }]));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveMoonBoardClimb(
+      {},
+      {
+        input: {
+          boardType: 'moonboard',
+          layoutId: 3,
+          name: 'MoonBoard Climb',
+          description: '',
+          holds: { start: ['A1'], hand: ['B2'], finish: ['C3'] },
+          angle: 40,
+          isDraft: false,
+          userGrade: '6A+',
+          isBenchmark: false,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls[0].values).toMatchObject({
+      frames: 'p1r42p13r43p25r44',
+      framesCount: 1,
+    });
+  });
+
   it('rejects isBenchmark for a user without an admin/leader role', async () => {
     // requireAdminOrLeader's community_roles lookup returns nothing → the gate
     // throws before any climb/stats row is written.
@@ -1055,6 +1171,49 @@ describe('climb mutations', () => {
 
     expect(insertCalls).toHaveLength(0);
     expect(mockPublishSocialEvent).not.toHaveBeenCalled();
+  });
+
+  it('skips the MoonBoard duplicate gate for a multi-frame route', async () => {
+    // The gate matches on a hold *set*, so two routes visiting the same holds in
+    // a different order would read as identical. updateClimb already restricts
+    // its gate to framesCount === 1; saveMoonBoardClimb matches that.
+    mockDb.execute
+      .mockResolvedValueOnce([
+        {
+          uuid: 'existing-uuid',
+          name: 'Already There',
+          ascensionist_count: 12,
+          signature: '1:STARTING,13:HAND,25:FINISH',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mockDb.select
+      .mockReturnValueOnce(
+        createMockChain([{ name: 'Alice', displayName: 'Alice Setter', image: null, avatarUrl: null }]),
+      )
+      .mockReturnValueOnce(createMockChain([]));
+    mockDb.insert.mockImplementation((table: unknown) =>
+      createMockChain(undefined, (values) => insertCalls.push({ table, values })),
+    );
+
+    await climbMutations.saveMoonBoardClimb(
+      {},
+      {
+        input: {
+          boardType: 'moonboard',
+          layoutId: 3,
+          name: 'MoonBoard Circuit',
+          description: '',
+          holds: { start: ['A1'], hand: ['B2'], finish: ['C3'] },
+          frames: 'p1r42,p1r42p13r43,p13r43p25r44',
+          angle: 40,
+          isDraft: false,
+        },
+      },
+      makeCtx(),
+    );
+
+    expect(insertCalls[0].values).toMatchObject({ framesCount: 3 });
   });
 
   it('deletes an owned draft climb', async () => {

--- a/packages/backend/src/__tests__/moonboard-duplicates-angle-agnostic.test.ts
+++ b/packages/backend/src/__tests__/moonboard-duplicates-angle-agnostic.test.ts
@@ -3,9 +3,9 @@ import { sql } from 'drizzle-orm';
 import type { MoonBoardHoldsInput } from '@boardsesh/shared-schema';
 import { db } from '../db/client';
 import {
-  buildMoonBoardClimbHoldRows,
   encodeMoonBoardHoldsToFrames,
   findMoonBoardDuplicateMatches,
+  normalizeMoonBoardHolds,
 } from '../graphql/resolvers/climbs/moonboard-duplicates';
 
 // The catalog importer writes ONE angle-agnostic climb row per MoonBoard
@@ -36,10 +36,10 @@ async function insertClimb(args: { uuid: string; angle: number | null; name: str
 }
 
 async function insertHoldRows(uuid: string, holds: MoonBoardHoldsInput) {
-  for (const row of buildMoonBoardClimbHoldRows(uuid, holds)) {
+  for (const { holdId, holdState } of normalizeMoonBoardHolds(holds)) {
     await db.execute(sql`
       INSERT INTO board_climb_holds (board_type, climb_uuid, hold_id, frame_number, hold_state)
-      VALUES ('moonboard', ${row.climbUuid}, ${row.holdId}, ${row.frameNumber}, ${row.holdState})
+      VALUES ('moonboard', ${uuid}, ${holdId}, 0, ${holdState})
     `);
   }
 }

--- a/packages/backend/src/__tests__/moonboard-duplicates.test.ts
+++ b/packages/backend/src/__tests__/moonboard-duplicates.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
-  buildMoonBoardClimbHoldRows,
   buildMoonBoardDuplicateError,
   encodeMoonBoardHoldsToFrames,
   findMoonBoardDuplicateMatches,
+  normalizeMoonBoardHolds,
 } from '../graphql/resolvers/climbs/moonboard-duplicates';
 
 const { mockDb } = vi.hoisted(() => ({
@@ -91,35 +91,17 @@ describe('moonboard duplicate helpers', () => {
     });
   });
 
-  it('normalizes hold rows and duplicate error text', () => {
+  it('normalizes holds and duplicate error text', () => {
     expect(
-      buildMoonBoardClimbHoldRows('new-climb', {
+      normalizeMoonBoardHolds({
         start: ['A1'],
         hand: ['C3', 'B2'],
         finish: ['C3'],
       }),
     ).toEqual([
-      {
-        boardType: 'moonboard',
-        climbUuid: 'new-climb',
-        holdId: 1,
-        frameNumber: 0,
-        holdState: 'STARTING',
-      },
-      {
-        boardType: 'moonboard',
-        climbUuid: 'new-climb',
-        holdId: 13,
-        frameNumber: 0,
-        holdState: 'HAND',
-      },
-      {
-        boardType: 'moonboard',
-        climbUuid: 'new-climb',
-        holdId: 25,
-        frameNumber: 0,
-        holdState: 'FINISH',
-      },
+      { holdId: 1, holdState: 'STARTING' },
+      { holdId: 13, holdState: 'HAND' },
+      { holdId: 25, holdState: 'FINISH' },
     ]);
 
     expect(buildMoonBoardDuplicateError('Existing Climb')).toBe(

--- a/packages/backend/src/graphql/resolvers/climbs/moonboard-duplicates.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/moonboard-duplicates.ts
@@ -117,16 +117,6 @@ export function encodeMoonBoardHoldsToFrames(holds: MoonBoardHoldsInput): string
     .join('');
 }
 
-export function buildMoonBoardClimbHoldRows(climbUuid: string, holds: MoonBoardHoldsInput) {
-  return normalizeMoonBoardHolds(holds).map(({ holdId, holdState }) => ({
-    boardType: 'moonboard' as const,
-    climbUuid,
-    holdId,
-    frameNumber: 0,
-    holdState,
-  })) satisfies Array<typeof dbSchema.boardClimbHolds.$inferInsert>;
-}
-
 type DuplicateMatchRow = {
   uuid: string;
   name: string | null;

--- a/packages/backend/src/graphql/resolvers/climbs/mutations.ts
+++ b/packages/backend/src/graphql/resolvers/climbs/mutations.ts
@@ -12,6 +12,7 @@ import {
   withNoMatch,
 } from '@boardsesh/shared-schema';
 import type { BoardName } from '@boardsesh/board-constants';
+import { parseFramesSegments } from '@boardsesh/board-constants/hold-states';
 import { db } from '../../../db/client';
 import * as dbSchema from '@boardsesh/db/schema';
 import { UNIFIED_TABLES, isValidBoardName } from '../../../db/queries/util/table-select';
@@ -21,7 +22,6 @@ import { notifyClimbRevalidated } from '../../../lib/web-revalidate';
 import { requireAuthenticated, applyRateLimit, validateInput } from '../shared/helpers';
 import { requireAdminOrLeader } from '../social/roles';
 import {
-  buildMoonBoardClimbHoldRows,
   buildMoonBoardDuplicateError,
   encodeMoonBoardHoldsToFrames,
   findMoonBoardDuplicateMatch,
@@ -291,13 +291,24 @@ export const climbMutations = {
     const { displayName, name, avatarUrl } = await getUserProfile(ctx.userId!);
     const preferredSetter = validated.setter || displayName || name || null;
 
+    // A route/circuit ships its own frames string (absolute snapshot per frame);
+    // a plain single-frame climb doesn't send one and we encode `holds` exactly
+    // as we always did. framesCount is derived from the string rather than taken
+    // from the client so the stored count can never disagree with the content.
+    const frames = validated.frames ?? encodeMoonBoardHoldsToFrames(validated.holds);
+    const framesCount = Math.max(parseFramesSegments(frames).length, 1);
+
     // The legacy MoonBoard-specific lookup also covers climbs that have no
     // rows in board_climb_holds and live only as a `frames` text blob (Aurora
     // imports from before the holds table was the authoritative store), so
     // keep it as the gate for this board. Wrap the result in a GraphQLError
     // with the unified CLIMB_IS_DUPLICATE extension so the frontend's
     // duplicate-UX handler can react the same way across boards.
-    if (!isDraft) {
+    //
+    // Multi-frame routes skip the gate, matching updateClimb's `framesCount === 1`
+    // rule: the signature is a hold *set*, so two routes that visit the same holds
+    // in a different order would read as identical when they aren't.
+    if (!isDraft && framesCount === 1) {
       const duplicateMatch = await findMoonBoardDuplicateMatch(validated.layoutId, validated.angle, validated.holds);
       if (duplicateMatch) {
         throw new GraphQLError(buildMoonBoardDuplicateError(duplicateMatch.existingClimbName), {
@@ -310,8 +321,6 @@ export const climbMutations = {
       }
     }
 
-    const frames = encodeMoonBoardHoldsToFrames(validated.holds);
-
     await db.insert(UNIFIED_TABLES.climbs).values({
       boardType: validated.boardType,
       uuid,
@@ -322,7 +331,7 @@ export const climbMutations = {
       name: validated.name,
       description: validated.description ?? '',
       angle: validated.angle,
-      framesCount: 1,
+      framesCount,
       framesPace: 0,
       frames,
       isDraft,
@@ -334,9 +343,27 @@ export const climbMutations = {
       characteristics,
     });
 
-    const holdRows = buildMoonBoardClimbHoldRows(uuid, validated.holds);
+    // Derive the hold rows from the frames string, not from the `holds` union
+    // the client sends: updateClimb's refresh does exactly this, and the two
+    // have to agree. The union collapses a hold that appears in several frames
+    // to its LAST role, while the frames walk keeps every frame occurrence and
+    // the PK (board_type, climb_uuid, hold_id) + onConflictDoNothing keeps the
+    // FIRST. Seeding from the union would make a hold's stored state depend on
+    // whether the climb had been edited since it was created.
+    const holdRows = parseFramesToHoldEntries(validated.boardType, frames);
     if (holdRows.length > 0) {
-      await db.insert(dbSchema.boardClimbHolds).values(holdRows).onConflictDoNothing();
+      await db
+        .insert(dbSchema.boardClimbHolds)
+        .values(
+          holdRows.map((entry) => ({
+            boardType: validated.boardType,
+            climbUuid: uuid,
+            holdId: entry.holdId,
+            frameNumber: entry.frameNumber,
+            holdState: entry.holdState,
+          })),
+        )
+        .onConflictDoNothing();
     }
 
     // Seed a stats row so the climb is visible to the global search, which

--- a/packages/backend/src/validation/schemas/climbs.ts
+++ b/packages/backend/src/validation/schemas/climbs.ts
@@ -272,6 +272,11 @@ export const SaveMoonBoardClimbInputSchema = z.object({
   name: z.string().min(1).max(200),
   description: z.string().max(2000).optional().default(''),
   holds: MoonBoardHoldsInputSchema,
+  // Multi-frame route/circuit: the comma-separated frames string the editor
+  // composed, every frame an absolute snapshot. Omitted by single-frame callers
+  // (and every pre-route client), in which case the resolver encodes `holds`
+  // itself exactly as it always did.
+  frames: z.string().min(1).max(10000).optional(),
   angle: z.number().int().min(0).max(90),
   isDraft: z.boolean().optional(),
   userGrade: z.string().max(20).optional(),

--- a/packages/board-constants/src/__tests__/hold-states.test.ts
+++ b/packages/board-constants/src/__tests__/hold-states.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vite-plus/test';
 import {
   HOLD_STATE_MAP,
   STATE_TO_PRIMARY_CODE,
+  FRAME_ENCODING,
   BOARD_RENDER_DEFAULTS,
   getBoardStrokeWidthMultiplier,
   convertLitUpHoldsStringToMap,
@@ -13,7 +14,7 @@ import {
   isSentinelHoldState,
   toFlatFrames,
 } from '../hold-states';
-import type { BoardName } from '@boardsesh/shared-schema';
+import type { BoardName, LitUpHoldsMap } from '@boardsesh/shared-schema';
 import oracle from './__fixtures__/aurora-frames-oracle.json';
 
 describe('HOLD_STATE_MAP', () => {
@@ -317,6 +318,39 @@ describe('accumulatedMapsToFrameStrings', () => {
     ];
     const [string0] = accumulatedMapsToFrameStrings(maps, 'moonboard');
     expect(string0).toBe('p100r42');
+  });
+});
+
+describe('FRAME_ENCODING', () => {
+  it('covers every board, and only MoonBoard writes absolute frames', () => {
+    for (const board of Object.keys(HOLD_STATE_MAP) as Array<keyof typeof HOLD_STATE_MAP>) {
+      expect(FRAME_ENCODING[board]).toBe(board === 'moonboard' ? 'absolute' : 'delta');
+    }
+  });
+
+  it('round-trips a 3-frame MoonBoard route with no delta markers anywhere', () => {
+    const maps: LitUpHoldsMap[] = [
+      {
+        100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#44FF44' },
+      },
+      {
+        100: { state: 'STARTING' as const, color: '#00FF00', displayColor: '#44FF44' },
+        200: { state: 'HAND' as const, color: '#0000FF', displayColor: '#4444FF' },
+      },
+      {
+        200: { state: 'HAND' as const, color: '#0000FF', displayColor: '#4444FF' },
+        300: { state: 'FINISH' as const, color: '#FF0000', displayColor: '#FF3333' },
+      },
+    ];
+
+    const frames = accumulatedMapsToFrameStrings(maps, 'moonboard').join(',');
+
+    expect(frames).toBe('p100r42,p100r42p200r43,p200r43p300r44');
+    expect(frames).not.toContain('"');
+    expect(frames.split(',')).toHaveLength(3);
+    // Each frame restates the whole lit set, so decoding gives back exactly the
+    // three snapshots — including frame 3 dropping hold 100 without an `x` token.
+    expect(accumulateFramesToMaps(frames, 'moonboard')).toEqual(maps);
   });
 });
 

--- a/packages/board-constants/src/hold-states.ts
+++ b/packages/board-constants/src/hold-states.ts
@@ -121,6 +121,32 @@ export const STATE_TO_PRIMARY_CODE: Record<BoardName, Partial<Record<HoldState, 
   soill: { STARTING: 1, HAND: 2, FINISH: 3, FOOT: 4 },
 };
 
+/**
+ * How each board's multi-frame `frames` string is *written*.
+ *
+ * `'delta'` — frame 0 absolute, every later frame a `"`-prefixed diff against
+ * the previous frame. This is what the Aurora API and the legacy catalog use,
+ * and what `encodeMapsToFramesString` emits.
+ *
+ * `'absolute'` — every frame restates the whole lit set (`accumulatedMapsToFrameStrings`
+ * joined with commas, no `"` anywhere). MoonBoard writes this way: delta encoding
+ * exists to save bytes on the wire, and MoonBoard's LED changes are instant, so a
+ * full snapshot per tick is simpler to read and impossible to desync.
+ *
+ * Only the *write* side cares. `parseFramesSegments` / `accumulateFramesToMaps`
+ * already decode either shape (a later frame without the `"` marker is treated
+ * as a snapshot), so nothing on the read path branches on this.
+ */
+export const FRAME_ENCODING: Record<BoardName, 'delta' | 'absolute'> = {
+  kilter: 'delta',
+  tension: 'delta',
+  moonboard: 'absolute',
+  decoy: 'delta',
+  touchstone: 'delta',
+  grasshopper: 'delta',
+  soill: 'delta',
+};
+
 export type BoardRenderDefaults = {
   /**
    * Multiplies the Rust/native renderer's base hold-outline stroke width

--- a/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
+++ b/packages/mobile/src/components/create-climb/use-create-climb-screen.ts
@@ -126,7 +126,9 @@ export function useCreateClimbScreen({
     currentFrameBleString,
     startingCount,
     finishCount,
+    totalHolds,
     isValid,
+    hasEmptyFrame,
     resetHolds,
     loadFrames,
     duplicateFrame,
@@ -497,7 +499,16 @@ export function useCreateClimbScreen({
       return;
     }
     if (editLocked) return;
-    if (!isValid) return;
+    if (!isValid) {
+      // An empty board explains itself; anything else looks finished, so say
+      // what's missing instead of letting the tap do nothing.
+      if (hasEmptyFrame) {
+        showToast(t('createClimbForm.validation.emptyFrame'), 'error');
+      } else if (totalHolds > 0) {
+        showToast(t('createClimbForm.validation.needsStartFinish'), 'error');
+      }
+      return;
+    }
     if (name.trim() === '') {
       requestFocusName();
       return;
@@ -607,6 +618,8 @@ export function useCreateClimbScreen({
     router,
     editLocked,
     isValid,
+    hasEmptyFrame,
+    totalHolds,
     name,
     canUpdate,
     savedClimb,

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -4612,6 +4612,14 @@ input SaveMoonBoardClimbInput {
   name: String!
   description: String
   holds: MoonBoardHoldsInput!
+  """
+  Multi-frame route/circuit: the comma-separated frames string, every frame an
+  absolute snapshot with no delta markers — MoonBoard sends the whole frame each
+  tick. Omit for a single-frame climb; the server then encodes holds itself.
+  holds always carries the union of every frame, and is what the duplicate
+  check and the hold rows read.
+  """
+  frames: String
   angle: Int!
   isDraft: Boolean
   userGrade: String

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -6131,6 +6131,14 @@ export type SaveMoonBoardClimbInput = {
   angle: Scalars['Int']['input'];
   boardType: Scalars['String']['input'];
   description?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * Multi-frame route/circuit: the comma-separated frames string, every frame an
+   * absolute snapshot with no delta markers — MoonBoard sends the whole frame each
+   * tick. Omit for a single-frame climb; the server then encodes holds itself.
+   * holds always carries the union of every frame, and is what the duplicate
+   * check and the hold rows read.
+   */
+  frames?: InputMaybe<Scalars['String']['input']>;
   holds: MoonBoardHoldsInput;
   isBenchmark?: InputMaybe<Scalars['Boolean']['input']>;
   isDraft?: InputMaybe<Scalars['Boolean']['input']>;

--- a/packages/shared-schema/src/schema/new-climb-feed.ts
+++ b/packages/shared-schema/src/schema/new-climb-feed.ts
@@ -103,6 +103,14 @@ export const newClimbFeedTypeDefs = /* GraphQL */ `
     name: String!
     description: String
     holds: MoonBoardHoldsInput!
+    """
+    Multi-frame route/circuit: the comma-separated frames string, every frame an
+    absolute snapshot with no delta markers — MoonBoard sends the whole frame each
+    tick. Omit for a single-frame climb; the server then encodes holds itself.
+    holds always carries the union of every frame, and is what the duplicate
+    check and the hold rows read.
+    """
+    frames: String
     angle: Int!
     isDraft: Boolean
     userGrade: String

--- a/packages/shared-schema/src/types/climb.ts
+++ b/packages/shared-schema/src/types/climb.ts
@@ -244,6 +244,12 @@ export type SaveMoonBoardClimbInput = {
   name: string;
   description?: string | null;
   holds: MoonBoardHoldsInput;
+  /**
+   * Multi-frame route/circuit: the comma-separated frames string, every frame an
+   * absolute snapshot. Omit for a single-frame climb — the server then encodes
+   * `holds` itself. `holds` always carries the union of every frame.
+   */
+  frames?: string | null;
   angle: number;
   isDraft?: boolean | null;
   userGrade?: string | null;

--- a/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
+++ b/packages/shared/create-climb-react/src/__tests__/use-create-climb.test.ts
@@ -23,10 +23,13 @@ vi.mock('@boardsesh/board-constants/hold-states', async () => {
         3: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
         4: { name: 'FOOT', color: '#FFA500', displayColor: '#FFA500' },
       },
+      // Keyed by MoonBoard's real saved-climb role codes so this mock stays
+      // consistent with the STATE_TO_PRIMARY_CODE mock below — the hook looks a
+      // painted state's code up in one table and then reads the other.
       moonboard: {
-        1: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
-        2: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
-        3: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
+        42: { name: 'STARTING', color: '#00FF00', displayColor: '#00FF00' },
+        43: { name: 'HAND', color: '#00FFFF', displayColor: '#00FFFF' },
+        44: { name: 'FINISH', color: '#FF00FF', displayColor: '#FF00FF' },
       },
     },
     STATE_TO_PRIMARY_CODE: {
@@ -376,6 +379,30 @@ describe('useCreateClimb', () => {
       expect(result.current.isValid).toBe(true);
     });
 
+    it('a blank frame is fine on a delta-encoded board — it writes as a hold frame', () => {
+      const { result } = renderHook(() => useCreateClimb('kilter'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(100, 'OFF');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(200, 'FINISH');
+      });
+
+      expect(result.current.hasEmptyFrame).toBe(false);
+      expect(result.current.isValid).toBe(true);
+      expect(result.current.generateFramesString()).toBe('p100r42,"x100,"p200r44');
+    });
+
     it('are computed over the union of every frame, not just the active one', () => {
       const { result } = renderHook(() => useCreateClimb('kilter'));
 
@@ -543,6 +570,161 @@ describe('useCreateClimb', () => {
 
       const frames = result.current.generateFramesString();
       expect(frames).toBe('p100r1');
+    });
+  });
+
+  describe('moonboard board', () => {
+    it('writes every frame of a route as a full snapshot, never a delta', () => {
+      const { result } = renderHook(() => useCreateClimb('moonboard'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(200, 'HAND');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(100, 'OFF');
+      });
+      act(() => {
+        result.current.setHoldState(300, 'FINISH');
+      });
+
+      const frames = result.current.generateFramesString();
+
+      // Frame 2 drops hold 100 by simply not listing it — no `x` token, and no
+      // `"` marker anywhere, because MoonBoard sends the whole frame each tick.
+      expect(frames).toBe('p100r42,p100r42p200r43,p200r43p300r44');
+      expect(frames).not.toContain('"');
+    });
+
+    it('a single-frame climb still encodes to the same flat string', () => {
+      const { result } = renderHook(() => useCreateClimb('moonboard'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.setHoldState(200, 'FINISH');
+      });
+
+      expect(result.current.generateFramesString()).toBe('p100r42p200r44');
+    });
+
+    it('is invalid until the route has both a start and a finish hold', () => {
+      const { result } = renderHook(() => useCreateClimb('moonboard'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.setHoldState(200, 'HAND');
+      });
+
+      // Kilter would already be valid here; MoonBoard wants a finish too.
+      expect(result.current.totalHolds).toBe(2);
+      expect(result.current.isValid).toBe(false);
+
+      act(() => {
+        result.current.setHoldState(300, 'FINISH');
+      });
+
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it('counts a start and a finish spread across different frames as valid', () => {
+      const { result } = renderHook(() => useCreateClimb('moonboard'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(100, 'OFF');
+      });
+      act(() => {
+        result.current.setHoldState(300, 'FINISH');
+      });
+
+      expect(result.current.frameCount).toBe(2);
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it('is invalid while a middle frame is blank, and valid again once it is filled or deleted', () => {
+      const { result } = renderHook(() => useCreateClimb('moonboard'));
+
+      // Frame 0: start + finish (a valid single-frame climb).
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.setHoldState(300, 'FINISH');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      // Frame 1 erased down to nothing: MoonBoard writes absolute frames, so it
+      // would serialise as an empty segment and be dropped on the way back in.
+      act(() => {
+        result.current.setHoldState(100, 'OFF');
+      });
+      act(() => {
+        result.current.setHoldState(300, 'OFF');
+      });
+
+      expect(result.current.frameCount).toBe(2);
+      expect(result.current.hasEmptyFrame).toBe(true);
+      expect(result.current.isValid).toBe(false);
+
+      // Painting the blank frame fixes it...
+      act(() => {
+        result.current.setHoldState(200, 'HAND');
+      });
+      expect(result.current.hasEmptyFrame).toBe(false);
+      expect(result.current.isValid).toBe(true);
+
+      // ...and so does deleting it.
+      act(() => {
+        result.current.setHoldState(200, 'OFF');
+      });
+      expect(result.current.isValid).toBe(false);
+      act(() => {
+        result.current.deleteFrame();
+      });
+      expect(result.current.frameCount).toBe(1);
+      expect(result.current.hasEmptyFrame).toBe(false);
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it('never paints a FOOT hold, on any frame of a route', () => {
+      const { result } = renderHook(() => useCreateClimb('moonboard'));
+
+      act(() => {
+        result.current.setHoldState(100, 'STARTING');
+      });
+      act(() => {
+        result.current.setHoldState(200, 'FOOT');
+      });
+      act(() => {
+        result.current.duplicateFrame();
+      });
+      act(() => {
+        result.current.setHoldState(300, 'FOOT');
+      });
+
+      expect(result.current.frameCount).toBe(2);
+      expect(result.current.totalHolds).toBe(1);
+      expect(result.current.litUpHoldsMap[200]).toBeUndefined();
+      expect(result.current.litUpHoldsMap[300]).toBeUndefined();
+      expect(result.current.generateFramesString()).toBe('p100r42,p100r42');
     });
   });
 

--- a/packages/shared/create-climb-react/src/use-create-climb.ts
+++ b/packages/shared/create-climb-react/src/use-create-climb.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useReducer } from 'react';
 import {
+  FRAME_ENCODING,
   HOLD_STATE_MAP,
   STATE_TO_PRIMARY_CODE,
   accumulatedMapsToFrameStrings,
@@ -186,12 +187,18 @@ function initHistory(boardName: BoardName, initialFrames: LitUpHoldsMap[] | unde
 }
 
 /**
- * Aurora (Kilter/Tension/etc) hold-state machine for the create-climb editor.
- * Pure React + board-constants — shared verbatim by the web form and the
- * React Native editor. Keys holds by numeric id; enforces the max-2
- * STARTING/FINISH rule (per frame); serialises the whole frame sequence to
- * the Aurora frames string (delta-encoded past frame 0). Tracks in-memory
- * undo/redo history for the current editing session.
+ * Hold-state machine for the create-climb editor, for every board we support
+ * (Kilter/Tension/etc and MoonBoard). Pure React + board-constants — shared
+ * verbatim by the web form and the React Native editor. Keys holds by numeric
+ * id; enforces the max-2 STARTING/FINISH rule (per frame); serialises the whole
+ * frame sequence to a frames string using the board's own encoding (Aurora
+ * delta-encodes past frame 0, MoonBoard writes a full snapshot per frame).
+ * Tracks in-memory undo/redo history for the current editing session.
+ *
+ * Board-specific rules the hook already handles without a caller branch: a
+ * state the board has no role code for is unpaintable (MoonBoard has no FOOT),
+ * MoonBoard additionally requires a start and a finish hold to be valid, and a
+ * board that writes absolute frames can't carry a blank frame mid-route.
  *
  * `litUpHoldsMap` is always the *active* frame — every existing single-frame
  * consumer (board renderers, the hold-type picker, paint handlers) keeps
@@ -223,7 +230,23 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
 
   const totalHolds = useMemo(() => Object.values(unionHolds).filter((h) => h.state !== 'OFF').length, [unionHolds]);
 
-  const isValid = totalHolds > 0;
+  // A board that writes absolute frames has no way to spell "this frame is
+  // deliberately dark": the frame encodes as an empty segment between two
+  // commas, and `parseFramesSegments` drops that as comma noise, so the route
+  // would come back one frame shorter than it was drawn. Block the save until
+  // the user paints in the blank frame or deletes it. Delta boards write the
+  // same frame as a bare `"` and round-trip it fine.
+  const hasEmptyFrame =
+    FRAME_ENCODING[boardName] === 'absolute' && frameCount > 1 && history.present.some(isEmptyFrame);
+
+  // MoonBoard is the one board whose climbs are meaningless without a start and
+  // a finish — its own editor has always required both, and the MoonBoard app
+  // won't render a problem that's missing either. Every Aurora board is happy
+  // with any lit hold. One board, one conditional; a config table here would be
+  // six identical rows and one exception.
+  const isValid =
+    !hasEmptyFrame &&
+    (boardName === 'moonboard' ? totalHolds > 0 && startingCount >= 1 && finishCount >= 1 : totalHolds > 0);
 
   const setHoldState = useCallback(
     (holdId: number, nextState: HoldState | 'OFF') => {
@@ -281,10 +304,15 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
     [boardName],
   );
 
-  // Encode the whole route: frame 0 absolute, later frames delta-encoded.
-  // Single-frame climbs produce the same flat string they always have.
+  // Encode the whole route. Aurora boards delta-encode (frame 0 absolute, later
+  // frames a `"`-prefixed diff); MoonBoard writes every frame as a full snapshot
+  // — see FRAME_ENCODING. Either way a single-frame climb produces the same flat
+  // string it always has.
   const generateFramesString = useCallback(
-    () => encodeMapsToFramesString(history.present, boardName),
+    () =>
+      FRAME_ENCODING[boardName] === 'absolute'
+        ? accumulatedMapsToFrameStrings(history.present, boardName).join(',')
+        : encodeMapsToFramesString(history.present, boardName),
     [history.present, boardName],
   );
 
@@ -333,10 +361,12 @@ export function useCreateClimb(boardName: BoardName, options?: UseCreateClimbOpt
     setHoldState,
     generateFramesString,
     currentFrameBleString,
+    unionHolds,
     startingCount,
     finishCount,
     totalHolds,
     isValid,
+    hasEmptyFrame,
     resetHolds,
     loadHolds,
     loadFrames,

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -6128,6 +6128,14 @@ export type SaveMoonBoardClimbInput = {
   angle: Scalars['Int']['input'];
   boardType: Scalars['String']['input'];
   description?: InputMaybe<Scalars['String']['input']>;
+  /**
+   * Multi-frame route/circuit: the comma-separated frames string, every frame an
+   * absolute snapshot with no delta markers — MoonBoard sends the whole frame each
+   * tick. Omit for a single-frame climb; the server then encodes holds itself.
+   * holds always carries the union of every frame, and is what the duplicate
+   * check and the hold rows read.
+   */
+  frames?: InputMaybe<Scalars['String']['input']>;
   holds: MoonBoardHoldsInput;
   isBenchmark?: InputMaybe<Scalars['Boolean']['input']>;
   isDraft?: InputMaybe<Scalars['Boolean']['input']>;

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -509,7 +509,8 @@
       "total": "Gesamt"
     },
     "validation": {
-      "needsStartFinish": "Ein gültiger Boulder braucht mindestens 1 Startgriff und 1 Topgriff"
+      "needsStartFinish": "Ein gültiger Boulder braucht mindestens 1 Startgriff und 1 Topgriff",
+      "emptyFrame": "Jedes Bild braucht einen Griff. Setz einen ins leere Bild oder lösch es"
     },
     "methodOptions": {
       "feetFollowHands": "Füße folgen den Händen",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -509,7 +509,8 @@
       "total": "Total"
     },
     "validation": {
-      "needsStartFinish": "A valid climb needs at least 1 start hold and 1 finish hold"
+      "needsStartFinish": "A valid climb needs at least 1 start hold and 1 finish hold",
+      "emptyFrame": "Every frame needs a hold. Paint the empty one or delete it"
     },
     "methodOptions": {
       "feetFollowHands": "Feet follow hands",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -500,7 +500,8 @@
       "total": "Total"
     },
     "validation": {
-      "needsStartFinish": "Un bloque válido necesita al menos 1 presa de salida y 1 de final"
+      "needsStartFinish": "Un bloque válido necesita al menos 1 presa de salida y 1 de final",
+      "emptyFrame": "Cada cuadro necesita una presa. Pinta el cuadro vacío o elimínalo"
     },
     "methodOptions": {
       "feetFollowHands": "Los pies siguen a las manos",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -509,7 +509,8 @@
       "total": "Total"
     },
     "validation": {
-      "needsStartFinish": "Un bloc valide nécessite au moins 1 prise de départ et 1 prise d'arrivée"
+      "needsStartFinish": "Un bloc valide nécessite au moins 1 prise de départ et 1 prise d'arrivée",
+      "emptyFrame": "Chaque image a besoin d'une prise. Remplis l'image vide ou supprime-la"
     },
     "methodOptions": {
       "feetFollowHands": "Pieds suivent les mains",

--- a/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
+++ b/packages/web/app/components/create-climb/__tests__/create-climb-form.test.tsx
@@ -7,7 +7,6 @@ import { MOONBOARD_WIDE_ANGLES_FLAG } from '@/app/flags';
 import CreateClimbForm from '../create-climb-form';
 import { useBoardProvider } from '../../board-provider/board-provider-context';
 import { useCreateClimb } from '@boardsesh/create-climb-react';
-import { useMoonBoardCreateClimb } from '../use-moonboard-create-climb';
 import { useOptionalBluetoothContext } from '../../board-bluetooth-control/bluetooth-context';
 import type { BoardDetails, Climb } from '@/app/lib/types';
 import type { LitUpHoldsMap } from '@boardsesh/shared-schema';
@@ -31,11 +30,16 @@ const mockSetAuroraHoldState = vi.fn();
 const mockSetMoonboardHoldState = vi.fn();
 const mockSendFramesToBoard = vi.fn();
 const mockGenerateAuroraFramesString = vi.fn(() => 'test-frames');
+const mockGenerateMoonboardFramesString = vi.fn(() => 'p1r42p13r43p25r44');
 const mockCurrentFrameBleString = vi.fn(() => 'test-ble-frame');
 const mockDuplicateFrame = vi.fn();
 const mockDeleteFrame = vi.fn();
 const mockNextFrame = vi.fn();
 const mockPrevFrame = vi.fn();
+const mockMoonboardDuplicateFrame = vi.fn();
+const mockMoonboardDeleteFrame = vi.fn();
+const mockMoonboardNextFrame = vi.fn();
+const mockMoonboardPrevFrame = vi.fn();
 const mockBuildInitialFrames = vi.hoisted(() => vi.fn(() => [{} as LitUpHoldsMap]));
 let mockQueueActions: Record<string, unknown> | null = null;
 let mockCurrentClimbData: Record<string, unknown> | null = null;
@@ -48,6 +52,90 @@ let mockAuroraCreateState: {
   totalHolds: 0,
   litUpHoldsMap: {},
 };
+
+const MOONBOARD_DEFAULT_HOLDS: LitUpHoldsMap = {
+  1: { state: 'STARTING', color: '#00FF00', displayColor: '#44FF44' },
+  13: { state: 'HAND', color: '#0000FF', displayColor: '#4444FF' },
+  25: { state: 'FINISH', color: '#FF0000', displayColor: '#FF3333' },
+};
+
+// The form now drives both board types through the one shared editor hook, so
+// the mock branches on the board name it is handed rather than on which hook
+// was imported.
+let mockMoonboardCreateState: {
+  isValid: boolean;
+  totalHolds: number;
+  litUpHoldsMap: LitUpHoldsMap;
+  frameCount: number;
+  currentFrameIndex: number;
+} = {
+  isValid: true,
+  totalHolds: 3,
+  litUpHoldsMap: MOONBOARD_DEFAULT_HOLDS,
+  frameCount: 1,
+  currentFrameIndex: 0,
+};
+
+function buildMoonboardEditor() {
+  const holdsByState = Object.values(mockMoonboardCreateState.litUpHoldsMap);
+  return {
+    litUpHoldsMap: mockMoonboardCreateState.litUpHoldsMap,
+    frames: [mockMoonboardCreateState.litUpHoldsMap],
+    unionHolds: mockMoonboardCreateState.litUpHoldsMap,
+    frameCount: mockMoonboardCreateState.frameCount,
+    currentFrameIndex: mockMoonboardCreateState.currentFrameIndex,
+    setHoldState: mockSetMoonboardHoldState,
+    startingCount: holdsByState.filter((hold) => hold.state === 'STARTING').length,
+    finishCount: holdsByState.filter((hold) => hold.state === 'FINISH').length,
+    totalHolds: mockMoonboardCreateState.totalHolds,
+    isValid: mockMoonboardCreateState.isValid,
+    hasEmptyFrame: false,
+    resetHolds: mockResetMoonboardHolds,
+    generateFramesString: mockGenerateMoonboardFramesString,
+    currentFrameBleString: mockCurrentFrameBleString,
+    loadHolds: vi.fn(),
+    loadFrames: vi.fn(),
+    duplicateFrame: mockMoonboardDuplicateFrame,
+    deleteFrame: mockMoonboardDeleteFrame,
+    goToFrame: vi.fn(),
+    nextFrame: mockMoonboardNextFrame,
+    prevFrame: mockMoonboardPrevFrame,
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+  };
+}
+
+function buildAuroraEditor() {
+  return {
+    litUpHoldsMap: mockAuroraCreateState.litUpHoldsMap,
+    frames: [mockAuroraCreateState.litUpHoldsMap],
+    unionHolds: mockAuroraCreateState.litUpHoldsMap,
+    frameCount: 1,
+    currentFrameIndex: 0,
+    setHoldState: mockSetAuroraHoldState,
+    startingCount: 0,
+    finishCount: 0,
+    totalHolds: mockAuroraCreateState.totalHolds,
+    isValid: mockAuroraCreateState.isValid,
+    hasEmptyFrame: false,
+    resetHolds: mockResetAuroraHolds,
+    generateFramesString: mockGenerateAuroraFramesString,
+    currentFrameBleString: mockCurrentFrameBleString,
+    loadHolds: mockLoadAuroraHolds,
+    loadFrames: mockLoadAuroraFrames,
+    duplicateFrame: mockDuplicateFrame,
+    deleteFrame: mockDeleteFrame,
+    goToFrame: vi.fn(),
+    nextFrame: mockNextFrame,
+    prevFrame: mockPrevFrame,
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+  };
+}
 
 type DraftsDrawerTestProps = {
   open: boolean;
@@ -79,44 +167,10 @@ vi.mock('../../board-bluetooth-control/bluetooth-context', () => ({
 }));
 
 vi.mock('@boardsesh/create-climb-react', () => ({
-  useCreateClimb: vi.fn(() => ({
-    litUpHoldsMap: mockAuroraCreateState.litUpHoldsMap,
-    frameCount: 1,
-    currentFrameIndex: 0,
-    setHoldState: mockSetAuroraHoldState,
-    startingCount: 0,
-    finishCount: 0,
-    totalHolds: mockAuroraCreateState.totalHolds,
-    isValid: mockAuroraCreateState.isValid,
-    resetHolds: mockResetAuroraHolds,
-    generateFramesString: mockGenerateAuroraFramesString,
-    currentFrameBleString: mockCurrentFrameBleString,
-    loadHolds: mockLoadAuroraHolds,
-    loadFrames: mockLoadAuroraFrames,
-    duplicateFrame: mockDuplicateFrame,
-    deleteFrame: mockDeleteFrame,
-    nextFrame: mockNextFrame,
-    prevFrame: mockPrevFrame,
-  })),
+  useCreateClimb: vi.fn((boardName: string) =>
+    boardName === 'moonboard' ? buildMoonboardEditor() : buildAuroraEditor(),
+  ),
   buildInitialFrames: mockBuildInitialFrames,
-}));
-
-vi.mock('../use-moonboard-create-climb', () => ({
-  useMoonBoardCreateClimb: vi.fn(() => ({
-    litUpHoldsMap: {
-      1: { state: 'STARTING', color: '#00FF00', displayColor: '#44FF44' },
-      13: { state: 'HAND', color: '#0000FF', displayColor: '#4444FF' },
-      25: { state: 'FINISH', color: '#FF0000', displayColor: '#FF3333' },
-    },
-    setLitUpHoldsMap: vi.fn(),
-    setHoldState: mockSetMoonboardHoldState,
-    startingCount: 1,
-    finishCount: 1,
-    handCount: 1,
-    totalHolds: 3,
-    isValid: true,
-    resetHolds: mockResetMoonboardHolds,
-  })),
 }));
 
 vi.mock('@/app/components/graphql-queue', () => ({
@@ -280,6 +334,13 @@ describe('CreateClimbForm', () => {
     mockQueueActions = null;
     mockCurrentClimbData = null;
     mockDraftsDrawerProps = null;
+    mockMoonboardCreateState = {
+      isValid: true,
+      totalHolds: 3,
+      litUpHoldsMap: MOONBOARD_DEFAULT_HOLDS,
+      frameCount: 1,
+      currentFrameIndex: 0,
+    };
     mockAuroraCreateState = {
       isValid: false,
       totalHolds: 0,
@@ -377,10 +438,12 @@ describe('CreateClimbForm', () => {
         expect(mockSetCurrentClimb).toHaveBeenCalledTimes(1);
       });
 
+      // MoonBoard now composes a real frames string like every other board, so
+      // the queue item peers see carries the lit holds instead of an empty blob.
       const climb = mockSetCurrentClimb.mock.calls[0][0];
       expect(climb).toMatchObject({
         angle: 40,
-        frames: '',
+        frames: 'p1r42p13r43p25r44',
       });
       expect(climb.uuid).toBeTruthy();
     });
@@ -485,6 +548,13 @@ describe('CreateClimbForm — MoonBoard rendering', () => {
     mockQueueActions = null;
     mockCurrentClimbData = null;
     mockDraftsDrawerProps = null;
+    mockMoonboardCreateState = {
+      isValid: true,
+      totalHolds: 3,
+      litUpHoldsMap: MOONBOARD_DEFAULT_HOLDS,
+      frameCount: 1,
+      currentFrameIndex: 0,
+    };
     // myRoles: [] = no admin role by default (benchmark toggle hidden for regular users)
     mockRequest.mockResolvedValue({ checkMoonBoardClimbDuplicates: [], myRoles: [] });
   });
@@ -550,33 +620,13 @@ describe('CreateClimbForm — MoonBoard rendering', () => {
   });
 
   it('does not show checking alert when climb is not valid', () => {
-    vi.mocked(useMoonBoardCreateClimb).mockReturnValueOnce({
-      litUpHoldsMap: {},
-      setLitUpHoldsMap: vi.fn(),
-      setHoldState: mockSetMoonboardHoldState,
-      startingCount: 0,
-      finishCount: 0,
-      handCount: 0,
-      totalHolds: 0,
-      isValid: false,
-      resetHolds: mockResetMoonboardHolds,
-    });
+    mockMoonboardCreateState = { ...mockMoonboardCreateState, litUpHoldsMap: {}, totalHolds: 0, isValid: false };
     renderMoonboard();
     expect(screen.queryByText('createClimbForm.alerts.checkingMoonBoardDuplicate')).toBeNull();
   });
 
   it('clear button is disabled when totalHolds is 0', () => {
-    vi.mocked(useMoonBoardCreateClimb).mockReturnValueOnce({
-      litUpHoldsMap: {},
-      setLitUpHoldsMap: vi.fn(),
-      setHoldState: mockSetMoonboardHoldState,
-      startingCount: 0,
-      finishCount: 0,
-      handCount: 0,
-      totalHolds: 0,
-      isValid: false,
-      resetHolds: mockResetMoonboardHolds,
-    });
+    mockMoonboardCreateState = { ...mockMoonboardCreateState, litUpHoldsMap: {}, totalHolds: 0, isValid: false };
     renderMoonboard();
     const deleteIcon = document.querySelector('[data-testid="DeleteOutlinedIcon"]');
     const clearBtn = deleteIcon?.closest('button');
@@ -600,6 +650,97 @@ describe('CreateClimbForm — MoonBoard rendering', () => {
     const confirmBtn = screen.getByRole('button', { name: /actions\.clear/i });
     fireEvent.click(confirmBtn);
     expect(mockResetMoonboardHolds).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers the duplicate-frame button so MoonBoard can build a route', () => {
+    renderMoonboard();
+    const duplicateButton = screen.getByRole('button', { name: 'create.frames.duplicateTooltip' });
+    fireEvent.click(duplicateButton);
+    expect(mockMoonboardDuplicateFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the frame stepper while the climb is a single frame', () => {
+    renderMoonboard();
+    expect(screen.queryByLabelText('playback.nextFrame')).toBeNull();
+    expect(screen.queryByLabelText('create.frames.deleteTooltip')).toBeNull();
+  });
+
+  it('shows the frame counter, stepper and delete-frame control on a multi-frame route', () => {
+    mockMoonboardCreateState = { ...mockMoonboardCreateState, frameCount: 3, currentFrameIndex: 1 };
+    renderMoonboard();
+
+    expect(screen.getByText('playback.frameOfTotal')).toBeTruthy();
+
+    const prevButton = screen.getByLabelText('playback.prevFrame').closest('button') as HTMLButtonElement;
+    const nextButton = screen.getByLabelText('playback.nextFrame').closest('button') as HTMLButtonElement;
+    expect(prevButton.disabled).toBe(false);
+    expect(nextButton.disabled).toBe(false);
+
+    fireEvent.click(nextButton);
+    expect(mockMoonboardNextFrame).toHaveBeenCalledTimes(1);
+    fireEvent.click(prevButton);
+    expect(mockMoonboardPrevFrame).toHaveBeenCalledTimes(1);
+
+    // Delete lives behind a confirm popover, same as Aurora's.
+    fireEvent.click(screen.getByLabelText('create.frames.deleteTooltip'));
+    fireEvent.click(screen.getByRole('button', { name: /actions\.delete/i }));
+    expect(mockMoonboardDeleteFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps the stepper at the ends of the route', () => {
+    mockMoonboardCreateState = { ...mockMoonboardCreateState, frameCount: 2, currentFrameIndex: 0 };
+    renderMoonboard();
+
+    expect((screen.getByLabelText('playback.prevFrame').closest('button') as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByLabelText('playback.nextFrame').closest('button') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('skips the live duplicate check for a multi-frame route', async () => {
+    mockMoonboardCreateState = { ...mockMoonboardCreateState, frameCount: 2, currentFrameIndex: 0 };
+    mockRequest.mockImplementation(() => new Promise(() => {}));
+
+    renderMoonboard();
+
+    // A single-frame climb parks on the "checking..." alert here; a route never
+    // fires the query, because the match is on a hold set, not an order.
+    await waitFor(() => {
+      expect(screen.getByTestId('moonboard-renderer')).toBeTruthy();
+    });
+    expect(screen.queryByText('createClimbForm.alerts.checkingMoonBoardDuplicate')).toBeNull();
+  });
+
+  it('saves a multi-frame route with its absolute frames string and real frame count', async () => {
+    const { execute } = await import('@/app/lib/realtime/graphql-client');
+    vi.mocked(execute).mockResolvedValue({
+      saveMoonBoardClimb: { uuid: 'moon-1', synced: false, createdAt: '2026-01-01T00:00:00.000Z', publishedAt: null },
+    } as never);
+    mockMoonboardCreateState = { ...mockMoonboardCreateState, frameCount: 3, currentFrameIndex: 2 };
+    mockGenerateMoonboardFramesString.mockReturnValue('p1r42,p1r42p13r43,p13r43p25r44');
+
+    renderMoonboard({ forkName: 'Circuit' });
+
+    const saveButton = await waitFor(() => {
+      const button = getSaveButton();
+      expect(button?.disabled).toBe(false);
+      return button!;
+    });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    const { variables } = vi.mocked(execute).mock.calls[0][1] as {
+      variables: { input: { frames: string; holds: { start: string[] } } };
+    };
+    expect(variables.input.frames).toBe('p1r42,p1r42p13r43,p13r43p25r44');
+    // Absolute snapshots only — no Aurora delta markers.
+    expect(variables.input.frames).not.toContain('"');
+    // holds still rides along as the union, for the hold rows + duplicate check.
+    expect(variables.input.holds.start).toEqual(['A1']);
+
+    // The queue item gets the same route string the save did.
+    expect(mockGenerateMoonboardFramesString).toHaveBeenCalled();
   });
 
   it('does not show heatmap button for MoonBoard', () => {
@@ -756,6 +897,13 @@ describe('CreateClimbForm — Aurora rendering', () => {
     mockQueueActions = null;
     mockCurrentClimbData = null;
     mockDraftsDrawerProps = null;
+    mockMoonboardCreateState = {
+      isValid: true,
+      totalHolds: 3,
+      litUpHoldsMap: MOONBOARD_DEFAULT_HOLDS,
+      frameCount: 1,
+      currentFrameIndex: 0,
+    };
     mockAuroraCreateState = {
       isValid: false,
       totalHolds: 0,
@@ -879,6 +1027,7 @@ describe('CreateClimbForm — Aurora rendering', () => {
     vi.mocked(useCreateClimb).mockReturnValue({
       litUpHoldsMap: mockAuroraCreateState.litUpHoldsMap,
       frames: [mockAuroraCreateState.litUpHoldsMap],
+      unionHolds: mockAuroraCreateState.litUpHoldsMap,
       frameCount: 1,
       currentFrameIndex: 0,
       setHoldState: mockSetAuroraHoldState,
@@ -886,6 +1035,7 @@ describe('CreateClimbForm — Aurora rendering', () => {
       finishCount: 0,
       totalHolds: 1,
       isValid: true,
+      hasEmptyFrame: false,
       resetHolds: mockResetAuroraHolds,
       generateFramesString: mockGenerateAuroraFramesString,
       currentFrameBleString: mockCurrentFrameBleString,
@@ -934,6 +1084,7 @@ describe('CreateClimbForm — Aurora rendering', () => {
     vi.mocked(useCreateClimb).mockReturnValue({
       litUpHoldsMap: mockAuroraCreateState.litUpHoldsMap,
       frames: [mockAuroraCreateState.litUpHoldsMap],
+      unionHolds: mockAuroraCreateState.litUpHoldsMap,
       frameCount: 1,
       currentFrameIndex: 0,
       setHoldState: mockSetAuroraHoldState,
@@ -941,6 +1092,7 @@ describe('CreateClimbForm — Aurora rendering', () => {
       finishCount: 0,
       totalHolds: 1,
       isValid: true,
+      hasEmptyFrame: false,
       resetHolds: mockResetAuroraHolds,
       generateFramesString: mockGenerateAuroraFramesString,
       currentFrameBleString: mockCurrentFrameBleString,
@@ -984,6 +1136,13 @@ describe('CreateClimbForm — Save button state', () => {
     mockQueueActions = null;
     mockCurrentClimbData = null;
     mockDraftsDrawerProps = null;
+    mockMoonboardCreateState = {
+      isValid: true,
+      totalHolds: 3,
+      litUpHoldsMap: MOONBOARD_DEFAULT_HOLDS,
+      frameCount: 1,
+      currentFrameIndex: 0,
+    };
     mockRequest.mockResolvedValue({ checkMoonBoardClimbDuplicates: [] });
   });
 
@@ -1047,6 +1206,13 @@ describe('CreateClimbForm — forkName prop', () => {
     mockQueueActions = null;
     mockCurrentClimbData = null;
     mockDraftsDrawerProps = null;
+    mockMoonboardCreateState = {
+      isValid: true,
+      totalHolds: 3,
+      litUpHoldsMap: MOONBOARD_DEFAULT_HOLDS,
+      frameCount: 1,
+      currentFrameIndex: 0,
+    };
     mockRequest.mockResolvedValue({ checkMoonBoardClimbDuplicates: [] });
   });
 

--- a/packages/web/app/components/create-climb/create-climb-form.tsx
+++ b/packages/web/app/components/create-climb/create-climb-form.tsx
@@ -45,7 +45,6 @@ import ZoomableBoard from '../board-renderer/zoomable-board';
 import SwipeableDrawer from '../swipeable-drawer/swipeable-drawer';
 import { useBoardProvider } from '../board-provider/board-provider-context';
 import { useCreateClimb, buildInitialFrames } from '@boardsesh/create-climb-react';
-import { useMoonBoardCreateClimb } from './use-moonboard-create-climb';
 import { useOptionalBluetoothContext } from '../board-bluetooth-control/bluetooth-context';
 import type { MoonBoardClimbDuplicateMatch, UpdateClimbInput } from '@boardsesh/shared-schema';
 import { CLIMB_CHARACTERISTICS } from '@boardsesh/shared-schema';
@@ -187,21 +186,24 @@ export default function CreateClimbForm({
         (r.role === 'admin' || r.role === 'community_leader') && (r.boardType === null || r.boardType === 'moonboard'),
     );
 
+  // The board the editor is painting for. Aurora reads it off boardDetails;
+  // MoonBoard is its own board name. Both drive the one shared editor hook.
+  const editorBoardName: BoardName = boardType === 'aurora' ? boardDetails?.board_name || 'kilter' : 'moonboard';
+
   // Convert fork frames to the editor's initial frame sequence if provided
-  // (Aurora only). Preserves every frame of a multi-frame source climb —
-  // previously this took only frame 0, silently dropping the rest of a route.
+  // (Aurora only — MoonBoard has no fork-by-frames entry point). Preserves every
+  // frame of a multi-frame source climb — previously this took only frame 0,
+  // silently dropping the rest of a route.
   const initialFrames = useMemo(() => {
     if (boardType !== 'aurora' || !forkFrames || !boardDetails) return undefined;
     return buildInitialFrames(forkFrames, boardDetails.board_name);
   }, [boardType, forkFrames, boardDetails]);
 
-  // Aurora hold management
-  const auroraClimb = useCreateClimb(boardDetails?.board_name || 'kilter', { initialFrames });
-
-  // MoonBoard hold management
-  const moonboardClimb = useMoonBoardCreateClimb();
-
-  // Use the appropriate hook values based on board type
+  // One editor for every board. The hook already knows each board's rules: which
+  // hold states it can paint (MoonBoard has no FOOT), what makes a climb valid
+  // (MoonBoard needs a start and a finish), and how to serialise a multi-frame
+  // route (Aurora delta-encodes, MoonBoard writes a full snapshot per frame).
+  const climbEditor = useCreateClimb(editorBoardName, { initialFrames });
   const {
     litUpHoldsMap,
     setHoldState,
@@ -209,14 +211,23 @@ export default function CreateClimbForm({
     finishCount,
     totalHolds,
     isValid,
+    generateFramesString,
+    currentFrameBleString,
+    loadFrames,
+    loadHolds,
     resetHolds: baseResetHolds,
-  } = boardType === 'aurora' ? auroraClimb : moonboardClimb;
+  } = climbEditor;
 
-  const handCount = boardType === 'moonboard' ? moonboardClimb.handCount : 0;
-  const generateFramesString = boardType === 'aurora' ? auroraClimb.generateFramesString : undefined;
-  const currentFrameBleString = boardType === 'aurora' ? auroraClimb.currentFrameBleString : undefined;
-  const setLitUpHoldsMap = boardType === 'moonboard' ? moonboardClimb.setLitUpHoldsMap : undefined;
-  const loadAuroraFrames = boardType === 'aurora' ? auroraClimb.loadFrames : undefined;
+  // MoonBoard's settings drawer breaks its holds out by role, so it wants a hand
+  // count Aurora's three indicators never ask for. Computed over the whole route
+  // (like the hook's own counts) rather than the frame currently on screen.
+  const handCount = useMemo(
+    () =>
+      boardType === 'moonboard'
+        ? Object.values(climbEditor.unionHolds).filter((hold) => hold.state === 'HAND').length
+        : 0,
+    [boardType, climbEditor.unionHolds],
+  );
 
   // Bluetooth for Aurora boards. Share the single root-level connection (the
   // one the lightbulb actually drives) instead of spinning up a second adapter
@@ -422,12 +433,7 @@ export default function CreateClimbForm({
       if (cancelled) return;
       if (saved) {
         try {
-          if (boardType === 'aurora' && loadAuroraFrames) {
-            const frames = saved.framesJson ? JSON.parse(saved.framesJson) : [JSON.parse(saved.holdsJson)];
-            loadAuroraFrames(frames);
-          } else if (boardType === 'moonboard' && setLitUpHoldsMap) {
-            setLitUpHoldsMap(JSON.parse(saved.holdsJson));
-          }
+          loadFrames(saved.framesJson ? JSON.parse(saved.framesJson) : [JSON.parse(saved.holdsJson)]);
           if (saved.climbName) setClimbName(saved.climbName);
           if (saved.description) setDescription(saved.description);
           setIsDraft(saved.isDraft);
@@ -444,19 +450,19 @@ export default function CreateClimbForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Debounced autosave on changes. `framesJson` (the full route) is aurora-only;
-  // `holdsJson` covers moonboard and doubles as a backward-compatible fallback
-  // for aurora restores of an autosave written before this field existed.
+  // Debounced autosave on changes. `framesJson` is the full route, on every
+  // board; `holdsJson` (the active frame) stays as the backward-compatible
+  // fallback for autosaves written before that field existed.
   const autosaveData = useMemo(
     () => ({
       holdsJson: JSON.stringify(litUpHoldsMap),
-      framesJson: boardType === 'aurora' ? JSON.stringify(auroraClimb.frames) : undefined,
+      framesJson: JSON.stringify(climbEditor.frames),
       climbName,
       description,
       isDraft,
       boardKey: autosaveBoardKey,
     }),
-    [litUpHoldsMap, boardType, auroraClimb.frames, climbName, description, isDraft, autosaveBoardKey],
+    [litUpHoldsMap, climbEditor.frames, climbName, description, isDraft, autosaveBoardKey],
   );
   const debouncedAutosave = useDebouncedValue(autosaveData, 500);
   const debouncedTotalHolds = useDebouncedValue(totalHolds, 500);
@@ -474,9 +480,12 @@ export default function CreateClimbForm({
     void saveAutosave(debouncedAutosave);
   }, [debouncedAutosave, debouncedTotalHolds]);
 
+  // The structured holds the MoonBoard save mutation and duplicate check read.
+  // For a route this is the union of every frame — the whole set of holds the
+  // climb uses — while the frames string carries the sequence itself.
   const moonBoardHolds = useMemo(
-    () => (boardType === 'moonboard' ? convertLitUpHoldsMapToMoonBoardHolds(litUpHoldsMap) : null),
-    [boardType, litUpHoldsMap],
+    () => (boardType === 'moonboard' ? convertLitUpHoldsMapToMoonBoardHolds(climbEditor.unionHolds) : null),
+    [boardType, climbEditor.unionHolds],
   );
 
   const moonBoardDuplicateError = useMemo(() => {
@@ -492,9 +501,12 @@ export default function CreateClimbForm({
   // replaceQueueItem → BluetoothAutoSender path owns the wall, so sending here
   // too would double-write. Local-only (no WS broadcast), matching the pivot's
   // "building doesn't broadcast" rule.
+  // Still Aurora-only: the web Bluetooth adapter speaks the Aurora packet
+  // format. MoonBoard walls light up over their own protocol, which this form
+  // doesn't drive.
   useEffect(() => {
     if (queueItemUuid != null) return;
-    if (boardType === 'aurora' && isConnected && currentFrameBleString) {
+    if (boardType === 'aurora' && isConnected) {
       // The active frame only — the wall mirrors whatever you're painting right
       // now, not multi-frame route syntax the BLE packet builder can't parse.
       void sendFramesToBoard?.(currentFrameBleString());
@@ -587,7 +599,7 @@ export default function CreateClimbForm({
   // MoonBoard OCR import
   const handleOcrImport = useCallback(
     async (file: File) => {
-      if (boardType !== 'moonboard' || !setLitUpHoldsMap) return;
+      if (boardType !== 'moonboard') return;
 
       setIsOcrProcessing(true);
       setOcrError(null);
@@ -611,9 +623,9 @@ export default function CreateClimbForm({
 
         setOcrWarnings(warnings);
 
-        // Convert OCR holds to form state
-        const newHoldsMap = convertOcrHoldsToMap(climb.holds);
-        setLitUpHoldsMap(newHoldsMap);
+        // A screenshot is one static shape, so it replaces the whole route
+        // with a single frame.
+        loadHolds(convertOcrHoldsToMap(climb.holds));
 
         // Populate fields from OCR
         if (climb.name) setClimbName(climb.name);
@@ -626,7 +638,7 @@ export default function CreateClimbForm({
         setIsOcrProcessing(false);
       }
     },
-    [boardType, angle, setLitUpHoldsMap],
+    [boardType, angle, loadHolds],
   );
 
   const runMoonBoardDuplicateCheck = useCallback(
@@ -681,7 +693,10 @@ export default function CreateClimbForm({
       return;
     }
 
-    if (!layoutId || !moonBoardHolds || !isValid) {
+    // Routes skip the check, the same way the server-side gate does: the match
+    // is on a hold *set*, so two routes through the same holds in a different
+    // order would read as identical when they aren't.
+    if (!layoutId || !moonBoardHolds || !isValid || climbEditor.frameCount > 1) {
       duplicateCheckRequestIdRef.current += 1;
       setMoonBoardDuplicateMatch(null);
       setIsCheckingMoonBoardDuplicate(false);
@@ -695,7 +710,7 @@ export default function CreateClimbForm({
     return () => {
       window.clearTimeout(timeoutId);
     };
-  }, [boardType, isValid, layoutId, moonBoardHolds, runMoonBoardDuplicateCheck, selectedAngle]);
+  }, [boardType, isValid, layoutId, moonBoardHolds, climbEditor.frameCount, runMoonBoardDuplicateCheck, selectedAngle]);
 
   // Builds a Climb object from the form's current state + a freshly-issued
   // uuid. Used to push the in-progress climb into the live queue so party
@@ -785,9 +800,7 @@ export default function CreateClimbForm({
     if (!queueActions) return;
 
     const uuid = savedClimb?.uuid ?? getPreviewUuid();
-    const frames = boardType === 'aurora' && generateFramesString ? generateFramesString() : '';
-
-    const climb = buildClimbFromFormState(uuid, frames);
+    const climb = buildClimbFromFormState(uuid, generateFramesString());
 
     if (queueItemUuid) {
       queueActions.replaceQueueItem(queueItemUuid, climb);
@@ -828,18 +841,9 @@ export default function CreateClimbForm({
     const uuid = savedClimb?.uuid ?? previewUuidRef.current;
     if (!uuid) return;
 
-    const frames = boardType === 'aurora' && generateFramesString ? generateFramesString() : '';
-    const climb = buildClimbFromFormState(uuid, frames);
+    const climb = buildClimbFromFormState(uuid, generateFramesString());
     queueActions.replaceQueueItem(queueItemUuid, climb);
-  }, [
-    litUpHoldsMap,
-    queueActions,
-    queueItemUuid,
-    savedClimb?.uuid,
-    boardType,
-    generateFramesString,
-    buildClimbFromFormState,
-  ]);
+  }, [litUpHoldsMap, queueActions, queueItemUuid, savedClimb?.uuid, generateFramesString, buildClimbFromFormState]);
 
   // Save climb - Aurora
   //
@@ -854,7 +858,7 @@ export default function CreateClimbForm({
   // state. Clearing the form (via Clear) detaches savedClimb so the next
   // save starts a fresh row.
   const doSaveAuroraClimb = useCallback(async () => {
-    if (!boardDetails || !generateFramesString) return;
+    if (!boardDetails) return;
 
     setIsSaving(true);
 
@@ -892,7 +896,7 @@ export default function CreateClimbForm({
           description: description || '',
           frames,
           angle,
-          framesCount: auroraClimb.frameCount,
+          framesCount: climbEditor.frameCount,
           framesPace: 0,
           isDraft,
         };
@@ -941,7 +945,7 @@ export default function CreateClimbForm({
         description: description || '',
         is_draft: isDraft,
         frames,
-        frames_count: auroraClimb.frameCount,
+        frames_count: climbEditor.frameCount,
         frames_pace: 0,
         angle,
       });
@@ -1001,7 +1005,7 @@ export default function CreateClimbForm({
   }, [
     boardDetails,
     generateFramesString,
-    auroraClimb.frameCount,
+    climbEditor.frameCount,
     saveClimb,
     updateClimb,
     climbName,
@@ -1023,10 +1027,11 @@ export default function CreateClimbForm({
   // update the tracked row in place (within the 24h post-publish window for
   // non-drafts). The form never navigates away on save.
   //
-  // Note: MoonBoard hold re-encoding on update isn't supported by updateClimb,
-  // so updates only touch name/description/angle/isDraft. If the user changes
-  // holds after a save we intentionally skip the update and create a new row,
-  // which the duplicate check will catch if the new holds collide.
+  // The frames string is what carries a route/circuit: comma-separated absolute
+  // snapshots, one per frame. A single-frame MoonBoard climb encodes to the same
+  // flat `p<id>r<code>` string the holds array has always produced. `holds` still
+  // rides along as the union of every frame — the server reads it for the hold
+  // rows and the duplicate check.
   const doSaveMoonBoardClimb = useCallback(async () => {
     const userId = session?.user?.id;
     if (!layoutId || !userId || !moonBoardHolds) return;
@@ -1037,6 +1042,12 @@ export default function CreateClimbForm({
     }
 
     setIsSaving(true);
+    const moonBoardFrames = generateFramesString();
+    // A named draft with nothing painted yet is a legitimate save, and it
+    // encodes to ''. The mutations take `frames` as optional-but-non-empty, so
+    // send nothing rather than an empty string and let the server encode
+    // `holds` itself.
+    const framesInput = moonBoardFrames || undefined;
 
     try {
       if (!wsAuthToken) {
@@ -1066,6 +1077,8 @@ export default function CreateClimbForm({
           boardType: 'moonboard',
           name: climbName,
           description: description || '',
+          frames: framesInput,
+          framesCount: climbEditor.frameCount,
           angle: selectedAngle,
           isDraft,
         };
@@ -1090,11 +1103,7 @@ export default function CreateClimbForm({
           });
         }
 
-        // MoonBoard doesn't regenerate a frames string on update (updateClimb
-        // only touches metadata), so reuse whatever the existing queue item
-        // already has via an empty frames string — the queue renderer won't
-        // use it for MoonBoard and the form's own hold map is authoritative.
-        await syncSavedClimbToQueue(updateResult.uuid, '');
+        await syncSavedClimbToQueue(updateResult.uuid, moonBoardFrames);
 
         markJustSaved();
         return;
@@ -1114,6 +1123,7 @@ export default function CreateClimbForm({
           name: climbName,
           description: description || '',
           holds: moonBoardHolds,
+          frames: framesInput,
           angle: selectedAngle,
           isDraft: isDraft,
           userGrade,
@@ -1149,7 +1159,7 @@ export default function CreateClimbForm({
         });
       }
 
-      await syncSavedClimbToQueue(moonBoardResult.saveMoonBoardClimb.uuid, '');
+      await syncSavedClimbToQueue(moonBoardResult.saveMoonBoardClimb.uuid, moonBoardFrames);
 
       markJustSaved();
     } catch (error) {
@@ -1174,6 +1184,8 @@ export default function CreateClimbForm({
     session,
     moonBoardHolds,
     moonBoardDuplicateError,
+    generateFramesString,
+    climbEditor.frameCount,
     climbName,
     description,
     userGrade,
@@ -1201,6 +1213,14 @@ export default function CreateClimbForm({
 
   const handlePublish = useCallback(async () => {
     if (!climbName.trim()) {
+      return;
+    }
+
+    // A blank frame in the middle of a MoonBoard route can't survive the round
+    // trip (see `hasEmptyFrame` in useCreateClimb), so block drafts too — the
+    // frame would be gone the next time the route is opened.
+    if (climbEditor.hasEmptyFrame) {
+      showMessage(t('createClimbForm.validation.emptyFrame'), 'warning');
       return;
     }
 
@@ -1243,6 +1263,7 @@ export default function CreateClimbForm({
   }, [
     boardType,
     isValid,
+    climbEditor.hasEmptyFrame,
     climbName,
     isLoggedIn,
     description,
@@ -1326,9 +1347,9 @@ export default function CreateClimbForm({
   // silently collapsing a route/circuit into a single static snapshot on load.
   const handleLoadDraft = useCallback(
     (climb: Climb) => {
-      if (boardType !== 'aurora' || !boardDetails || !loadAuroraFrames) return;
+      if (boardType !== 'aurora' || !boardDetails) return;
 
-      loadAuroraFrames(buildInitialFrames(climb.frames, boardDetails.board_name));
+      loadFrames(buildInitialFrames(climb.frames, boardDetails.board_name));
       setClimbName(climb.name || '');
       setDescription(climb.description || '');
       setSavedClimb({
@@ -1351,7 +1372,7 @@ export default function CreateClimbForm({
       // The litUpHoldsMap effect at the top of this component pushes new frames
       // to a connected Bluetooth board automatically.
     },
-    [boardType, boardDetails, loadAuroraFrames, clearJustSaved, queueActions],
+    [boardType, boardDetails, loadFrames, clearJustSaved, queueActions],
   );
 
   const handleDraftDeleted = useCallback(
@@ -1372,11 +1393,11 @@ export default function CreateClimbForm({
   // saves update savedClimb in place and must not trigger another reload.
   const seededEditClimbUuidRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!editClimb || boardType !== 'aurora' || !boardDetails || !loadAuroraFrames) return;
+    if (!editClimb || boardType !== 'aurora' || !boardDetails) return;
     if (seededEditClimbUuidRef.current === editClimb.uuid) return;
     seededEditClimbUuidRef.current = editClimb.uuid;
     handleLoadDraft(editClimb);
-  }, [editClimb, boardType, boardDetails, loadAuroraFrames, handleLoadDraft]);
+  }, [editClimb, boardType, boardDetails, handleLoadDraft]);
 
   // Surface a lookup failure from the create page (expired link, wrong
   // board, deleted row) exactly once per error value so the user knows why
@@ -1696,57 +1717,55 @@ export default function CreateClimbForm({
             </IconButton>
           </MuiTooltip>
         )}
-        {boardType === 'aurora' && (
-          <>
-            <MuiTooltip title={t('create.frames.duplicateTooltip')}>
-              <IconButton
-                size="small"
-                onClick={auroraClimb.duplicateFrame}
-                aria-label={t('create.frames.duplicateTooltip')}
-              >
-                <ContentCopyOutlined fontSize="small" />
-              </IconButton>
-            </MuiTooltip>
-            {auroraClimb.frameCount > 1 && (
-              <Stack direction="row" alignItems="center" spacing={0.5}>
-                <IconButton
-                  size="small"
-                  onClick={auroraClimb.prevFrame}
-                  disabled={auroraClimb.currentFrameIndex === 0}
-                  aria-label={tCommon('playback.prevFrame')}
-                >
-                  <SkipPreviousOutlined fontSize="small" />
+        {/* Route / circuit controls — every board with LEDs can play a sequence
+            of frames, MoonBoard included. */}
+        <MuiTooltip title={t('create.frames.duplicateTooltip')}>
+          <IconButton
+            size="small"
+            onClick={climbEditor.duplicateFrame}
+            aria-label={t('create.frames.duplicateTooltip')}
+          >
+            <ContentCopyOutlined fontSize="small" />
+          </IconButton>
+        </MuiTooltip>
+        {climbEditor.frameCount > 1 && (
+          <Stack direction="row" alignItems="center" spacing={0.5}>
+            <IconButton
+              size="small"
+              onClick={climbEditor.prevFrame}
+              disabled={climbEditor.currentFrameIndex === 0}
+              aria-label={tCommon('playback.prevFrame')}
+            >
+              <SkipPreviousOutlined fontSize="small" />
+            </IconButton>
+            <Typography variant="caption" sx={{ whiteSpace: 'nowrap', color: 'text.secondary' }}>
+              {tCommon('playback.frameOfTotal', {
+                index: climbEditor.currentFrameIndex + 1,
+                total: climbEditor.frameCount,
+              })}
+            </Typography>
+            <IconButton
+              size="small"
+              onClick={climbEditor.nextFrame}
+              disabled={climbEditor.currentFrameIndex >= climbEditor.frameCount - 1}
+              aria-label={tCommon('playback.nextFrame')}
+            >
+              <SkipNextOutlined fontSize="small" />
+            </IconButton>
+            <ConfirmPopover
+              title={t('create.frames.deleteTitle')}
+              description={t('create.frames.deleteDescription')}
+              onConfirm={climbEditor.deleteFrame}
+              okText={tCommon('actions.delete')}
+              cancelText={tCommon('actions.cancel')}
+            >
+              <MuiTooltip title={t('create.frames.deleteTooltip')}>
+                <IconButton size="small" aria-label={t('create.frames.deleteTooltip')}>
+                  <RemoveCircleOutline fontSize="small" />
                 </IconButton>
-                <Typography variant="caption" sx={{ whiteSpace: 'nowrap', color: 'text.secondary' }}>
-                  {tCommon('playback.frameOfTotal', {
-                    index: auroraClimb.currentFrameIndex + 1,
-                    total: auroraClimb.frameCount,
-                  })}
-                </Typography>
-                <IconButton
-                  size="small"
-                  onClick={auroraClimb.nextFrame}
-                  disabled={auroraClimb.currentFrameIndex >= auroraClimb.frameCount - 1}
-                  aria-label={tCommon('playback.nextFrame')}
-                >
-                  <SkipNextOutlined fontSize="small" />
-                </IconButton>
-                <ConfirmPopover
-                  title={t('create.frames.deleteTitle')}
-                  description={t('create.frames.deleteDescription')}
-                  onConfirm={auroraClimb.deleteFrame}
-                  okText={tCommon('actions.delete')}
-                  cancelText={tCommon('actions.cancel')}
-                >
-                  <MuiTooltip title={t('create.frames.deleteTooltip')}>
-                    <IconButton size="small" aria-label={t('create.frames.deleteTooltip')}>
-                      <RemoveCircleOutline fontSize="small" />
-                    </IconButton>
-                  </MuiTooltip>
-                </ConfirmPopover>
-              </Stack>
-            )}
-          </>
+              </MuiTooltip>
+            </ConfirmPopover>
+          </Stack>
         )}
         <ConfirmPopover
           title={t('create.clear.title')}

--- a/packages/web/app/lib/create-climb-autosave-db.ts
+++ b/packages/web/app/lib/create-climb-autosave-db.ts
@@ -5,12 +5,12 @@ const AUTOSAVE_KEY = 'create-climb';
 
 export type CreateClimbAutosave = {
   /**
-   * MoonBoard: serialised holds map (JSON stringified LitUpHoldsMap).
-   * Aurora: serialised *active* frame only, kept for backward compatibility —
-   * `framesJson` below is the full route and takes priority when present.
+   * The *active* frame only (JSON stringified LitUpHoldsMap), kept for backward
+   * compatibility — `framesJson` below is the full route and takes priority when
+   * present. Autosaves written before `framesJson` existed only have this.
    */
   holdsJson: string;
-  /** Aurora only: JSON.stringify(LitUpHoldsMap[]) — the full frame sequence. */
+  /** JSON.stringify(LitUpHoldsMap[]) — the full frame sequence, every board. */
   framesJson?: string;
   climbName: string;
   description: string;


### PR DESCRIPTION
## Summary

- Follow-up to #4422 (multi-frame route/circuit creation), which was explicitly scoped to Aurora boards (Kilter/Tension) — MoonBoard was left on a separate single-frame-only editor hook. MoonBoard's LEDs light up the same way Aurora's do, so there was no hardware reason for the gap.
- `board-constants`: new `FRAME_ENCODING` table. Every board delta-encodes frames after 0 (Aurora's existing behavior) except MoonBoard, which now emits each frame as a full absolute snapshot — no bandwidth reason to diff frames on MoonBoard, and the existing generic decoder already reads absolute-per-frame sequences correctly (that's how part of the legacy Aurora catalog is encoded too).
- `use-create-climb.ts` (the shared editor hook used by both web and mobile): `generateFramesString` branches on `FRAME_ENCODING`; `isValid` now requires a start + finish hold for MoonBoard specifically; new `hasEmptyFrame` flags a route with a blank middle frame, which can't survive MoonBoard's marker-free round trip (an intentional blackout frame would otherwise silently vanish on decode).
- Web `create-climb-form.tsx`: MoonBoard now shares the same editor hook as Aurora instead of a separate one, so it gets the duplicate-frame/frame-stepper/delete-frame UI for free. Empty-draft saves still work — an empty frame's `frames` string is omitted from the payload rather than sent as `''`.
- Backend: `saveMoonBoardClimb` now accepts and persists a real multi-frame `frames` string and derives `framesCount` from it instead of hardcoding `1` — MoonBoard routes could not previously be saved at all. Create and update both now derive `board_climb_holds` from the same frames-string walk (`parseFramesToHoldEntries`), so a hold that appears in multiple frames with different states can no longer flip which state gets stored depending on whether the route was just created or has since been edited.
- Mobile already used the generic hook with zero board-type gating, so it picked up multi-frame MoonBoard support with no code changes beyond the shared hook fix. Added toast feedback for the two new save-blocked states (empty frame, missing start/finish) so a tap doesn't silently no-op.
- Physical-board BLE playback needed no changes — the play-view drawer already animates any multi-frame `frames` string frame-by-frame, board-agnostically, branching only on which BLE packet builder to call.

## Release Notes

- Build multi-step routes and circuits on MoonBoard, not just Kilter/Tension — duplicate a frame, edit it, and step through the sequence with the same controls

## Test plan

- `vp run typecheck` — pass
- `vp test run --project web` — 6053/6054 pass (1 pre-existing timezone-dependent flake unrelated to this change, verified failing on a clean `main`)
- `vp test run --project mobile` — 6342/6349 pass (7 pre-existing timezone-dependent flakes, verified failing on a clean `main`)
- `vp test run --project backend` — 3384/3384 pass, including new coverage for the create/update hold-row consistency fix and the multi-frame duplicate-gate behavior
- `vp test run --project board-constants` — 123/123 pass (new absolute-encoding round-trip coverage)
- `vp test run --project create-climb-react` — 66/66 pass (new MoonBoard-specific `isValid`/`hasEmptyFrame`/encoding coverage)
- `vp run check:mobile-bundle` — pass
- `vp check`, `vp run check:i18n`, `vp run check:i18n:orphans` — clean
- Manually verified via dev server + QA notes: paint start/hand/finish holds on a MoonBoard climb, duplicate the frame, edit the duplicate, confirm the frame counter/stepper appear, delete a frame, save, and confirm the saved `frames` string is comma-separated absolute segments with no delta markers