### PR TITLE
fix(mobile): show a real label on the zoom reset button

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,11 @@ jobs:
 
   i18n:
     needs: [changes]
-    if: needs.changes.outputs.web == 'true' || needs.changes.outputs.i18nCatalogs == 'true' || needs.changes.outputs.rootCi == 'true'
+    # `mobile` is in the filter because check:i18n:orphans scans
+    # packages/mobile/{src,app} too. #4416 shipped a raw `playView.resetZoom`
+    # label from a mobile-only commit — without this the guard would skip the
+    # exact class of PR that introduces the bug.
+    if: needs.changes.outputs.web == 'true' || needs.changes.outputs.mobile == 'true' || needs.changes.outputs.i18nCatalogs == 'true' || needs.changes.outputs.rootCi == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -482,7 +486,10 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Check hardcoded user-facing strings
         run: vp run check:i18n
-      - name: Check orphaned i18n keys
+      # Two-way: orphaned catalog keys, plus keys referenced from code that exist
+      # in no catalog (they ship as raw `playView.resetZoom` strings — #4416) and
+      # mobile files reading a namespace Metro never bundles.
+      - name: Check i18n keys (orphaned + missing)
         run: vp run check:i18n:orphans
 
   deploy-config:

--- a/packages/mobile/src/components/ClimbFilterSheet.tsx
+++ b/packages/mobile/src/components/ClimbFilterSheet.tsx
@@ -790,7 +790,7 @@ export function ClimbFilterSheet({
                     onPress={handleClearNameField}
                     hitSlop={8}
                     accessibilityRole="button"
-                    accessibilityLabel={tCommon('clear')}
+                    accessibilityLabel={tCommon('actions.clear')}
                   >
                     <Icon name="close" size={14} color={systemColors.tertiaryLabel} />
                   </Pressable>

--- a/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-filter-sheet.test.tsx
@@ -873,11 +873,11 @@ describe('ClimbFilterSheet name field (#3606)', () => {
     const input = getByLabelText('mobile.filter.section.name') as HTMLInputElement;
     expect(input.value).toBe('foot');
 
-    fireEvent.click(getByLabelText('clear'));
+    fireEvent.click(getByLabelText('actions.clear'));
 
     expect(input.value).toBe('');
     expect(onClearName).toHaveBeenCalledTimes(1);
-    expect(queryByLabelText('clear')).toBeNull();
+    expect(queryByLabelText('actions.clear')).toBeNull();
   });
 
   it('resyncs the name field from an external searchName change, but ignores a trim-only difference', () => {

--- a/packages/mobile/src/components/gym-directory/WallFinderFilterChips.tsx
+++ b/packages/mobile/src/components/gym-directory/WallFinderFilterChips.tsx
@@ -156,7 +156,7 @@ export function WallFinderFilterChips({
       {hasActive ? (
         <Pressable onPress={onClear} hitSlop={8} accessibilityRole="button" style={styles.clear}>
           <Text variant="caption1" color={brandColors.primary} style={styles.chipLabel}>
-            {t('clear')}
+            {t('actions.clear')}
           </Text>
         </Pressable>
       ) : null}

--- a/packages/mobile/src/components/gym-directory/__tests__/wall-finder-filter-chips.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/wall-finder-filter-chips.test.tsx
@@ -108,15 +108,15 @@ describe('WallFinderFilterChips', () => {
 
   it('hides Clear when nothing is active and shows it once any filter is set', () => {
     const { queryByText, rerender, getByText } = render(<WallFinderFilterChips {...baseProps()} />);
-    expect(queryByText('clear')).toBeNull();
+    expect(queryByText('actions.clear')).toBeNull();
     rerender(<WallFinderFilterChips {...baseProps({ multiBoardTypeOnly: true })} />);
-    expect(getByText('clear')).toBeTruthy();
+    expect(getByText('actions.clear')).toBeTruthy();
   });
 
   it('calls onClear when Clear is tapped', () => {
     const onClear = vi.fn();
     const { getByText } = render(<WallFinderFilterChips {...baseProps({ selected: ['kilter'], onClear })} />);
-    fireEvent.click(getByText('clear'));
+    fireEvent.click(getByText('actions.clear'));
     expect(onClear).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
+++ b/packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx
@@ -95,6 +95,10 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
   swipeIsAnimating,
 }: SwipeBoardCarouselProps) {
   const { t } = useTranslation('session');
+  // The reset-zoom pill reuses the already-translated `common:board.resetZoom`
+  // that the other two zoomable boards render (InteractiveFilterBoard,
+  // InteractiveCreateBoard) instead of a `session`-local duplicate.
+  const { t: tCommon } = useTranslation('common');
   const { width: screenWidth } = useWindowDimensions();
   // Measured box the board is laid out into. The board is sized to *fit* this
   // box (contain) so the play drawer's full-screen first view can keep the
@@ -351,11 +355,11 @@ export const SwipeBoardCarousel = React.memo(function SwipeBoardCarousel({
             onPress={resetZoom}
             style={styles.resetZoomButton}
             accessibilityRole="button"
-            accessibilityLabel={t('playView.resetZoom')}
+            accessibilityLabel={tCommon('board.resetZoom')}
             hitSlop={8}
           >
             <Icon name="crop.free" size={14} color={overlays.onScrim} />
-            <Text style={styles.resetZoomLabel}>{t('playView.resetZoom')}</Text>
+            <Text style={styles.resetZoomLabel}>{tCommon('board.resetZoom')}</Text>
           </Pressable>
         </Animated.View>
       </View>

--- a/packages/mobile/src/components/you/YouCharts.tsx
+++ b/packages/mobile/src/components/you/YouCharts.tsx
@@ -208,7 +208,7 @@ function ChartFrame({ height, loading, emptyLabel, isEmpty, zoomable, children }
             floatingElevation,
           ]}
           accessibilityRole="button"
-          accessibilityLabel={t('resetZoom')}
+          accessibilityLabel={t('board.resetZoom')}
           hitSlop={8}
         >
           <Icon name="crop.free" size={15} color={systemColors.label} />

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -372,7 +372,7 @@
     "yes": "Ja",
     "no": "Nein",
     "cancel": "Abbrechen",
-    "clear": "Löschen",
+    "clear": "Zurücksetzen",
     "delete": "Löschen",
     "edit": "Bearbeiten",
     "close": "Schließen",

--- a/packages/shared/i18n/locales/de/common.json
+++ b/packages/shared/i18n/locales/de/common.json
@@ -372,6 +372,7 @@
     "yes": "Ja",
     "no": "Nein",
     "cancel": "Abbrechen",
+    "clear": "Löschen",
     "delete": "Löschen",
     "edit": "Bearbeiten",
     "close": "Schließen",

--- a/packages/shared/i18n/locales/de/feed.json
+++ b/packages/shared/i18n/locales/de/feed.json
@@ -31,6 +31,7 @@
   },
   "ascentsFeed": {
     "mirrored": "Gespiegelt",
+    "setBy": "Gebaut von {{name}}",
     "benchmark": "Benchmark",
     "empty": "Noch keine Begehungen eingetragen"
   },

--- a/packages/shared/i18n/locales/en-US/common.json
+++ b/packages/shared/i18n/locales/en-US/common.json
@@ -372,6 +372,7 @@
     "yes": "Yes",
     "no": "No",
     "cancel": "Cancel",
+    "clear": "Clear",
     "delete": "Delete",
     "edit": "Edit",
     "close": "Close",

--- a/packages/shared/i18n/locales/en-US/feed.json
+++ b/packages/shared/i18n/locales/en-US/feed.json
@@ -31,6 +31,7 @@
   },
   "ascentsFeed": {
     "mirrored": "Mirrored",
+    "setBy": "Set by {{name}}",
     "benchmark": "Benchmark",
     "empty": "No ascents logged yet"
   },

--- a/packages/shared/i18n/locales/es/common.json
+++ b/packages/shared/i18n/locales/es/common.json
@@ -9,6 +9,7 @@
     "yes": "Sí",
     "no": "No",
     "cancel": "Cancelar",
+    "clear": "Borrar",
     "delete": "Eliminar",
     "edit": "Editar",
     "close": "Cerrar",

--- a/packages/shared/i18n/locales/es/feed.json
+++ b/packages/shared/i18n/locales/es/feed.json
@@ -31,6 +31,7 @@
   },
   "ascentsFeed": {
     "mirrored": "Espejo",
+    "setBy": "Creado por {{name}}",
     "benchmark": "Referencia",
     "empty": "Aún no hay ascensos"
   },

--- a/packages/shared/i18n/locales/fr/common.json
+++ b/packages/shared/i18n/locales/fr/common.json
@@ -372,6 +372,7 @@
     "yes": "Oui",
     "no": "Non",
     "cancel": "Annuler",
+    "clear": "Effacer",
     "delete": "Supprimer",
     "edit": "Modifier",
     "close": "Fermer",

--- a/packages/shared/i18n/locales/fr/feed.json
+++ b/packages/shared/i18n/locales/fr/feed.json
@@ -31,6 +31,7 @@
   },
   "ascentsFeed": {
     "mirrored": "Miroir",
+    "setBy": "Ouvert par {{name}}",
     "benchmark": "Référence",
     "empty": "Aucune ascension pour le moment"
   },

--- a/packages/web/app/components/activity-feed/ascents-feed.tsx
+++ b/packages/web/app/components/activity-feed/ascents-feed.tsx
@@ -152,6 +152,9 @@ const GroupedFeedItem: React.FC<{
   isDeleting?: boolean;
 }> = ({ group, isOwnProfile = false, onDeleteTick, isDeleting = false }) => {
   const { t } = useTranslation('common');
+  // The card's chips and setter line live in the `feed` catalog, not `common` —
+  // reading them off the `common` binding rendered the raw keys.
+  const { t: tFeed } = useTranslation('feed');
   const latestItem = group.items.reduce((latest, item) =>
     tickTimeMs(item.climbedAt) > tickTimeMs(latest.climbedAt) ? item : latest,
   );
@@ -216,8 +219,8 @@ const GroupedFeedItem: React.FC<{
               <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.boardType}>
                 {boardDisplay}
               </MuiTypography>
-              {group.isMirror && <Chip label={t('ascentsFeed.mirrored')} size="small" color="secondary" />}
-              {group.isBenchmark && <Chip label={t('ascentsFeed.benchmark')} size="small" />}
+              {group.isMirror && <Chip label={tFeed('ascentsFeed.mirrored')} size="small" color="secondary" />}
+              {group.isBenchmark && <Chip label={tFeed('ascentsFeed.benchmark')} size="small" />}
             </Box>
 
             {hasSuccess && group.bestQuality && (
@@ -226,7 +229,7 @@ const GroupedFeedItem: React.FC<{
 
             {group.setterUsername && (
               <MuiTypography variant="body2" component="span" color="text.secondary" className={styles.setter}>
-                {t('ascentsFeed.setBy', { name: group.setterUsername })}
+                {tFeed('ascentsFeed.setBy', { name: group.setterUsername })}
               </MuiTypography>
             )}
 

--- a/packages/web/scripts/check-orphaned-i18n-keys.test.ts
+++ b/packages/web/scripts/check-orphaned-i18n-keys.test.ts
@@ -1,11 +1,43 @@
 import { describe, expect, it } from 'vitest';
-import { analyzeFile, computeOrphans } from './check-orphaned-i18n-keys';
+import {
+  analyzeFile,
+  computeForeignMobileNamespaces,
+  computeMissingKeys,
+  computeOrphans,
+  formatReport,
+} from './check-orphaned-i18n-keys';
 
 const fakePath = '/tmp/fake-component.tsx';
 const fakeTsPath = '/tmp/fake-helper.ts';
 
 function analyze(source: string, path: string = fakePath) {
   return analyzeFile(path, source);
+}
+
+const mobilePath = '/repo/packages/mobile/src/components/Fake.tsx';
+const webPath = '/repo/packages/web/app/components/Fake.tsx';
+
+function toCatalogMap(catalog: Record<string, string[]>) {
+  const catalogMap = new Map<string, Set<string>>();
+  for (const [namespace, keys] of Object.entries(catalog)) {
+    catalogMap.set(namespace, new Set(keys));
+  }
+  return catalogMap;
+}
+
+function missingKeys(catalog: Record<string, string[]>, analyses: ReturnType<typeof analyzeFile>[]) {
+  return computeMissingKeys(
+    toCatalogMap(catalog),
+    analyses.flatMap((analysis) => analysis.references),
+  );
+}
+
+function foreignMobileNamespaces(analysesByFile: Record<string, ReturnType<typeof analyzeFile>>) {
+  const namespacesByFile = new Map<string, ReadonlySet<string>>();
+  for (const [file, analysis] of Object.entries(analysesByFile)) {
+    namespacesByFile.set(file, analysis.referencedNamespaces);
+  }
+  return computeForeignMobileNamespaces(namespacesByFile);
 }
 
 function namespaceOrphans(
@@ -392,5 +424,256 @@ describe('*I18nKey property convention', () => {
       }
     `);
     expect(analysis.unanalyzable).toHaveLength(0);
+  });
+});
+
+describe('missing keys (the inverse direction)', () => {
+  it('reports the #4416 shape: a session-bound t() reading a key no catalog defines', () => {
+    const analysis = analyze(
+      `
+      import { useTranslation } from 'react-i18next';
+      export default function SwipeBoardCarousel() {
+        const { t } = useTranslation('session');
+        return <button aria-label={t('playView.resetZoom')}>{t('playView.resetZoom')}</button>;
+      }
+    `,
+      mobilePath,
+    );
+    const missing = missingKeys({ session: ['playView.play', 'playView.pause'], common: ['board.resetZoom'] }, [
+      analysis,
+    ]);
+    expect(missing).toHaveLength(2);
+    expect(missing[0].key).toBe('playView.resetZoom');
+    expect(missing[0].namespaces).toEqual(['session']);
+    expect(missing[0].file).toBe(mobilePath);
+    expect(missing[0].line).toBe(5);
+  });
+
+  it('reports nothing once the call points at the key that exists', () => {
+    const analysis = analyze(
+      `
+      import { useTranslation } from 'react-i18next';
+      export default function SwipeBoardCarousel() {
+        const { t } = useTranslation('session');
+        const { t: tCommon } = useTranslation('common');
+        return <button aria-label={tCommon('board.resetZoom')}>{t('playView.play')}</button>;
+      }
+    `,
+      mobilePath,
+    );
+    expect(missingKeys({ session: ['playView.play'], common: ['board.resetZoom'] }, [analysis])).toEqual([]);
+  });
+
+  it('counts a base key as defined when only its plural variants are in the catalog', () => {
+    const analysis = analyze(`
+      import { useTranslation } from 'react-i18next';
+      export default function Foo({ count }: { count: number }) {
+        const { t } = useTranslation('common');
+        return <span>{t('ascents.sent', { count })}</span>;
+      }
+    `);
+    expect(missingKeys({ common: ['ascents.sent_one', 'ascents.sent_other'] }, [analysis])).toEqual([]);
+  });
+
+  it('counts ordinal plural variants too', () => {
+    const analysis = analyze(`
+      import { useTranslation } from 'react-i18next';
+      export default function Foo({ count }: { count: number }) {
+        const { t } = useTranslation('common');
+        return <span>{t('place', { count, ordinal: true })}</span>;
+      }
+    `);
+    expect(missingKeys({ common: ['place_ordinal_one', 'place_ordinal_other'] }, [analysis])).toEqual([]);
+  });
+
+  it('is lenient about a t() it could not bind: defined in any namespace counts', () => {
+    const analysis = analyze(
+      `
+      import type { TFunction } from 'i18next';
+      export function format(t: TFunction) {
+        return t('ascents.statusFlash');
+      }
+    `,
+      fakeTsPath,
+    );
+    expect(missingKeys({ common: ['unrelated'], feed: ['ascents.statusFlash'] }, [analysis])).toEqual([]);
+  });
+
+  it('still reports an unbindable t() whose key exists in no namespace at all', () => {
+    const analysis = analyze(
+      `
+      import type { TFunction } from 'i18next';
+      export function format(t: TFunction) {
+        return t('ascents.statusFlash');
+      }
+    `,
+      fakeTsPath,
+    );
+    const missing = missingKeys({ common: ['unrelated'], feed: ['other'] }, [analysis]);
+    expect(missing).toHaveLength(1);
+    expect(missing[0].key).toBe('ascents.statusFlash');
+  });
+
+  it('skips template-literal keys entirely — a glob cannot be verified in this direction', () => {
+    const analysis = analyze(`
+      import { useTranslation } from 'react-i18next';
+      export default function Foo({ kind }: { kind: string }) {
+        const { t } = useTranslation('admin');
+        return <span>{t(\`settings.rows.\${kind}.label\`)}</span>;
+      }
+    `);
+    expect(missingKeys({ admin: ['unrelated'] }, [analysis])).toEqual([]);
+  });
+
+  it('accepts a key defined in any one of several bound namespaces', () => {
+    const analysis = analyze(`
+      import { useTranslation } from 'react-i18next';
+      export default function Foo() {
+        const { t } = useTranslation(['climbs', 'session']);
+        return <span>{t('shared.label')}</span>;
+      }
+    `);
+    expect(missingKeys({ climbs: ['other'], session: ['shared.label'] }, [analysis])).toEqual([]);
+  });
+
+  it('resolves an explicit ns:key prefix against that namespace', () => {
+    const analysis = analyze(`
+      import { useTranslation } from 'react-i18next';
+      export default function Foo() {
+        const { t } = useTranslation('common');
+        return <span>{t('feed:ascentsFeed.setBy', { name: 'sam' })}</span>;
+      }
+    `);
+    expect(missingKeys({ common: [], feed: ['ascentsFeed.setBy'] }, [analysis])).toEqual([]);
+    const missing = missingKeys({ common: ['ascentsFeed.setBy'], feed: [] }, [analysis]);
+    expect(missing).toHaveLength(1);
+    expect(missing[0].namespaces).toEqual(['feed']);
+  });
+
+  it('does not flag a <Trans> whose i18nKey exists, and does flag one whose key does not', () => {
+    const good = analyze(`
+      import { useTranslation, Trans } from 'react-i18next';
+      export default function Foo() {
+        const { t } = useTranslation('settings');
+        return <Trans i18nKey="account.delete.body" t={t} components={{ strong: <strong /> }} />;
+      }
+    `);
+    expect(missingKeys({ settings: ['account.delete.body'] }, [good])).toEqual([]);
+
+    const bad = analyze(`
+      import { useTranslation, Trans } from 'react-i18next';
+      export default function Foo() {
+        const { t } = useTranslation('settings');
+        return <Trans i18nKey="account.delete.missing" t={t} />;
+      }
+    `);
+    const missing = missingKeys({ settings: ['account.delete.body'] }, [bad]);
+    expect(missing).toHaveLength(1);
+    expect(missing[0].key).toBe('account.delete.missing');
+  });
+
+  it('does not flag the *I18nKey property convention when the key exists somewhere', () => {
+    const analysis = analyze(
+      `
+      export const PRESETS = [{ slug: 'a', titleI18nKey: 'library.smart.fiveStars.title' }];
+    `,
+      fakeTsPath,
+    );
+    expect(missingKeys({ playlists: ['library.smart.fiveStars.title'], common: [] }, [analysis])).toEqual([]);
+  });
+
+  it('reports each distinct call site, not one entry per duplicate key', () => {
+    const analysis = analyze(`
+      import { useTranslation } from 'react-i18next';
+      export default function Foo() {
+        const { t } = useTranslation('common');
+        return <span>{t('nope.one')}{t('nope.one')}</span>;
+      }
+    `);
+    const missing = missingKeys({ common: ['yes'] }, [analysis]);
+    expect(missing).toHaveLength(2);
+    expect(missing.map((entry) => entry.column)).toEqual([...new Set(missing.map((entry) => entry.column))]);
+  });
+});
+
+describe('mobile namespace guard', () => {
+  it('flags a file under packages/mobile reading a namespace Metro never bundles', () => {
+    const analysis = analyze(
+      `
+      import { useTranslation } from 'react-i18next';
+      export default function Foo() {
+        const { t } = useTranslation('marketing');
+        return <span>{t('home.hero.title')}</span>;
+      }
+    `,
+      mobilePath,
+    );
+    const foreign = foreignMobileNamespaces({ [mobilePath]: analysis });
+    expect(foreign).toEqual([{ namespace: 'marketing', file: mobilePath }]);
+  });
+
+  it('leaves the same namespace alone in a web file', () => {
+    const analysis = analyze(
+      `
+      import { useTranslation } from 'react-i18next';
+      export default function Foo() {
+        const { t } = useTranslation('marketing');
+        return <span>{t('home.hero.title')}</span>;
+      }
+    `,
+      webPath,
+    );
+    expect(foreignMobileNamespaces({ [webPath]: analysis })).toEqual([]);
+  });
+
+  it('accepts the namespaces that are in the mobile bundle', () => {
+    const analysis = analyze(
+      `
+      import { useTranslation } from 'react-i18next';
+      export default function Foo() {
+        const { t } = useTranslation('common');
+        const { t: tSession } = useTranslation('session');
+        return <span>{t('board.resetZoom')}{tSession('playView.play')}</span>;
+      }
+    `,
+      mobilePath,
+    );
+    expect(foreignMobileNamespaces({ [mobilePath]: analysis })).toEqual([]);
+  });
+});
+
+describe('formatReport exit codes', () => {
+  const emptyReport = {
+    totalFiles: 1,
+    totalKeys: 1,
+    totalReferences: 1,
+    orphans: [],
+    missing: [],
+    foreignMobileNamespaces: [],
+    unanalyzable: [],
+  };
+
+  it('exits 0 and says both directions passed when everything resolves', () => {
+    const formatted = formatReport(emptyReport);
+    expect(formatted.exitCode).toBe(0);
+    expect(formatted.lines.join('\n')).toContain('static key reference(s) resolve to a catalog entry');
+  });
+
+  it('exits 1 when a referenced key is missing from every catalog', () => {
+    const formatted = formatReport({
+      ...emptyReport,
+      missing: [{ namespaces: ['session'], key: 'playView.resetZoom', file: mobilePath, line: 5, column: 7 }],
+    });
+    expect(formatted.exitCode).toBe(1);
+    expect(formatted.lines.join('\n')).toContain('session -> playView.resetZoom');
+  });
+
+  it('exits 1 when a mobile file reads an unbundled namespace', () => {
+    const formatted = formatReport({
+      ...emptyReport,
+      foreignMobileNamespaces: [{ namespace: 'marketing', file: mobilePath }],
+    });
+    expect(formatted.exitCode).toBe(1);
+    expect(formatted.lines.join('\n')).toContain('not bundled on mobile');
   });
 });

--- a/packages/web/scripts/check-orphaned-i18n-keys.ts
+++ b/packages/web/scripts/check-orphaned-i18n-keys.ts
@@ -1,9 +1,21 @@
 #!/usr/bin/env bun
 /**
- * Static check that fails when a key in `packages/shared/i18n/locales/en-US/<ns>.json`
- * has no live reference under `packages/web/app/`, `packages/web/scripts/`, or
- * `packages/mobile/{src,app}/`. en-US is the source of truth — `es`, `fr`, and `de`
- * fall back through i18next, so an orphan in en-US is an orphan in every locale.
+ * Two-way static check over the i18n catalogs and the code that reads them,
+ * across `packages/web/app/`, `packages/web/scripts/`, and `packages/mobile/{src,app}/`:
+ *
+ *   - ORPHANS — a key in `packages/shared/i18n/locales/en-US/<ns>.json` with no
+ *     live reference. en-US is the source of truth — `es`, `fr`, and `de` fall
+ *     back through i18next, so an orphan in en-US is an orphan in every locale.
+ *   - MISSING — a `t()` / `<Trans>` reference to a key that exists in no catalog.
+ *     i18next has no `parseMissingKeyHandler` here, so it renders the raw key: a
+ *     button labelled `playView.resetZoom` instead of "Reset zoom" (#4416).
+ *   - MOBILE NAMESPACES — a file under `packages/mobile/` reading a namespace
+ *     that `MOBILE_NAMESPACES` leaves out of the mobile bundle, so every key in
+ *     it renders raw on device while resolving fine on web.
+ *
+ * The missing direction is deliberately lenient — it only reports a key when the
+ * reference is statically resolvable and no candidate namespace defines it (see
+ * `computeMissingKeys`). Template-literal globs are skipped entirely.
  *
  * What gets resolved as a reference:
  *   1. `t('foo.bar')` / `t('marketing:foo.bar')` with a static string literal,
@@ -41,6 +53,7 @@ import { fileURLToPath } from 'node:url';
 // source-text parser or `forEachChild`. The API returns in 7.1; until then this
 // AST walk runs on a pinned 6.x copy. See `typescript-compiler-api` in package.json.
 import ts from 'typescript-compiler-api';
+import { MOBILE_NAMESPACES } from '@boardsesh/i18n';
 import { DEFAULT_NAMESPACE } from '../app/lib/i18n/config';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -65,6 +78,13 @@ type GlobPattern = { segments: GlobSegment[] };
 type NsContext = { primary: string; bound: readonly string[] };
 type Binding = { start: number; aliasName: string; scope: ts.Node; ctx: NsContext };
 type UnanalyzableSite = { file: string; line: number; column: number; snippet: string };
+/**
+ * One statically-resolved `t()` / `<Trans>` reference. `namespaces` is the set
+ * of namespaces the key could land in: the bound list for `useTranslation([a, b])`,
+ * a single entry for `t('ns:key')`, or `[ANY_NAMESPACE]` when the `t` identifier
+ * couldn't be traced back to a binding.
+ */
+type KeyReference = { key: string; namespaces: readonly string[]; file: string; line: number; column: number };
 
 const ANY_CTX: NsContext = { primary: ANY_NAMESPACE, bound: [ANY_NAMESPACE] };
 
@@ -295,6 +315,8 @@ function pluralBaseKey(key: string): string | undefined {
 type FileAnalysis = {
   usedKeys: Map<string, Set<string>>;
   globs: Map<string, GlobPattern[]>;
+  references: KeyReference[];
+  referencedNamespaces: Set<string>;
   unanalyzable: UnanalyzableSite[];
   keepHints: Set<string>;
 };
@@ -310,6 +332,8 @@ function analyzeFile(filePath: string, sourceOverride?: string): FileAnalysis {
   );
   const usedKeys = new Map<string, Set<string>>();
   const globs = new Map<string, GlobPattern[]>();
+  const references: KeyReference[] = [];
+  const referencedNamespaces = new Set<string>();
   const unanalyzable: UnanalyzableSite[] = [];
   const keepHints = new Set<string>();
   const bindings: Binding[] = [];
@@ -321,6 +345,7 @@ function analyzeFile(filePath: string, sourceOverride?: string): FileAnalysis {
       usedKeys.set(ns, set);
     }
     set.add(key);
+    if (ns !== ANY_NAMESPACE) referencedNamespaces.add(ns);
   }
 
   function recordGlob(ns: string, pattern: GlobPattern) {
@@ -330,6 +355,12 @@ function analyzeFile(filePath: string, sourceOverride?: string): FileAnalysis {
       globs.set(ns, arr);
     }
     arr.push(pattern);
+    if (ns !== ANY_NAMESPACE) referencedNamespaces.add(ns);
+  }
+
+  function recordReference(namespaces: readonly string[], key: string, node: ts.Node) {
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    references.push({ key, namespaces, file: filePath, line: line + 1, column: character + 1 });
   }
 
   function findApplicableCtx(callNode: ts.Node, identifierName: string): NsContext | undefined {
@@ -348,17 +379,19 @@ function analyzeFile(filePath: string, sourceOverride?: string): FileAnalysis {
     return best;
   }
 
-  function resolveStaticKey(rawKey: string, ctx: NsContext) {
+  function resolveStaticKey(rawKey: string, ctx: NsContext, node: ts.Node) {
     const colonIndex = rawKey.indexOf(':');
     if (colonIndex >= 0) {
       const ns = rawKey.slice(0, colonIndex);
       const key = rawKey.slice(colonIndex + 1);
       recordKey(ns, key);
+      recordReference([ns], key, node);
       return;
     }
     for (const ns of ctx.bound) {
       recordKey(ns, rawKey);
     }
+    recordReference(ctx.bound, rawKey, node);
   }
 
   // Returns true if the argument was statically resolvable (key recorded);
@@ -368,7 +401,7 @@ function analyzeFile(filePath: string, sourceOverride?: string): FileAnalysis {
   // every literal branch.
   function resolveArgument(arg: ts.Expression, ctx: NsContext): boolean {
     if (ts.isStringLiteral(arg) || ts.isNoSubstitutionTemplateLiteral(arg)) {
-      resolveStaticKey(arg.text, ctx);
+      resolveStaticKey(arg.text, ctx, arg);
       return true;
     }
     if (ts.isTemplateExpression(arg)) {
@@ -503,7 +536,7 @@ function analyzeFile(filePath: string, sourceOverride?: string): FileAnalysis {
       if (propertyName && propertyName.endsWith('I18nKey')) {
         const init = node.initializer;
         if (ts.isStringLiteral(init) || ts.isNoSubstitutionTemplateLiteral(init)) {
-          resolveStaticKey(init.text, ANY_CTX);
+          resolveStaticKey(init.text, ANY_CTX, init);
         }
       }
     }
@@ -535,7 +568,7 @@ function analyzeFile(filePath: string, sourceOverride?: string): FileAnalysis {
           }
         }
         const ctx = findApplicableCtx(node, tName) ?? ANY_CTX;
-        resolveStaticKey(key, ctx);
+        resolveStaticKey(key, ctx, node);
       }
     }
 
@@ -553,7 +586,7 @@ function analyzeFile(filePath: string, sourceOverride?: string): FileAnalysis {
     if (token) keepHints.add(token);
   }
 
-  return { usedKeys, globs, unanalyzable, keepHints };
+  return { usedKeys, globs, references, referencedNamespaces, unanalyzable, keepHints };
 }
 
 type Orphan = { namespace: string; key: string };
@@ -609,10 +642,107 @@ function computeOrphans(
   return orphans;
 }
 
+type MissingKey = { namespaces: readonly string[]; key: string; file: string; line: number; column: number };
+type ForeignMobileNamespace = { namespace: string; file: string };
+
+const MOBILE_PATH_MARKER = '/packages/mobile/';
+
+function isMobileFile(filePath: string): boolean {
+  return filePath.split(sep).join('/').includes(MOBILE_PATH_MARKER);
+}
+
+/**
+ * Does the catalog define this key? i18next resolves a `t('items', { count })`
+ * call against the suffixed forms (`items_one`, `items_other`, …) and the
+ * catalog only ever stores those, so the bare base counts as defined when any
+ * variant — plain or ordinal — is present.
+ */
+function catalogHasKey(catalog: Map<string, Set<string>>, namespace: string, key: string): boolean {
+  const keys = catalog.get(namespace);
+  if (!keys) return false;
+  if (keys.has(key)) return true;
+  for (const suffix of PLURAL_SUFFIXES) {
+    if (keys.has(`${key}${suffix}`)) return true;
+    if (keys.has(`${key}_ordinal${suffix}`)) return true;
+  }
+  return false;
+}
+
+/**
+ * The inverse of `computeOrphans`: every statically-resolved reference whose key
+ * exists in none of its candidate namespaces. That is the #4416 failure mode —
+ * i18next renders the raw key string into the UI.
+ *
+ * Leniency, so this can never redden CI for code that actually works:
+ *   - a reference the AST couldn't bind to a namespace (ANY_NAMESPACE) counts as
+ *     defined when the key exists in *any* namespace;
+ *   - a multi-namespace binding counts as defined when *any* bound namespace has it;
+ *   - plural variants count (see `catalogHasKey`);
+ *   - template-literal globs are never recorded as references, so `prefix.${x}`
+ *     is skipped rather than guessed at.
+ */
+function computeMissingKeys(catalog: Map<string, Set<string>>, references: readonly KeyReference[]): MissingKey[] {
+  const missing: MissingKey[] = [];
+  const seen = new Set<string>();
+
+  for (const reference of references) {
+    const anyNamespace = reference.namespaces.includes(ANY_NAMESPACE);
+    const candidates = anyNamespace ? [...catalog.keys()] : reference.namespaces;
+    const defined = candidates.some((namespace) => catalogHasKey(catalog, namespace, reference.key));
+    if (defined) continue;
+
+    const namespaces = anyNamespace ? [ANY_NAMESPACE] : reference.namespaces;
+    const dedupeKey = `${namespaces.join(',')}|${reference.key}|${reference.file}|${reference.line}|${reference.column}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    missing.push({
+      namespaces,
+      key: reference.key,
+      file: reference.file,
+      line: reference.line,
+      column: reference.column,
+    });
+  }
+
+  missing.sort((a, b) => {
+    if (a.file !== b.file) return a.file.localeCompare(b.file);
+    if (a.line !== b.line) return a.line - b.line;
+    return a.key.localeCompare(b.key);
+  });
+  return missing;
+}
+
+/**
+ * Namespaces read from a file under `packages/mobile/` that Metro never bundles,
+ * because `MOBILE_NAMESPACES` leaves them out. Those keys resolve on web and
+ * render raw on device, so the bug only shows up in a store build.
+ */
+function computeForeignMobileNamespaces(
+  namespacesByFile: ReadonlyMap<string, ReadonlySet<string>>,
+): ForeignMobileNamespace[] {
+  const foreign: ForeignMobileNamespace[] = [];
+  const mobileNamespaces = new Set<string>(MOBILE_NAMESPACES);
+  for (const [file, namespaces] of namespacesByFile) {
+    if (!isMobileFile(file)) continue;
+    for (const namespace of namespaces) {
+      if (mobileNamespaces.has(namespace)) continue;
+      foreign.push({ namespace, file });
+    }
+  }
+  foreign.sort((a, b) => {
+    if (a.file !== b.file) return a.file.localeCompare(b.file);
+    return a.namespace.localeCompare(b.namespace);
+  });
+  return foreign;
+}
+
 type Report = {
   totalFiles: number;
   totalKeys: number;
+  totalReferences: number;
   orphans: Orphan[];
+  missing: MissingKey[];
+  foreignMobileNamespaces: ForeignMobileNamespace[];
   unanalyzable: UnanalyzableSite[];
 };
 
@@ -622,11 +752,15 @@ function run(): Report {
   const files = discoverFiles([appRoot, scriptsRoot, mobileSrcRoot, mobileAppRoot]);
   const usedKeys = new Map<string, Set<string>>();
   const globs = new Map<string, GlobPattern[]>();
+  const references: KeyReference[] = [];
+  const namespacesByFile = new Map<string, ReadonlySet<string>>();
   const unanalyzable: UnanalyzableSite[] = [];
   const keepHints = new Set<string>();
 
   for (const file of files) {
     const analysis = analyzeFile(file);
+    references.push(...analysis.references);
+    namespacesByFile.set(file, analysis.referencedNamespaces);
     for (const [ns, keys] of analysis.usedKeys) {
       let target = usedKeys.get(ns);
       if (!target) {
@@ -651,13 +785,31 @@ function run(): Report {
   for (const keys of catalog.values()) totalKeys += keys.size;
 
   const orphans = computeOrphans(catalog, usedKeys, globs, keepHints);
-  return { totalFiles: files.length, totalKeys, orphans, unanalyzable };
+  const missing = computeMissingKeys(catalog, references);
+  const foreignMobileNamespaces = computeForeignMobileNamespaces(namespacesByFile);
+  return {
+    totalFiles: files.length,
+    totalKeys,
+    totalReferences: references.length,
+    orphans,
+    missing,
+    foreignMobileNamespaces,
+    unanalyzable,
+  };
+}
+
+function describeNamespaces(namespaces: readonly string[]): string {
+  if (namespaces.includes(ANY_NAMESPACE)) return 'any namespace';
+  if (namespaces.length === 1) return namespaces[0];
+  return namespaces.join(' | ');
 }
 
 function formatReport(report: Report): { exitCode: 0 | 1; lines: string[] } {
   const lines: string[] = [];
   const hasUnanalyzable = report.unanalyzable.length > 0;
   const hasOrphans = report.orphans.length > 0;
+  const hasMissing = report.missing.length > 0;
+  const hasForeignMobileNamespaces = report.foreignMobileNamespaces.length > 0;
 
   if (hasUnanalyzable) {
     for (const site of report.unanalyzable) {
@@ -691,12 +843,42 @@ function formatReport(report: Report): { exitCode: 0 | 1; lines: string[] } {
     );
   }
 
-  if (hasOrphans || hasUnanalyzable) {
+  if (hasMissing) {
+    if (hasUnanalyzable || hasOrphans) lines.push('');
+    for (const entry of report.missing) {
+      const rel = relative(repoRoot, entry.file);
+      lines.push(
+        `${rel}:${entry.line}:${entry.column}  missing key: ${describeNamespaces(entry.namespaces)} -> ${entry.key}`,
+      );
+    }
+    lines.push('');
+    lines.push(`Found ${report.missing.length} reference(s) to key(s) that exist in no catalog.`);
+    lines.push(
+      "i18next renders the raw key when it can't resolve one, so each of these ships as visible gibberish. Add the key to all four locale catalogs (en-US, es, fr, de) or point the call at a key that already exists.",
+    );
+  }
+
+  if (hasForeignMobileNamespaces) {
+    if (hasUnanalyzable || hasOrphans || hasMissing) lines.push('');
+    for (const entry of report.foreignMobileNamespaces) {
+      const rel = relative(repoRoot, entry.file);
+      lines.push(`${rel}  reads namespace '${entry.namespace}', which is not bundled on mobile`);
+    }
+    lines.push('');
+    lines.push(
+      `Found ${report.foreignMobileNamespaces.length} mobile file(s) reading a namespace outside MOBILE_NAMESPACES.`,
+    );
+    lines.push(
+      'Metro only bundles the MOBILE_NAMESPACES subset, so every key in those namespaces renders raw on device. Move the copy into a bundled namespace, or add the namespace to MOBILE_NAMESPACES in packages/shared/i18n/src/config.ts.',
+    );
+  }
+
+  if (hasOrphans || hasUnanalyzable || hasMissing || hasForeignMobileNamespaces) {
     return { exitCode: 1, lines };
   }
 
   lines.push(
-    `check-orphaned-i18n-keys: OK — scanned ${report.totalFiles} source file(s), every one of ${report.totalKeys} catalog key(s) has a live reference.`,
+    `check-orphaned-i18n-keys: OK — scanned ${report.totalFiles} source file(s): every one of ${report.totalKeys} catalog key(s) has a live reference, and all ${report.totalReferences} static key reference(s) resolve to a catalog entry in a mobile-safe namespace.`,
   );
   return { exitCode: 0, lines };
 }
@@ -713,5 +895,13 @@ if (import.meta.main) {
   main();
 }
 
-export { analyzeFile, computeOrphans, formatReport, loadCatalog, run };
-export type { Orphan, Report };
+export {
+  analyzeFile,
+  computeForeignMobileNamespaces,
+  computeMissingKeys,
+  computeOrphans,
+  formatReport,
+  loadCatalog,
+  run,
+};
+export type { ForeignMobileNamespace, KeyReference, MissingKey, Orphan, Report };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -420,6 +420,8 @@ export default defineConfig({
         command: 'bun packages/web/scripts/check-untranslated-strings.ts',
         cache: false,
       },
+      // Two-way i18n guard: catalog keys with no reference, code references with
+      // no catalog key (#4416), and mobile files reading an unbundled namespace.
       'check:i18n:orphans': {
         command: 'bun packages/web/scripts/check-orphaned-i18n-keys.ts',
         cache: false,


### PR DESCRIPTION
## Summary

Closes #4416.

Pinch to zoom a climb in the Play drawer and the reset pill read `playView.resetZoom`. `SwipeBoardCarousel` binds `t` to the `session` namespace and asks for `playView.resetZoom`, but that key was never added to `session.json` in any locale — i18next has no `parseMissingKeyHandler` here, so it hands back the key and we render it. Shipping since 3ddc71f77 (2026-05-29), the commit that moved the reset button into the carousel.

The fix is to stop inventing a key: `common:board.resetZoom` already exists in all four locales and is already what the other two zoomable boards (`InteractiveFilterBoard`, `InteractiveCreateBoard`) render on the same button.

Auditing every statically-resolvable `t()` literal across web + mobile turned up that this was not a one-off. **Seven references, four distinct keys, five surfaces** were reading keys that exist in no catalog:

| Key referenced | Where | What the user saw | Fix |
| --- | --- | --- | --- |
| `session:playView.resetZoom` | `SwipeBoardCarousel.tsx` (visible label + a11y label) | `playView.resetZoom` on the zoom pill | point at `common:board.resetZoom` |
| `common:resetZoom` | `YouCharts.tsx` (a11y label) | screen reader read `resetZoom` | point at `common:board.resetZoom` |
| `common:clear` | `WallFinderFilterChips.tsx` (**visible**) | lowercase `clear` on the gym-directory wall-finder filter row | new `common:actions.clear` |
| `common:clear` | `ClimbFilterSheet.tsx` (a11y label) | screen reader read `clear` | new `common:actions.clear` |
| `common:ascentsFeed.mirrored` / `.benchmark` / `.setBy` | `ascents-feed.tsx` (**visible**) | chips reading `ascentsFeed.mirrored` / `ascentsFeed.benchmark`, and no setter line at all | these keys live in `feed`, not `common` — bind a second `tFeed` |

Two genuinely new keys, added to en-US, es, fr and de: `common:actions.clear` (Clear / Borrar / Effacer / Löschen, matching the house translation already used for the same word in `climbs.json`) and `feed:ascentsFeed.setBy` (Set by / Creado por / Ouvert par / Gebaut von — French per the glossary: an ouvreur *opens* a line).

### The actual deliverable: the check now runs both ways

None of this was catchable. `check:i18n:orphans` only ever asked *"is this catalog key referenced from code?"* It never asked the inverse, *"does this referenced key exist in a catalog?"* — which is the direction that produces user-visible gibberish. Mobile has no runtime missing-key reporter either, so nothing told us in telemetry.

Rather than write a second scanner, this extends the existing one — it already walks `packages/web/{app,scripts}` + `packages/mobile/{src,app}` with the TS AST and resolves every `t` / `<Trans>` binding to its namespace(s). It now reports three things:

1. **Orphans** — unchanged.
2. **Missing keys** — a statically-resolved reference whose key exists in none of its candidate namespaces.
3. **Mobile namespaces** — a file under `packages/mobile/` reading a namespace `MOBILE_NAMESPACES` leaves out of the Metro bundle. Those keys resolve fine on web and render raw on device, so the bug only shows up in a store build. Clean today, previously unguarded.

The missing direction is deliberately lenient, because a checker that reddens `main` for working code gets deleted:

- a `t` the AST cannot bind to a namespace counts as defined when the key exists in **any** namespace;
- `useTranslation(['a', 'b'])` counts as defined when **either** namespace has it;
- plural variants count — the catalog stores `items_one` / `items_other`, never the bare `items` the call site asks for (ordinal forms too);
- template-literal globs (`t(\`prefix.${x}.suffix\`)`) are never recorded as references, so nothing is guessed at;
- `t('ns:key')` resolves against `ns`.

Across the real tree that is 4669 static references over 1632 files with **zero** false positives.

**Proof it can fail**, since a guard that cannot fail is decorative — both runs exit 1:

```
# reverting SwipeBoardCarousel to the original #4416 shape:
packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx:358:35  missing key: session -> playView.resetZoom
packages/mobile/src/components/play-drawer/SwipeBoardCarousel.tsx:362:52  missing key: session -> playView.resetZoom
Found 2 reference(s) to key(s) that exist in no catalog.

# pointing a mobile file at a web-only namespace:
packages/mobile/src/components/you/YouCharts.tsx  reads namespace 'gyms', which is not bundled on mobile
Found 1 mobile file(s) reading a namespace outside MOBILE_NAMESPACES.
```

**Wired into CI**, in the same `i18n` job as `check:i18n` and `check:i18n:orphans` (same task name — `vite.config.ts` and the pre-commit staged-file map both point at it). One change was needed to make that real: the `i18n` job only ran for `web` / `i18nCatalogs` / `rootCi` changes, so a **mobile-only** PR skipped it — exactly the shape of the commit that introduced this bug. `mobile` is now in that filter.

## Release Notes

- The zoom reset button in the Play drawer says "Reset zoom" again instead of showing raw code
- The gym directory wall finder now has a proper "Clear" on its filter row, and the ascents feed shows its Mirrored and Benchmark tags and who set the climb

## Test plan

- `vp run check:i18n:orphans` — green both directions: *"every one of 3822 catalog key(s) has a live reference, and all 4669 static key reference(s) resolve to a catalog entry in a mobile-safe namespace"*. Proven to exit 1 on both deliberately-broken fixtures above before being trusted green.
- `vp test run --project web --reporter=agent check-orphaned` — 43 passed (25 existing + 18 new): the #4416 fixture reported, the fixed form silent, plural + ordinal variants, unbindable `t`, multi-namespace bindings, `ns:key` prefixes, `<Trans>` both ways, the `*I18nKey` convention, and `formatReport` exit codes.
- `vp test run --project i18n` — catalog parity across the four locales after the two new keys.
- `vp run test:mobile` — includes the two suites that asserted on the raw `'clear'` key (their i18n mock returns the key verbatim, so they encoded the bug).
- `vp run typecheck`, `vp check`, `vp run check:mobile-bundle`.
- Nothing native changes (TS + JSON only), so this rides OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016552Be7ctNKKH8QM9rkryN
