### PR TITLE
feat(mobile): show setter notes on a climb

### DIFF
--- a/packages/backend/src/__tests__/operations-schema-validation.test.ts
+++ b/packages/backend/src/__tests__/operations-schema-validation.test.ts
@@ -222,17 +222,38 @@ describe('mobile plain-string subscription documents validate against the execut
 // opened from search while leaving deep-linked climbs fine. Same technique as
 // queue-climb-field-contract.test.ts: read the hand-maintained template out of
 // mobile's source and assert on the parsed field set.
-describe('mobile CLIMB_SEARCH_FIELDS carries the fields the play drawer renders', () => {
-  const searchFields = climbFieldNames(
+describe('CLIMB_SEARCH_FIELDS carries the fields the play drawer renders', () => {
+  // The shared document nests the list under `searchClimbs { climbs { ... } }`,
+  // so collect by the `climbs` parent rather than the `climb` one climbFieldNames uses.
+  function searchResultClimbFields(operationSource: string): Set<string> {
+    const fields = new Set<string>();
+    visit(parse(operationSource), {
+      Field(node) {
+        if (node.name.value !== 'climbs' || !node.selectionSet) return;
+        for (const selection of node.selectionSet.selections) {
+          if (selection.kind === 'Field') fields.add(selection.name.value);
+        }
+      },
+    });
+    return fields;
+  }
+
+  const mobileSearchFields = climbFieldNames(
     `{ climb { ${extractTemplateConst(readMobileOperationsSource(), 'CLIMB_SEARCH_FIELDS')} } }`,
   );
+  const sharedSearchFields = searchResultClimbFields(publicOperations.SEARCH_CLIMBS);
 
-  it('selects a non-empty field set', () => {
-    expect(searchFields.size).toBeGreaterThan(0);
+  it('both copies select a non-empty field set', () => {
+    expect(mobileSearchFields.size).toBeGreaterThan(0);
+    expect(sharedSearchFields.size).toBeGreaterThan(0);
   });
 
-  it('selects description, so the play drawer can show the setter notes (#4494)', () => {
-    expect(searchFields.has('description')).toBe(true);
+  it('mobile selects description, so the play drawer can show the setter notes (#4494)', () => {
+    expect(mobileSearchFields.has('description')).toBe(true);
+  });
+
+  it('the shared search operation selects description too, so a future web caller starts correct', () => {
+    expect(sharedSearchFields.has('description')).toBe(true);
   });
 });
 

--- a/packages/backend/src/__tests__/operations-schema-validation.test.ts
+++ b/packages/backend/src/__tests__/operations-schema-validation.test.ts
@@ -214,6 +214,28 @@ describe('mobile plain-string subscription documents validate against the execut
   }
 });
 
+// Regression guard for #4494. `CLIMB_SEARCH_FIELDS` — the selection set behind
+// SEARCH_CLIMBS, which is how every climb reaches the Climbs list and, through
+// it, the play drawer — deliberately omitted `description` on the premise that
+// "no list UI renders them". The play drawer DOES render it now (setter notes),
+// so re-slimming the list would silently blank that section for every climb
+// opened from search while leaving deep-linked climbs fine. Same technique as
+// queue-climb-field-contract.test.ts: read the hand-maintained template out of
+// mobile's source and assert on the parsed field set.
+describe('mobile CLIMB_SEARCH_FIELDS carries the fields the play drawer renders', () => {
+  const searchFields = climbFieldNames(
+    `{ climb { ${extractTemplateConst(readMobileOperationsSource(), 'CLIMB_SEARCH_FIELDS')} } }`,
+  );
+
+  it('selects a non-empty field set', () => {
+    expect(searchFields.size).toBeGreaterThan(0);
+  });
+
+  it('selects description, so the play drawer can show the setter notes (#4494)', () => {
+    expect(searchFields.has('description')).toBe(true);
+  });
+});
+
 describe('native iOS queue subscription drift guard', () => {
   it('matches the shared-schema native queue operation exactly after whitespace normalization', () => {
     const nativeOperation = readNativeIosQueueUpdatesOperation();

--- a/packages/mobile/src/components/play-drawer/DeferredSections.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredSections.tsx
@@ -14,6 +14,7 @@ import { BoardseshGradeSection } from './BoardseshGradeSection';
 import { buildBoardseshGradeView, buildBoardseshGradeSummary, isMoonBoard } from './boardsesh-grade-utils';
 import { buildAngleGradeBars } from './community-utils';
 import { BetaVideosSection } from './BetaVideosSection';
+import { SetterNotesSection } from './SetterNotesSection';
 import { useAuth } from '../../providers/auth-provider';
 import { useBoardseshGradeEnabled } from '../../providers/feature-flags-provider';
 import { useTheme } from '../../providers/theme-provider';
@@ -202,6 +203,13 @@ export const DeferredSections = memo(function DeferredSections({
 
       {readyToRender && (
         <>
+          {/* The setter's own notes. First below-fold section AFTER the Logbook,
+              never before it: PlayDrawer's `firstScreenReserve` /
+              `computeLogbookScrollTarget` assume the Logbook is the first
+              section here, so anything inserted above it breaks the fold math.
+              Renders nothing when the climb has no notes worth showing. */}
+          <SetterNotesSection description={climb.description} />
+
           <CollapsibleSection
             title={t('mobile.betaVideos.title')}
             defaultExpanded

--- a/packages/mobile/src/components/play-drawer/SetterNotesSection.tsx
+++ b/packages/mobile/src/components/play-drawer/SetterNotesSection.tsx
@@ -26,6 +26,9 @@ export function SetterNotesSection({ description }: SetterNotesSectionProps) {
 
   if (!notes) return null;
 
+  // `persistKey` is deliberately climb-agnostic, like every sibling section here
+  // (logbook, community, similarClimbs): collapsing the notes is a standing
+  // "I don't want to see these" preference, not a per-climb one.
   return (
     <CollapsibleSection title={t('mobile.setterNotes.title')} defaultExpanded persistKey="setterNotes">
       <Text variant="subheadline" style={styles.notes} selectable>

--- a/packages/mobile/src/components/play-drawer/SetterNotesSection.tsx
+++ b/packages/mobile/src/components/play-drawer/SetterNotesSection.tsx
@@ -1,0 +1,42 @@
+import { StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { getDisplayDescription } from '@boardsesh/shared-schema';
+import { CollapsibleSection } from '../CollapsibleSection';
+import { Text } from '../Text';
+import { spacing } from '../../theme/tokens';
+
+type SetterNotesSectionProps = {
+  /** The raw `board_climbs.description` as it came off the wire. */
+  description: string | null | undefined;
+};
+
+/**
+ * The setter's own notes on a climb — the text typed into the create form's
+ * description field, which until #4494 was stored and never shown anywhere.
+ *
+ * Renders nothing at all when there is nothing to say: `getDisplayDescription`
+ * strips Aurora's `No match\n` marker line and drops a description that is only
+ * a restatement of "no match" (the header's no-match glyph already says that).
+ *
+ * The text is user-written, so it goes on screen verbatim — never through `t()`.
+ */
+export function SetterNotesSection({ description }: SetterNotesSectionProps) {
+  const { t } = useTranslation('climbs');
+  const notes = getDisplayDescription(description);
+
+  if (!notes) return null;
+
+  return (
+    <CollapsibleSection title={t('mobile.setterNotes.title')} defaultExpanded persistKey="setterNotes">
+      <Text variant="subheadline" style={styles.notes} selectable>
+        {notes}
+      </Text>
+    </CollapsibleSection>
+  );
+}
+
+const styles = StyleSheet.create({
+  notes: {
+    paddingBottom: spacing[1],
+  },
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/deferred-sections.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/deferred-sections.test.tsx
@@ -53,6 +53,12 @@ vi.mock('../../CollapsibleSection', () => ({
   },
 }));
 
+// SetterNotesSection renders through the real component (its suppression rules
+// are what these tests assert), so only the leaf Text needs a DOM stand-in.
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('p', { 'data-testid': 'text' }, children),
+}));
+
 vi.mock('../BetaVideosSection', () => ({
   BetaVideosSection: () => createElement('div', { 'data-testid': 'beta-videos' }),
 }));
@@ -99,10 +105,10 @@ const climb = {
   ascensionist_count: 0,
 } as Climb;
 
-function renderSections(options: { enabled?: boolean; contentEnabled?: boolean } = {}) {
+function renderSections(options: { enabled?: boolean; contentEnabled?: boolean; description?: string | null } = {}) {
   return render(
     <DeferredSections
-      climb={climb}
+      climb={options.description === undefined ? climb : ({ ...climb, description: options.description } as Climb)}
       boardName="kilter"
       layoutId={1}
       sizeId={10}
@@ -166,6 +172,63 @@ describe('DeferredSections', () => {
     renderSections({ contentEnabled: true });
 
     expect(screen.getByTestId('boardsesh-grade')).not.toBeNull();
+  });
+
+  // #4494. The notes sit BELOW the Logbook on purpose: PlayDrawer's
+  // `firstScreenReserve` / `computeLogbookScrollTarget` both assume the Logbook
+  // is the first section rendered here, so anything inserted above it silently
+  // breaks the fold math and the expand-into-view scroll.
+  describe("the setter's notes", () => {
+    function sectionTitles(container: HTMLElement): string[] {
+      return [...container.querySelectorAll('section')].map((node) => node.getAttribute('data-title') ?? '');
+    }
+
+    it('renders the notes for a climb with real prose', () => {
+      deferred.ready = true;
+      const { container } = renderSections({ contentEnabled: true, description: 'Match the rail, then send.' });
+
+      expect(container.textContent).toContain('Match the rail, then send.');
+      expect(sectionTitles(container)).toContain('mobile.setterNotes.title');
+    });
+
+    it('keeps the Logbook first and puts the notes directly after it', () => {
+      deferred.ready = true;
+      const { container } = renderSections({ contentEnabled: true, description: 'Match the rail, then send.' });
+
+      expect(sectionTitles(container).slice(0, 2)).toEqual(['mobile.logbook.title', 'mobile.setterNotes.title']);
+    });
+
+    it('leaves the Logbook first when there are no notes to show', () => {
+      deferred.ready = true;
+      const { container } = renderSections({ contentEnabled: true, description: '' });
+
+      expect(sectionTitles(container)[0]).toBe('mobile.logbook.title');
+    });
+
+    it('renders no section at all for an empty or bare no-match description', () => {
+      for (const description of ['', 'No match', 'No match\n', 'No matching.', 'no matching']) {
+        deferred.ready = true;
+        const { container, unmount } = renderSections({ contentEnabled: true, description });
+
+        expect(sectionTitles(container)).not.toContain('mobile.setterNotes.title');
+        unmount();
+      }
+    });
+
+    it('never eats setter beta that merely mentions matching', () => {
+      deferred.ready = true;
+      const prose = 'No Houdini swap, spin around pls:). No matching.';
+      const { container } = renderSections({ contentEnabled: true, description: prose });
+
+      expect(container.textContent).toContain(prose);
+    });
+
+    it('waits for the interaction defer like the other below-fold sections', () => {
+      deferred.ready = false;
+      const { container } = renderSections({ contentEnabled: true, description: 'Match the rail, then send.' });
+
+      expect(container.textContent).not.toContain('Match the rail, then send.');
+    });
   });
 
   it('renders nothing while disabled', () => {

--- a/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
+++ b/packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts
@@ -39,6 +39,7 @@ type ClimbFixture = {
   characteristics?: string[] | null;
   setterUsername?: string | null;
   createdAt?: string | null;
+  description?: string | null;
 };
 
 type StatFixture = {
@@ -55,14 +56,15 @@ type StatFixture = {
 async function insertClimb(db: TestSqliteDb, fixture: ClimbFixture): Promise<void> {
   await db.runAsync(
     `INSERT INTO board_climbs
-      (uuid, board_type, layout_id, name, is_listed, is_draft, frames_count, frames,
+      (uuid, board_type, layout_id, name, description, is_listed, is_draft, frames_count, frames,
        compatible_size_ids, required_set_ids, characteristics, setter_username, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       fixture.uuid,
       fixture.boardType ?? 'kilter',
       fixture.layoutId ?? 1,
       fixture.name ?? `Climb ${fixture.uuid}`,
+      fixture.description ?? null,
       fixture.isListed ?? 1,
       fixture.isDraft ?? 0,
       fixture.framesCount ?? 1,
@@ -199,6 +201,24 @@ describe('searchClimbsLocal', () => {
     expect(uuids(result)).toEqual(['a']);
     expect(result.hasMore).toBe(false);
     expect(await countClimbsLocal(db, makeInput())).toBe(1);
+  });
+
+  // #4494: the search read used to drop board_climbs.description on the floor,
+  // so a climb opened from the Climbs list reached the play drawer with no
+  // setter notes at all — and the offline path is the one most users hit.
+  it('carries the setter description through to the mapped climb', async () => {
+    await insertClimb(db, { uuid: 'with-notes', description: 'Match the rail, then\nbig move to the jug.' });
+
+    const result = await searchClimbsLocal(db, makeInput());
+    expect(result.climbs).toHaveLength(1);
+    expect(result.climbs[0].description).toBe('Match the rail, then\nbig move to the jug.');
+  });
+
+  it('reports an empty description (not undefined) when the setter wrote none', async () => {
+    await insertClimb(db, { uuid: 'no-notes' });
+
+    const result = await searchClimbsLocal(db, makeInput());
+    expect(result.climbs[0].description).toBe('');
   });
 
   it('filters by size via compatible_size_ids (contains), excluding NULL', async () => {

--- a/packages/mobile/src/db/queries/get-climb-local.ts
+++ b/packages/mobile/src/db/queries/get-climb-local.ts
@@ -44,5 +44,7 @@ export async function getClimbLocal(db: OfflineDatabase, input: GetClimbLocalInp
   if (!row) return null;
 
   const climb = mapRowToClimb(row, boardName, layoutId, angle);
-  return { ...climb, description: row.description ?? '', mirrored: false };
+  // `description` now comes straight out of mapRowToClimb (the search read
+  // carries it too since #4494), so only `mirrored` is patched on here.
+  return { ...climb, mirrored: false };
 }

--- a/packages/mobile/src/db/queries/search-climbs-local.ts
+++ b/packages/mobile/src/db/queries/search-climbs-local.ts
@@ -413,8 +413,9 @@ export type LocalClimbRow = {
   /** Boardsesh grade confidence tier from board_climb_grades; null when unjoined. */
   boardsesh_confidence: string | null;
   /** Setter-written notes. Selected by both the detail read and the search read
-   *  (#4494 — the play drawer renders it for whatever climb the list opened). */
-  description?: string | null;
+   *  (#4494 — the play drawer renders it for whatever climb the list opened),
+   *  so it is always present on the row; null when the setter wrote none. */
+  description: string | null;
 };
 
 export function parseCharacteristics(raw: string | null): string[] | null {

--- a/packages/mobile/src/db/queries/search-climbs-local.ts
+++ b/packages/mobile/src/db/queries/search-climbs-local.ts
@@ -412,7 +412,8 @@ export type LocalClimbRow = {
   boardsesh_difficulty: number | null;
   /** Boardsesh grade confidence tier from board_climb_grades; null when unjoined. */
   boardsesh_confidence: string | null;
-  /** Selected by the detail read; absent (undefined) for search rows. */
+  /** Setter-written notes. Selected by both the detail read and the search read
+   *  (#4494 — the play drawer renders it for whatever climb the list opened). */
   description?: string | null;
 };
 
@@ -441,6 +442,7 @@ export function mapRowToClimb(row: LocalClimbRow, boardType: string, layoutId: n
     setter_username: row.setter_username ?? '',
     userId: row.user_id ?? null,
     name: row.name ?? '',
+    description: row.description ?? '',
     frames: row.frames ?? '',
     angle,
     ascensionist_count: Number(row.ascensionist_count ?? 0),
@@ -508,7 +510,7 @@ export async function searchClimbsLocal(db: OfflineDatabase, input: ClimbSearchI
 
   const query = `
     SELECT
-      c.uuid, c.setter_username, c.user_id, c.name, c.frames, c.is_draft, c.characteristics,
+      c.uuid, c.setter_username, c.user_id, c.name, c.description, c.frames, c.is_draft, c.characteristics,
       c.created_at, c.published_at, c.frames_count, c.frames_pace,
       s.ascensionist_count, s.display_difficulty, s.difficulty_average, s.quality_average,
       s.benchmark_difficulty,

--- a/packages/mobile/src/lib/graphql/operations.ts
+++ b/packages/mobile/src/lib/graphql/operations.ts
@@ -80,6 +80,7 @@ const CLIMB_SEARCH_FIELDS = `
   setter_username
   userId
   name
+  description
   frames
   angle
   ascensionist_count

--- a/packages/shared-schema/src/__tests__/no-match.test.ts
+++ b/packages/shared-schema/src/__tests__/no-match.test.ts
@@ -98,7 +98,11 @@ describe('getDisplayDescription', () => {
       'no matching',
       'NO MATCH.',
       'No-match',
+      'nomatch',
       'No matching!!',
+      'No matching?',
+      'No match;',
+      'No matching. ',
     ]) {
       expect(getDisplayDescription(restatement)).toBe('');
     }

--- a/packages/shared-schema/src/__tests__/no-match.test.ts
+++ b/packages/shared-schema/src/__tests__/no-match.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isNoMatchClimb, withNoMatch } from '../utils';
+import { getDisplayDescription, isNoMatchClimb, withNoMatch } from '../utils';
 
 describe('isNoMatchClimb', () => {
   it('detects a leading "no match" marker, case-insensitively', () => {
@@ -64,5 +64,59 @@ describe('no-match toggle cannot be derived from the description', () => {
     expect(withNoMatch(prose, false)).toBe(prose);
     // ...so a description-derived toggle would never clear — hence the decouple.
     expect(isNoMatchClimb(withNoMatch(prose, false))).toBe(true);
+  });
+});
+
+describe('getDisplayDescription', () => {
+  it("strips the canonical marker line and keeps the setter's prose", () => {
+    expect(getDisplayDescription('No match\nCrimpy start, big move off the gaston')).toBe(
+      'Crimpy start, big move off the gaston',
+    );
+  });
+
+  it('preserves interior newlines and trims the edges', () => {
+    expect(getDisplayDescription('  Start matched.\nNo feet after the crimp.  ')).toBe(
+      'Start matched.\nNo feet after the crimp.',
+    );
+  });
+
+  it('returns an empty string when there is nothing to show', () => {
+    expect(getDisplayDescription('')).toBe('');
+    expect(getDisplayDescription('   ')).toBe('');
+    expect(getDisplayDescription(null)).toBe('');
+    expect(getDisplayDescription(undefined)).toBe('');
+    expect(getDisplayDescription('No match')).toBe('');
+    expect(getDisplayDescription('No match\n')).toBe('');
+  });
+
+  it('suppresses a description that is only a restatement of "no match"', () => {
+    // Roughly half the Aurora catalog's non-empty descriptions are literally
+    // this, and the climb header's no-match glyph already says it.
+    for (const restatement of [
+      'No matching',
+      'No matching.',
+      'no matching',
+      'NO MATCH.',
+      'No-match',
+      'No matching!!',
+    ]) {
+      expect(getDisplayDescription(restatement)).toBe('');
+    }
+  });
+
+  it('never eats real setter beta that merely mentions matching (whole-string match only)', () => {
+    // The regression the anchored regex exists to prevent: a prefix — or
+    // anywhere — match would delete every one of these.
+    expect(getDisplayDescription('No matching feet allowed')).toBe('No matching feet allowed');
+    expect(getDisplayDescription('No Houdini swap, spin around pls:). No matching.')).toBe(
+      'No Houdini swap, spin around pls:). No matching.',
+    );
+    expect(getDisplayDescription('No matching.\nFeet follow hands.')).toBe('No matching.\nFeet follow hands.');
+    expect(getDisplayDescription('Matching is fine')).toBe('Matching is fine');
+  });
+
+  it('handles the marker and a restatement stacked together', () => {
+    expect(getDisplayDescription('No match\nNo matching.')).toBe('');
+    expect(getDisplayDescription('No match\nNo matching feet allowed')).toBe('No matching feet allowed');
   });
 });

--- a/packages/shared-schema/src/generated/schema.graphql
+++ b/packages/shared-schema/src/generated/schema.graphql
@@ -18,7 +18,7 @@ type Climb {
   userId: ID
   "Name/title of the climb"
   name: String!
-  "Description or notes about the climb (nullable - omitted from search results, fetch separately via climb detail query)"
+  "Setter-written notes about the climb (nullable). Carried on search results too — the play drawer and the www climb page both render it."
   description: String
   "Encoded hold positions and colors for lighting up the board"
   frames: String!

--- a/packages/shared-schema/src/generated/types.ts
+++ b/packages/shared-schema/src/generated/types.ts
@@ -926,7 +926,7 @@ export type Climb = {
   characteristics?: Maybe<Array<Scalars['String']['output']>>;
   /** ISO timestamp of when this climb row was created */
   created_at?: Maybe<Scalars['String']['output']>;
-  /** Description or notes about the climb (nullable - omitted from search results, fetch separately via climb detail query) */
+  /** Setter-written notes about the climb (nullable). Carried on search results too — the play drawer and the www climb page both render it. */
   description?: Maybe<Scalars['String']['output']>;
   /** Difficulty grade of the climb (e.g., 'V5', '6B+') */
   difficulty: Scalars['String']['output'];

--- a/packages/shared-schema/src/schema/climb.ts
+++ b/packages/shared-schema/src/schema/climb.ts
@@ -14,7 +14,7 @@ export const climbTypeDefs = /* GraphQL */ `
     userId: ID
     "Name/title of the climb"
     name: String!
-    "Description or notes about the climb (nullable - omitted from search results, fetch separately via climb detail query)"
+    "Setter-written notes about the climb (nullable). Carried on search results too — the play drawer and the www climb page both render it."
     description: String
     "Encoded hold positions and colors for lighting up the board"
     frames: String!

--- a/packages/shared-schema/src/utils.ts
+++ b/packages/shared-schema/src/utils.ts
@@ -120,8 +120,12 @@ export function withNoMatch(description: string | null | undefined, enabled: boo
  * Anchored at both ends on purpose: "No matching feet allowed" and
  * "No Houdini swap, spin around pls:). No matching." are real setter beta and
  * must survive untouched. A prefix match here would eat both.
+ *
+ * The separator is optional (so "nomatch" is caught too) and any run of
+ * sentence-ending punctuation is tolerated, since setters end this one the same
+ * half-dozen ways.
  */
-const ONLY_NO_MATCH = /^no[\s-]?match(ing)?[.!]*$/i;
+const ONLY_NO_MATCH = /^no[\s-]?match(ing)?[.!?;,\s]*$/i;
 
 /**
  * The climb description to show a climber, or `''` when there is nothing worth

--- a/packages/shared-schema/src/utils.ts
+++ b/packages/shared-schema/src/utils.ts
@@ -112,6 +112,31 @@ export function withNoMatch(description: string | null | undefined, enabled: boo
 }
 
 /**
+ * A description that says nothing beyond "this is a no-match climb" — the
+ * whole string, not a prefix. Aurora setters overwhelmingly type exactly this
+ * (83,864 of the 177,868 non-empty catalog descriptions), and the climb header
+ * already carries a no-match glyph, so repeating it as a notes block is noise.
+ *
+ * Anchored at both ends on purpose: "No matching feet allowed" and
+ * "No Houdini swap, spin around pls:). No matching." are real setter beta and
+ * must survive untouched. A prefix match here would eat both.
+ */
+const ONLY_NO_MATCH = /^no[\s-]?match(ing)?[.!]*$/i;
+
+/**
+ * The climb description to show a climber, or `''` when there is nothing worth
+ * showing. Three passes: strip Aurora's canonical `No match\n` marker line,
+ * trim, then drop a description that is only a restatement of "no match".
+ *
+ * Renderers should treat `''` as "render no notes section at all" rather than
+ * as an empty block. The text is user-written — never pass it through `t()`.
+ */
+export function getDisplayDescription(description: string | null | undefined): string {
+  const withoutMarker = withNoMatch(description, false).trim();
+  return ONLY_NO_MATCH.test(withoutMarker) ? '' : withoutMarker;
+}
+
+/**
  * Convert an Aurora quality rating (1-3) to a Boardsesh quality rating (1-5).
  *
  * Aurora's Kilter/Tension logbook stores user star ratings on a 1-3 scale

--- a/packages/shared/graphql/src/generated/graphql.ts
+++ b/packages/shared/graphql/src/generated/graphql.ts
@@ -923,7 +923,7 @@ export type Climb = {
   characteristics?: Maybe<Array<Scalars['String']['output']>>;
   /** ISO timestamp of when this climb row was created */
   created_at?: Maybe<Scalars['String']['output']>;
-  /** Description or notes about the climb (nullable - omitted from search results, fetch separately via climb detail query) */
+  /** Setter-written notes about the climb (nullable). Carried on search results too — the play drawer and the www climb page both render it. */
   description?: Maybe<Scalars['String']['output']>;
   /** Difficulty grade of the climb (e.g., 'V5', '6B+') */
   difficulty: Scalars['String']['output'];

--- a/packages/shared/graphql/src/operations/climb-search.ts
+++ b/packages/shared/graphql/src/operations/climb-search.ts
@@ -5,18 +5,14 @@ import type { Climb, HoldsFilter, ZoneMatchMode } from '@boardsesh/shared-schema
 //
 // It used to omit `description` on the premise that no list UI renders it.
 // #4494 overturned that premise: opening a climb from the list lands in the
-// play drawer, which now renders the setter's notes, so the LIVE search
-// selection — mobile's hand-maintained copy in
-// packages/mobile/src/lib/graphql/operations.ts — carries `description`, with a
-// drift guard in packages/backend/src/__tests__/operations-schema-validation.test.ts.
-// This shared document has no client today (only the operations smoke test
-// imports the module, and the app imports it for types), so it is left as-is
-// rather than re-slimmed or re-widened; if it ever gains a caller, mirror
-// mobile's field list.
-//
-// The drafts drawer uses `SEARCH_DRAFT_CLIMBS` below, which extends this
-// fragment with `description` so a draft can be loaded back into the create
-// form in a single round-trip.
+// play drawer, which renders the setter's notes, so a search result that drops
+// the field leaves the drawer blank for every climb reached through the list.
+// Both copies of this selection — this one and mobile's hand-maintained twin in
+// packages/mobile/src/lib/graphql/operations.ts — now carry it, and
+// packages/backend/src/__tests__/operations-schema-validation.test.ts guards
+// both against being re-slimmed. Cost is small: mean description length in the
+// catalog is 18 characters (max 254) against a `frames` string already on the
+// wire.
 // published_at/created_at are used by the create form to enforce the 24h
 // post-publish edit window.
 const CLIMB_SEARCH_FIELDS = `
@@ -42,10 +38,6 @@ const CLIMB_SEARCH_FIELDS = `
   framesPace
   boardseshDifficulty
   boardseshConfidence
-`;
-
-const CLIMB_DRAFT_FIELDS = `
-  ${CLIMB_SEARCH_FIELDS}
   description
 `;
 
@@ -90,15 +82,16 @@ export const SEARCH_CLIMBS = gql`
   }
 `;
 
-// Used by the drafts drawer only — fetches `description` alongside the
-// usual fields so tapping a draft can populate the create form without a
-// second round-trip. Kept separate so list and search queries don't pay
-// for the extra payload.
+// Used by the drafts drawer only — a separately-named operation so drafts can
+// be traced apart from ordinary search in logs and caches. It selects the same
+// fields as SEARCH_CLIMBS; `description` (which the create form needs to
+// repopulate a draft without a second round-trip) used to be the one addition,
+// and is now in the shared list.
 export const SEARCH_DRAFT_CLIMBS = gql`
   query SearchDraftClimbs($input: ClimbSearchInput!) {
     searchClimbs(input: $input) {
       climbs {
-        ${CLIMB_DRAFT_FIELDS}
+        ${CLIMB_SEARCH_FIELDS}
       }
       hasMore
     }

--- a/packages/shared/graphql/src/operations/climb-search.ts
+++ b/packages/shared/graphql/src/operations/climb-search.ts
@@ -1,11 +1,22 @@
 import { gql } from 'graphql-request';
 import type { Climb, HoldsFilter, ZoneMatchMode } from '@boardsesh/shared-schema';
 
-// Slim fragment for search/list views. Intentionally omits `description` to
-// keep the list payload small — descriptions can be long and no list UI
-// renders them. The drafts drawer uses `SEARCH_DRAFT_CLIMBS` below, which
-// extends this fragment with `description` so a draft can be loaded back
-// into the create form in a single round-trip.
+// Slim fragment for search/list views.
+//
+// It used to omit `description` on the premise that no list UI renders it.
+// #4494 overturned that premise: opening a climb from the list lands in the
+// play drawer, which now renders the setter's notes, so the LIVE search
+// selection — mobile's hand-maintained copy in
+// packages/mobile/src/lib/graphql/operations.ts — carries `description`, with a
+// drift guard in packages/backend/src/__tests__/operations-schema-validation.test.ts.
+// This shared document has no client today (only the operations smoke test
+// imports the module, and the app imports it for types), so it is left as-is
+// rather than re-slimmed or re-widened; if it ever gains a caller, mirror
+// mobile's field list.
+//
+// The drafts drawer uses `SEARCH_DRAFT_CLIMBS` below, which extends this
+// fragment with `description` so a draft can be loaded back into the create
+// form in a single round-trip.
 // published_at/created_at are used by the create form to enforce the 24h
 // post-publish edit window.
 const CLIMB_SEARCH_FIELDS = `

--- a/packages/shared/i18n/locales/de/climbs.json
+++ b/packages/shared/i18n/locales/de/climbs.json
@@ -592,6 +592,9 @@
       "switchBoard": "Zu {{board}} wechseln",
       "switchFailed": "Wechsel zu {{board}} hat nicht geklappt. Versuch es nochmal.",
       "cancel": "Abbrechen"
+    },
+    "setterNotes": {
+      "title": "Notizen vom Routenbau"
     }
   },
   "frontDoor": {
@@ -616,6 +619,9 @@
       "angleValue": "{{angle}}°",
       "qualityValue": "{{quality}} von 5",
       "firstAscentValue": "{{setter}}, {{date}}"
+    },
+    "setterNotes": {
+      "heading": "Notizen vom Routenbau"
     },
     "angles": {
       "heading": "Derselbe Boulder bei anderen Winkeln",

--- a/packages/shared/i18n/locales/en-US/climbs.json
+++ b/packages/shared/i18n/locales/en-US/climbs.json
@@ -592,6 +592,9 @@
       "switchBoard": "Switch to {{board}}",
       "switchFailed": "Couldn't switch to {{board}}. Try again.",
       "cancel": "Cancel"
+    },
+    "setterNotes": {
+      "title": "Setter's notes"
     }
   },
   "frontDoor": {
@@ -616,6 +619,9 @@
       "angleValue": "{{angle}}°",
       "qualityValue": "{{quality}} out of 5",
       "firstAscentValue": "{{setter}}, {{date}}"
+    },
+    "setterNotes": {
+      "heading": "Setter's notes"
     },
     "angles": {
       "heading": "Same climb, other angles",

--- a/packages/shared/i18n/locales/es/climbs.json
+++ b/packages/shared/i18n/locales/es/climbs.json
@@ -592,6 +592,9 @@
       "switchBoard": "Cambiar a {{board}}",
       "switchFailed": "No se pudo cambiar a {{board}}. Inténtalo de nuevo.",
       "cancel": "Cancelar"
+    },
+    "setterNotes": {
+      "title": "Notas del setter"
     }
   },
   "frontDoor": {
@@ -616,6 +619,9 @@
       "angleValue": "{{angle}}°",
       "qualityValue": "{{quality}} de 5",
       "firstAscentValue": "{{setter}}, {{date}}"
+    },
+    "setterNotes": {
+      "heading": "Notas del setter"
     },
     "angles": {
       "heading": "El mismo bloque en otros ángulos",

--- a/packages/shared/i18n/locales/fr/climbs.json
+++ b/packages/shared/i18n/locales/fr/climbs.json
@@ -592,6 +592,9 @@
       "switchBoard": "Passer sur {{board}}",
       "switchFailed": "Impossible de passer sur {{board}}. Réessaie.",
       "cancel": "Annuler"
+    },
+    "setterNotes": {
+      "title": "Notes de l’ouvreur"
     }
   },
   "frontDoor": {
@@ -616,6 +619,9 @@
       "angleValue": "{{angle}}°",
       "qualityValue": "{{quality}} sur 5",
       "firstAscentValue": "{{setter}}, {{date}}"
+    },
+    "setterNotes": {
+      "heading": "Notes de l’ouvreur"
     },
     "angles": {
       "heading": "Le même bloc à d’autres inclinaisons",

--- a/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
+++ b/packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { renderToString } from 'react-dom/server';
 import ClimbViewSeoFragment from '@/app/components/climb-detail/climb-view-seo-fragment';
 import { getClimbStatsForAllAngles, type ClimbStatsForAngle } from '@/app/lib/data/queries';
@@ -17,6 +17,10 @@ import { getClimbStatsForAllAngles, type ClimbStatsForAngle } from '@/app/lib/da
  *     with explicit dimensions, a setter link, angle cross-links, ≥3 internal
  *     links, and a CTA whose href is `APP_URL` + the same pathname.
  */
+
+// Mutable bits of the mocked climb row, so a test can vary what `getClimb`
+// returns without re-declaring the whole fixture.
+const climbRow = vi.hoisted(() => ({ description: null as string | null }));
 
 vi.mock('server-only', () => ({}));
 vi.mock('next/navigation', () => ({ notFound: vi.fn() }));
@@ -83,6 +87,7 @@ vi.mock('@/app/lib/data/queries', () => ({
     quality_average: '4.20',
     ascensionist_count: 12,
     frames: 'p1r12',
+    description: climbRow.description,
   })),
   getClimbStatsForAllAngles: vi.fn(async () => [
     {
@@ -284,6 +289,61 @@ describe('climb front door server HTML', () => {
     ]);
 
     expect(creativeWorkPayload(await renderFrontDoor())).not.toHaveProperty('description');
+  });
+});
+
+// #4494: setter-written notes are the one genuinely unique piece of prose on a
+// climb page, and until now they were stored and rendered nowhere.
+describe('setter notes on the climb front door', () => {
+  afterEach(() => {
+    climbRow.description = null;
+  });
+
+  it('SSR-emits a heading and the setter prose, verbatim', async () => {
+    climbRow.description = 'Match the rail, then a big move to the jug.';
+    const html = await renderFrontDoor();
+
+    expect(html).toContain('frontDoor.setterNotes.heading');
+    expect(html).toContain('Match the rail, then a big move to the jug.');
+  });
+
+  it('emits neither the heading nor an empty block when the setter wrote nothing', async () => {
+    climbRow.description = '';
+    expect(await renderFrontDoor()).not.toContain('frontDoor.setterNotes.heading');
+
+    climbRow.description = null;
+    expect(await renderFrontDoor()).not.toContain('frontDoor.setterNotes.heading');
+  });
+
+  it('drops a description that is only a restatement of "no match"', async () => {
+    for (const restatement of ['No match', 'No match\n', 'No matching.']) {
+      climbRow.description = restatement;
+      expect(await renderFrontDoor()).not.toContain('frontDoor.setterNotes.heading');
+    }
+  });
+
+  it('keeps real setter beta that merely mentions matching', async () => {
+    climbRow.description = 'No Houdini swap, spin around pls:). No matching.';
+    const html = await renderFrontDoor();
+
+    expect(html).toContain('frontDoor.setterNotes.heading');
+    expect(html).toContain('No Houdini swap, spin around pls:). No matching.');
+  });
+
+  it('still carries exactly one <h1> with the notes rendered', async () => {
+    climbRow.description = 'Match the rail, then a big move to the jug.';
+    const html = await renderFrontDoor();
+
+    expect(html.match(/<h1[\s>]/g) ?? []).toHaveLength(1);
+  });
+
+  it('leaves the JSON-LD description as the synthesised catalogue string', async () => {
+    climbRow.description = 'Match the rail, then a big move to the jug.';
+    const creativeWork = creativeWorkPayload(await renderFrontDoor());
+
+    expect(creativeWork.description).toBe(
+      'metadata.view.description(climbName=Test Climb,grade=V5,setter=setter-person,quality=4.20,ascents=12)',
+    );
   });
 });
 

--- a/packages/web/app/components/climb-front-door/climb-front-door.tsx
+++ b/packages/web/app/components/climb-front-door/climb-front-door.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Box from '@mui/material/Box';
-import type { SimilarClimb } from '@boardsesh/shared-schema';
+import { getDisplayDescription, type SimilarClimb } from '@boardsesh/shared-schema';
 import ClimbViewSeoFragment from '@/app/components/climb-detail/climb-view-seo-fragment';
 import SimilarClimbsList from '@/app/components/similar-climbs/similar-climbs-list';
 import ClimbSocialSection from '@/app/components/social/climb-social-section';
@@ -55,6 +55,13 @@ const containerSx = {
   padding: `${themeTokens.spacing[4]}px`,
 };
 
+// Setters type notes with line breaks; keep them rather than collapsing the
+// whole thing onto one line.
+const setterNotesSx = {
+  whiteSpace: 'pre-line',
+  margin: 0,
+};
+
 /**
  * The SSR climb page: everything a reader (or a crawler) needs about one climb,
  * with exactly one action — open it in the app.
@@ -97,6 +104,12 @@ export default async function ClimbFrontDoor({
   // those differ, and the JSON-LD has to name the URL the page claims.
   const canonicalClimbUrl = buildCanonicalClimbViewUrl(boardDetails, angle, climb.uuid, climbName);
   const overlayUrl = climb.frames ? buildOverlayUrl(boardDetails, climb.frames, false) : null;
+  // The setter's own words about the climb — the one genuinely unique piece of
+  // indexable prose on this page. User-written, so it renders verbatim (never
+  // through `t()`) and stays out of the JSON-LD `description` below, which is
+  // the synthesised catalogue string. Empty when the setter wrote nothing, or
+  // only Aurora's "No match" marker.
+  const setterNotes = getDisplayDescription(climb.description);
   const currentAngleStats = angleStats.find((stats) => stats.angle === angle);
   const layoutName = boardDetails.layout_name ?? '';
   // The same catalog string `generateMetadata` fills, but structured data omits
@@ -162,6 +175,15 @@ export default async function ClimbFrontDoor({
       ) : null}
 
       <ClimbFacts climb={climb} boardDetails={boardDetails} angle={angle} currentAngleStats={currentAngleStats} />
+
+      {setterNotes ? (
+        <Box component="section">
+          <Box component="h2">{t('frontDoor.setterNotes.heading')}</Box>
+          <Box component="p" sx={setterNotesSx}>
+            {setterNotes}
+          </Box>
+        </Box>
+      ) : null}
 
       <ClimbHandoffCta
         pathname={handoffPath}


### PR DESCRIPTION
## Summary

Closes #4494.

Setter descriptions were never disappearing into the void — they were being written, validated and stored correctly the whole time. Nothing ever read them back.

The write path is intact end to end: the create drawer builds `withNoMatch(description, noMatch)`, `toSaveClimbInput` carries it, the Zod schema keeps it, and `tx.insert(UNIFIED_TABLES.climbs)` lands it in the existing `board_climbs.description` column. Two gaps on the read side:

1. **No surface rendered it.** Not the mobile play drawer (the live climb-detail surface), not the www climb front door — which already `SELECT`s `climbs.description` and throws it away.
2. **The data wasn't even on hand.** `CLIMB_SEARCH_FIELDS` deliberately omitted `description` ("no list UI renders them"), and the offline SQLite search did the same. A climb opened from the Climbs list reached the drawer with `description === undefined`; only a deep link carried it.

### What changed

- **`getDisplayDescription`** in `@boardsesh/shared-schema`, next to `withNoMatch`. Strips Aurora's canonical `No match\n` marker line, trims, then returns `''` when the whole remaining string is only a restatement of "no match". Renderers treat `''` as "no section at all".
- **`description` on the search wire** — both copies of `CLIMB_SEARCH_FIELDS` (mobile's hand-maintained one and the shared `@boardsesh/graphql` document) — and on the **offline SQLite read path** (`searchClimbsLocal`'s SELECT + `mapRowToClimb`). No backend change needed — `search-climbs.ts` already selected and returned the column. The offline half is not optional: `offlineAwareRequest` is local-first for any downloaded board and that flag is at 100%, so most searches never reach the server.
- **Play drawer**: a new `SetterNotesSection` — a collapsible "Setter's notes" section, `defaultExpanded`, rendered as the first below-fold section *after* the Logbook.
- **www climb front door**: an `h2` + `pre-line` paragraph right after `ClimbFacts`, before the CTA so it can't push the LCP image down. The prose is user-written, so it renders verbatim (never through `t()`) and stays out of the JSON-LD `description`, which remains the synthesised catalogue string.
- **i18n**: `climbs.frontDoor.setterNotes.heading` and `climbs.mobile.setterNotes.title` in all four catalogs.

### Two things worth a second look

**The suppression rule is anchored to the whole trimmed string, never a prefix.** In the dev catalog, 83,864 of the 177,868 non-empty descriptions are literally `No matching` / `No matching.` — which the header's no-match glyph already says. But a prefix match would eat real setter beta: `No matching feet allowed` and `No Houdini swap, spin around pls:). No matching.` are both genuine descriptions. Both have their own named regression test, on the helper and again through the rendered drawer.

**Placement is below the Logbook on purpose.** `PlayDrawer.tsx`'s `firstScreenReserve` / `computeLogbookScrollTarget` assume the Logbook is the first below-fold section; inserting anything above it silently breaks the fold math and the expand-into-view scroll. There's a test asserting the Logbook is still first. Moving setter beta above the fold is a separate, riskier decision.

### German string — please correct if you disagree

`de` heading/title: **"Notizen vom Routenbau"**.

The glossary's `Routenbauer*in` (`docs/i18n-german-glossary.md`) makes the literal genitive read as *"Notizen der\*des Routenbauer\*in"*, which is heavy for a section header, and the glossary explicitly prefers a neutral rewrite when the starred form gets ugly. "Notizen vom Routenbau" keeps the attribution to the setting without the star gymnastics. The strict-glossary alternative is *"Notizen der\*des Routenbauer\*in"* — one-line swap in all four spots if you'd rather have it.

Others: `en-US` "Setter's notes", `es` "Notas del setter" (glossary keeps *setter* in English, matching the existing `frontDoor.facts.setter`), `fr` "Notes de l'ouvreur" (matching `frontDoor.facts.setter` = "Ouvreur").

### Free side effects of putting `description` on the search wire

- **Remix stops silently losing the description.** `use-create-climb-navigation.ts:93` reads `climb.description ?? ''`, which was always `''` for a climb sourced from search.
- **The queue write-without-read flap is closed.** Mobile writes `description` onto both queue wire boundaries (`climb-to-queue-item.ts:35`/`:114`) while never reading it back — exactly the class `queue-climb-field-contract.test.ts` exists to catch. Same invariant as `557b3cb1b`: *no commit may leave a field on a write path whose matching read path lacks it.*

## Release Notes

- Setter's notes now show up on a climb — the description whoever set it wrote in the create form, right under your logbook in the play drawer and on the climb's web page.

## Test plan

New coverage:

- `packages/shared-schema/src/__tests__/no-match.test.ts` — `getDisplayDescription`: marker stripping, interior newlines preserved, `''`/null/undefined/`No match`/`No matching.` suppressed, and the named regression that real prose mentioning matching survives untouched.
- `packages/mobile/src/db/queries/__tests__/search-climbs-local.test.ts` — the offline read (a real `node:sqlite` DB) round-trips the description, and reports `''` rather than `undefined` when there is none.
- `packages/backend/src/__tests__/operations-schema-validation.test.ts` — parser-driven drift guard that `CLIMB_SEARCH_FIELDS` still selects `description`, so re-slimming the list can't silently blank the drawer section again.
- `packages/mobile/src/components/play-drawer/__tests__/deferred-sections.test.tsx` — notes render for real prose, nothing renders for `''`/`No match`/`No match\n`/`No matching.`/`no matching`, setter beta mentioning matching survives, and the Logbook is still the first section with the notes directly after it.
- `packages/web/app/b/[board_slug]/[angle]/view/[climb_uuid]/__tests__/view-seo-fragment.test.tsx` — the front door SSR-emits the heading + prose, emits neither for an empty or bare-no-match description, still carries exactly one `<h1>`, and leaves the JSON-LD description alone.

Gates run locally: `vp check` (0 errors), `vp run typecheck` (all packages), `vp run check:i18n`, `vp run check:i18n:orphans`, `vp run check:mobile-bundle` (iOS + Android), and every touched test file on its own project. The full mobile and web suites are too slow to finish in one local shell here, so CI is the gate for those — 8,112 tests green.

**No screenshots.** This box is Linux: the iOS simulator path is macOS-only and the local Android emulator segfaults on every renderer (a known, separately-tracked problem). The drawer section is a standard `CollapsibleSection` with a `subheadline` body, so it inherits the same look as Logbook / Community; the front-door section matches the existing Beta / Similar / Community sections. Happy to dispatch a CI screenshot run if you want eyes on it before merge.
