### PR TITLE
fix(mobile): tell two same-brand boards apart in the board picker

### DIFF
--- a/packages/mobile/app/boards/index.tsx
+++ b/packages/mobile/app/boards/index.tsx
@@ -18,7 +18,7 @@ import { ActivityIndicator } from '../../src/components/ActivityIndicator';
 import { BoardCarousel } from '../../src/components/board-discovery/BoardCarousel';
 import { BoardModeCard, type ModeCardState } from '../../src/components/board-discovery/BoardModeCard';
 import { BluetoothQuickstartSheet } from '../../src/components/board-discovery/BluetoothQuickstartSheet';
-import { userBoardToItem, popularConfigToItem } from '../../src/components/board-discovery/board-items';
+import { userBoardsToItems, popularConfigToItem } from '../../src/components/board-discovery/board-items';
 import { offlineBoardRows } from '../../src/components/board-discovery/offline-board-items';
 import type { DiscoveryBoardItem } from '../../src/components/board-discovery/BoardDiscoveryCard';
 import { useBottomChromeMetrics } from '../../src/hooks/use-bottom-chrome-metrics';
@@ -184,24 +184,15 @@ export default function BoardSelection() {
     [enabledScopeKeys, downloadedScopeKeys],
   );
   const myBoardItems = useMemo(
-    () =>
-      myBoards
-        .map((board) => userBoardToItem(board, activeBoard?.uuid, boardOfflineState(board)))
-        .filter((item): item is DiscoveryBoardItem => item !== null),
+    () => userBoardsToItems(myBoards, activeBoard?.uuid, boardOfflineState),
     [myBoards, activeBoard?.uuid, boardOfflineState],
   );
   const nearbyItems = useMemo(
-    () =>
-      (nearby?.boards ?? [])
-        .map((board) => userBoardToItem(board, activeBoard?.uuid))
-        .filter((item): item is DiscoveryBoardItem => item !== null),
+    () => userBoardsToItems(nearby?.boards ?? [], activeBoard?.uuid),
     [nearby?.boards, activeBoard?.uuid],
   );
   const offlineItems = useMemo(
-    () =>
-      offlineRows
-        .map((board) => userBoardToItem(board, activeBoard?.uuid))
-        .filter((item): item is DiscoveryBoardItem => item !== null),
+    () => userBoardsToItems(offlineRows, activeBoard?.uuid),
     [offlineRows, activeBoard?.uuid],
   );
   const popularItems = useMemo(

--- a/packages/mobile/src/components/board-discovery/BluetoothQuickstartSheet.tsx
+++ b/packages/mobile/src/components/board-discovery/BluetoothQuickstartSheet.tsx
@@ -8,6 +8,7 @@ import { useAndroidScanLocationHint } from '../../lib/ble/use-android-scan-locat
 import { useBoardsBySerialNumbers } from '../../lib/graphql/hooks';
 import { spacing, borderRadius } from '../../theme/tokens';
 import { useTheme } from '../../providers/theme-provider';
+import { boardRowSubtitle } from './board-labels';
 import { Sheet } from '../Sheet';
 import { Text } from '../Text';
 import { Icon } from '../Icon';
@@ -95,7 +96,7 @@ export const BluetoothQuickstartSheet = forwardRef<BottomSheet, BluetoothQuickst
                 <View style={styles.rowText}>
                   <Text variant="headline">{board.name}</Text>
                   <Text variant="subheadline" color={systemColors.secondaryLabel}>
-                    {board.boardType} · {board.sizeName ?? ''}
+                    {boardRowSubtitle(board)}
                   </Text>
                 </View>
                 <Icon name="add" size={20} color={systemColors.tertiaryLabel} />

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { View, Pressable, StyleSheet, Platform } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import type { BoardName } from '@boardsesh/shared-schema';
@@ -60,7 +60,17 @@ type BoardDiscoveryCardProps = {
   downloadLabel?: string;
 };
 
-export function BoardDiscoveryCard({ item, onPress, onDownload, downloadLabel }: BoardDiscoveryCardProps) {
+/**
+ * One board in a carousel. Memoized: three carousels stacked on the Boards tab
+ * re-render together whenever any of their queries settle, and each card resolves
+ * board art.
+ */
+export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
+  item,
+  onPress,
+  onDownload,
+  downloadLabel,
+}: BoardDiscoveryCardProps) {
   const { systemColors, brandColors } = useTheme();
   const scale = useSharedValue(1);
 
@@ -165,7 +175,10 @@ export function BoardDiscoveryCard({ item, onPress, onDownload, downloadLabel }:
         ) : null}
       </View>
 
-      <Text variant="subheadline" numberOfLines={1} style={styles.title}>
+      {/* Two lines: board names routinely run past the 168pt card ("Bergen
+          Klatresenter Danmarksplass"), and one line ellipsised two same-gym
+          boards into the same string. */}
+      <Text variant="subheadline" numberOfLines={2} style={styles.title}>
         {item.title}
       </Text>
       {item.subtitle ? (
@@ -175,7 +188,7 @@ export function BoardDiscoveryCard({ item, onPress, onDownload, downloadLabel }:
       ) : null}
     </AnimatedPressable>
   );
