### PR TITLE
fix(backend): guard the Boardsesh-grades sync pull against DSM exhaustion

### DIFF
--- a/packages/backend/src/__tests__/sync-climb-stats-serial-plan.test.ts
+++ b/packages/backend/src/__tests__/sync-climb-stats-serial-plan.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Serial-plan guard coverage for BOTH per-board reference pulls — board_climb_stats
+ * and board_climb_grades. They share one helper (`runScopedBoardRefSyncPage`)
+ * precisely because syncClimbGrades once built the same correlated-EXISTS scope
+ * and ran it on the bare pool with no `SET LOCAL` (#4528), so pin both here.
+ */
 import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import type { SQL } from 'drizzle-orm';
@@ -68,6 +74,57 @@ describe('syncClimbStats serial-plan guard', () => {
     expect(transactionDatabase.execute).toHaveBeenCalledTimes(2);
     expect(recordedHandles).toEqual(['transaction', 'transaction']);
     expect(renderStatement(transactionDatabase.execute.mock.calls[0][0])).toMatch(SERIAL_PLAN_GUARD);
-    expect(renderStatement(transactionDatabase.execute.mock.calls[1][0])).toContain('FROM board_climb_stats');
+    const pageStatement = renderStatement(transactionDatabase.execute.mock.calls[1][0]);
+    expect(pageStatement).toContain('FROM board_climb_stats');
+    expect(pageStatement).toContain(
+      'EXISTS (SELECT 1 FROM board_climbs bc WHERE bc.uuid = board_climb_stats.climb_uuid',
+    );
+  });
+});
+
+describe('syncClimbGrades serial-plan guard', () => {
+  it('runs SET LOCAL before the scoped page query on the same transaction', async () => {
+    const result = (await syncQueries.syncClimbGrades(
+      undefined,
+      { boardType: 'tension', layoutId: 10, sizeId: 6, cursor: null, limit: 500 },
+      connectionContext(),
+    )) as SyncResult;
+
+    expect(result).toEqual({
+      documents: [],
+      cursor: { updatedAt: '1970-01-01T00:00:00.000Z', syncSeq: '0' },
+      hasMore: false,
+    });
+    expect(database.transaction).toHaveBeenCalledTimes(1);
+    expect(database.execute).not.toHaveBeenCalled();
+    expect(transactionDatabase.execute).toHaveBeenCalledTimes(2);
+    expect(recordedHandles).toEqual(['transaction', 'transaction']);
+    expect(renderStatement(transactionDatabase.execute.mock.calls[0][0])).toMatch(SERIAL_PLAN_GUARD);
+
+    const pageStatement = renderStatement(transactionDatabase.execute.mock.calls[1][0]);
+    expect(pageStatement).toContain('FROM board_climb_grades');
+    expect(pageStatement).toContain(
+      'EXISTS (SELECT 1 FROM board_climbs bc WHERE bc.uuid = board_climb_grades.climb_uuid',
+    );
+  });
+
+  // The guard is deliberately unconditional: a full-table walk of
+  // board_climb_grades can pick a parallel plan too, so don't let a future
+  // refactor make it depend on the layout/size scope being present.
+  it('guards the unscoped board_type-only pull as well', async () => {
+    await syncQueries.syncClimbGrades(
+      undefined,
+      { boardType: 'tension', layoutId: null, sizeId: null, cursor: null, limit: 500 },
+      connectionContext(),
+    );
+
+    expect(database.transaction).toHaveBeenCalledTimes(1);
+    expect(database.execute).not.toHaveBeenCalled();
+    expect(recordedHandles).toEqual(['transaction', 'transaction']);
+    expect(renderStatement(transactionDatabase.execute.mock.calls[0][0])).toMatch(SERIAL_PLAN_GUARD);
+
+    const pageStatement = renderStatement(transactionDatabase.execute.mock.calls[1][0]);
+    expect(pageStatement).toContain('FROM board_climb_grades');
+    expect(pageStatement).not.toContain('EXISTS (');
   });
 });

