### PR TITLE
fix(mobile): stop a failed avatar encode from saving an empty picture

### DIFF
--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -33,7 +33,7 @@ const COMPRESSION_QUALITY = 0.85;
  * camera roll — can't be uploaded honestly without the manipulator, so the
  * fallback refuses it rather than mislabelling the bytes as JPEG.
  */
-const FALLBACK_FILE_NAMES: Record<string, string> = {
+const FALLBACK_FILE_NAMES: Partial<Record<string, string>> = {
   'image/jpeg': 'avatar.jpg',
   'image/png': 'avatar.png',
   'image/gif': 'avatar.gif',

--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -24,8 +24,21 @@ const DISPLAY_NAME_MAX = 100;
 const MAX_DIMENSION = 1024;
 const COMPRESSION_QUALITY = 0.85;
 
-/** A picked image that has been read off disk and proven to have bytes in it. */
-type CompressedAvatar = { uri: string; bytes: Uint8Array };
+/**
+ * Filenames for the image types the backend accepts (`ALLOWED_MIME_TYPES` in
+ * `packages/backend/src/handlers/avatars.ts`, which derives the stored file's
+ * extension from the declared type). Only consulted for the fallback: the
+ * compressed path re-encodes to JPEG, so it knows what it produced. A pick the
+ * picker reports as anything else — HEIC, most often, straight off an Android
+ * camera roll — can't be uploaded honestly without the manipulator, so the
+ * fallback refuses it rather than mislabelling the bytes as JPEG.
+ */
+const FALLBACK_FILE_NAMES: Record<string, string> = {
+  'image/jpeg': 'avatar.jpg',
+  'image/png': 'avatar.png',
+  'image/gif': 'avatar.gif',
+  'image/webp': 'avatar.webp',
+};
 
 /**
  * Resize (if needed) and re-encode a picked image to a small JPEG, returning the
@@ -81,14 +94,14 @@ class AvatarCompressionError extends Error {
  * resize/re-encode. `expo-image-picker`'s Android exporter drops the same
  * `Boolean`, so the fallback gets its own length check instead of being trusted.
  */
-async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<CompressedAvatar> {
+async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<AvatarUploadFile> {
   let compressedBytes = new Uint8Array();
   let failure: unknown = null;
   try {
     const compressedUri = await renderCompressedJpeg(asset);
     compressedBytes = await new File(compressedUri).bytes();
     if (compressedBytes.length > 0) {
-      return { uri: compressedUri, bytes: compressedBytes };
+      return { uri: compressedUri, bytes: compressedBytes, name: 'avatar.jpg', type: 'image/jpeg' };
     }
   } catch (error) {
     failure = error;
@@ -103,18 +116,26 @@ async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<Comp
     failure ??= error;
   }
 
+  // The fallback skips the re-encode, so these bytes are whatever the picker
+  // handed us — on Android that is routinely PNG or HEIC, not JPEG. Send them
+  // under their real type, and give up when it isn't one the backend takes.
+  const fallbackType = asset.mimeType;
+  const fallbackName = fallbackType ? FALLBACK_FILE_NAMES[fallbackType] : undefined;
+  const canUseOriginal =
+    fallbackName !== undefined && originalBytes.length > 0 && originalBytes.length <= MAX_AVATAR_BYTES;
+
   // There is no telemetry on this path today (zero avatar/manipulator/picker
   // events in 90 days), which is exactly why the failure went unnoticed for so
-  // long. Sizes and platform only — no URIs, no user identifiers. Reported once,
-  // here, at the severity the climber actually experiences: a warning when the
-  // fallback rescues the save, an error when they lose the pick.
-  const canUseOriginal = originalBytes.length > 0 && originalBytes.length <= MAX_AVATAR_BYTES;
+  // long. Sizes, MIME type and platform only — no URIs, no user identifiers.
+  // Reported once, here, at the severity the climber actually experiences: a
+  // warning when the fallback rescues the save, an error when they lose the pick.
   reportHandledError(failure ?? new Error('Avatar compression produced an empty file'), {
     level: canUseOriginal ? 'warning' : 'error',
     tags: { source: 'avatar-compress' },
     extra: {
       compressedBytes: compressedBytes.length,
       originalBytes: originalBytes.length,
+      originalType: fallbackType ?? 'unknown',
       platform: Platform.OS,
     },
   });
@@ -122,7 +143,7 @@ async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<Comp
   if (!canUseOriginal) {
     throw new AvatarCompressionError('Avatar compression produced an unusable file');
   }
-  return { uri: asset.uri, bytes: originalBytes };
+  return { uri: asset.uri, bytes: originalBytes, name: fallbackName, type: fallbackType };
 }
 
 export function EditProfileScreen() {
@@ -178,9 +199,7 @@ export function EditProfileScreen() {
         quality: 1,
       });
       if (result.canceled) return;
-      const asset = result.assets[0];
-      const { uri, bytes } = await compressAvatar(asset);
-      setPickedAvatar({ uri, bytes, name: 'avatar.jpg', type: 'image/jpeg' });
+      setPickedAvatar(await compressAvatar(result.assets[0]));
     } catch (error) {
       // `compressAvatar` already reported this one with the byte counts attached.
       if (!(error instanceof AvatarCompressionError)) {

--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -54,13 +54,14 @@ async function renderCompressedJpeg(asset: ImagePicker.ImagePickerAsset): Promis
   }
 }
 
-/** Read a local file, treating an unreadable one as empty rather than throwing. */
-async function readBytesOrEmpty(uri: string): Promise<Uint8Array> {
-  try {
-    return await new File(uri).bytes();
-  } catch {
-    return new Uint8Array();
-  }
+/**
+ * Thrown when neither the compressed image nor the picker's own crop is usable.
+ * Named so `handlePickAvatar` can tell it apart: `compressAvatar` has already
+ * reported it with the byte counts attached, and reporting again there would
+ * file the same failure twice.
+ */
+class AvatarCompressionError extends Error {
+  override name = 'AvatarCompressionError';
 }
 
 /**
@@ -82,7 +83,7 @@ async function readBytesOrEmpty(uri: string): Promise<Uint8Array> {
  */
 async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<CompressedAvatar> {
   let compressedBytes = new Uint8Array();
-  let compressionError: unknown = null;
+  let failure: unknown = null;
   try {
     const compressedUri = await renderCompressedJpeg(asset);
     compressedBytes = await new File(compressedUri).bytes();
@@ -90,15 +91,26 @@ async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<Comp
       return { uri: compressedUri, bytes: compressedBytes };
     }
   } catch (error) {
-    compressionError = error;
+    failure = error;
   }
 
-  const originalBytes = await readBytesOrEmpty(asset.uri);
+  let originalBytes = new Uint8Array();
+  try {
+    originalBytes = await new File(asset.uri).bytes();
+  } catch (error) {
+    // Keep the manipulator's failure if there already is one — it explains more
+    // than "the picker's file wouldn't read either".
+    failure ??= error;
+  }
+
   // There is no telemetry on this path today (zero avatar/manipulator/picker
   // events in 90 days), which is exactly why the failure went unnoticed for so
-  // long. Sizes and platform only — no URIs, no user identifiers.
-  reportHandledError(compressionError ?? new Error('Avatar compression produced an empty file'), {
-    level: 'warning',
+  // long. Sizes and platform only — no URIs, no user identifiers. Reported once,
+  // here, at the severity the climber actually experiences: a warning when the
+  // fallback rescues the save, an error when they lose the pick.
+  const canUseOriginal = originalBytes.length > 0 && originalBytes.length <= MAX_AVATAR_BYTES;
+  reportHandledError(failure ?? new Error('Avatar compression produced an empty file'), {
+    level: canUseOriginal ? 'warning' : 'error',
     tags: { source: 'avatar-compress' },
     extra: {
       compressedBytes: compressedBytes.length,
@@ -107,8 +119,8 @@ async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<Comp
     },
   });
 
-  if (originalBytes.length === 0 || originalBytes.length > MAX_AVATAR_BYTES) {
-    throw new Error('Avatar compression produced an unusable file');
+  if (!canUseOriginal) {
+    throw new AvatarCompressionError('Avatar compression produced an unusable file');
   }
   return { uri: asset.uri, bytes: originalBytes };
 }
@@ -170,7 +182,10 @@ export function EditProfileScreen() {
       const { uri, bytes } = await compressAvatar(asset);
       setPickedAvatar({ uri, bytes, name: 'avatar.jpg', type: 'image/jpeg' });
     } catch (error) {
-      reportError(error);
+      // `compressAvatar` already reported this one with the byte counts attached.
+      if (!(error instanceof AvatarCompressionError)) {
+        reportError(error);
+      }
       showToast(t('profile.validation.compressionFailed'), 'error');
     }
   };

--- a/packages/mobile/src/components/EditProfileScreen.tsx
+++ b/packages/mobile/src/components/EditProfileScreen.tsx
@@ -1,15 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ScrollView, StyleSheet, View } from 'react-native';
+import { Platform, ScrollView, StyleSheet, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import * as ImagePicker from 'expo-image-picker';
+import { File } from 'expo-file-system';
 import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import type { UpdateProfileInput } from '@boardsesh/shared-schema';
 import { useTheme } from '../providers/theme-provider';
 import { useToast } from '../providers/toast-provider';
 import { useProfile, useUpdateProfile } from '../lib/graphql/hooks';
-import { uploadAvatar, type AvatarUploadFile } from '../lib/avatar-upload';
-import { reportError } from '../lib/error-reporting';
+import { MAX_AVATAR_BYTES, uploadAvatar, type AvatarUploadFile } from '../lib/avatar-upload';
+import { reportError, reportHandledError } from '../lib/error-reporting';
 import { spacing } from '../theme/tokens';
 import { Avatar } from './Avatar';
 import { AuthTextInput } from './AuthTextInput';
@@ -23,17 +24,20 @@ const DISPLAY_NAME_MAX = 100;
 const MAX_DIMENSION = 1024;
 const COMPRESSION_QUALITY = 0.85;
 
+/** A picked image that has been read off disk and proven to have bytes in it. */
+type CompressedAvatar = { uri: string; bytes: Uint8Array };
+
 /**
  * Resize (if needed) and re-encode a picked image to a small JPEG, returning the
  * local file URI. Resizing a single dimension preserves the aspect ratio; we
  * constrain whichever side is longer. A 0 dimension (the picker couldn't report
  * size) skips the resize but still re-encodes to shrink the file.
  */
-async function compressAvatar(uri: string, width: number, height: number): Promise<string> {
-  const context = ImageManipulator.manipulate(uri);
-  const longestSide = Math.max(width, height);
+async function renderCompressedJpeg(asset: ImagePicker.ImagePickerAsset): Promise<string> {
+  const context = ImageManipulator.manipulate(asset.uri);
+  const longestSide = Math.max(asset.width, asset.height);
   if (longestSide > MAX_DIMENSION) {
-    if (width >= height) {
+    if (asset.width >= asset.height) {
       context.resize({ width: MAX_DIMENSION });
     } else {
       context.resize({ height: MAX_DIMENSION });
@@ -48,6 +52,65 @@ async function compressAvatar(uri: string, width: number, height: number): Promi
     // path on disk and stays valid after the ref is gone.
     image.release();
   }
+}
+
+/** Read a local file, treating an unreadable one as empty rather than throwing. */
+async function readBytesOrEmpty(uri: string): Promise<Uint8Array> {
+  try {
+    return await new File(uri).bytes();
+  } catch {
+    return new Uint8Array();
+  }
+}
+
+/**
+ * Compress a picked image and hand back both its URI and its bytes, so nothing
+ * downstream has to trust that the file on disk is an image.
+ *
+ * Android's `saveAsync` throws away the `Boolean` that `Bitmap.compress()`
+ * returns, so a failed encode still resolves with a URI — pointing at a 0-byte
+ * file. iOS raises `CorruptedImageDataException` at the same spot, which is why
+ * only Android saw this. Nothing further down noticed either: reading an empty
+ * file returns an empty array without throwing, the multipart encoder writes a
+ * zero-length part, and the backend answered 200 with a URL we persisted. The
+ * user watched the crop land in the preview and lost it on the next screen.
+ *
+ * So check the bytes here, where we can still recover: fall back to the picker's
+ * own crop, which is already square (`aspect: [1, 1]`) and only misses the
+ * resize/re-encode. `expo-image-picker`'s Android exporter drops the same
+ * `Boolean`, so the fallback gets its own length check instead of being trusted.
+ */
+async function compressAvatar(asset: ImagePicker.ImagePickerAsset): Promise<CompressedAvatar> {
+  let compressedBytes = new Uint8Array();
+  let compressionError: unknown = null;
+  try {
+    const compressedUri = await renderCompressedJpeg(asset);
+    compressedBytes = await new File(compressedUri).bytes();
+    if (compressedBytes.length > 0) {
+      return { uri: compressedUri, bytes: compressedBytes };
+    }
+  } catch (error) {
+    compressionError = error;
+  }
+
+  const originalBytes = await readBytesOrEmpty(asset.uri);
+  // There is no telemetry on this path today (zero avatar/manipulator/picker
+  // events in 90 days), which is exactly why the failure went unnoticed for so
+  // long. Sizes and platform only — no URIs, no user identifiers.
+  reportHandledError(compressionError ?? new Error('Avatar compression produced an empty file'), {
+    level: 'warning',
+    tags: { source: 'avatar-compress' },
+    extra: {
+      compressedBytes: compressedBytes.length,
+      originalBytes: originalBytes.length,
+      platform: Platform.OS,
+    },
+  });
+
+  if (originalBytes.length === 0 || originalBytes.length > MAX_AVATAR_BYTES) {
+    throw new Error('Avatar compression produced an unusable file');
+  }
+  return { uri: asset.uri, bytes: originalBytes };
 }
 
 export function EditProfileScreen() {
@@ -104,8 +167,8 @@ export function EditProfileScreen() {
       });
       if (result.canceled) return;
       const asset = result.assets[0];
-      const compressedUri = await compressAvatar(asset.uri, asset.width, asset.height);
-      setPickedAvatar({ uri: compressedUri, name: 'avatar.jpg', type: 'image/jpeg' });
+      const { uri, bytes } = await compressAvatar(asset);
+      setPickedAvatar({ uri, bytes, name: 'avatar.jpg', type: 'image/jpeg' });
     } catch (error) {
       reportError(error);
       showToast(t('profile.validation.compressionFailed'), 'error');

--- a/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
@@ -167,7 +167,7 @@ beforeEach(() => {
   requestMediaLibraryPermissionsMock.mockResolvedValue({ granted: true });
   launchImageLibraryMock.mockResolvedValue({
     canceled: false,
-    assets: [{ uri: 'file://picked-avatar.jpg', width: 2400, height: 1600 }],
+    assets: [{ uri: 'file://picked-avatar.jpg', width: 2400, height: 1600, mimeType: 'image/jpeg' }],
   });
   saveAsyncMock.mockResolvedValue({ uri: 'file://compressed-avatar.jpg' });
   renderAsyncMock.mockResolvedValue({ saveAsync: saveAsyncMock, release: releaseMock });
@@ -250,8 +250,61 @@ describe('EditProfileScreen', () => {
     expect(context).toMatchObject({
       level: 'warning',
       tags: { source: 'avatar-compress' },
-      extra: { compressedBytes: 0, originalBytes: 4 },
+      extra: { compressedBytes: 0, originalBytes: 4, originalType: 'image/jpeg' },
     });
+  });
+
+  // The fallback skips the JPEG re-encode, so the bytes are whatever the picker
+  // produced. Declaring them `image/jpeg` regardless would store a PNG under a
+  // .jpg key with a lying content-type.
+  it("sends the fallback crop under the picker's own MIME type", async () => {
+    launchImageLibraryMock.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file://picked-avatar.png', width: 2400, height: 1600, mimeType: 'image/png' }],
+    });
+    fileBytesByUri.set('file://picked-avatar.png', new Uint8Array([7, 7]));
+    fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('file://picked-avatar.png');
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'profile.save' }));
+
+    await waitFor(() => {
+      expect(uploadAvatarMock).toHaveBeenCalledWith(
+        {
+          uri: 'file://picked-avatar.png',
+          bytes: new Uint8Array([7, 7]),
+          name: 'avatar.png',
+          type: 'image/png',
+        },
+        '11111111-1111-4111-8111-111111111111',
+      );
+    });
+  });
+
+  it('refuses a fallback crop the backend would not accept, rather than mislabelling it', async () => {
+    launchImageLibraryMock.mockResolvedValue({
+      canceled: false,
+      assets: [{ uri: 'file://picked-avatar.heic', width: 2400, height: 1600, mimeType: 'image/heic' }],
+    });
+    fileBytesByUri.set('file://picked-avatar.heic', new Uint8Array([5, 5, 5]));
+    fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+    });
+    expect(uploadAvatarMock).not.toHaveBeenCalled();
+
+    const [, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(context).toMatchObject({ level: 'error', extra: { originalType: 'image/heic' } });
   });
 
   it('falls back to the picker crop when the manipulator throws outright', async () => {
@@ -289,7 +342,7 @@ describe('EditProfileScreen', () => {
     expect(context).toMatchObject({
       level: 'warning',
       tags: { source: 'avatar-compress' },
-      extra: { compressedBytes: 0, originalBytes: 4 },
+      extra: { compressedBytes: 0, originalBytes: 4, originalType: 'image/jpeg' },
     });
   });
 
@@ -332,7 +385,7 @@ describe('EditProfileScreen', () => {
     expect(context).toMatchObject({
       level: 'error',
       tags: { source: 'avatar-compress' },
-      extra: { compressedBytes: 0, originalBytes: MAX_AVATAR_BYTES + 1 },
+      extra: { compressedBytes: 0, originalBytes: MAX_AVATAR_BYTES + 1, originalType: 'image/jpeg' },
     });
   });
 });

--- a/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
@@ -14,6 +14,11 @@ const resizeMock = vi.hoisted(() => vi.fn());
 const renderAsyncMock = vi.hoisted(() => vi.fn());
 const saveAsyncMock = vi.hoisted(() => vi.fn());
 const releaseMock = vi.hoisted(() => vi.fn());
+const reportHandledErrorMock = vi.hoisted(() => vi.fn());
+// Bytes the stubbed expo-file-system `File` hands back, keyed by URI. Missing
+// entries read back as empty — which is exactly the Android failure under test:
+// a 0-byte file reads as an empty array instead of throwing.
+const fileBytesByUri = vi.hoisted(() => new Map<string, Uint8Array>());
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
@@ -39,6 +44,18 @@ vi.mock('expo-image-picker', () => ({
 vi.mock('expo-image-manipulator', () => ({
   ImageManipulator: { manipulate: manipulateMock },
   SaveFormat: { JPEG: 'jpeg' },
+}));
+
+vi.mock('expo-file-system', () => ({
+  File: class {
+    uri: string;
+    constructor(uri: string) {
+      this.uri = uri;
+    }
+    bytes() {
+      return Promise.resolve(fileBytesByUri.get(this.uri) ?? new Uint8Array());
+    }
+  },
 }));
 
 vi.mock('../../providers/theme-provider', () => ({
@@ -68,10 +85,14 @@ vi.mock('../../lib/graphql/hooks', () => ({
 
 vi.mock('../../lib/avatar-upload', () => ({
   uploadAvatar: uploadAvatarMock,
+  // Kept in step with the real module deliberately: the fallback crop is
+  // rejected against this cap, so a drift here would silently stop testing it.
+  MAX_AVATAR_BYTES: 2 * 1024 * 1024,
 }));
 
 vi.mock('../../lib/error-reporting', () => ({
   reportError: vi.fn(),
+  reportHandledError: reportHandledErrorMock,
 }));
 
 vi.mock('../Avatar', () => ({
@@ -130,6 +151,11 @@ beforeEach(() => {
   renderAsyncMock.mockReset();
   saveAsyncMock.mockReset();
   releaseMock.mockReset();
+  reportHandledErrorMock.mockReset();
+
+  fileBytesByUri.clear();
+  fileBytesByUri.set('file://picked-avatar.jpg', new Uint8Array([9, 9, 9, 9]));
+  fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array([1, 2, 3]));
 
   requestMediaLibraryPermissionsMock.mockResolvedValue({ granted: true });
   launchImageLibraryMock.mockResolvedValue({
@@ -164,7 +190,12 @@ describe('EditProfileScreen', () => {
 
     await waitFor(() => {
       expect(uploadAvatarMock).toHaveBeenCalledWith(
-        { uri: 'file://compressed-avatar.jpg', name: 'avatar.jpg', type: 'image/jpeg' },
+        {
+          uri: 'file://compressed-avatar.jpg',
+          bytes: new Uint8Array([1, 2, 3]),
+          name: 'avatar.jpg',
+          type: 'image/jpeg',
+        },
         '11111111-1111-4111-8111-111111111111',
       );
     });
@@ -172,5 +203,105 @@ describe('EditProfileScreen', () => {
       avatarUrl: 'https://ws.example.com/static/avatars/11111111-1111-4111-8111-111111111111.jpg?v=upload-123',
     });
     expect(routerBackMock).toHaveBeenCalledOnce();
+    expect(reportHandledErrorMock).not.toHaveBeenCalled();
+  });
+
+  // Android's `saveAsync` ignores the Boolean `Bitmap.compress()` returns, so a
+  // failed encode resolves with a URI pointing at a 0-byte file. Every layer
+  // below treated that as success, and the user's picture vanished on the next
+  // screen with nothing logged anywhere.
+  it('falls back to the picker crop when the compressed file comes back empty', async () => {
+    fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('file://picked-avatar.jpg');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.save' }));
+
+    await waitFor(() => {
+      expect(uploadAvatarMock).toHaveBeenCalledWith(
+        {
+          uri: 'file://picked-avatar.jpg',
+          bytes: new Uint8Array([9, 9, 9, 9]),
+          name: 'avatar.jpg',
+          type: 'image/jpeg',
+        },
+        '11111111-1111-4111-8111-111111111111',
+      );
+    });
+    expect(routerBackMock).toHaveBeenCalledOnce();
+
+    // The whole reason this went unnoticed: nothing reported it.
+    expect(reportHandledErrorMock).toHaveBeenCalledOnce();
+    const [reportedError, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(reportedError.message).toBe('Avatar compression produced an empty file');
+    expect(context).toMatchObject({
+      level: 'warning',
+      tags: { source: 'avatar-compress' },
+      extra: { compressedBytes: 0, originalBytes: 4 },
+    });
+  });
+
+  it('falls back to the picker crop when the manipulator throws outright', async () => {
+    saveAsyncMock.mockRejectedValue(new Error('CorruptedImageDataException'));
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('file://picked-avatar.jpg');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.save' }));
+
+    await waitFor(() => {
+      expect(uploadAvatarMock).toHaveBeenCalledWith(
+        {
+          uri: 'file://picked-avatar.jpg',
+          bytes: new Uint8Array([9, 9, 9, 9]),
+          name: 'avatar.jpg',
+          type: 'image/jpeg',
+        },
+        '11111111-1111-4111-8111-111111111111',
+      );
+    });
+    expect(showToastMock).not.toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+  });
+
+  it('tells the user when neither the compressed file nor the picker crop is usable', async () => {
+    fileBytesByUri.clear();
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+    });
+    // No avatar was picked, so Save stays disabled and nothing is uploaded.
+    expect(screen.getByTestId('avatar').getAttribute('data-uri')).toBe('');
+    expect(screen.getByRole('button', { name: 'profile.save' })).toHaveProperty('disabled', true);
+    expect(uploadAvatarMock).not.toHaveBeenCalled();
+    expect(routerBackMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a fallback crop that is over the backend cap rather than uploading it', async () => {
+    fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
+    fileBytesByUri.set('file://picked-avatar.jpg', new Uint8Array(2 * 1024 * 1024 + 1));
+
+    render(createElement(EditProfileScreen));
+
+    fireEvent.click(screen.getByRole('button', { name: 'profile.avatar.upload' }));
+
+    await waitFor(() => {
+      expect(showToastMock).toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+    });
+    expect(uploadAvatarMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
@@ -279,6 +279,18 @@ describe('EditProfileScreen', () => {
       );
     });
     expect(showToastMock).not.toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
+    expect(routerBackMock).toHaveBeenCalledOnce();
+
+    // The manipulator's own error is what gets reported here, not a synthetic
+    // "empty file" — the two failure shapes stay distinguishable in triage.
+    expect(reportHandledErrorMock).toHaveBeenCalledOnce();
+    const [reportedError, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(reportedError.message).toBe('CorruptedImageDataException');
+    expect(context).toMatchObject({
+      level: 'warning',
+      tags: { source: 'avatar-compress' },
+      extra: { compressedBytes: 0, originalBytes: 4 },
+    });
   });
 
   it('tells the user when neither the compressed file nor the picker crop is usable', async () => {

--- a/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
+++ b/packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx
@@ -83,11 +83,17 @@ vi.mock('../../lib/graphql/hooks', () => ({
   useUpdateProfile: () => ({ mutateAsync: mutateAsyncMock }),
 }));
 
-vi.mock('../../lib/avatar-upload', () => ({
+// `authenticatedFetch` drags in auth-store → expo-secure-store, which doesn't
+// load under jsdom. Stubbing it is what lets the avatar-upload mock below be a
+// *partial* one, so `MAX_AVATAR_BYTES` is the real constant and the over-cap
+// test can't drift away from the boundary it's meant to exercise.
+vi.mock('../../lib/auth-interceptor', () => ({
+  authenticatedFetch: vi.fn(),
+}));
+
+vi.mock('../../lib/avatar-upload', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../lib/avatar-upload')>()),
   uploadAvatar: uploadAvatarMock,
-  // Kept in step with the real module deliberately: the fallback crop is
-  // rejected against this cap, so a drift here would silently stop testing it.
-  MAX_AVATAR_BYTES: 2 * 1024 * 1024,
 }));
 
 vi.mock('../../lib/error-reporting', () => ({
@@ -137,6 +143,7 @@ vi.mock('../Text', () => ({
   Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
 }));
 
+import { MAX_AVATAR_BYTES } from '../../lib/avatar-upload';
 import { EditProfileScreen } from '../EditProfileScreen';
 
 beforeEach(() => {
@@ -289,11 +296,12 @@ describe('EditProfileScreen', () => {
     expect(screen.getByRole('button', { name: 'profile.save' })).toHaveProperty('disabled', true);
     expect(uploadAvatarMock).not.toHaveBeenCalled();
     expect(routerBackMock).not.toHaveBeenCalled();
+    expect(reportHandledErrorMock).toHaveBeenCalledOnce();
   });
 
   it('refuses a fallback crop that is over the backend cap rather than uploading it', async () => {
     fileBytesByUri.set('file://compressed-avatar.jpg', new Uint8Array());
-    fileBytesByUri.set('file://picked-avatar.jpg', new Uint8Array(2 * 1024 * 1024 + 1));
+    fileBytesByUri.set('file://picked-avatar.jpg', new Uint8Array(MAX_AVATAR_BYTES + 1));
 
     render(createElement(EditProfileScreen));
 
@@ -303,5 +311,16 @@ describe('EditProfileScreen', () => {
       expect(showToastMock).toHaveBeenCalledWith('profile.validation.compressionFailed', 'error');
     });
     expect(uploadAvatarMock).not.toHaveBeenCalled();
+
+    // Losing the pick outright is reported at `error`, not the `warning` the
+    // rescued-by-fallback path uses — and only once, not once here and again
+    // from the screen's catch block.
+    expect(reportHandledErrorMock).toHaveBeenCalledOnce();
+    const [, context] = reportHandledErrorMock.mock.calls[0] as [Error, Record<string, unknown>];
+    expect(context).toMatchObject({
+      level: 'error',
+      tags: { source: 'avatar-compress' },
+      extra: { compressedBytes: 0, originalBytes: MAX_AVATAR_BYTES + 1 },
+    });
   });
 });

--- a/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
+++ b/packages/mobile/src/lib/__tests__/avatar-upload.test.ts
@@ -13,21 +13,19 @@ vi.mock('../auth-interceptor', () => ({
   authenticatedFetch: (...args: unknown[]) => mockAuthenticatedFetch(...args),
 }));
 
-// expo-file-system is native; stub the File class so `.bytes()` resolves to a
-// fixed payload in Node.
-const fileBytes = new Uint8Array([1, 2, 3]);
-// What the stubbed File hands back, plus a read counter — a test points this at
-// an empty payload to simulate a picked file that has become unreadable.
-const stubbedFile = { bytes: fileBytes as Uint8Array, reads: 0 };
+// expo-file-system is native. `uploadAvatar` must not touch it at all any more —
+// the caller reads the picked file at pick time and passes the bytes in — so the
+// stub exists purely to fail loudly if a lazy read ever creeps back in.
+const fileConstructions = { count: 0 };
 vi.mock('expo-file-system', () => ({
   File: class {
     uri: string;
     constructor(uri: string) {
+      fileConstructions.count += 1;
       this.uri = uri;
     }
     bytes() {
-      stubbedFile.reads += 1;
-      return Promise.resolve(stubbedFile.bytes);
+      return Promise.resolve(new Uint8Array());
     }
   },
 }));
@@ -49,10 +47,11 @@ class RecordingFormData {
 }
 vi.stubGlobal('FormData', RecordingFormData);
 
-import { absolutizeAvatarUrl, uploadAvatar } from '../avatar-upload';
+import { absolutizeAvatarUrl, MAX_AVATAR_BYTES, uploadAvatar } from '../avatar-upload';
 
 const BACKEND = 'https://ws.example.com';
-const file = { uri: 'file:///tmp/avatar.jpg', name: 'avatar.jpg', type: 'image/jpeg' };
+const fileBytes = new Uint8Array([1, 2, 3]);
+const file = { uri: 'file:///tmp/avatar.jpg', bytes: fileBytes, name: 'avatar.jpg', type: 'image/jpeg' };
 const userId = '11111111-2222-3333-4444-555555555555';
 
 function jsonResponse(body: unknown, ok = true): Response {
@@ -61,8 +60,7 @@ function jsonResponse(body: unknown, ok = true): Response {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  stubbedFile.bytes = fileBytes;
-  stubbedFile.reads = 0;
+  fileConstructions.count = 0;
 });
 
 describe('absolutizeAvatarUrl', () => {
@@ -104,15 +102,21 @@ describe('uploadAvatar', () => {
     expect(typeof avatarPart.bytes).toBe('function');
     await expect(avatarPart.bytes()).resolves.toBe(fileBytes);
 
-    // Read once, before the POST: the encoder only awaits `bytes()` at encode
-    // time, so a lazy read could hand it an empty part after the file went away.
-    expect(stubbedFile.reads).toBe(1);
+    // The bytes come from the descriptor, not from a fresh read of the URI: the
+    // encoder only awaits `bytes()` at encode time, so a lazy read could hand it
+    // an empty part after the picked file went away.
+    expect(fileConstructions.count).toBe(0);
   });
 
   it('refuses to POST an empty file instead of storing a zero-byte avatar', async () => {
-    stubbedFile.bytes = new Uint8Array([]);
+    await expect(uploadAvatar({ ...file, bytes: new Uint8Array() }, userId)).rejects.toThrow('Avatar upload failed');
+    expect(mockAuthenticatedFetch).not.toHaveBeenCalled();
+  });
 
-    await expect(uploadAvatar(file, userId)).rejects.toThrow('Avatar upload failed');
+  it("refuses to POST a file over the backend's 2MB cap instead of wasting the upload", async () => {
+    const oversized = new Uint8Array(MAX_AVATAR_BYTES + 1);
+
+    await expect(uploadAvatar({ ...file, bytes: oversized }, userId)).rejects.toThrow('Avatar upload failed');
     expect(mockAuthenticatedFetch).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/lib/avatar-upload.ts
+++ b/packages/mobile/src/lib/avatar-upload.ts
@@ -1,4 +1,3 @@
-import { File } from 'expo-file-system';
 import { authenticatedFetch } from './auth-interceptor';
 import { BACKEND_URL } from './env';
 
@@ -7,10 +6,30 @@ import { BACKEND_URL } from './env';
 // in practice every upload is a small JPEG well under the limit.
 const AVATAR_ENDPOINT = `${BACKEND_URL}/api/avatars`;
 
+/**
+ * The same cap the backend enforces (`MAX_FILE_SIZE` in
+ * `packages/backend/src/handlers/avatars.ts`). Kept mobile-local rather than
+ * shared: it is a property of the avatar endpoint, and duplicating one number
+ * beats making every consumer of `@boardsesh/shared-schema` care about it.
+ * Checking it here turns a wasted multi-megabyte upload into an instant refusal.
+ */
+export const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
+
 /** A picked (and already-compressed) local image ready to upload. */
 export type AvatarUploadFile = {
-  /** Local file URI (file://...) from the picker/manipulator. */
+  /**
+   * Local file URI (file://...) from the picker/manipulator. Used for the
+   * on-screen preview; the upload itself goes off `bytes`.
+   */
   uri: string;
+  /**
+   * The image bytes, already read from `uri` and proven non-empty at pick time.
+   * Carrying the bytes instead of re-reading the URI here is deliberate: on
+   * Android a failed encode leaves a 0-byte file behind that reads back as an
+   * empty array without throwing, so the read has to happen where we can still
+   * recover (see `compressAvatar` in EditProfileScreen).
+   */
+  bytes: Uint8Array;
   /** Filename sent in the multipart part; defaults to `avatar.jpg`. */
   name?: string;
   /** MIME type; defaults to `image/jpeg` (what the manipulator emits). */
@@ -48,15 +67,13 @@ function withCacheBuster(url: string): string {
  * added by the fetch layer, and `authenticatedFetch` only touches `Authorization`.
  */
 export async function uploadAvatar(file: AvatarUploadFile, userId: string): Promise<string> {
-  const localFile = new File(file.uri);
-
-  // Read the bytes now instead of handing the encoder a lazy `bytes()` closure.
-  // The multipart encoder only awaits `bytes()` at encode time, so a picked file
-  // that has since become unreadable (cache eviction) would be encoded as an
-  // empty part and stored as a zero-byte avatar that renders as a blank circle.
-  // Reading here turns that into an error the caller can surface, before the POST.
-  const avatarBytes = await localFile.bytes();
-  if (avatarBytes.length === 0) {
+  // Last gate before the POST. The multipart encoder only awaits `bytes()` at
+  // encode time and writes whatever it gets, empty included, so an unusable
+  // image that reaches here would be stored as a zero-byte avatar behind a URL
+  // we then persist forever — the picture looks saved and renders as initials.
+  // Refusing costs the user a warning toast; accepting costs them their avatar.
+  const avatarBytes = file.bytes;
+  if (avatarBytes.length === 0 || avatarBytes.length > MAX_AVATAR_BYTES) {
     throw new Error('Avatar upload failed');
   }
 


### PR DESCRIPTION
## Summary

Closes #4532. Stacked on #4273 (`fix/4228-avatar-zero-byte-fallback`) — see "Stacking" below.

The reporter's account of it (app_feedback #10204, Android, 2.3.1): *"Upload, crop, hit save, see it
in the pfp, exit to main screen, pfp gone."* That is not a persistence bug — the URL round-trips
fine. The **bytes** never made it, and four consecutive layers treated zero bytes as success.

1. `expo-image-manipulator`'s Android `saveAsync` writes `resultBitmap.compress(fmt, q, fileOut)`
   and throws away the `Boolean` it returns (`ImageManipulatorModule.kt`), so a failed encode still
   resolves with a `uri` — pointing at a 0-byte file. iOS raises `CorruptedImageDataException` in
   the same place (`ImageManipulatorUtils.swift`), which is why this one is labelled Android.
2. `File.bytes()` on an existing-but-empty file returns an empty `ByteArray` without throwing.
3. Expo's WinterCG multipart encoder awaits the part's `bytes()` at encode time and writes whatever
   it gets, empty included.
4. The backend's `Buffer.concat([])` is truthy, so it sailed past the `!fileBuffer` check, PUT an
   empty object to S3 and answered `200 {avatarUrl}` — which the client dutifully persisted.

The preview on the edit screen reads the *local* file URI, so the crop looks right the whole time.
The moment you navigate away, `<Image>` can't decode the empty body, `Avatar` fires `onError`, and
you get initials. Nothing threw anywhere — matching Sentry, which has **zero** avatar / manipulator
/ picker errors across 90 days while the Android error stream is otherwise healthy (25 issue groups
in 30 days).

### What this PR changes (mobile only)

- **`compressAvatar` reads its own output and recovers.** It now takes the picker asset, reads the
  compressed file, and returns `{ uri, bytes }`. If the bytes come back empty — or the manipulator
  throws — it falls back to the picker's own crop, which is already square (`aspect: [1, 1]`) and
  only misses the resize/re-encode. `expo-image-picker`'s Android exporter drops the same
  `Boolean` in `CompressionImageExporter.writeImage`, so the fallback gets its own length check
  rather than being trusted, and is rejected above the backend's 2MB cap.
- **The fallback is sent under its real image type.** It skips the JPEG re-encode, so the bytes are
  whatever the picker produced — on Android routinely PNG or HEIC. The declared type comes from
  `asset.mimeType` with a matching filename, rather than claiming `image/jpeg` for everything.
- **A genuinely unusable pick now says so.** When neither the compressed file nor the picker crop
  has bytes — or the picker's type isn't one the backend accepts (HEIC, most often) —
  `compressAvatar` throws and the existing "could not compress" toast fires at pick time instead of
  a silent blank or a confusing upload failure on save. No new strings —
  `profile.validation.compressionFailed` and `profile.avatarUploadFailed` already exist in all four
  locales.
- **Telemetry on the fallback.** One `reportHandledError` per failure, tagged
  `source: avatar-compress`, carrying the two byte counts, the picker's MIME type and
  `Platform.OS` — sizes, type and platform only, no URIs or identifiers. `warning` when the
  fallback rescues the save, `error` when the climber loses the pick. This path had *no* telemetry
  at all, which is why it went unnoticed for so long; now we can see which layer produced the empty
  file rather than inferring it.
- **`AvatarUploadFile` carries bytes, not a URI to re-read.** #4273 made `uploadAvatar` read
  eagerly; this moves the read up to pick time, where a failure can still be recovered instead of
  only reported. `uploadAvatar` keeps the last-gate check and now also refuses anything over 2MB
  before wasting the POST. The cap stays mobile-local (`MAX_AVATAR_BYTES` next to
  `AVATAR_ENDPOINT`), mirroring the backend's `MAX_FILE_SIZE`.

JS/TS only. No native module, no Expo plugin, no native config — **OTA-safe, no fingerprint
change**. No migration, no new dependencies, not BLE.

### Stacking

Based on **`fix/4228-avatar-zero-byte-fallback`** (#4273), which already fixes the backend half —
`POST /api/avatars` rejects an empty part, and `/static/avatars/*` 404s a zero-byte object with
`Cache-Control: no-store`. Both PRs edit `packages/mobile/src/lib/avatar-upload.ts`, so landing
them independently on `main` would conflict in `uploadAvatar`. **If #4273 merges first, retarget
this PR to `main`.** The diff shown here is only this PR's half.

They are complementary, not duplicates: #4273 turns silent corruption into a visible warning; this
one lets the climber actually save a picture on the affected devices.

### Proven vs inferred — please read

I could not query production. There is no `DB_URL` credential on the machine this was written on,
and there is no unauthenticated surface that returns an `avatarUrl`, so **no live avatar's
`Content-Length` was measured for this issue.**

**Proven by code reading:**

- The four unchecked layers above, each read at the exact source line.
- The URL round-trips: `profile` and `updateProfile` both select and return
  `userProfiles.avatarUrl`, the mobile operations request it, and the hook writes it into
  `['profile']` and invalidates. "It doesn't persist" is ruled out at the code level.
- The iOS/Android divergence, which explains why #4228 (iOS) presents as a blank circle and #4532
  (Android) as initials.

**Inferred:**

- That the reporter's stored object is specifically zero bytes. The support for this is indirect:
  Sentry's silence rules out every failure mode that throws, and #4273 already *measured* zero-byte
  avatar objects in production on this bucket (`200 image/jpeg`, 0 bytes, against ~422KB for a
  healthy one). That leaves "persisted URL, unrenderable bytes".

**The one query that would settle it**, for anyone with the prod credential — read-only, safe:

```sql
select up.avatar_url, af.created_at
from app_feedback af
join user_profiles up on up.user_id = af.user_id
where af.id = 10204;
```

Then `curl -sI` that URL with the CDN bypassed. `200` with `content-length: 0` confirms this
outright. A healthy body would mean the URL is fine and the bug is in rendering instead — in which
case this PR is still correct hardening but is not the fix, and #4532 should be reopened.

### Not in this PR

Accounts that already stored a zero-byte object keep a non-null `avatar_url`. With #4273 in place
it now 404s, so they render initials, and **re-uploading repairs the row on its own** — which is
exactly what this PR makes possible again on Android. Nulling those rows would be a production data
write, so it is deliberately left for @marcodejongh to decide rather than done here.

## Release Notes

- Your profile picture sticks this time — on Android a photo that failed to compress was saved as an empty image, so it vanished the second you left the screen
- If a photo really can't be used, you get told up front instead of finding an empty circle later

## Test plan

`packages/mobile/src/lib/__tests__/avatar-upload.test.ts`

- The multipart part's bytes come from the descriptor, and `expo-file-system`'s `File` is never
  constructed — a lazy re-read can't creep back in
- Empty bytes reject with `Avatar upload failed` and `authenticatedFetch` is never called
- Over 2MB rejects the same way, before the POST

`packages/mobile/src/components/__tests__/EditProfileScreen.test.tsx`

- Compressed output empty + picker crop readable → uploads the picker crop's bytes, save completes,
  and exactly one `reportHandledError` warning fires carrying `compressedBytes: 0` /
  `originalBytes: 4` / `originalType`
- `saveAsync` rejects but the picker crop is readable → still falls back and saves, no error toast,
  and the manipulator's own error is what gets reported (not a synthetic "empty file")
- PNG pick → uploaded as `avatar.png` / `image/png`, not mislabelled as JPEG
- HEIC pick → refused at pick time with the toast and an `error`-level report, rather than sending
  the backend a type it rejects
- Neither readable → `profile.validation.compressionFailed` toast, Save stays disabled,
  `uploadAvatar` and `router.back()` never called
- Fallback crop over 2MB → refused with the same toast, reported once at `error` (which also pins
  that the screen's catch block doesn't file a second event for the same failure)
- Happy path unchanged, and asserts nothing is reported

Gates run locally: `vp run typecheck:mobile`, `vp run test:mobile`, `vp run check:mobile-bundle`,
`vp check`.

**Device QA still owed** (nothing here can cover it): on a real Android phone, Profile → Edit →
pick a photo → crop → Save → back to the main screen → the avatar is still there; force-quit and
relaunch → still there.

Related: #4228, #4273