-}
+});
 
 const styles = StyleSheet.create({
   container: {
@@ -243,5 +256,8 @@ const styles = StyleSheet.create({
   },
   title: {
     fontWeight: '600',
+    // Reserve both lines (subheadline lineHeight is 20) so a one-line card and a
+    // two-line card keep their subtitles on the same baseline across the row.
+    minHeight: 40,
   },
 });

--- a/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardDiscoveryCard.tsx
@@ -6,6 +6,7 @@ import { getBoardRenderData } from '../../lib/board-details';
 import { hapticLight } from '../../lib/haptics';
 import { springs } from '../../theme/animations';
 import { spacing, borderRadius, overlays } from '../../theme/tokens';
+import { textStyles } from '../../theme/typography';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { useTheme } from '../../providers/theme-provider';
 import { Text } from '../Text';
@@ -37,6 +38,15 @@ export type DiscoveryBoardItem = {
 };
 
 export const DISCOVERY_CARD_WIDTH = 168;
+
+/**
+ * Lines the board name gets. Board names routinely run past a 168pt card
+ * ("Bergen Klatresenter Danmarksplass"), and one line ellipsised two boards at
+ * the same gym into the same string. The title box reserves all of them so a
+ * one-line card and a two-line card keep their subtitles on the same baseline
+ * across the row.
+ */
+const TITLE_LINES = 2;
 
 /** Distance badge copy: metres under 1km, one-decimal km above. */
 function formatDistance(meters: number): string {
@@ -175,10 +185,7 @@ export const BoardDiscoveryCard = memo(function BoardDiscoveryCard({
         ) : null}
       </View>
 
-      {/* Two lines: board names routinely run past the 168pt card ("Bergen
-          Klatresenter Danmarksplass"), and one line ellipsised two same-gym
-          boards into the same string. */}
-      <Text variant="subheadline" numberOfLines={2} style={styles.title}>
+      <Text variant="subheadline" numberOfLines={TITLE_LINES} style={styles.title}>
         {item.title}
       </Text>
       {item.subtitle ? (
@@ -256,8 +263,8 @@ const styles = StyleSheet.create({
   },
   title: {
     fontWeight: '600',
-    // Reserve both lines (subheadline lineHeight is 20) so a one-line card and a
-    // two-line card keep their subtitles on the same baseline across the row.
-    minHeight: 40,
+    // Both type scales (HIG and Material) give subheadline the same lineHeight,
+    // so one read covers both UI variants — see textStylesByVariant.
+    minHeight: TITLE_LINES * textStyles.subheadline.lineHeight,
   },
 });

--- a/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
+++ b/packages/mobile/src/components/board-discovery/BoardManageRow.tsx
@@ -5,7 +5,7 @@ import type { UserBoard } from '@boardsesh/shared-schema';
 import { toBoardName } from '@boardsesh/board-config';
 import { SwipeableRow } from '../SwipeableRow';
 import { BoardImageNative } from '../BoardImageNative';
-import { boardTypeLabel } from './board-builder-labels';
+import { boardRowSubtitle } from './board-labels';
 import { BoardOfflineToggle } from './BoardOfflineToggle';
 import type { BoardDownloadNotice, BoardDownloadProgress, BoardDownloadState } from './board-offline-state';
 import { OfflineDownloadProgressBar } from './OfflineDownloadProgressBar';
@@ -124,12 +124,9 @@ function BoardManageRowComponent({
       : { width: THUMB_SIZE * aspect, height: THUMB_SIZE };
   }, [renderData]);
 
-  // Proper-cased board name for trademark correctness when used as a fallback.
-  const boardTypeText = boardName ? boardTypeLabel(boardName) : board.boardType;
-  // Owned: size / location tells one of your walls apart. Followed: whose board it is.
-  const subtitle = isOwned
-    ? (board.sizeName ?? board.locationName ?? boardTypeText)
-    : (board.ownerDisplayName ?? boardTypeText);
+  // Owned: where the board is (or what it is) tells one of your walls apart.
+  // Followed: whose board it is.
+  const subtitle = isOwned ? boardRowSubtitle(board) : (board.ownerDisplayName ?? boardRowSubtitle(board));
 
   // Live bootstrap always wins over persisted history: the engine may retry a
   // scope whose previous run selected a paged fallback, and showing both would

--- a/packages/mobile/src/components/board-discovery/__tests__/bluetooth-quickstart-sheet.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/bluetooth-quickstart-sheet.test.tsx
@@ -244,3 +244,39 @@ describe('BluetoothQuickstartSheet', () => {
     expect(scan.reset).not.toHaveBeenCalled();
   });
 });
+
+describe('BluetoothQuickstartSheet board rows', () => {
+  beforeEach(() => {
+    scan.status = 'done';
+    scan.serials = ['1234'];
+    boards.isLoading = false;
+  });
+
+  // The row used to render `{board.boardType} · {board.sizeName ?? ''}`, and the
+  // server sends sizeName as null on every board — so every hit read "kilter · "
+  // with a dangling separator.
+  it('shows where a resolved board is, not a dangling board type', () => {
+    boards.data = [
+      {
+        uuid: 'board-1',
+        name: 'Home wall',
+        boardType: 'kilter',
+        layoutId: 1,
+        sizeId: 7,
+        gymName: 'Bergen Klatresenter',
+        sizeName: null,
+      },
+    ];
+    const { container } = renderSheet();
+
+    expect(hasText(container, 'Bergen Klatresenter')).toBe(true);
+    expect(hasText(container, 'kilter · ')).toBe(false);
+  });
+
+  it('falls back to the board config when it has no gym or location', () => {
+    boards.data = [{ uuid: 'board-1', name: 'Garage', boardType: 'kilter', layoutId: 1, sizeId: 7, sizeName: null }];
+    const { container } = renderSheet();
+
+    expect(hasText(container, 'Original 12×14')).toBe(true);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/__tests__/board-detail-fields.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-detail-fields.test.ts
@@ -70,3 +70,23 @@ describe('isActiveBoard', () => {
     expect(isActiveBoard(base, undefined)).toBe(false);
   });
 });
+
+describe('getBoardDetailFields size fallback', () => {
+  // The server sends sizeName/sizeDescription as null on every board, which left
+  // the Size spec row permanently hidden. Resolve it from the bundled tables.
+  const kilterBoard = { ...base, boardType: 'kilter', layoutId: 1, sizeId: 7 } as unknown as UserBoard;
+
+  it('resolves the size from the bundled tables when the server sends null', () => {
+    expect(getBoardDetailFields(kilterBoard).sizeText).toBe('12 x 14 · Commerical');
+  });
+
+  it('still prefers the server values when it does send them', () => {
+    const withServerSize = { ...kilterBoard, sizeName: '9 x 9', sizeDescription: 'Custom' } as UserBoard;
+    expect(getBoardDetailFields(withServerSize).sizeText).toBe('9 x 9 · Custom');
+  });
+
+  it('stays undefined for a board type the bundled tables do not know', () => {
+    const unknown = { ...kilterBoard, boardType: 'not-a-board' } as unknown as UserBoard;
+    expect(getBoardDetailFields(unknown).sizeText).toBeUndefined();
+  });
+});

--- a/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-items.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
-import { userBoardToItem, popularConfigToItem, findOwnedBoardForConfig } from '../board-items';
+import { userBoardToItem, userBoardsToItems, popularConfigToItem, findOwnedBoardForConfig } from '../board-items';
 
 const board = {
   uuid: 'b-1',
@@ -38,7 +38,7 @@ describe('userBoardToItem', () => {
       sizeId: 2,
       setIds: '3,4',
       title: 'My Kilter',
-      subtitle: '12x12',
+      subtitle: 'Original',
       distanceMeters: 250,
     });
   });
@@ -51,6 +51,40 @@ describe('userBoardToItem', () => {
   it('drops a board whose type is not a supported BoardName', () => {
     const bad = { ...board, boardType: 'not-a-board' } as unknown as UserBoard;
     expect(userBoardToItem(bad)).toBeNull();
+  });
+});
+
+describe('userBoardsToItems', () => {
+  const bergen = {
+    uuid: 'bergen-1',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 7,
+    setIds: '1,20',
+    name: 'Bergen Klatresenter Danmarksplass',
+    gymName: 'Bergen Klatresenter',
+    angle: 40,
+  } as unknown as UserBoard;
+
+  it('gives two boards run by the same gym different subtitles', () => {
+    const items = userBoardsToItems([bergen, { ...bergen, uuid: 'bergen-2', sizeId: 8 } as UserBoard]);
+    expect(items.map((item) => item.subtitle)).toEqual(['Bergen Klatresenter · 12×14', 'Bergen Klatresenter · 8×12']);
+  });
+
+  it('leaves a lone board with a plain subtitle', () => {
+    expect(userBoardsToItems([bergen])[0].subtitle).toBe('Bergen Klatresenter');
+  });
+
+  it('ignores a dropped board when deciding what needs disambiguating', () => {
+    const bad = { ...bergen, uuid: 'nope', boardType: 'not-a-board' } as UserBoard;
+    const items = userBoardsToItems([bad, bergen]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ key: 'bergen-1', subtitle: 'Bergen Klatresenter' });
+  });
+
+  it('passes each board its own offline state', () => {
+    const items = userBoardsToItems([bergen], 'bergen-1', () => 'downloaded');
+    expect(items[0]).toMatchObject({ isActive: true, offlineState: 'downloaded' });
   });
 });
 
@@ -68,6 +102,11 @@ describe('popularConfigToItem', () => {
 
   it('builds a stable key from the config tuple (configs have no uuid)', () => {
     expect(popularConfigToItem(config)?.key).toBe('popular:tension:9:8:7-6');
+  });
+
+  it('falls back to the brand name, never the raw lowercase board type', () => {
+    const bare = { ...config, sizeName: null, layoutName: null, boardType: 'kilter' } as unknown as PopularBoardConfig;
+    expect(popularConfigToItem(bare)?.subtitle).toBe('Kilter');
   });
 
   it('drops a config whose board type is unsupported', () => {

--- a/packages/mobile/src/components/board-discovery/__tests__/board-labels.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-labels.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  boardPlaceLabel,
+  boardConfigLabel,
+  boardRowSubtitle,
+  disambiguateBoardSubtitles,
+  type BoardLabelSource,
+} from '../board-labels';
+
+// Kilter layout 1 is "Kilter Board Original"; size 7 is "12 x 14" and size 8 is
+// "8 x 12" in the bundled @boardsesh/board-constants tables.
+const kilter: BoardLabelSource = {
+  boardType: 'kilter',
+  layoutId: 1,
+  sizeId: 7,
+  gymName: null,
+  locationName: null,
+  angle: 40,
+  serialNumber: null,
+};
+
+describe('boardPlaceLabel', () => {
+  it('prefers the linked gym over the free-text location', () => {
+    expect(boardPlaceLabel({ ...kilter, gymName: 'Bergen Klatresenter', locationName: 'Bergen' })).toBe(
+      'Bergen Klatresenter',
+    );
+  });
+
+  it('falls back to the free-text location', () => {
+    expect(boardPlaceLabel({ ...kilter, locationName: 'Danmarksplass' })).toBe('Danmarksplass');
+  });
+
+  it('is null when the board has neither', () => {
+    expect(boardPlaceLabel(kilter)).toBeNull();
+  });
+
+  it('treats a blank string from the API as absent', () => {
+    expect(boardPlaceLabel({ ...kilter, gymName: '   ', locationName: 'Bergen' })).toBe('Bergen');
+  });
+});
+
+describe('boardConfigLabel', () => {
+  it('resolves layout and size names from the bundled tables', () => {
+    expect(boardConfigLabel(kilter)).toBe('Original 12×14');
+  });
+
+  it('keeps the layout when the size id is unknown — never renders the raw id', () => {
+    expect(boardConfigLabel({ ...kilter, sizeId: 99999 })).toBe('Original');
+  });
+
+  it('is null when the board type is not one the bundled tables know', () => {
+    expect(boardConfigLabel({ ...kilter, boardType: 'not-a-board' })).toBeNull();
+  });
+
+  it('is null when neither layout nor size resolves', () => {
+    expect(boardConfigLabel({ ...kilter, layoutId: 99999, sizeId: 99999 })).toBeNull();
+  });
+});
+
+describe('boardRowSubtitle', () => {
+  it('shows where the board is when it has a place', () => {
+    expect(boardRowSubtitle({ ...kilter, gymName: 'Bergen Klatresenter' })).toBe('Bergen Klatresenter');
+  });
+
+  it('falls back to what the board is', () => {
+    expect(boardRowSubtitle(kilter)).toBe('Original 12×14');
+  });
+
+  it('falls back to the brand name, never the raw lowercase board type', () => {
+    expect(boardRowSubtitle({ ...kilter, layoutId: 99999, sizeId: 99999 })).toBe('Kilter');
+  });
+});
+
+describe('disambiguateBoardSubtitles', () => {
+  it('leaves boards with distinct subtitles alone', () => {
+    const boards: BoardLabelSource[] = [
+      { ...kilter, gymName: 'Bergen Klatresenter' },
+      { ...kilter, gymName: 'Åsane Klatresenter' },
+    ];
+    expect(disambiguateBoardSubtitles(boards)).toEqual(['Bergen Klatresenter', 'Åsane Klatresenter']);
+  });
+
+  it('separates two same-gym boards on the first facet that differs (size)', () => {
+    // The reported case: two Kilters, same operator, different walls.
+    const boards: BoardLabelSource[] = [
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 7 },
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 8 },
+    ];
+    expect(disambiguateBoardSubtitles(boards)).toEqual(['Bergen Klatresenter · 12×14', 'Bergen Klatresenter · 8×12']);
+  });
+
+  it('falls through to the layout when the size matches', () => {
+    const boards: BoardLabelSource[] = [
+      { boardType: 'tension', layoutId: 10, sizeId: 6, gymName: 'Klatreverket', angle: 40 },
+      { boardType: 'tension', layoutId: 11, sizeId: 6, gymName: 'Klatreverket', angle: 40 },
+    ];
+    const [first, second] = disambiguateBoardSubtitles(boards);
+    expect(first).toBe('Klatreverket · Mirror');
+    expect(second).toBe('Klatreverket · Spray');
+  });
+
+  it('falls through to the angle when the config matches', () => {
+    const boards: BoardLabelSource[] = [
+      { ...kilter, gymName: 'Bergen Klatresenter', angle: 40 },
+      { ...kilter, gymName: 'Bergen Klatresenter', angle: 25 },
+    ];
+    expect(disambiguateBoardSubtitles(boards)).toEqual(['Bergen Klatresenter · 40°', 'Bergen Klatresenter · 25°']);
+  });
+
+  it('falls through to the serial tail when everything else matches', () => {
+    const boards: BoardLabelSource[] = [
+      { ...kilter, gymName: 'Bergen Klatresenter', serialNumber: 'KL-00081234' },
+      { ...kilter, gymName: 'Bergen Klatresenter', serialNumber: 'KL-00085678' },
+    ];
+    expect(disambiguateBoardSubtitles(boards)).toEqual(['Bergen Klatresenter · 1234', 'Bergen Klatresenter · 5678']);
+  });
+
+  it('leaves genuinely indistinguishable boards untouched — no invented distinction', () => {
+    const boards: BoardLabelSource[] = [
+      { ...kilter, gymName: 'Bergen Klatresenter' },
+      { ...kilter, gymName: 'Bergen Klatresenter' },
+    ];
+    expect(disambiguateBoardSubtitles(boards)).toEqual(['Bergen Klatresenter', 'Bergen Klatresenter']);
+  });
+
+  it('appends only to the members that have the facet', () => {
+    const boards: BoardLabelSource[] = [
+      { ...kilter, gymName: 'Bergen Klatresenter', angle: null },
+      { ...kilter, gymName: 'Bergen Klatresenter', angle: 25 },
+    ];
+    expect(disambiguateBoardSubtitles(boards)).toEqual(['Bergen Klatresenter', 'Bergen Klatresenter · 25°']);
+  });
+
+  it('scopes disambiguation to the colliding group only', () => {
+    const boards: BoardLabelSource[] = [
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 7 },
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 8 },
+      { ...kilter, gymName: 'Åsane Klatresenter', sizeId: 7 },
+    ];
+    expect(disambiguateBoardSubtitles(boards)).toEqual([
+      'Bergen Klatresenter · 12×14',
+      'Bergen Klatresenter · 8×12',
+      'Åsane Klatresenter',
+    ]);
+  });
+
+  it('handles an empty list', () => {
+    expect(disambiguateBoardSubtitles([])).toEqual([]);
+  });
+});

--- a/packages/mobile/src/components/board-discovery/__tests__/board-labels.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-labels.test.ts
@@ -144,6 +144,36 @@ describe('disambiguateBoardSubtitles', () => {
     ]);
   });
 
