### PR TITLE
feat(web): open the gym directory to everyone

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -4,7 +4,9 @@ Two kinds, and they fail in different ways.
 
 **Client flags** (`FEATURE_FLAG_KEYS` in `packages/web/app/flags.ts`) resolve in the browser via `FeatureFlagsProvider`. They hide a control. If PostHog is slow or unreachable the control stays hidden and nothing else happens.
 
-**Server flags** (`SERVER_FEATURE_FLAG_KEYS`) resolve during SSR via `getServerFeatureFlag` and decide whether a route renders at all. `gyms-directory` is the only one today: with it off, `/gyms` and its three facet routes are a plain `notFound()`. A client-resolved flag could not do this — by the time the browser knows the answer the HTML has already shipped.
+**Server flags** (`SERVER_FEATURE_FLAG_KEYS`) resolve during SSR via `getServerFeatureFlag` and decide whether a route renders at all — with one off, its route is a plain `notFound()`. A client-resolved flag could not do this: by the time the browser knows the answer the HTML has already shipped.
+
+The registry is **empty today**. `gyms-directory` was the only server flag; `/gyms` and its three facet routes now render for everyone and the flag is gone. The machinery below stays for the next route that needs it — and the diagnostics endpoint still answers any key you name.
 
 ## How a server flag resolves
 