--- a/packages/backend/src/__tests__/user-ticks-serial-plan.test.ts
+++ b/packages/backend/src/__tests__/user-ticks-serial-plan.test.ts
@@ -142,6 +142,16 @@ describe('userTicks serial-plan guard', () => {
     expect(state.selectHandles).toEqual(['tx']);
   });
 
+  it('still opens exactly one guarded transaction for an empty logbook', async () => {
+    const ticks = await tickQueries.userTicks(null, { userId: 'user-123', boardType: 'kilter' });
+
+    expect(ticks).toEqual([]);
+    expect(state.transactions).toBe(1);
+    expect(state.executed).toHaveLength(1);
+    expect(state.executed[0]).toMatch(GUARD_PATTERN);
+    expect(state.selectHandles).toEqual(['tx']);
+  });
+
   it('rejects an unknown board type before opening a transaction', async () => {
     await expect(tickQueries.userTicks(null, { userId: 'user-123', boardType: 'nope' })).rejects.toThrow();
 

--- a/packages/backend/src/__tests__/user-ticks-serial-plan.test.ts
+++ b/packages/backend/src/__tests__/user-ticks-serial-plan.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Postgres DSM guard for the public `userTicks` read (#4528, Sentry BOARDSESH-AK).
+ *
+ * `userTicks` selects a climber's ENTIRE logbook with no LIMIT and fans it out
+ * through five LEFT JOINs, two of them against the big catalog tables
+ * (`board_climbs`, `board_climb_stats`). Production plans that as a parallel
+ * hash join, and enough concurrent profile loads exhaust Postgres's dynamic
+ * shared memory on our small /dev/shm — pgCode 53100. It was the single largest
+ * remaining source of those events.
+ *
+ * The fix is the same one the You-page fan-out already uses: run the select
+ * inside a transaction that has issued `SET LOCAL
+ * max_parallel_workers_per_gather = 0` first. This pins that the select really
+ * lands on the transaction handle rather than the bare pool — passing the wrong
+ * handle silently skips the guard with no error.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import { tickQueries } from '../graphql/resolvers/ticks/queries';
+
+const GUARD_PATTERN = /SET LOCAL max_parallel_workers_per_gather\s*=\s*0/i;
+
+const { fakeDb, state } = vi.hoisted(() => {
+  const state = {
+    /** Rendered SQL of every `execute`d statement, in order. Real renderer assigned below. */
+    render: (_statement: unknown): string => '',
+    executed: [] as string[],
+    /** Which handle each execute ran on: 'db' (top-level pool) or 'tx' (transaction). */
+    executeHandles: [] as string[],
+    /** Which handle each awaited select builder ran on. */
+    selectHandles: [] as string[],
+    transactions: 0,
+    selectRows: [] as unknown[],
+  };
+
+  const makeSelectBuilder = (handle: string) => {
+    const builder: Record<string, unknown> = {};
+    for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'groupBy', 'having', 'orderBy', 'limit', 'as']) {
+      builder[method] = () => builder;
+    }
+    // Deliberate: drizzle's query builder is awaitable, so the fake has to be a
+    // real thenable for `await tx.select()...` to resolve like a genuine query.
+    // oxlint-disable-next-line no-thenable
+    builder.then = (
+      onFulfilled?: ((value: unknown) => unknown) | null,
+      onRejected?: ((reason: unknown) => unknown) | null,
+    ) => {
+      state.selectHandles.push(handle);
+      return Promise.resolve(state.selectRows).then(onFulfilled, onRejected);
+    };
+    return builder;
+  };
+
+  const makeExecute = (handle: string) => (statement: unknown) => {
+    state.executed.push(state.render(statement));
+    state.executeHandles.push(handle);
+    return Promise.resolve([]);
+  };
+
+  const fakeTx = {
+    execute: makeExecute('tx'),
+    select: () => makeSelectBuilder('tx'),
+    selectDistinct: () => makeSelectBuilder('tx'),
+  };
+
+  const fakeDb = {
+    execute: makeExecute('db'),
+    select: () => makeSelectBuilder('db'),
+    selectDistinct: () => makeSelectBuilder('db'),
+    transaction: (callback: (transactionDb: typeof fakeTx) => unknown) => {
+      state.transactions += 1;
+      return callback(fakeTx);
+    },
+  };
+
+  return { fakeDb, state };
+});
+
+vi.mock('../db/client', () => ({ db: fakeDb, dbRead: fakeDb }));
+
+const dialect = new PgDialect();
+state.render = (statement: unknown) => dialect.sqlToQuery(statement as SQL).sql;
+
+const TICK_ROW = {
+  tick: {
+    uuid: 'tick-1',
+    userId: 'user-123',
+    boardType: 'kilter',
+    climbUuid: 'climb-1',
+    angle: 40,
+    isMirror: false,
+    status: 'sent',
+    attemptCount: 1,
+    quality: 3,
+    difficulty: null,
+    isBenchmark: false,
+    comment: null,
+    climbedAt: new Date('2026-08-01T12:00:00.000Z'),
+    createdAt: new Date('2026-08-01T12:00:00.000Z'),
+    updatedAt: new Date('2026-08-01T12:00:00.000Z'),
+    sessionId: null,
+    auroraType: null,
+    auroraId: null,
+    auroraSyncedAt: null,
+  },
+  layoutId: 8,
+  effectiveDifficulty: 20,
+  boardseshDifficulty: 20.5,
+  boardseshConfidence: 0.9,
+  effectiveQuality: 3,
+};
+
+beforeEach(() => {
+  state.executed.length = 0;
+  state.executeHandles.length = 0;
+  state.selectHandles.length = 0;
+  state.transactions = 0;
+  state.selectRows = [];
+});
+
+describe('userTicks serial-plan guard', () => {
+  it('runs SET LOCAL and the logbook select on the same transaction handle', async () => {
+    state.selectRows = [TICK_ROW];
+
+    const ticks = (await tickQueries.userTicks(null, { userId: 'user-123', boardType: 'kilter' })) as Array<{
+      uuid: string;
+      layoutId: number;
+    }>;
+
+    expect(ticks).toHaveLength(1);
+    expect(ticks[0].uuid).toBe('tick-1');
+    expect(ticks[0].layoutId).toBe(8);
+
+    expect(state.transactions).toBe(1);
+    expect(state.executed).toHaveLength(1);
+    expect(state.executed[0]).toMatch(GUARD_PATTERN);
+    // Nothing on the bare pool: SET LOCAL only covers its own transaction, so a
+    // select that leaked back to `db` would be unguarded.
+    expect(state.executeHandles).toEqual(['tx']);
+    expect(state.selectHandles).toEqual(['tx']);
+  });
+
+  it('rejects an unknown board type before opening a transaction', async () => {
+    await expect(tickQueries.userTicks(null, { userId: 'user-123', boardType: 'nope' })).rejects.toThrow();
+
+    expect(state.transactions).toBe(0);
+    expect(state.executed).toHaveLength(0);
+    expect(state.selectHandles).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/graphql/resolvers/sync/queries.ts
+++ b/packages/backend/src/graphql/resolvers/sync/queries.ts
@@ -189,6 +189,70 @@ function boardClimbsScope(boardType: string, layoutId: number | null, sizeId: nu
   );
 }
 
+/**
+ * Run one page of a per-board reference table that has no layout_id of its own
+ * (board_climb_stats, board_climb_grades) — building the correlated-EXISTS scope
+ * AND running the page under the serial-plan guard, together, in one call.
+ *
+ * Both belong to the same function on purpose. Such a pull walks the reference
+ * table in cursor order and probes 375k-row board_climbs through the EXISTS
+ * filter; production chooses a Gather Merge for that shape, which has exhausted
+ * Postgres's DSM during sync bursts (Sentry BOARDSESH-AK, pgCode 53100). The
+ * guard's load-bearing part is `executor: transactionDb` — `runSyncPage`
+ * silently defaults to the bare pool, so a caller that builds the scope itself
+ * and forgets the executor gets no guard and no error. That is exactly how
+ * syncClimbGrades shipped unguarded (#4528) after the scope was copy-pasted from
+ * syncClimbStats (#4468). Keeping them in one helper makes the omission
+ * unrepresentable; `SET LOCAL` and the page SELECT stay on the same transaction
+ * handle.
+ *
+ * The guard is unconditional, including for the unscoped `board_type`-only pull:
+ * a full-table walk of either reference table can pick a parallel plan too, and
+ * a serial plan can only change latency, never results.
+ */
+async function runScopedBoardRefSyncPage(params: {
+  table: SQL;
+  climbUuidColumn: SQL;
+  selectList: SQL;
+  updatedAtColumn: SQL;
+  seqColumn: SQL;
+  boardType: string;
+  layoutId: number | null;
+  sizeId: number | null;
+  cursor: SyncCursorInput | null | undefined;
+  limit: number;
+}): Promise<SyncResult> {
+  const { table, climbUuidColumn, selectList, updatedAtColumn, seqColumn, boardType, layoutId, sizeId, cursor, limit } =
+    params;
+
+  // The reference row has no layout_id, so scope it to the climbs of that
+  // (layout, size) via a correlated EXISTS on board_climbs, reusing the same
+  // shared conditions syncClimbs uses (bc.-qualified here). No scope → plain
+  // board_type filter.
+  const scopeConditions = boardClimbsLayoutSizeConditions(boardType, layoutId, sizeId, sql`bc.`);
+  let scope: SQL = sql`board_type = ${boardType}`;
+  if (scopeConditions.length > 0) {
+    const sub = sql.join(
+      [sql`bc.uuid = ${climbUuidColumn}`, sql`bc.board_type = ${boardType}`, ...scopeConditions],
+      sql` AND `,
+    );
+    scope = sql`board_type = ${boardType} AND EXISTS (SELECT 1 FROM board_climbs bc WHERE ${sub})`;
+  }
+
+  return withSerialPlan(db, (transactionDb) =>
+    runSyncPage({
+      executor: transactionDb,
+      selectList,
+      fromClause: table,
+      scope,
+      updatedAtColumn,
+      seqColumn,
+      cursor,
+      limit,
+    }),
+  );
+}
+
 export const syncQueries = {
   /**
    * Pull the authenticated user's ticks. Local PK = uuid (the idempotency key).
@@ -422,37 +486,19 @@ export const syncQueries = {
       sizeId: sid,
     } = prepareBoardSync(ctx, cursor, limit, boardType, layoutId, sizeId);
 
-    // Stats have no layout_id, so scope them to the climbs of that (layout, size)
-    // via a correlated EXISTS on board_climbs, reusing the same shared conditions
-    // syncClimbs uses (bc.-qualified here). No scope → plain board_type filter.
-    const scopeConditions = boardClimbsLayoutSizeConditions(validBoardType, lid, sid, sql`bc.`);
-    let scope: SQL = sql`board_type = ${validBoardType}`;
-    if (scopeConditions.length > 0) {
-      const sub = sql.join(
-        [sql`bc.uuid = board_climb_stats.climb_uuid`, sql`bc.board_type = ${validBoardType}`, ...scopeConditions],
-        sql` AND `,
-      );
-      scope = sql`board_type = ${validBoardType} AND EXISTS (SELECT 1 FROM board_climbs bc WHERE ${sub})`;
-    }
-
-    // A scoped stats pull walks board_climb_stats in cursor order and probes
-    // board_climbs through the EXISTS filter. Production chooses a Gather
-    // Merge for that shape, which has exhausted Postgres's DSM during sync
-    // bursts (Sentry BOARDSESH-AK, pgCode 53100). Keep SET LOCAL and the page
-    // SELECT on the exact same transaction handle.
-    return withSerialPlan(db, (transactionDb) =>
-      runSyncPage({
-        executor: transactionDb,
-        selectList: sql`board_type, climb_uuid, angle, display_difficulty, benchmark_difficulty,
-          ascensionist_count, difficulty_average, quality_average, fa_username, fa_at, updated_at, sync_seq`,
-        fromClause: sql`board_climb_stats`,
-        scope,
-        updatedAtColumn: sql`board_climb_stats.updated_at`,
-        seqColumn: sql`board_climb_stats.sync_seq`,
-        cursor,
-        limit: lim,
-      }),
-    );
+    return runScopedBoardRefSyncPage({
+      table: sql`board_climb_stats`,
+      climbUuidColumn: sql`board_climb_stats.climb_uuid`,
+      selectList: sql`board_type, climb_uuid, angle, display_difficulty, benchmark_difficulty,
+        ascensionist_count, difficulty_average, quality_average, fa_username, fa_at, updated_at, sync_seq`,
+      updatedAtColumn: sql`board_climb_stats.updated_at`,
+      seqColumn: sql`board_climb_stats.sync_seq`,
+      boardType: validBoardType,
+      layoutId: lid,
+      sizeId: sid,
+      cursor,
+      limit: lim,
+    });
   },
 
   /**
@@ -488,26 +534,16 @@ export const syncQueries = {
       sizeId: sid,
     } = prepareBoardSync(ctx, cursor, limit, boardType, layoutId, sizeId);
 
-    // Grades have no layout_id, so scope them to the climbs of that (layout, size)
-    // via a correlated EXISTS on board_climbs, reusing the same shared conditions
-    // syncClimbs uses (bc.-qualified here). No scope → plain board_type filter.
-    const scopeConditions = boardClimbsLayoutSizeConditions(validBoardType, lid, sid, sql`bc.`);
-    let scope: SQL = sql`board_type = ${validBoardType}`;
-    if (scopeConditions.length > 0) {
-      const sub = sql.join(
-        [sql`bc.uuid = board_climb_grades.climb_uuid`, sql`bc.board_type = ${validBoardType}`, ...scopeConditions],
-        sql` AND `,
-      );
-      scope = sql`board_type = ${validBoardType} AND EXISTS (SELECT 1 FROM board_climbs bc WHERE ${sub})`;
-    }
-
-    return runSyncPage({
+    return runScopedBoardRefSyncPage({
+      table: sql`board_climb_grades`,
+      climbUuidColumn: sql`board_climb_grades.climb_uuid`,
       selectList: sql`board_type, climb_uuid, angle, local_grade, universal_grade, grade_low, grade_high,
         confidence, ascensionist_count, computed_at, sync_seq`,
-      fromClause: sql`board_climb_grades`,
-      scope,
       updatedAtColumn: sql`board_climb_grades.computed_at`,
       seqColumn: sql`board_climb_grades.sync_seq`,
+      boardType: validBoardType,
+      layoutId: lid,
+      sizeId: sid,
       cursor,
       limit: lim,
     });

--- a/packages/backend/src/graphql/resolvers/ticks/queries.ts
+++ b/packages/backend/src/graphql/resolvers/ticks/queries.ts
@@ -384,50 +384,59 @@ export const tickQueries = {
     // `effectiveDifficulty` that COALESCEs with the climb's consensus grade
     // for chart-bucket / aggregation consumers. NULL difficulty means "use
     // consensus" — see docs/ascents-and-attempts.md.
-    const results = await db
-      .select({
-        tick: dbSchema.boardseshTicks,
-        layoutId: dbSchema.boardClimbs.layoutId,
-        effectiveDifficulty: sql<
-          number | null
-        >`COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr})`,
-        boardseshDifficulty: boardseshDifficultyExpr,
-        boardseshConfidence: boardseshConfidenceExpr,
-        effectiveQuality: effectiveQualityExpr,
-      })
-      .from(dbSchema.boardseshTicks)
-      // Resolve dedup-merged climbs to their canonical UUID before joining
-      // board_climbs / board_climb_stats — both live on the canonical. See the
-      // `ticks` resolver for the COALESCE-fallback rationale.
-      .leftJoin(
-        dbSchema.boardClimbAliases,
-        and(
-          eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
-          eq(dbSchema.boardClimbAliases.boardType, boardType),
-        ),
-      )
-      .leftJoin(
-        dbSchema.boardClimbs,
-        and(
-          sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
-          eq(dbSchema.boardClimbs.boardType, boardType),
-        ),
-      )
-      .leftJoin(
-        dbSchema.boardClimbStats,
-        and(
-          sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbStats.climbUuid}`,
-          eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
-          eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
-        ),
-      )
-      // Boardsesh grade at the tick's OWN angle (aliases resolved above). LEFT JOIN
-      // so an ungraded climb still returns; the grade fields come back NULL.
-      .leftJoin(dbSchema.boardClimbGrades, BOARDSESH_GRADE_TICK_JOIN)
-      // Synced-rating fallback for quality — see boardClimbRatingsJoinCondition.
-      .leftJoin(dbSchema.boardClimbRatings, boardClimbRatingsJoinCondition)
-      .where(and(...conditions))
-      .orderBy(desc(dbSchema.boardseshTicks.climbedAt));
+    // Unbounded (no LIMIT) over one user's whole logbook, fanning out through
+    // five LEFT JOINs — board_climbs and board_climb_stats are the big ones.
+    // Production picks a parallel hash join for that shape, and enough
+    // concurrent profile loads exhaust Postgres's DSM on Railway's small
+    // /dev/shm (Sentry BOARDSESH-AK, pgCode 53100 — the largest remaining
+    // source of it, #4528). Same guard the You-page fan-out below uses; a
+    // serial plan only costs latency, it can't change the rows.
+    const results = await withSerialPlan(db, (transactionDb) =>
+      transactionDb
+        .select({
+          tick: dbSchema.boardseshTicks,
+          layoutId: dbSchema.boardClimbs.layoutId,
+          effectiveDifficulty: sql<
+            number | null
+          >`COALESCE(${dbSchema.boardseshTicks.difficulty}, ${consensusDifficultyExpr})`,
+          boardseshDifficulty: boardseshDifficultyExpr,
+          boardseshConfidence: boardseshConfidenceExpr,
+          effectiveQuality: effectiveQualityExpr,
+        })
+        .from(dbSchema.boardseshTicks)
+        // Resolve dedup-merged climbs to their canonical UUID before joining
+        // board_climbs / board_climb_stats — both live on the canonical. See the
+        // `ticks` resolver for the COALESCE-fallback rationale.
+        .leftJoin(
+          dbSchema.boardClimbAliases,
+          and(
+            eq(dbSchema.boardseshTicks.climbUuid, dbSchema.boardClimbAliases.aliasUuid),
+            eq(dbSchema.boardClimbAliases.boardType, boardType),
+          ),
+        )
+        .leftJoin(
+          dbSchema.boardClimbs,
+          and(
+            sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbs.uuid}`,
+            eq(dbSchema.boardClimbs.boardType, boardType),
+          ),
+        )
+        .leftJoin(
+          dbSchema.boardClimbStats,
+          and(
+            sql`COALESCE(${dbSchema.boardClimbAliases.canonicalUuid}, ${dbSchema.boardseshTicks.climbUuid}) = ${dbSchema.boardClimbStats.climbUuid}`,
+            eq(dbSchema.boardseshTicks.boardType, dbSchema.boardClimbStats.boardType),
+            eq(dbSchema.boardseshTicks.angle, dbSchema.boardClimbStats.angle),
+          ),
+        )
+        // Boardsesh grade at the tick's OWN angle (aliases resolved above). LEFT JOIN
+        // so an ungraded climb still returns; the grade fields come back NULL.
+        .leftJoin(dbSchema.boardClimbGrades, BOARDSESH_GRADE_TICK_JOIN)
+        // Synced-rating fallback for quality — see boardClimbRatingsJoinCondition.
+        .leftJoin(dbSchema.boardClimbRatings, boardClimbRatingsJoinCondition)
+        .where(and(...conditions))
+        .orderBy(desc(dbSchema.boardseshTicks.climbedAt)),
+    );
 
     return results.map(
       ({ tick, layoutId, effectiveDifficulty, boardseshDifficulty, boardseshConfidence, effectiveQuality }) => ({


### PR DESCRIPTION
## Summary

Closes #4528.

`syncClimbGrades` builds exactly the same correlated-EXISTS scope as `syncClimbStats` — the scope was copy-pasted when the grades pull shipped — but it called `runSyncPage` with no `executor`, and `runSyncPage` silently defaults to the module-level `db` pool. So the page SELECT ran unguarded: no `SET LOCAL max_parallel_workers_per_gather = 0`, no error, nothing downstream to re-add it. Production plans that shape as a Gather Merge, each worker allocates a DSM segment, and Railway's small `/dev/shm` runs out (`pgCode 53100`).

Two changes:

1. **`runScopedBoardRefSyncPage`** (new private helper in `sync/queries.ts`) builds the scope **and** runs the page under `withSerialPlan` in one call. `syncClimbStats` and `syncClimbGrades` both go through it now. The failure mode here was literally "copied the scope, forgot the guard", so the fix is to make that omission unrepresentable rather than to add a third hand-written `withSerialPlan(...)` wrap. The guard is unconditional, including for the unscoped `board_type`-only pull — that's what `syncClimbStats` already did, and a full-table walk can pick a parallel plan too.
2. **`userTicks` gets the same guard.** Same bug class, different file — see "Second fix" below.

The emitted SQL is unchanged for both resolvers: same select lists, same predicate, same cursor/ORDER BY. A serial plan can only change latency, never the rows.

### Correcting the issue's numbers

The issue quotes **456 events / 123 users (14d)**. That is the whole of Sentry `BOARDSESH-AK`, which is a catch-all group for *every* `pgCode 53100` event across ~12 different `graphqlPath` values — not this resolver. Broken down by `graphqlPath`:

| period | path | events |
| --- | --- | --- |
| 14d | (empty) | 149 |
| 14d | `similarClimbs` | 121 |
| 14d | `mySmartPlaylistCounts` | 114 |
| 14d | `userTicks` | 25 |
| 14d | `syncClimbGrades` | 12 |
| 14d | `syncClimbStats` | 7 |
| 3d | `userTicks` | 25 |
| 3d | `syncClimbGrades` | 12 |
| 3d | `userGroupedAscentsFeed` | 1 |

So `syncClimbGrades` is 12 of 456 — but **all 12 landed in the last 3 days**, i.e. after #4468 shipped, so it is genuinely live and worth fixing. Just not at the stated blast radius.

### Second fix in the same class: `userTicks`

That breakdown also shows `userTicks` is the **largest** remaining live source, at 25 events in 3d. It runs an unbounded (no `LIMIT`) select over one climber's entire logbook, fanning out through five LEFT JOINs — two of them against the big catalog tables. Identical shape, identical failure, and `withSerialPlan` was already imported in that file (the You-page fan-out two resolvers down uses it). Wrapping it here rather than in a follow-up, because shipping only the grades half leaves the bigger part of the alert firing.

It's a different file and a public unauthenticated read path, so calling it out explicitly: this is a deliberate second fix, not scope creep. Happy to split it into its own PR if a reviewer would rather.

### Deliberately not fixed

- `userGroupedAscentsFeed` — 1 event in 3d, below the noise floor. Noting it rather than growing the diff.
- `packages/backend/src/scripts/export-board-snapshots.ts` runs its own `GRADES_WHERE` on a dedicated pool, not through the resolver, so it's untouched. Its comment claims it mirrors the resolver's scope exactly — `snapshot-export-golden.test.ts` is what keeps that honest, and it still passes.
- No other resolver in `sync/queries.ts` needs the guard. I checked all ten: only `syncClimbStats` and `syncClimbGrades` build the correlated EXISTS against 375k-row `board_climbs`; the rest are single-table user-scoped index lookups or small joins.

## Release Notes

- Downloading a board for offline use no longer drops out partway through the grade sync when the servers are busy.
- Your logbook and stats load reliably during peak hours instead of erroring out.

## Test plan

**Verified locally**

- `SKIP_TEST_INFRA=1 vp test run packages/backend/src/__tests__/sync-climb-stats-serial-plan.test.ts packages/backend/src/__tests__/user-ticks-serial-plan.test.ts --reporter=agent` — 5 passed. New coverage:
  - `syncClimbGrades` scoped pull: one transaction, nothing on the bare pool, `SET LOCAL` first, then the page SELECT on the **same** handle.
  - `syncClimbGrades` unscoped (`layoutId: null, sizeId: null`) pull is guarded too, so the always-on choice is pinned rather than accidental.
  - `syncClimbStats` keeps its existing assertions, plus a new one pinning the exact rendered predicate (`EXISTS (SELECT 1 FROM board_climbs bc WHERE bc.uuid = board_climb_stats.climb_uuid`) — that's what proves the helper's `${climbUuidColumn}` interpolation emits byte-identical SQL to the hand-written literal it replaced. Same assertion added for grades.
  - New `user-ticks-serial-plan.test.ts`: the logbook select lands on the transaction handle, and an unknown board type still rejects before a transaction is opened.
- `vp run typecheck:backend` — clean.
- `vp check` — no errors or warnings on any of the four changed files. (The repo-wide run reports 2 pre-existing `TS2307: Cannot find module '@gorhom/bottom-sheet'` errors from the mobile web-shims nested install, unrelated to this change and present before it.)

**Left to CI**

The DB-backed suites that actually exercise these resolvers end to end — `sync-pull-grades`, `sync-pull-board-scope`, `snapshot-export-golden`, `tick-queries`, `aurora-twin-dedup` — auto-start postgres+redis on fixed ports. This machine has ~25 worktrees sharing those ports and the infra bring-up timed out locally, so I'm letting CI arbitrate rather than chasing a collision that isn't mine. `snapshot-export-golden` is the important one: it calls the real `syncQueries.syncClimbGrades` and asserts byte-identical rows against the exporter's own `GRADES_WHERE`, so it is the strongest check that the refactor didn't perturb the emitted SQL.

**Post-merge (not a CI gate)**

Re-run the Sentry breakdown `issue:BOARDSESH-AK`, fields `[graphqlPath, count()]`, period 3d, and confirm `syncClimbGrades` and `userTicks` both drop to 0 — the same way #4468 was confirmed for `similarClimbs` / `mySmartPlaylistCounts`.

## What I verified vs inferred

**Verified:** the guard is genuinely absent from `syncClimbGrades` (mocked-db test recorded handles `['database']`, `db.transaction` called 0 times, before the fix); `withSerialPlan` really does run `SET LOCAL` and the caller's query on one shared transaction handle; the mobile pull client always sends `layoutId`/`sizeId` for per-board tables, so the correlated-EXISTS branch is the production shape; the helper emits the same SQL as the code it replaced; the Sentry per-path breakdown above.

**Inferred:** that the specific plan Postgres chooses in production is a Gather Merge over `board_climb_grades` — I did not get an `EXPLAIN` from prod. The inference rests on the shape being identical to `syncClimbStats`, whose guard demonstrably cleared its own events, and on the segment-size ladder in the error messages matching a parallel hash join's DSA doubling. Prior rounds: #3856, #4105, #4235, #4468.