+  it('prefers a facet that separates every member over one that only splits the group', () => {
+    // Three boards at one gym: two share a size, so the size facet would leave
+    // two cards reading the same. The angle facet separates all three.
+    const boards: BoardLabelSource[] = [
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 7, angle: 40 },
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 7, angle: 25 },
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 8, angle: 55 },
+    ];
+    expect(disambiguateBoardSubtitles(boards)).toEqual([
+      'Bergen Klatresenter · 40°',
+      'Bergen Klatresenter · 25°',
+      'Bergen Klatresenter · 55°',
+    ]);
+  });
+
+  it('falls back to a partial split when no single facet separates everyone', () => {
+    // Two boards are identical on every facet — nothing can separate those two,
+    // but the third still gets pulled out on size.
+    const boards: BoardLabelSource[] = [
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 7 },
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 7 },
+      { ...kilter, gymName: 'Bergen Klatresenter', sizeId: 8 },
+    ];
+    expect(disambiguateBoardSubtitles(boards)).toEqual([
+      'Bergen Klatresenter · 12×14',
+      'Bergen Klatresenter · 12×14',
+      'Bergen Klatresenter · 8×12',
+    ]);
+  });
+
   it('handles an empty list', () => {
     expect(disambiguateBoardSubtitles([])).toEqual([]);
   });