@@ -40,7 +42,7 @@ Ask production. Signed in as a global admin, open:
 https://www.boardsesh.com/api/internal/feature-flags
 ```
 
-It is a normal session-cookie-authenticated GET, so the browser you are already signed in with is enough. `?key=<flag>` narrows it to one flag (any key, not only the registered ones — that is how you check whether the dashboard renamed it); with no key it covers every server flag.
+It is a normal session-cookie-authenticated GET, so the browser you are already signed in with is enough. `?key=<flag>` asks about one flag — any key, not only the registered ones, which is how you check whether the dashboard renamed it. With no key it covers every registered server flag, which while `SERVER_FEATURE_FLAG_KEYS` is empty means `?key=` is the only useful form.
 
 Per flag it reports a 2x2 — cached vs live, signed-out visitor vs you:
 
@@ -49,7 +51,7 @@ Per flag it reports a 2x2 — cached vs live, signed-out visitor vs you:
 - `live.public` — an uncached probe as a signed-out visitor (what a crawler gets)
 - `live.viewer` — an uncached probe as you
 
-Both halves matter because the cache is keyed per flag **and** per person, so your answer says nothing about theirs. The two `live` probes are uncached, so one request costs 2 PostHog calls per flag (each capped at 1.5s) — negligible for today's single server flag, worth a thought before `SERVER_FEATURE_FLAG_KEYS` grows long enough that an admin page load fans out dozens.
+Both halves matter because the cache is keyed per flag **and** per person, so your answer says nothing about theirs. The two `live` probes are uncached, so one request costs 2 PostHog calls per flag (each capped at 1.5s) — negligible at today's handful of keys, worth a thought before `SERVER_FEATURE_FLAG_KEYS` grows long enough that an admin page load fans out dozens.
 
 Read it like this:
 
@@ -61,7 +63,7 @@ Read it like this:
 
 ## The override lever
 
-`FEATURE_FLAG_OVERRIDES` is a comma-separated list, `gyms-directory` (forces ON) or `gyms-directory=false` (forces OFF).
+`FEATURE_FLAG_OVERRIDES` is a comma-separated list, `some-flag` (forces ON) or `some-flag=false` (forces OFF).
 
 Locally it is the only way in: the browser PostHog client refuses to initialise off a production hostname, so on localhost there is no person and nothing to evaluate against.
 
@@ -73,3 +75,19 @@ In production it is the kill switch and the "I need this reachable now" lever �
 2. Gate the route with `getServerFeatureFlag(KEY, { distinctId, allowAnonymous })`.
 3. Pass `allowAnonymous: true` for anything that must eventually be public. Without it a null distinct id short-circuits to off, so the surface stays signed-in-only however the dashboard is configured, and flipping the rollout to 100% changes nothing for visitors or crawlers.
 4. Ship `noindex` while the flag is on: a surface that 404s for half its visitors must not be in the index.
+
+## Retiring a server flag
+
+When the surface launches for everyone, delete the gate rather than pinning the
+dashboard to 100%: a flag left at 100% is still a PostHog round trip in front of
+every render, and still fails closed when PostHog does.
+
+1. Drop the `getServerFeatureFlag` call and the `notFound()` it guarded, plus the
+   `getPosthogDistinctId` read feeding it.
+2. Remove the key from `packages/web/app/flags.ts` and `SERVER_FEATURE_FLAG_KEYS`.
+3. Rewrite the gate's tests as "this route renders" rather than deleting them —
+   an unconditional surface still has to be reachable on every facet it claims.
+4. Archive the flag in the PostHog dashboard; nothing reads it any more.
+5. Revisit the `noindex` from step 4 above, but only on its own merits. The
+   directory kept its `noindex` past its launch because the reason for it was the
+   duplicate-gym queue, not the flag.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -82,8 +82,10 @@ When the surface launches for everyone, delete the gate rather than pinning the
 dashboard to 100%: a flag left at 100% is still a PostHog round trip in front of
 every render, and still fails closed when PostHog does.
 
-1. Drop the `getServerFeatureFlag` call and the `notFound()` it guarded, plus the
-   `getPosthogDistinctId` read feeding it.
+1. Drop the `getServerFeatureFlag` call and the `notFound()` it guarded. Check
+   what else used the `getPosthogDistinctId` read feeding it before deleting
+   that too — on the directory it also settled the claim call-out's viewer
+   state, so it stayed and only moved into the page's existing `Promise.all`.
 2. Remove the key from `packages/web/app/flags.ts` and `SERVER_FEATURE_FLAG_KEYS`.
 3. Rewrite the gate's tests as "this route renders" rather than deleting them —
    an unconditional surface still has to be reachable on every facet it claims.

--- a/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
@@ -53,15 +53,18 @@ describe('GET /api/internal/feature-flags', () => {
   });
 
   it('reports cached and live answers for both the visitor and the admin', async () => {
-    const response = await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=gyms-directory'));
+    const response = await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=some-server-flag'));
     expect(response.status).toBe(200);
     expect(response.headers.get('Cache-Control')).toBe('no-store');
 
     const body = await response.json();
     expect(body.flags).toHaveLength(1);
     expect(body.flags[0]).toEqual({
-      key: 'gyms-directory',
-      registered: true,
+      key: 'some-server-flag',
+      // `registered` is false because the registry is empty today, not because
+      // an ad-hoc key is second class — an ad-hoc `?key=` is answered with the
+      // same 2x2 either way.
+      registered: false,
       cached: {
         public: { enabled: false, reason: 'override', detail: null },
         viewer: { enabled: false, reason: 'override', detail: null },
@@ -74,22 +77,22 @@ describe('GET /api/internal/feature-flags', () => {
   });
 
   it('reads the ANONYMOUS cache entry, which is the one that 404s a visitor', async () => {
-    await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=gyms-directory'));
+    await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=some-server-flag'));
 
     // The data cache is keyed per flag AND per person, so the admin's entry says
     // nothing about the entry a signed-out visitor's request used. Reading only
     // the admin's would make "cached off, live on" mean either staleness or the
     // admin being in a person-targeted rollout — the exact ambiguity this
     // endpoint exists to remove.
-    expect(getServerFeatureFlagResolution).toHaveBeenCalledWith('gyms-directory', {
+    expect(getServerFeatureFlagResolution).toHaveBeenCalledWith('some-server-flag', {
       distinctId: null,
       allowAnonymous: true,
     });
-    expect(getServerFeatureFlagResolution).toHaveBeenCalledWith('gyms-directory', {
+    expect(getServerFeatureFlagResolution).toHaveBeenCalledWith('some-server-flag', {
       distinctId: 'admin-1',
       allowAnonymous: true,
     });
-    expect(probeServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', {
+    expect(probeServerFeatureFlag).toHaveBeenCalledWith('some-server-flag', {
       distinctId: null,
       allowAnonymous: true,
     });
@@ -106,15 +109,18 @@ describe('GET /api/internal/feature-flags', () => {
     expect(body.flags[0].live.public).toMatchObject({ reason: 'posthog-enabled' });
   });
 
-  it('covers every server flag when no key is given', async () => {
+  it('covers every registered server flag when no key is given', async () => {
     const response = await GET(request());
     const body = await response.json();
 
     // Derived from the registry rather than hardcoded: the behaviour under test
-    // is "covers every registered server flag", which a second flag must extend
-    // rather than break.
+    // is "covers every registered server flag", which the next server flag must
+    // extend rather than break. The registry is empty today — `/gyms` was the
+    // last server-gated route and it now ships unconditionally — so this asks
+    // for nothing and, importantly, spends no PostHog calls doing it.
     expect(body.flags.map((flag: { key: string }) => flag.key)).toEqual([...SERVER_FEATURE_FLAG_KEYS]);
     expect(body.flags.every((flag: { registered: boolean }) => flag.registered)).toBe(true);
+    expect(probeServerFeatureFlag).toHaveBeenCalledTimes(SERVER_FEATURE_FLAG_KEYS.length);
     expect(body.config).toMatchObject({
       apiKeySource: 'NEXT_PUBLIC_POSTHOG_KEY',
       anonymousDistinctId: 'anonymous-web-visitor',
@@ -125,7 +131,7 @@ describe('GET /api/internal/feature-flags', () => {
     describeServerFeatureFlagConfig.mockReturnValue({
       apiKeySource: 'POSTHOG_PROJECT_KEY',
       host: 'https://us.i.posthog.com',
-      overrides: { 'gyms-directory': true },
+      overrides: { 'some-server-flag': true },
     });
 
     const body = await (await GET(request())).text();
@@ -137,16 +143,20 @@ describe('GET /api/internal/feature-flags', () => {
     // but a null distinct id must never be probed as if it were a person.
     getPosthogDistinctId.mockResolvedValue(null);
 
-    const body = await (await GET(request())).json();
+    const body = await (
+      await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=some-server-flag'))
+    ).json();
     expect(body.flags[0].cached.viewer).toBeNull();
     expect(body.flags[0].live.viewer).toBeNull();
     expect(body.viewerDistinctId).toBeNull();
-    expect(probeServerFeatureFlag).toHaveBeenCalledTimes(SERVER_FEATURE_FLAG_KEYS.length);
-    expect(getServerFeatureFlagResolution).toHaveBeenCalledTimes(SERVER_FEATURE_FLAG_KEYS.length);
+    // One probe and one cached read for the public column, and nothing for the
+    // viewer one.
+    expect(probeServerFeatureFlag).toHaveBeenCalledTimes(1);
+    expect(getServerFeatureFlagResolution).toHaveBeenCalledTimes(1);
   });
 
   it('accepts a dot-separated key, which PostHog allows', async () => {
-    const response = await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=gyms.directory.v2'));
+    const response = await GET(request('https://www.boardsesh.com/api/internal/feature-flags?key=some.server.flag.v2'));
     expect(response.status).toBe(200);
   });
 

--- a/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/feature-flags/__tests__/route.test.ts
@@ -9,6 +9,13 @@ vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinc
 const getServerFeatureFlagResolution = vi.hoisted(() => vi.fn());
 const probeServerFeatureFlag = vi.hoisted(() => vi.fn());
 const describeServerFeatureFlagConfig = vi.hoisted(() => vi.fn());
+
+// A stand-in registry rather than the real one, which is empty today: with an
+// empty array every assertion about the no-key path passes vacuously, including
+// one against a route that had stopped reading the registry at all.
+const REGISTERED_KEYS = vi.hoisted(() => ['registry-flag-a', 'registry-flag-b']);
+vi.mock('@/app/flags', () => ({ SERVER_FEATURE_FLAG_KEYS: REGISTERED_KEYS }));
+
 vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({
   ANONYMOUS_DISTINCT_ID: 'anonymous-web-visitor',
   describeServerFeatureFlagConfig,
@@ -16,7 +23,6 @@ vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({
   probeServerFeatureFlag,
 }));
 
-import { SERVER_FEATURE_FLAG_KEYS } from '@/app/flags';
 import { GET } from '../route';
 
 const ADMIN = { authenticated: true as const, userId: 'admin-1', isAdmin: true, boardScopedOnly: false };
@@ -61,9 +67,8 @@ describe('GET /api/internal/feature-flags', () => {
     expect(body.flags).toHaveLength(1);
     expect(body.flags[0]).toEqual({
       key: 'some-server-flag',
-      // `registered` is false because the registry is empty today, not because
-      // an ad-hoc key is second class — an ad-hoc `?key=` is answered with the
-      // same 2x2 either way.
+      // Not in the registry, which is not a lesser answer — an ad-hoc `?key=`
+      // gets the same 2x2 as a registered one.
       registered: false,
       cached: {
         public: { enabled: false, reason: 'override', detail: null },
@@ -115,12 +120,12 @@ describe('GET /api/internal/feature-flags', () => {
 
     // Derived from the registry rather than hardcoded: the behaviour under test
     // is "covers every registered server flag", which the next server flag must
-    // extend rather than break. The registry is empty today — `/gyms` was the
-    // last server-gated route and it now ships unconditionally — so this asks
-    // for nothing and, importantly, spends no PostHog calls doing it.
-    expect(body.flags.map((flag: { key: string }) => flag.key)).toEqual([...SERVER_FEATURE_FLAG_KEYS]);
+    // extend rather than break.
+    expect(body.flags.map((flag: { key: string }) => flag.key)).toEqual(REGISTERED_KEYS);
     expect(body.flags.every((flag: { registered: boolean }) => flag.registered)).toBe(true);
-    expect(probeServerFeatureFlag).toHaveBeenCalledTimes(SERVER_FEATURE_FLAG_KEYS.length);
+    // Two audiences per key, so the fan-out grows with the registry — the cost
+    // the docs warn about before it is long.
+    expect(probeServerFeatureFlag).toHaveBeenCalledTimes(REGISTERED_KEYS.length * 2);
     expect(body.config).toMatchObject({
       apiKeySource: 'NEXT_PUBLIC_POSTHOG_KEY',
       anonymousDistinctId: 'anonymous-web-visitor',

--- a/packages/web/app/api/internal/feature-flags/route.ts
+++ b/packages/web/app/api/internal/feature-flags/route.ts
@@ -13,7 +13,9 @@ import {
 
 /**
  * Admin-only diagnostics for the SERVER-side feature flags — the ones that gate
- * whether a route renders at all (`gyms-directory` today).
+ * whether a route renders at all. `SERVER_FEATURE_FLAG_KEYS` is empty since
+ * `/gyms` launched unconditionally, so today every question comes in through
+ * `?key=`; a registered flag is covered automatically once one exists again.
  *
  * It exists because "the dashboard says 100% and the page still 404s" has half a
  * dozen causes that look identical from outside: no project key in the runtime
@@ -47,7 +49,8 @@ export const dynamic = 'force-dynamic';
  * Guards the free-text `?key=`, which is forwarded to PostHog verbatim.
  *
  * Deliberately a shape check rather than a `SERVER_FEATURE_FLAG_KEYS`
- * membership check: an unregistered key is a legitimate question here, because
+ * membership check: an unregistered key is a legitimate question here — the
+ * only kind there is while the registry is empty — because
  * `flag-missing` is precisely the answer to "did the dashboard rename it?" or
  * "does this project know that key at all?", and a membership check could only
  * ever answer keys we already know are fine.

--- a/packages/web/app/components/providers/analytics-identity.tsx
+++ b/packages/web/app/components/providers/analytics-identity.tsx
@@ -20,9 +20,9 @@ let hasReportedIdentityFailure = false;
  * `identify()` at all: `PartyProfileProvider` owned the identity effect and was
  * deleted with the climbing UI, so no PostHog person existed for
  * `session.user.id`. That is invisible until something reads a person — a
- * server-side flag keyed on a person property (the `/gyms` directory gate),
- * person-level segmentation, an anonymous → authenticated funnel — at which
- * point it silently resolves to nothing while every dashboard looks healthy.
+ * server-side flag keyed on a person property, person-level segmentation, an
+ * anonymous → authenticated funnel — at which point it silently resolves to
+ * nothing while every dashboard looks healthy.
  *
  * Mounted directly under `SessionProviderWrapper` in `app/layout.tsx`: it needs
  * `useSession()` and nothing else, it must run on every route (a person can be

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -28,21 +28,16 @@ export const GYM_KIOSK_FLAG = 'gym-kiosk';
 // here — matching the documented "flags gate the UI entry point only" pattern.
 export const MOONBOARD_WIDE_ANGLES_FLAG = 'moonboard-wide-angles';
 
-// Gates reachability of the public `/gyms` directory and its three board-type
-// facet routes. Unlike every other key here it is resolved on the SERVER
-// (`getServerFeatureFlag`) and decides whether the route renders at all rather
-// than whether a control is visible: the directory only goes public once the
-// duplicate-gym cleanup gate clears (#4382), and a client-resolved flag lands
-// after the HTML has already shipped, so it would gate nothing.
-export const GYMS_DIRECTORY_FLAG = 'gyms-directory';
-
 // Keys read from PostHog by FeatureFlagsProvider. Each must have a matching
 // PostHog feature flag; values stay `undefined` (OFF) until that flag resolves.
 export const FEATURE_FLAG_KEYS = [BOARDSESH_GRADE_FLAG, GYM_KIOSK_FLAG, MOONBOARD_WIDE_ANGLES_FLAG] as const;
 
-// Keys resolved server-side. Deliberately not in FEATURE_FLAG_KEYS: the browser
-// provider would fetch a flag no client component reads.
-export const SERVER_FEATURE_FLAG_KEYS = [GYMS_DIRECTORY_FLAG] as const;
+// Keys resolved server-side by `getServerFeatureFlag`, which gate whether a
+// route renders at all. Empty since `/gyms` launched unconditionally; the
+// machinery stays because that is a different gate from the client keys above
+// (see docs/feature-flags.md). Deliberately kept out of FEATURE_FLAG_KEYS: the
+// browser provider would fetch a flag no client component reads.
+export const SERVER_FEATURE_FLAG_KEYS: readonly string[] = [];
 
 // Vercel's flags discovery endpoint expects an allFlags export.
 export const allFlags: Array<{ key: string }> = [...FEATURE_FLAG_KEYS, ...SERVER_FEATURE_FLAG_KEYS].map((key) => ({

--- a/packages/web/app/flags.ts
+++ b/packages/web/app/flags.ts
@@ -37,7 +37,7 @@ export const FEATURE_FLAG_KEYS = [BOARDSESH_GRADE_FLAG, GYM_KIOSK_FLAG, MOONBOAR
 // machinery stays because that is a different gate from the client keys above
 // (see docs/feature-flags.md). Deliberately kept out of FEATURE_FLAG_KEYS: the
 // browser provider would fetch a flag no client component reads.
-export const SERVER_FEATURE_FLAG_KEYS: readonly string[] = [];
+export const SERVER_FEATURE_FLAG_KEYS = [] as const;
 
 // Vercel's flags discovery endpoint expects an allFlags export.
 export const allFlags: Array<{ key: string }> = [...FEATURE_FLAG_KEYS, ...SERVER_FEATURE_FLAG_KEYS].map((key) => ({

--- a/packages/web/app/gyms/__tests__/directory-metadata.test.ts
+++ b/packages/web/app/gyms/__tests__/directory-metadata.test.ts
@@ -10,11 +10,6 @@ vi.mock('@/app/lib/graphql/server-cached-client', () => ({
   createCachedGraphQLQuery: () => vi.fn(),
 }));
 
-// The route modules pull in the page renderer, which reaches next-auth (and
-// through it the db client) for the flag's distinct id. Metadata never needs a
-// session, so stub the module rather than standing up a database for it.
-vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinctId: vi.fn() }));
-vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({ getServerFeatureFlag: vi.fn() }));
 vi.mock('@/app/lib/gym-funnel-analytics', () => ({
   trackGymFunnelEvent: vi.fn(),
   viewerStateFrom: (isAuthenticated: boolean) => (isAuthenticated ? 'signed-in' : 'signed-out'),

--- a/packages/web/app/gyms/__tests__/directory-metadata.test.ts
+++ b/packages/web/app/gyms/__tests__/directory-metadata.test.ts
@@ -10,6 +10,10 @@ vi.mock('@/app/lib/graphql/server-cached-client', () => ({
   createCachedGraphQLQuery: () => vi.fn(),
 }));
 
+// The route modules pull in the page renderer, which reaches next-auth (and
+// through it the db client) for the claim call-out's viewer state. Metadata
+// never needs a session, so stub the module rather than standing up a database.
+vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinctId: vi.fn() }));
 vi.mock('@/app/lib/gym-funnel-analytics', () => ({
   trackGymFunnelEvent: vi.fn(),
   viewerStateFrom: (isAuthenticated: boolean) => (isAuthenticated ? 'signed-in' : 'signed-out'),

--- a/packages/web/app/gyms/__tests__/directory-page.test.tsx
+++ b/packages/web/app/gyms/__tests__/directory-page.test.tsx
@@ -10,12 +10,6 @@ const notFound = vi.hoisted(() =>
 );
 vi.mock('next/navigation', () => ({ notFound }));
 
-const getServerFeatureFlag = vi.hoisted(() => vi.fn());
-vi.mock('@/app/lib/feature-flags/server-feature-flag', () => ({ getServerFeatureFlag }));
-
-const getPosthogDistinctId = vi.hoisted(() => vi.fn());
-vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinctId }));
-
 const fetchDirectoryPage = vi.hoisted(() => vi.fn());
 const fetchFacetCounts = vi.hoisted(() => vi.fn());
 vi.mock('../directory-data', () => ({ fetchDirectoryPage, fetchFacetCounts }));
@@ -34,8 +28,6 @@ const props = { searchParams: Promise.resolve({}) };
 
 beforeEach(() => {
   notFound.mockClear();
-  getServerFeatureFlag.mockReset();
-  getPosthogDistinctId.mockReset().mockResolvedValue('user-uuid-1');
   fetchDirectoryPage.mockReset().mockResolvedValue({ ok: true, gyms: [], totalCount: 0 });
   fetchFacetCounts
     .mockReset()
@@ -47,61 +39,8 @@ beforeEach(() => {
   });
 });
 
-describe('feature-flag gate', () => {
-  it('404s the route when the flag is off, rather than only noindexing it', async () => {
-    getServerFeatureFlag.mockResolvedValue(false);
-
-    await expect(renderGymDirectory('all', props)).rejects.toThrow('NEXT_NOT_FOUND');
-    expect(notFound).toHaveBeenCalledTimes(1);
-    // The gate fires before any data is fetched.
-    expect(fetchDirectoryPage).not.toHaveBeenCalled();
-  });
-
-  it('gates every facet route, not just /gyms', async () => {
-    getServerFeatureFlag.mockResolvedValue(false);
-
-    for (const facet of ['kilter', 'moonboard', 'tension'] as const) {
-      await expect(renderGymDirectory(facet, { searchParams: Promise.resolve({}) })).rejects.toThrow('NEXT_NOT_FOUND');
-    }
-    expect(notFound).toHaveBeenCalledTimes(3);
-  });
-
-  it('asks PostHog about the authenticated person, not an anonymous id', async () => {
-    getServerFeatureFlag.mockResolvedValue(true);
-
-    await renderGymDirectory('kilter', props);
-
-    // Person-property targeting only resolves when the evaluation names a
-    // person PostHog holds those properties for. Anything else returns false
-    // for a perfectly configured flag with nothing erroring anywhere.
-    expect(getServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', {
-      distinctId: 'user-uuid-1',
-      allowAnonymous: true,
-    });
-  });
-
-  it('asks for a signed-out visitor too, instead of short-circuiting them to a 404', async () => {
-    getPosthogDistinctId.mockResolvedValue(null);
-    getServerFeatureFlag.mockResolvedValue(true);
-
-    await renderGymDirectory('all', props);
-
-    // `allowAnonymous` is what makes #4382's flag flip able to launch this
-    // page. Without it the directory is signed-in-only however the PostHog
-    // rollout is configured, and every crawler gets a 404.
-    expect(getServerFeatureFlag).toHaveBeenCalledWith('gyms-directory', { distinctId: null, allowAnonymous: true });
-  });
-
-  it('still 404s a signed-out visitor when the flag says no', async () => {
-    getPosthogDistinctId.mockResolvedValue(null);
-    getServerFeatureFlag.mockResolvedValue(false);
-
-    await expect(renderGymDirectory('all', props)).rejects.toThrow('NEXT_NOT_FOUND');
-  });
-
-  it('renders once the flag is on', async () => {
-    getServerFeatureFlag.mockResolvedValue(true);
-
+describe('reachability', () => {
+  it('renders /gyms for anyone who asks, with no flag in the way', async () => {
     const element = await renderGymDirectory('all', props);
 
     expect(element).toBeTruthy();
@@ -110,8 +49,14 @@ describe('feature-flag gate', () => {
     expect(fetchFacetCounts).toHaveBeenCalledTimes(1);
   });
 
+  it('renders every facet route, not just /gyms', async () => {
+    for (const facet of ['kilter', 'moonboard', 'tension'] as const) {
+      await expect(renderGymDirectory(facet, { searchParams: Promise.resolve({}) })).resolves.toBeTruthy();
+    }
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
   it('asks for one page of results per request, never a drain loop', async () => {
-    getServerFeatureFlag.mockResolvedValue(true);
     fetchDirectoryPage.mockResolvedValue({ ok: true, gyms: [], totalCount: 500 });
 
     await renderGymDirectory('all', { searchParams: Promise.resolve({ page: '3' }) });
@@ -122,10 +67,6 @@ describe('feature-flag gate', () => {
 });
 
 describe('out-of-range pages', () => {
-  beforeEach(() => {
-    getServerFeatureFlag.mockResolvedValue(true);
-  });
-
   it('404s a page past the real last page instead of serving an empty 200', async () => {
     // 30 gyms is two pages of 24. Page 3 is not a page.
     fetchDirectoryPage.mockResolvedValue({ ok: true, gyms: [], totalCount: 30 });
@@ -167,10 +108,6 @@ describe('out-of-range pages', () => {
 });
 
 describe('backend failure', () => {
-  beforeEach(() => {
-    getServerFeatureFlag.mockResolvedValue(true);
-  });
-
   it('renders the error state rather than a confident "0 gyms" when the list fails', async () => {
     fetchDirectoryPage.mockResolvedValue({ ok: false });
 

--- a/packages/web/app/gyms/__tests__/directory-page.test.tsx
+++ b/packages/web/app/gyms/__tests__/directory-page.test.tsx
@@ -10,6 +10,9 @@ const notFound = vi.hoisted(() =>
 );
 vi.mock('next/navigation', () => ({ notFound }));
 
+const getPosthogDistinctId = vi.hoisted(() => vi.fn());
+vi.mock('@/app/lib/feature-flags/server-distinct-id', () => ({ getPosthogDistinctId }));
+
 const fetchDirectoryPage = vi.hoisted(() => vi.fn());
 const fetchFacetCounts = vi.hoisted(() => vi.fn());
 vi.mock('../directory-data', () => ({ fetchDirectoryPage, fetchFacetCounts }));
@@ -28,6 +31,7 @@ const props = { searchParams: Promise.resolve({}) };
 
 beforeEach(() => {
   notFound.mockClear();
+  getPosthogDistinctId.mockReset().mockResolvedValue('user-uuid-1');
   fetchDirectoryPage.mockReset().mockResolvedValue({ ok: true, gyms: [], totalCount: 0 });
   fetchFacetCounts
     .mockReset()
@@ -54,6 +58,17 @@ describe('reachability', () => {
       await expect(renderGymDirectory(facet, { searchParams: Promise.resolve({}) })).resolves.toBeTruthy();
     }
     expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('reads the session for the claim call-out, not for a gate', async () => {
+    // The only thing left that needs a person: `viewerState` on the claim CTA.
+    // A signed-out visitor gets the page either way — that is the whole point of
+    // dropping the flag — so the read must never decide reachability.
+    getPosthogDistinctId.mockResolvedValue(null);
+
+    await expect(renderGymDirectory('all', props)).resolves.toBeTruthy();
+    expect(notFound).not.toHaveBeenCalled();
+    expect(getPosthogDistinctId).toHaveBeenCalledTimes(1);
   });
 
   it('asks for one page of results per request, never a drain loop', async () => {

--- a/packages/web/app/gyms/directory-page.tsx
+++ b/packages/web/app/gyms/directory-page.tsx
@@ -8,9 +8,6 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import MuiLink from '@mui/material/Link';
 import type { GymClaimViewerState } from '@boardsesh/analytics';
-import { GYMS_DIRECTORY_FLAG } from '@/app/flags';
-import { getServerFeatureFlag } from '@/app/lib/feature-flags/server-feature-flag';
-import { getPosthogDistinctId } from '@/app/lib/feature-flags/server-distinct-id';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import I18nProvider from '@/app/components/providers/i18n-provider';
@@ -61,8 +58,11 @@ export type DirectoryRouteProps = {
  * this issue exists to build. `/gyms?boardType=grasshopper` canonicalises to
  * `/gyms` for the mirror-image reason: the long tail gets no page of its own.
  *
- * Every route is `noindex, follow` while the directory is flag-gated. Launch
- * (#4382) removes the noindex; nothing else here has to change.
+ * Every route is `noindex, follow`. The routes themselves are public and
+ * unconditional, but the listings stay out of the index until the duplicate-gym
+ * queue is drained and the gyms sitemap shard can enumerate them (#4372,
+ * #4381) — indexed duplicates outlive their merges in Google's cache. Removing
+ * the noindex is a one-line change here once that lands.
  */
 export async function generateGymDirectoryMetadata(facet: DirectoryFacet): Promise<Metadata> {
   const { t, locale } = await getServerTranslation('gyms');
@@ -80,20 +80,6 @@ export async function generateGymDirectoryMetadata(facet: DirectoryFacet): Promi
  * `/gyms/tension`. Each route file is a four-line delegate to this.
  */
 export async function renderGymDirectory(facet: DirectoryFacet, props: DirectoryRouteProps) {
-  // Reachability gate, not a display gate: with the flag off the route is a
-  // plain 404. Shipping only the `noindex` would leave a publicly reachable
-  // directory of gyms the dedup pass hasn't finished merging yet.
-  const distinctId = await getPosthogDistinctId();
-  // `allowAnonymous` is what makes this launchable. Without it a null distinct
-  // id short-circuits to false, so the directory would be signed-in-only
-  // forever and #4382's "flip the flag" would change nothing for the public or
-  // for a crawler. The flag's condition has to move from person-targeting to a
-  // percentage rollout at flip time; a rollout needs *a* distinct id, not a
-  // *known* one.
-  if (!(await getServerFeatureFlag(GYMS_DIRECTORY_FLAG, { distinctId, allowAnonymous: true }))) {
-    notFound();
-  }
-
   const searchParams = await props.searchParams;
   const query = parseDirectoryQuery(facet, searchParams);
 

--- a/packages/web/app/gyms/directory-page.tsx
+++ b/packages/web/app/gyms/directory-page.tsx
@@ -8,6 +8,7 @@ import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import MuiLink from '@mui/material/Link';
 import type { GymClaimViewerState } from '@boardsesh/analytics';
+import { getPosthogDistinctId } from '@/app/lib/feature-flags/server-distinct-id';
 import { getServerTranslation } from '@/app/lib/i18n/server';
 import { createNoIndexMetadata } from '@/app/lib/seo/metadata';
 import I18nProvider from '@/app/components/providers/i18n-provider';
@@ -90,7 +91,14 @@ export async function renderGymDirectory(facet: DirectoryFacet, props: Directory
   }
 
   const { t, locale } = await getServerTranslation('gyms');
-  const [pageResult, facetCountsResult] = await Promise.all([fetchDirectoryPage(query), fetchFacetCounts()]);
+  // The distinct id rides along with the two fetches rather than gating them:
+  // it is only needed for the claim call-out's `viewerState`, and a session read
+  // in series would add a round trip in front of every render.
+  const [pageResult, facetCountsResult, distinctId] = await Promise.all([
+    fetchDirectoryPage(query),
+    fetchFacetCounts(),
+    getPosthogDistinctId(),
+  ]);
 
   // Either fetch failing means we cannot state the counts the body copy is
   // built around. Render the outage instead of a confident "0 gyms".
@@ -132,6 +140,8 @@ export async function renderGymDirectory(facet: DirectoryFacet, props: Directory
   // hydration still reports the truth. Derived inline rather than through
   // `viewerStateFrom` so this server module doesn't pull the browser analytics
   // client into its import graph — same call the gym page makes off its cookie.
+  // `getPosthogDistinctId` is the session read: it returns `users.id` or null,
+  // which is both "is anyone signed in" and the person the funnel events land on.
   const viewerState: GymClaimViewerState = distinctId !== null ? 'signed-in' : 'signed-out';
   // The map's pill numbers, computed from the page the server actually
   // rendered — not from the catalog total, which would claim coverage for gyms

--- a/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
+++ b/packages/web/app/lib/feature-flags/__tests__/server-feature-flag.test.ts
@@ -18,7 +18,7 @@ vi.mock('next/cache', () => ({
 const captureMessage = vi.hoisted(() => vi.fn());
 vi.mock('@sentry/nextjs', () => ({ captureMessage }));
 
-const FLAG = 'gyms-directory';
+const FLAG = 'some-server-flag';
 
 type FeatureFlagModule = typeof import('../server-feature-flag');
 
@@ -58,21 +58,21 @@ afterEach(() => {
 describe('parseFeatureFlagOverrides', () => {
   it('reads the bare-key form as ON', async () => {
     const { parseFeatureFlagOverrides } = await loadModule();
-    expect(parseFeatureFlagOverrides('gyms-directory')).toEqual({ 'gyms-directory': true });
+    expect(parseFeatureFlagOverrides('some-server-flag')).toEqual({ 'some-server-flag': true });
   });
 
   it('reads the key=value form in both directions', async () => {
     const { parseFeatureFlagOverrides } = await loadModule();
-    expect(parseFeatureFlagOverrides('gyms-directory=true,gym-kiosk=false')).toEqual({
-      'gyms-directory': true,
+    expect(parseFeatureFlagOverrides('some-server-flag=true,gym-kiosk=false')).toEqual({
+      'some-server-flag': true,
       'gym-kiosk': false,
     });
   });
 
   it('ignores blank entries and unparseable values instead of throwing', async () => {
     const { parseFeatureFlagOverrides } = await loadModule();
-    expect(parseFeatureFlagOverrides(' , gyms-directory = ON ,broken=maybe,=true')).toEqual({
-      'gyms-directory': true,
+    expect(parseFeatureFlagOverrides(' , some-server-flag = ON ,broken=maybe,=true')).toEqual({
+      'some-server-flag': true,
     });
   });
 

--- a/packages/web/app/lib/feature-flags/server-feature-flag.ts
+++ b/packages/web/app/lib/feature-flags/server-feature-flag.ts
@@ -10,8 +10,9 @@ import * as Sentry from '@sentry/nextjs';
  * the browser knows the answer the server has already rendered and sent the
  * page. A surface that must 404 when its flag is off has to ask PostHog before
  * it renders, which is what this module does. It is deliberately generic — the
- * gym directory is the first caller, every later flag-gated SSR surface reuses
- * it.
+ * gym directory was the first caller and has since launched unconditionally,
+ * so nothing gates a route on it today; every later flag-gated SSR surface
+ * reuses it rather than reinventing the fail-closed path.
  *
  * Resolution order, and the reasoning behind each step:
  *
@@ -69,8 +70,8 @@ const FALSY_OVERRIDE_VALUES = new Set(['0', 'false', 'off', 'no']);
  * Parse `FEATURE_FLAG_OVERRIDES` into a key -> boolean map.
  *
  * Two forms, comma separated:
- *   `gyms-directory`        — bare key, forces ON
- *   `gyms-directory=false`  — explicit value, forces ON or OFF
+ *   `some-flag`        — bare key, forces ON
+ *   `some-flag=false`  — explicit value, forces ON or OFF
  *
  * An explicit OFF matters as much as an ON: it is how you check the 404 branch
  * without editing the PostHog dashboard. Entries that parse to neither are


### PR DESCRIPTION
## Summary

`/gyms` and its three board-type facet routes rendered only when `getServerFeatureFlag('gyms-directory')` said yes. They now render for everyone, and the flag is deleted rather than pinned to 100% in the dashboard — a flag left on is still a PostHog round trip in front of every render, and still fails closed when PostHog does.

- **`packages/web/app/gyms/directory-page.tsx`** — the gate is gone from `renderGymDirectory`. The `getPosthogDistinctId()` session read stays for the one thing that still needs a person, the claim call-out's `viewerState`, and moved into the page's existing `Promise.all` so it rides along with the two fetches instead of adding a round trip in front of the render.
- **`packages/web/app/flags.ts`** — `GYMS_DIRECTORY_FLAG` deleted; `SERVER_FEATURE_FLAG_KEYS` is now an empty registry. The server-flag machinery stays for the next route that needs it, and `/api/internal/feature-flags` still answers any ad-hoc `?key=`.
- **Tests** — the flag-gate suite is now a reachability suite (every facet renders; a signed-out visitor gets the page, so the session read can never creep back into deciding reachability), renamed to `directory-page.test.tsx`. The diagnostics-route test mocks a two-key stand-in registry, because against the real empty one every no-key assertion passed vacuously — including for a route that had stopped reading the registry at all.
- **Docs** — `docs/feature-flags.md` records the empty registry and gains a "Retiring a server flag" section.

Two things deliberately left alone, because neither is the flag:

1. **The `noindex` stays.** Its reason is the duplicate-gym queue and the empty gyms sitemap shard (`buildGymEntries()` returns `[]` — there is no public-gyms enumeration query yet, #4372 / #4381), not the flag. The comment on `generateGymDirectoryMetadata` now says that instead of "launch removes the noindex".
2. **Nothing on the site links to `/gyms`.** No header, footer, or homepage entry point exists, so the directory is reachable by URL only. Adding one needs copy in all four locales and is a separate call.

Follow-up for whoever merges this: archive the `gyms-directory` flag in the PostHog dashboard — nothing reads it any more.

## Release Notes

- The gym directory is open to everyone now — browse every gym with a board at /gyms, or filter to just Kilter, Tension or MoonBoard.

## Test plan

- `vp run typecheck:web` — clean.
- `vp test run --project web` — 3924 tests across 356 files, 0 failures.
- `vp check` — formatting clean across 4827 files. Lint reports two `TS2307: Cannot find module '@gorhom/bottom-sheet'` errors in `packages/mobile/src/web-shims/bottom-sheet.tsx`; they are the nested `packages/mobile/web-runtime` install missing in this environment, not this diff (no mobile file is touched), and CI's `lint` and `check` jobs are green.
- CI on the current head: typecheck, lint, both `test-default` shards, i18n, codegen-drift, `check` all green.
- The first push was red (`ReferenceError: distinctId is not defined` — the gate's binding was still feeding `viewerState`); the second commit fixes it.
- `commit-lint` is red against a title that no longer exists: the job ran a minute before the PR was renamed to its current Conventional Commit title, and `ci.yml` uses a bare `on: pull_request` (opened/synchronize/reopened), so a rename does not re-trigger it. A re-run from the Actions tab, or any further push to the branch, clears it.