### PR TITLE
fix(web): give each SSR request its own i18n instance

### DIFF
--- a/packages/web/app/lib/i18n/__tests__/client-browser-singleton.test.tsx
+++ b/packages/web/app/lib/i18n/__tests__/client-browser-singleton.test.tsx
@@ -27,6 +27,9 @@ function Probe() {
 
 afterEach(() => {
   cleanup();
+  // Module scope, so it would otherwise carry entries into a watch-mode re-run
+  // or into a second `it` in this describe.
+  mountedInstances.length = 0;
 });
 
 describe('I18nProvider in the browser', () => {

--- a/packages/web/app/lib/i18n/__tests__/client-browser-singleton.test.tsx
+++ b/packages/web/app/lib/i18n/__tests__/client-browser-singleton.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import React, { useContext } from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { I18nContext, useTranslation } from 'react-i18next';
+import { I18nProvider } from '../client';
+
+// The other half of issue #4519. Giving the server a per-render instance must
+// not cost the browser its single instance per tab: one i18next object,
+// accumulating bundles across mounts, is what keeps a client-side navigation
+// from re-bootstrapping i18next and re-rendering every translated subtree from
+// scratch (PR #1778).
+//
+// jsdom on purpose — the provider branches on `typeof window`, so the node run
+// (ssr-locale-isolation.test.tsx) covers the server half.
+
+// Read the instance off the context rather than off `useTranslation`, which
+// hands back a per-language wrapper object with its own identity.
+const mountedInstances: unknown[] = [];
+
+function Probe() {
+  const context = useContext(I18nContext) as { i18n: unknown } | undefined;
+  mountedInstances.push(context?.i18n);
+  const { t } = useTranslation('common');
+  return <span>{t('hello')}</span>;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('I18nProvider in the browser', () => {
+  it('reuses one instance and keeps the bundles earlier mounts added', async () => {
+    const german = render(
+      <I18nProvider locale="de" resources={{ common: { hello: 'Hallo' } }}>
+        <Probe />
+      </I18nProvider>,
+    );
+    expect(german.container.textContent).toBe('Hallo');
+    german.unmount();
+
+    const french = render(
+      <I18nProvider locale="fr" resources={{ common: { hello: 'Bonjour' } }}>
+        <Probe />
+      </I18nProvider>,
+    );
+    await french.findByText('Bonjour');
+    french.unmount();
+
+    // Third mount ships NO resources at all, and `hello` is not a real catalog
+    // key — `Hallo` can only come back if the same instance is still holding
+    // the bundle the first mount registered.
+    const germanAgain = render(
+      <I18nProvider locale="de" resources={{}}>
+        <Probe />
+      </I18nProvider>,
+    );
+    await germanAgain.findByText('Hallo');
+
+    expect(mountedInstances).toHaveLength(3);
+    expect(new Set(mountedInstances).size).toBe(1);
+  });
+});

--- a/packages/web/app/lib/i18n/__tests__/ssr-locale-isolation.test.tsx
+++ b/packages/web/app/lib/i18n/__tests__/ssr-locale-isolation.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vite-plus/test';
+import { PassThrough } from 'node:stream';
+import React, { Suspense } from 'react';
+import { renderToPipeableStream } from 'react-dom/server';
+import { useTranslation } from 'react-i18next';
+import { I18nProvider } from '../client';
+
+// `'use client'` components are rendered to HTML on the server on every
+// request, and one Node process interleaves many requests. Issue #4519: the
+// provider used to hand every one of them the same module-scoped i18next
+// instance, so a `/fr` request starting mid-render flipped the language under
+// a half-rendered `/de` page and shipped it French markup.
+//
+// This file runs in the `node` environment on purpose — `typeof window` is what
+// the provider branches on, so a jsdom run would exercise the browser
+// singleton instead (see client-browser-singleton.test.tsx for that half).
+
+const flushMacrotask = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+// A component that suspends until released, so a render can be parked halfway
+// the way Next.js streaming SSR parks one on an await.
+function createSuspenseGate() {
+  let isOpen = false;
+  let openGate = () => {};
+  const pending = new Promise<void>((resolve) => {
+    openGate = () => {
+      isOpen = true;
+      resolve();
+    };
+  });
+
+  function Gate({ children }: { children: React.ReactNode }) {
+    if (!isOpen) throw pending;
+    return <>{children}</>;
+  }
+
+  return {
+    Gate,
+    release: () => {
+      openGate();
+    },
+  };
+}
+
+function renderRequest(element: React.ReactElement): Promise<string> {
+  const sink = new PassThrough();
+  let body = '';
+  sink.on('data', (chunk: Buffer) => {
+    body += chunk.toString('utf8');
+  });
+
+  const finished = new Promise<string>((resolve, reject) => {
+    sink.on('end', () => resolve(body));
+    sink.on('error', reject);
+  });
+
+  const { pipe } = renderToPipeableStream(element, {
+    onShellReady() {
+      pipe(sink);
+    },
+  });
+
+  return finished;
+}
+
+function LocaleProbe() {
+  const { t, i18n } = useTranslation('common');
+  return <span>{`${i18n.language}|${t('hello')}`}</span>;
+}
+
+function NestedProbe() {
+  const { t } = useTranslation('marketing');
+  // Key from the OUTER provider's namespace, which this provider never loaded.
+  return <span>{t('common:hello')}</span>;
+}
+
+describe('I18nProvider server rendering', () => {
+  it('keeps two concurrent renders on their own locale', async () => {
+    const gateDe = createSuspenseGate();
+    const gateFr = createSuspenseGate();
+
+    // Request A (`/de/...`) starts and parks inside its Suspense boundary.
+    const germanHtml = renderRequest(
+      <I18nProvider locale="de" resources={{ common: { hello: 'Hallo' } }}>
+        <Suspense fallback={<span>pending</span>}>
+          <gateDe.Gate>
+            <LocaleProbe />
+          </gateDe.Gate>
+        </Suspense>
+      </I18nProvider>,
+    );
+    await flushMacrotask();
+
+    // Request B (`/fr/...`) arrives while A is still parked. On the old shared
+    // instance this is the `changeLanguage('fr')` that poisoned A.
+    const frenchHtml = renderRequest(
+      <I18nProvider locale="fr" resources={{ common: { hello: 'Bonjour' } }}>
+        <Suspense fallback={<span>pending</span>}>
+          <gateFr.Gate>
+            <LocaleProbe />
+          </gateFr.Gate>
+        </Suspense>
+      </I18nProvider>,
+    );
+    await flushMacrotask();
+
+    gateDe.release();
+    await flushMacrotask();
+    gateFr.release();
+
+    const [german, french] = await Promise.all([germanHtml, frenchHtml]);
+
+    expect(german).toContain('de|Hallo');
+    expect(german).not.toContain('Bonjour');
+    expect(french).toContain('fr|Bonjour');
+    expect(french).not.toContain('Hallo');
+  });
+
+  it('lets a nested provider resolve its parent namespaces', async () => {
+    // The root layout and the page each mount their own provider with disjoint
+    // namespace sets. Per-render instances would strand the inner subtree on
+    // raw keys unless it inherits the outer provider's bundles.
+    const html = await renderRequest(
+      <I18nProvider locale="de" resources={{ common: { hello: 'Hallo' } }}>
+        <I18nProvider locale="de" resources={{ marketing: { tagline: 'Los' } }}>
+          <NestedProbe />
+        </I18nProvider>
+      </I18nProvider>,
+    );
+
+    expect(html).toContain('Hallo');
+    expect(html).not.toContain('>hello<');
+  });
+
+  it('ignores a parent parked on another locale', async () => {
+    const html = await renderRequest(
+      <I18nProvider locale="fr" resources={{ common: { hello: 'Bonjour' } }}>
+        <I18nProvider locale="de" resources={{ common: { hello: 'Hallo' }, marketing: { tagline: 'Los' } }}>
+          <NestedProbe />
+        </I18nProvider>
+      </I18nProvider>,
+    );
+
+    expect(html).toContain('Hallo');
+    expect(html).not.toContain('Bonjour');
+  });
+});

--- a/packages/web/app/lib/i18n/client.tsx
+++ b/packages/web/app/lib/i18n/client.tsx
@@ -79,6 +79,11 @@ function getClientInstance(
     // Seed from the enclosing provider so nested providers still resolve each
     // other's namespaces. The language guard stops a parent sitting on another
     // locale from seeding the wrong strings.
+    //
+    // `getDataByLanguage` hands back every namespace the parent holds for this
+    // locale, not just the ones it was mounted with — that breadth is the
+    // point. It is what the old shared instance gave the inner subtree, so
+    // don't narrow the spread.
     const inherited =
       (parentInstance?.language === locale ? parentInstance.getDataByLanguage(locale) : undefined) ?? {};
     return createConfiguredInstance(locale, { ...inherited, ...resources });

--- a/packages/web/app/lib/i18n/client.tsx
+++ b/packages/web/app/lib/i18n/client.tsx
@@ -112,7 +112,10 @@ export function I18nProvider({
 }) {
   // react-i18next types `I18nContext` as always carrying an instance, but the
   // context is created with no default value — the outermost provider really
-  // does read `undefined` here.
+  // does read `undefined` here. If a future react-i18next reshapes the context
+  // value, this reads `undefined` and the server loses inheritance rather than
+  // breaking; the nested-provider case in ssr-locale-isolation.test.tsx is what
+  // turns that into a visible failure.
   const parentContext = useContext(I18nContext) as { i18n: i18n } | undefined;
   const parentInstance = parentContext?.i18n;
   const instance = useMemo(

--- a/packages/web/app/lib/i18n/client.tsx
+++ b/packages/web/app/lib/i18n/client.tsx
@@ -7,20 +7,24 @@
 // (`count=0` renders `_other` instead of `_one`) and categories like `many`
 // vanish (issue #1852).
 import 'intl-pluralrules';
-import React, { useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import i18next, { type i18n } from 'i18next';
 import resourcesToBackend from 'i18next-resources-to-backend';
-import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { I18nContext, I18nextProvider, initReactI18next } from 'react-i18next';
 import { loadCatalog } from '@boardsesh/i18n/catalog-loader';
 import { DEFAULT_LOCALE, DEFAULT_NAMESPACE, SUPPORTED_LOCALES, type Locale } from './config';
 import { reportMissingI18nKey } from './missing-key-reporter';
 
-// Module-level singleton. The language switcher routes via `next/link` so the
-// browser navigates to the new locale's URL — that re-runs the server pipeline,
-// re-mounts the provider with fresh resources, and React reconciles every
-// translated subtree. We only fall through to `changeLanguage` here for the
-// rare case where a parent re-renders this provider with a new `locale` prop
-// without a navigation.
+// This provider has two lifetimes, because `'use client'` does not mean
+// "browser only" — a client component is rendered to HTML on the server on
+// every request too.
+//
+// Browser: the module-level singleton below, one instance per tab. The language
+// switcher routes via `next/link` so the browser navigates to the new locale's
+// URL — that re-runs the server pipeline, re-mounts the provider with fresh
+// resources, and React reconciles every translated subtree. We only fall
+// through to `changeLanguage` here for the rare case where a parent re-renders
+// this provider with a new `locale` prop without a navigation.
 //
 // Known limitation in that no-navigation path: `changeLanguage` is async and
 // fired without await, and the singleton's object identity is stable across
@@ -28,21 +32,23 @@ import { reportMissingI18nKey } from './missing-key-reporter';
 // Consumers can therefore see the previous locale's strings for one render
 // tick. Acceptable for v1 because the no-navigation path is unused — revisit
 // if we add an in-app locale toggle that doesn't route. See PR #1778 review.
+//
+// Server: one instance per render, never the singleton, and `changeLanguage` is
+// never called. One Node process interleaves many requests, so a shared
+// instance let request B's `changeLanguage('fr')` flip the language out from
+// under request A's half-rendered `/de` page and serve it French markup
+// (issue #4519). A per-render instance has nothing left to share.
+//
+// The catch: providers nest. The root layout mounts one `I18nProvider` and
+// pages mount their own with a disjoint namespace set (`app/page.tsx` carries
+// `marketing` but not `common`). Those used to collapse onto the one shared
+// instance, so a page-provider subtree read the root provider's namespaces for
+// free. A per-render instance loses that unless it starts from the enclosing
+// provider's bundles — hence the `parentInstance` seed below, without which a
+// nested subtree renders raw keys.
 let clientInstance: i18n | undefined;
 
-function getClientInstance(locale: Locale, resources: Record<string, Record<string, unknown>>): i18n {
-  if (clientInstance) {
-    for (const [ns, bundle] of Object.entries(resources)) {
-      if (!clientInstance.hasResourceBundle(locale, ns)) {
-        clientInstance.addResourceBundle(locale, ns, bundle, true, true);
-      }
-    }
-    if (clientInstance.language !== locale) {
-      void clientInstance.changeLanguage(locale);
-    }
-    return clientInstance;
-  }
-
+function createConfiguredInstance(locale: Locale, resources: Record<string, Record<string, unknown>>): i18n {
   const instance = i18next.createInstance();
   instance
     .use(resourcesToBackend((lng: string, ns: string) => loadCatalog(lng, ns)))
@@ -61,6 +67,36 @@ function getClientInstance(locale: Locale, resources: Record<string, Record<stri
         reportMissingI18nKey({ lngs, ns, key, fallbackValue });
       },
     });
+  return instance;
+}
+
+function getClientInstance(
+  locale: Locale,
+  resources: Record<string, Record<string, unknown>>,
+  parentInstance?: i18n,
+): i18n {
+  if (typeof window === 'undefined') {
+    // Seed from the enclosing provider so nested providers still resolve each
+    // other's namespaces. The language guard stops a parent sitting on another
+    // locale from seeding the wrong strings.
+    const inherited =
+      (parentInstance?.language === locale ? parentInstance.getDataByLanguage(locale) : undefined) ?? {};
+    return createConfiguredInstance(locale, { ...inherited, ...resources });
+  }
+
+  if (clientInstance) {
+    for (const [ns, bundle] of Object.entries(resources)) {
+      if (!clientInstance.hasResourceBundle(locale, ns)) {
+        clientInstance.addResourceBundle(locale, ns, bundle, true, true);
+      }
+    }
+    if (clientInstance.language !== locale) {
+      void clientInstance.changeLanguage(locale);
+    }
+    return clientInstance;
+  }
+
+  const instance = createConfiguredInstance(locale, resources);
   clientInstance = instance;
   return instance;
 }
@@ -74,6 +110,14 @@ export function I18nProvider({
   resources: Record<string, Record<string, unknown>>;
   children: React.ReactNode;
 }) {
-  const instance = useMemo(() => getClientInstance(locale, resources), [locale, resources]);
+  // react-i18next types `I18nContext` as always carrying an instance, but the
+  // context is created with no default value — the outermost provider really
+  // does read `undefined` here.
+  const parentContext = useContext(I18nContext) as { i18n: i18n } | undefined;
+  const parentInstance = parentContext?.i18n;
+  const instance = useMemo(
+    () => getClientInstance(locale, resources, parentInstance),
+    [locale, resources, parentInstance],
+  );
   return <I18nextProvider i18n={instance}>{children}</I18nextProvider>;
 }


### PR DESCRIPTION
## Summary

`packages/web/app/lib/i18n/client.tsx` kept one i18next instance in module scope. `'use client'` does not mean "browser only" — a client component is rendered to HTML on the server on every request, and one Node process interleaves many requests, so that module-scoped instance was shared by all of them. A `/fr` request arriving while a `/de` page was mid-render hit the reuse branch, fired `changeLanguage('fr')` on the shared object without awaiting it, and the `/de` render finished in French.

The server now builds a fresh instance per render and never calls `changeLanguage`. The browser keeps its singleton unchanged — one instance per tab, accumulating bundles across mounts — including the documented no-navigation `changeLanguage` limitation from PR #1778, which stays out of scope.

Closes #4519

### The part worth reviewing: nested providers

The issue's own "cheapest fix" sketch (fresh instance per SSR render, nothing else) silently regresses nested providers, so this PR does one more thing.

`app/layout.tsx` mounts a 9-namespace root `I18nProvider`, and pages mount their own with a **disjoint** set — `app/page.tsx` carries `marketing` but not `common`; `app/gyms/directory-page.tsx` carries `common` and `gyms`. Today all of those collapse onto the one shared server instance, so a page-provider subtree transparently reads the root provider's namespaces. Cut the sharing and the inner subtree renders raw keys instead of strings.

So the server path seeds each new instance from the enclosing provider's bundles for the same locale, read off `I18nContext`:

```ts
const inherited = (parentInstance?.language === locale ? parentInstance.getDataByLanguage(locale) : undefined) ?? {};
return createConfiguredInstance(locale, { ...inherited, ...resources });
```

The `language === locale` guard keeps a parent sitting on another locale from seeding the wrong strings. In the browser `parentInstance` is the stable singleton (or `undefined` at the root), so the added `useMemo` dep does not churn.

Both halves have a test that fails without them — see the test plan.

### Audit

Inheritance only covers namespaces an **ancestor** provider loaded, where the old cross-request accumulation could mask a gap. I walked every `useTranslation('ns')` in `packages/web/app` up its import graph to the route entry, against the root-layout set plus every provider on the path. **No client component reads a namespace no ancestor supplies.** Every cross-namespace `t('ns:key')` call in the app targets `common`, `boards` or `feed`, all three in the root set.

### Cost

One i18next object construction per provider per SSR render — two per request on most pages (root + page). Resources are already loaded and handed in by `loadServerResources`, so this is object setup, not catalog I/O.

Blast radius is `packages/web` only. `packages/mobile` has its own instance (`src/providers/i18n-provider.tsx` → `../lib/i18n/config`), and the Expo browser target behind Next at `/app` uses that same mobile provider, so neither the native fingerprint nor the mobile bundle is touched.

## Release Notes

- Pages now always render in the language you asked for, even when the site is busy serving several languages at once

## Test plan

Two new files. Vitest picks its environment per file, so the SSR and browser halves have to live apart.

`app/lib/i18n/__tests__/ssr-locale-isolation.test.tsx` (`node`):

- **Interleaved requests.** Two `renderToPipeableStream` renders in one process, each parked inside a Suspense boundary that a test-controlled gate releases. Start `/de`, start `/fr` while `/de` is parked, then release them in order. Against `main` the `/de` render emits `<span>fr|Bonjour</span>` — the exact bug. A plain back-to-back pair of renders passes on `main`, because `changeLanguage` resolves synchronously once the bundles are loaded; only a render suspended across an await point exposes it, which is what Next.js streaming SSR does on every request.
- **Nested providers.** Outer provider with `common`, inner with `marketing`, a probe calling `t('common:hello')`. Against a fresh-instance-per-render fix *without* the inheritance step this renders the raw key `hello`; verified by patching the inheritance out and watching it go red.
- A parent parked on another locale does not seed the child.

`app/lib/i18n/__tests__/client-browser-singleton.test.tsx` (`jsdom`) — mount `de`, then `fr`, then `de` again with an **empty** resources object; `Hallo` still resolves, and all three mounts read the same instance off the context. That only holds while one instance per tab survives with its accumulated bundles, so it goes red if someone later deletes the browser singleton (verified by forcing the server branch on).

Also run: `vp check`, `vp run typecheck`, `vp test run --project web`, `vp run check:i18n` / `check:i18n:orphans` (both clean — no catalog keys added, and `__tests__/` is excluded from the untranslated-string scan).