--- a/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-manage-row.test.tsx
@@ -425,3 +425,27 @@ describe('BoardManageRow edit mode', () => {
     expect(onDelete).toHaveBeenCalledWith(board);
   });
 });
+
+describe('BoardManageRow subtitle', () => {
+  // The server sends sizeName as null on every board, so the old
+  // `board.sizeName ?? ...` first term never fired and every row read "Kilter".
+  it('shows where an owned board is', () => {
+    const gymBoard = { ...board, gymName: 'Bergen Klatresenter', sizeName: null } as unknown as UserBoard;
+    const { queryByText } = render(<BoardManageRow {...rowProps} board={gymBoard} downloadState={undefined} />);
+    expect(queryByText('Bergen Klatresenter')).not.toBeNull();
+  });
+
+  it('falls back to what an owned board is when it has no place', () => {
+    const placeless = { ...board, sizeName: null } as unknown as UserBoard;
+    const { queryByText } = render(<BoardManageRow {...rowProps} board={placeless} downloadState={undefined} />);
+    expect(queryByText('Original 12×12 with kickboard')).not.toBeNull();
+  });
+
+  it('shows the owner on a followed board', () => {
+    const followed = { ...board, ownerDisplayName: 'Marco' } as unknown as UserBoard;
+    const { queryByText } = render(
+      <BoardManageRow {...rowProps} board={followed} isOwned={false} downloadState={undefined} />,
+    );
+    expect(queryByText('Marco')).not.toBeNull();
+  });
+});

--- a/packages/mobile/src/components/board-discovery/board-builder-labels.ts
+++ b/packages/mobile/src/components/board-discovery/board-builder-labels.ts
@@ -5,19 +5,16 @@
 // (packages/backend/src/graphql/resolvers/social/boards.ts) — minus the
 // abbreviations, since a builder wants readable names, not compact ones.
 
-// Trademark-correct board type names (CLAUDE.md).
-const BOARD_LABELS: Record<string, string> = {
-  kilter: 'Kilter',
-  tension: 'Tension',
-  moonboard: 'MoonBoard',
-  decoy: 'Decoy',
-  touchstone: 'Touchstone',
-  grasshopper: 'Grasshopper',
-  soill: 'So iLL',
-};
+import { BOARD_TYPE_LABELS } from '@boardsesh/board-constants';
 
+/**
+ * Trademark-correct board type name. Shares the brand map with web
+ * (@boardsesh/board-constants) but keeps mobile's title-case fallback: the
+ * builder can be pointed at a board type the shared map has not learned yet,
+ * and "Kilter" reads better than "kilter" in a suggested board name.
+ */
 export function boardTypeLabel(boardName: string): string {
-  return BOARD_LABELS[boardName] ?? boardName.charAt(0).toUpperCase() + boardName.slice(1);
+  return BOARD_TYPE_LABELS[boardName] ?? boardName.charAt(0).toUpperCase() + boardName.slice(1);
 }
 
 /**

--- a/packages/mobile/src/components/board-discovery/board-detail-fields.ts
+++ b/packages/mobile/src/components/board-discovery/board-detail-fields.ts
@@ -1,4 +1,7 @@
 import type { UserBoard } from '@boardsesh/shared-schema';
+import { toBoardName } from '@boardsesh/board-config';
+import { getProductSize } from '@boardsesh/board-constants';
+import { boardPlaceLabel } from './board-labels';
 
 export type BoardDetailFields = {
   /** Gym name if linked, else the free-text location, else undefined. */
@@ -11,9 +14,16 @@ export type BoardDetailFields = {
 
 /** Derive the display strings shown in the board-detail sheet. Pure. */
 export function getBoardDetailFields(board: UserBoard): BoardDetailFields {
-  const subLocation = board.gymName ?? board.locationName ?? undefined;
+  const subLocation = boardPlaceLabel(board) ?? undefined;
   const setNames = (board.setNames ?? []).join(' · ');
-  const sizeText = [board.sizeName, board.sizeDescription].filter(Boolean).join(' · ') || undefined;
+  // The server sends sizeName/sizeDescription as null on every board, which left
+  // the Size row permanently hidden — fall back to the bundled size table.
+  const boardName = toBoardName(board.boardType);
+  const bundledSize = boardName === null ? null : getProductSize(boardName, board.sizeId);
+  const sizeText =
+    [board.sizeName ?? bundledSize?.name, board.sizeDescription ?? bundledSize?.description]
+      .filter(Boolean)
+      .join(' · ') || undefined;
   return { subLocation, setNames, sizeText };
 }
 

--- a/packages/mobile/src/components/board-discovery/board-items.ts
+++ b/packages/mobile/src/components/board-discovery/board-items.ts
@@ -2,7 +2,7 @@
 // single DiscoveryBoardItem the carousel renders. Keeps the screen free of
 // per-shape branching.
 
-import type { BoardName, UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
+import type { UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { toBoardName, normaliseSetIds } from '@boardsesh/board-config';
 import type { DiscoveryBoardItem } from './BoardDiscoveryCard';
 import { boardTypeLabel } from './board-builder-labels';

--- a/packages/mobile/src/components/board-discovery/board-items.ts
+++ b/packages/mobile/src/components/board-discovery/board-items.ts
@@ -5,6 +5,8 @@
 import type { BoardName, UserBoard, PopularBoardConfig } from '@boardsesh/shared-schema';
 import { toBoardName, normaliseSetIds } from '@boardsesh/board-config';
 import type { DiscoveryBoardItem } from './BoardDiscoveryCard';
+import { boardTypeLabel } from './board-builder-labels';
+import { boardRowSubtitle, disambiguateBoardSubtitles } from './board-labels';
 import type { BoardDownloadState } from './board-offline-state';
 
 export function userBoardToItem(
@@ -27,11 +29,33 @@ export function userBoardToItem(
     sizeId: board.sizeId,
     setIds: board.setIds,
     title: board.name,
-    subtitle: board.sizeName ?? board.boardType,
+    subtitle: boardRowSubtitle(board),
     distanceMeters: board.distanceMeters ?? undefined,
     isActive: activeUuid != null && board.uuid === activeUuid,
     offlineState,
   };
+}
+
+/**
+ * The whole carousel's items in one pass, with same-subtitle boards pulled apart
+ * (see `disambiguateBoardSubtitles`). Disambiguation is scoped to the one list
+ * the user is looking at, and runs here — at the list level — never per row.
+ */
+export function userBoardsToItems(
+  boards: UserBoard[],
+  activeUuid?: string | null,
+  offlineStateFor?: (board: UserBoard) => BoardDownloadState,
+): DiscoveryBoardItem[] {
+  // Only boards that actually render take part: a board dropped for an
+  // unsupported type must not push its neighbour into a disambiguation the user
+  // can see no reason for.
+  const rendered: { item: DiscoveryBoardItem; board: UserBoard }[] = [];
+  for (const board of boards) {
+    const item = userBoardToItem(board, activeUuid, offlineStateFor?.(board));
+    if (item !== null) rendered.push({ item, board });
+  }
+  const subtitles = disambiguateBoardSubtitles(rendered.map((entry) => entry.board));
+  return rendered.map((entry, index) => ({ ...entry.item, subtitle: subtitles[index] }));
 }
 
 export function popularConfigToItem(config: PopularBoardConfig): DiscoveryBoardItem | null {
@@ -45,7 +69,7 @@ export function popularConfigToItem(config: PopularBoardConfig): DiscoveryBoardI
     sizeId: config.sizeId,
     setIds: config.setIds.join(','),
     title: config.displayName,
-    subtitle: config.sizeName ?? config.layoutName ?? config.boardType,
+    subtitle: config.sizeName ?? config.layoutName ?? boardTypeLabel(config.boardType),
   };
 }
 

--- a/packages/mobile/src/components/board-discovery/board-labels.ts
+++ b/packages/mobile/src/components/board-discovery/board-labels.ts
@@ -105,10 +105,12 @@ const DISAMBIGUATION_FACETS: ((board: BoardLabelSource) => string | null)[] = [
  * Subtitles for one rendered list, with same-subtitle boards pulled apart.
  *
  * Returns one subtitle per input board, in order. Boards that collide on their
- * base subtitle get ` · <facet>` appended using the first facet that actually
- * differs within that collision group — so two Kilter boards run by the same
+ * base subtitle get ` · <facet>` appended — so two Kilter boards run by the same
  * gym separate on their size, angle or serial instead of both reading "Bergen
- * Klatresenter". A group whose members are identical on every facet is left
+ * Klatresenter". Facets are tried in order and the first one that leaves every
+ * member of the group reading differently wins; if none does (a gym with three
+ * boards where two share a size), we fall back to the first facet that at least
+ * splits the group. A group whose members are identical on every facet is left
  * alone; we never invent a distinction.
  *
  * Runs once per list (call it from the list's `useMemo`, never from a row) and
@@ -126,17 +128,30 @@ export function disambiguateBoardSubtitles(boards: BoardLabelSource[]): string[]
 
   for (const group of indicesBySubtitle.values()) {
     if (group.length < 2) continue;
+    const base = subtitles[group[0]];
+    // The best labelling found so far — splits the group, but not completely.
+    let bestLabelling: string[] | null = null;
     for (const facet of DISAMBIGUATION_FACETS) {
-      const values = group.map((index) => facet(boards[index]));
-      const distinct = new Set(values);
-      // A facet every member shares (or none of them has) separates nothing.
-      if (distinct.size < 2) continue;
-      group.forEach((index, position) => {
-        const value = values[position];
-        if (value !== null) subtitles[index] = `${subtitles[index]} · ${value}`;
+      // A member with no value for this facet keeps the bare subtitle rather
+      // than being labelled with a fact we don't have — it still reads
+      // differently from the members that do carry one.
+      const labelling = group.map((index) => {
+        const value = facet(boards[index]);
+        return value === null ? base : `${base} · ${value}`;
       });
-      break;
+      const distinct = new Set(labelling).size;
+      if (distinct === group.length) {
+        bestLabelling = labelling;
+        break;
+      }
+      // A facet every member shares (or none of them has) separates nothing.
+      if (distinct > 1 && bestLabelling === null) bestLabelling = labelling;
     }
+    if (bestLabelling === null) continue;
+    const chosen = bestLabelling;
+    group.forEach((index, position) => {
+      subtitles[index] = chosen[position];
+    });
   }
 
   return subtitles;

--- a/packages/mobile/src/components/board-discovery/board-labels.ts
+++ b/packages/mobile/src/components/board-discovery/board-labels.ts
@@ -1,0 +1,143 @@
+// Subtitles for every surface that lists boards (the Boards-tab carousels, My
+// Boards, the gym directory, the Bluetooth quickstart sheet).
+//
+// The server sends `layoutName`, `sizeName`, `sizeDescription` and `setNames` as
+// null on every UserBoard (see enrichBoard in
+// packages/backend/src/graphql/resolvers/social/boards.ts), so a subtitle built
+// from those fields always collapsed to the raw board type — two Kilter boards
+// at two locations both read "kilter". Everything needed to tell them apart is
+// already on the wire (gym, location, layout/size ids, angle, serial) and the
+// layout/size name tables ship in @boardsesh/board-constants, so we resolve the
+// names on the device instead. Works offline, no round-trip.
+
+import { toBoardName } from '@boardsesh/board-config';
+import { getLayoutName, getProductSize } from '@boardsesh/board-constants';
+import { boardTypeLabel, cleanLayoutName, formatSizeDimensions } from './board-builder-labels';
+
+/**
+ * The board fields these labels read. Structural rather than `UserBoard` so a
+ * partially-populated board (a BLE-resolved hit, an offline snapshot row) works
+ * without casting.
+ */
+export type BoardLabelSource = {
+  boardType: string;
+  layoutId: number;
+  sizeId: number;
+  gymName?: string | null;
+  locationName?: string | null;
+  angle?: number | null;
+  serialNumber?: string | null;
+};
+
+/** Trimmed value, or null for null/undefined/blank. Blank strings come back from the API. */
+function present(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+/**
+ * Where the board is: the linked gym, else the free-text location. Matches the
+ * ordering BoardDisambiguationSheet and the board-detail sheet already use.
+ */
+export function boardPlaceLabel(board: BoardLabelSource): string | null {
+  return present(board.gymName) ?? present(board.locationName);
+}
+
+/** The board's cleaned layout name ("Kilter Board Original" → "Original"), or null. */
+function layoutFacet(board: BoardLabelSource): string | null {
+  const boardName = toBoardName(board.boardType);
+  if (boardName === null) return null;
+  const rawName = present(getLayoutName(boardName, board.layoutId));
+  return rawName === null ? null : present(cleanLayoutName(rawName, boardName));
+}
+
+/** The board's size dimensions ("12 x 14" → "12×14"), or null. */
+function sizeFacet(board: BoardLabelSource): string | null {
+  const boardName = toBoardName(board.boardType);
+  if (boardName === null) return null;
+  const size = getProductSize(boardName, board.sizeId);
+  return size === null ? null : present(formatSizeDimensions(size));
+}
+
+function angleFacet(board: BoardLabelSource): string | null {
+  return board.angle == null ? null : `${board.angle}°`;
+}
+
+/** Enough of the serial to separate two otherwise identical boards, never the whole thing. */
+function serialFacet(board: BoardLabelSource): string | null {
+  const serial = present(board.serialNumber);
+  return serial === null ? null : serial.slice(-4);
+}
+
+/**
+ * What the board is: "Original 12×14". Resolved from the bundled layout/size
+ * tables, never from the (always-null) server fields. Null when neither the
+ * layout nor the size is known to the bundled tables — we show no config rather
+ * than a raw id.
+ */
+export function boardConfigLabel(board: BoardLabelSource): string | null {
+  const parts = [layoutFacet(board), sizeFacet(board)].filter((part): part is string => part !== null);
+  return parts.length > 0 ? parts.join(' ') : null;
+}
+
+/**
+ * The one-line subtitle under a board's name: where it is, else what it is,
+ * else the brand. Never the raw lowercase board type (CLAUDE.md trademark rule).
+ */
+export function boardRowSubtitle(board: BoardLabelSource): string {
+  return boardPlaceLabel(board) ?? boardConfigLabel(board) ?? boardTypeLabel(board.boardType);
+}
+
+/**
+ * Facets tried, in order, when two boards in the same list land on the same
+ * subtitle. Place first (a different wall in the same gym), then the physical
+ * config, then how it is set up, then the serial as the last resort — two boards
+ * can share everything else but never a serial.
+ */
+const DISAMBIGUATION_FACETS: ((board: BoardLabelSource) => string | null)[] = [
+  sizeFacet,
+  layoutFacet,
+  angleFacet,
+  serialFacet,
+];
+
+/**
+ * Subtitles for one rendered list, with same-subtitle boards pulled apart.
+ *
+ * Returns one subtitle per input board, in order. Boards that collide on their
+ * base subtitle get ` · <facet>` appended using the first facet that actually
+ * differs within that collision group — so two Kilter boards run by the same
+ * gym separate on their size, angle or serial instead of both reading "Bergen
+ * Klatresenter". A group whose members are identical on every facet is left
+ * alone; we never invent a distinction.
+ *
+ * Runs once per list (call it from the list's `useMemo`, never from a row) and
+ * is O(boards × facets).
+ */
+export function disambiguateBoardSubtitles(boards: BoardLabelSource[]): string[] {
+  const subtitles = boards.map(boardRowSubtitle);
+
+  const indicesBySubtitle = new Map<string, number[]>();
+  subtitles.forEach((subtitle, index) => {
+    const group = indicesBySubtitle.get(subtitle);
+    if (group) group.push(index);
+    else indicesBySubtitle.set(subtitle, [index]);
+  });
+
+  for (const group of indicesBySubtitle.values()) {
+    if (group.length < 2) continue;
+    for (const facet of DISAMBIGUATION_FACETS) {
+      const values = group.map((index) => facet(boards[index]));
+      const distinct = new Set(values);
+      // A facet every member shares (or none of them has) separates nothing.
+      if (distinct.size < 2) continue;
+      group.forEach((index, position) => {
+        const value = values[position];
+        if (value !== null) subtitles[index] = `${subtitles[index]} · ${value}`;
+      });
+      break;
+    }
+  }
+
+  return subtitles;
+}

--- a/packages/mobile/src/components/gym-directory/GymListPanel.tsx
+++ b/packages/mobile/src/components/gym-directory/GymListPanel.tsx
@@ -11,6 +11,8 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { ActivityIndicator } from '../ActivityIndicator';
 import { PressableSurface } from '../PressableSurface';
+import { boardTypeLabel } from '../board-discovery/board-builder-labels';
+import { boardConfigLabel } from '../board-discovery/board-labels';
 import { useTheme } from '../../providers/theme-provider';
 import { applySectionCaption } from '../../theme/variants/variant-tokens';
 import { spacing, borderRadius, shadows } from '../../theme/tokens';
@@ -352,7 +354,9 @@ const BoardRow = memo(function BoardRow({
       <View style={styles.rowText}>
         <Text variant="subheadline">{board.name}</Text>
         <Text variant="caption1" color={systemColors.tertiaryLabel}>
-          {board.boardType}
+          {/* Inside an expanded gym the place is redundant — show what the board
+              is instead, never the raw lowercase type. */}
+          {boardConfigLabel(board) ?? boardTypeLabel(board.boardType)}
         </Text>
       </View>
       {board.canEdit ? <EditButton onPress={handleEdit} label={t('mobile.gyms.editBoard')} /> : null}

--- a/packages/mobile/src/components/gym-directory/__tests__/gym-list-panel.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/gym-list-panel.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 import { createElement, forwardRef, type ReactNode, type Ref } from 'react';
-import type { Gym } from '@boardsesh/shared-schema';
+import type { Gym, UserBoard } from '@boardsesh/shared-schema';
 import type { GymListRow } from '../gym-list-rows';
 
 type Children = { children?: ReactNode };
@@ -102,7 +102,10 @@ vi.mock('../../../providers/theme-provider', () => ({
   }),
 }));
 
-vi.mock('@boardsesh/board-config', () => ({
+// Partial mock: the panel's badge formatting is stubbed, but the nested board
+// rows resolve their caption through the real toBoardName + bundled tables.
+vi.mock('@boardsesh/board-config', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@boardsesh/board-config')>()),
   formatBoardDisplayName: (boardType: string) => boardType.charAt(0).toUpperCase() + boardType.slice(1),
 }));
 
@@ -249,5 +252,53 @@ describe('GymListPanel', () => {
     expect(getByTestId('loc-prompt')).toBeTruthy();
     // The list (and its gym rows) is not rendered while the prompt is shown.
     expect(queryByText('Movement')).toBeNull();
+  });
+});
+
+describe('GymListPanel board rows', () => {
+  // The nested board caption used to render the raw `board.boardType`, so every
+  // board inside an expanded gym read a lowercase "kilter". Inside a gym the
+  // place is redundant, so the caption shows what the board is.
+  const gymBoard = {
+    uuid: 'b1',
+    name: 'Comp wall',
+    boardType: 'kilter',
+    layoutId: 1,
+    sizeId: 7,
+    gymName: 'Movement',
+  } as unknown as UserBoard;
+
+  function makeExpandedGymData(board: UserBoard): GymListRow[] {
+    return [
+      { kind: 'gym', key: 'gym:g1', gym, subtitle: '1 Crag St', expanded: true, selected: false, boards: [board] },
+    ];
+  }
+
+  function renderExpanded(board: UserBoard) {
+    return render(
+      <GymListPanel
+        data={makeExpandedGymData(board)}
+        mapAvailable
+        onPressGym={vi.fn()}
+        onActivateBoard={vi.fn()}
+        onEditGym={vi.fn()}
+        onEditBoard={vi.fn()}
+        noBoardsLabel="No boards yet"
+        searchSlot={<div>search</div>}
+      />,
+    );
+  }
+
+  it('captions a board with its config, not the raw board type', () => {
+    const { getByText, queryByText } = renderExpanded(gymBoard);
+    expect(getByText('Comp wall')).toBeTruthy();
+    expect(getByText('Original 12×14')).toBeTruthy();
+    expect(queryByText('kilter')).toBeNull();
+  });
+
+  it('falls back to the brand name when the config is unknown to the bundled tables', () => {
+    const { getByText, queryByText } = renderExpanded({ ...gymBoard, layoutId: 99999, sizeId: 99999 } as UserBoard);
+    expect(getByText('Kilter')).toBeTruthy();
+    expect(queryByText('kilter')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Two Kilter boards run by the same gym at two different locations rendered as the same card in the
Boards tab: a one-line name that ellipsised both to the same prefix, over a subtitle that read
`kilter` on both.

The subtitle was built from `board.sizeName`, and the backend hard-codes `layoutName`, `sizeName`,
`sizeDescription` and `setNames` to `null` on **every** `UserBoard` it returns — all three enrichment
paths in `packages/backend/src/graphql/resolvers/social/boards.ts` (`:451`, `:645`, `:1118`) carry a
`TODO: resolve from board-specific layout/size/set tables if needed`. So the subtitle always fell
through to the raw lowercase board type. Meanwhile the payload already carried `gymName`,
`locationName`, `layoutId`/`sizeId`, `angle` and `serialNumber`, and `@boardsesh/board-constants`
bundles the layout and product-size name tables on the device.

The fix is entirely client-side (no backend change, works offline, rides OTA):

- New `board-labels.ts` with `boardPlaceLabel` / `boardConfigLabel` / `boardRowSubtitle`. A board's
  subtitle is now where it is (gym, else location), else what it is (`Original 12×14`, resolved from
  the bundled tables), else the brand name — never the raw lowercase type.
- `disambiguateBoardSubtitles` runs once per rendered list: boards that still land on the same
  subtitle get ` · <facet>` appended. Facets are tried in order — size, layout, angle, then the last
  4 of the serial — and the first one that leaves every member of the group reading differently
  wins, falling back to the first that at least splits the group (a gym with three boards where two
  share a size). Boards that are genuinely identical on every facet are left alone; we don't invent
  a distinction.
- The carousel card now gives the name two lines with a fixed two-line reservation, so card heights
  stay uniform and a long name is no longer cut at the point where two boards look the same. The card
  is now `React.memo`'d (it was the only un-memoized row in the board-discovery set).
- Same always-null first term fixed on the My Boards management list, the board-detail sheet (whose
  Size spec row was permanently hidden), the expanded-gym rows in the directory, and the Bluetooth
  quickstart sheet (which rendered a dangling `kilter · `).
- Dropped mobile's duplicated board-brand map in favour of `BOARD_TYPE_LABELS` from
  `@boardsesh/board-constants`, which the shared file's own docstring asks call sites to migrate to.

Disambiguation is a list-level pass inside the existing `useMemo`s — never per row. `renderItem`
deps, `keyExtractor` and the FlashList setup are unchanged.

The backend TODO is deliberately out of scope here (the client resolves the same names offline), but
it is the reason the picker said "kilter" in the first place and is being filed as its own follow-up.

Closes #4412

## Release Notes

- Tell your boards apart in the picker: cards now show the gym or location under the name, fall back
  to the layout and size, and add the size, angle or serial when two boards would otherwise read the
  same
- Long board names get two lines instead of being cut off mid-word

## Test plan

- `vp run test:mobile` — 6555/6556 locally. The one failure is
  `queue-provider-session-updates.test.tsx`, a `waitFor` timeout under a load average of ~60 on this
  box; it passes on re-run of the same file with the same code and touches nothing this PR changes.
  Both CI `test-default` shards are green.
- `src/components/board-discovery` went 12 files / 172 tests → 13 files / 205 tests; with
  `src/components/gym-directory` the two dirs are 19 files / 250 tests.
- New `board-labels.test.ts` covers gym-over-location precedence, layout/size resolution against real
  bundled ids, an unknown id returning `null` rather than an id or `undefined`, and every rung of the
  disambiguation ladder — including the reported case (two same-gym Kilters), a three-board gym where
  only the second facet separates everyone, and the genuinely-indistinguishable case, which must be
  left untouched.
- The two other changed surfaces got integration coverage too: the gym directory's nested board rows
  (`gym-list-panel.test.tsx`) and the Bluetooth quickstart rows
  (`bluetooth-quickstart-sheet.test.tsx`).
- `vp run typecheck:mobile`, `vp check` and the pre-commit hook clean locally; CI `typecheck`,
  `lint`, `check` and `mobile-bundle` all green.
- `ota-check` confirms no native fingerprint change — this rides OTA.

### Visual sign-off needed — @marcodejongh

**This PR is not auto-mergeable and I could not produce screenshots.** I ran
`vp run mobile:android-shots` on this host and it failed with
`Emulator did not finish booting within 300s`; the emulator log ends in
`xvfb-run: Segmentation fault (core dumped)` partway through "Emulator is performing a full startup".
That is a limitation of this machine's software GPU, not of the change, and it reproduces with a
clean tree. The `ios-screenshots` path is macOS-only, and the committed Maestro app-store flow never
visits the Boards tab, so the CI Android screenshot job would capture nothing relevant either. I did
not mock anything up.

Two things worth eyeballing on a device:

1. **Boards tab carousel** with at least two same-brand boards — check the two-line name reservation
   keeps card heights uniform when one title wraps and its neighbour does not, and that the subtitle
   line reads the gym/location.
2. **My Boards** list and the **board-detail sheet** — the detail sheet's Size row now renders for the
   first time (it was hidden by the null server field), so it is worth confirming the string reads
   sensibly for a Homewall size like `12 x 12 with kickboard · Square`.

Reproducing the exact reported collision needs an account with two boards at one gym; if you have the
reporter's setup handy that is the fastest check.
