### PR TITLE
fix(mobile): stop the gyms screen crashing in the browser when location is blocked

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -142,6 +142,11 @@
             "object": "Intl",
             "property": "ListFormat",
             "message": "Hermes does not implement Intl.ListFormat \u2014 crashes mobile release builds. Join the parts manually or via i18n."
+          },
+          {
+            "object": "Linking",
+            "property": "openSettings",
+            "message": "Linking.openSettings() does not exist in the Expo web runtime (react-native-web's Linking has no such method) \u2014 it throws on app.boardsesh.com. Use openAppSettings() from src/lib/open-app-settings, which Platform-gates and never throws."
           }
         ]
       }

--- a/packages/mobile/app/gyms/index.tsx
+++ b/packages/mobile/app/gyms/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Linking, Pressable, StyleSheet, TextInput, View } from 'react-native';
+import { Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -16,10 +16,10 @@ import { hapticSelection } from '../../src/lib/haptics';
 import { resolveBoardReturnTo } from '../../src/lib/boards/board-return-to';
 import { Text } from '../../src/components/Text';
 import { Icon } from '../../src/components/Icon';
-import { Button } from '../../src/components/Button';
 import { ActivityIndicator } from '../../src/components/ActivityIndicator';
 import { GymMap, type GymMapHandle, type GymMapMarker } from '../../src/components/gym-directory/GymMap';
 import { GymListPanel, type GymListPanelHandle } from '../../src/components/gym-directory/GymListPanel';
+import { GymLocationPrompt } from '../../src/components/gym-directory/GymLocationPrompt';
 import { ClaimGymSheet } from '../../src/components/gym-directory/ClaimGymSheet';
 import { WallFinderFilterChips } from '../../src/components/gym-directory/WallFinderFilterChips';
 import { buildGymListRows } from '../../src/components/gym-directory/gym-list-rows';
@@ -487,29 +487,8 @@ export default function GymDiscovery() {
 
   // No place to show yet: prompt for location inside the panel (the header search
   // still works for browsing a typed place without granting it).
-  const waitingForLocation = location.status === 'idle' || location.status === 'loading';
   const locationPrompt = !center ? (
-    waitingForLocation ? (
-      <ActivityIndicator size="large" />
-    ) : (
-      <>
-        <Icon name="location" size={40} color={systemColors.tertiaryLabel} />
-        <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.centerText}>
-          {t('mobile.gyms.locationNeeded')}
-        </Text>
-        <Button
-          title={t('mobile.gyms.grantLocation')}
-          variant="outlined"
-          // After a denial the one-shot hook won't re-prompt (iOS only asks once),
-          // so send the user to Settings instead of a no-op.
-          onPress={() => {
-            if (location.status === 'denied') void Linking.openSettings();
-            else void location.request();
-          }}
-          style={styles.centerButton}
-        />
-      </>
-    )
+    <GymLocationPrompt status={location.status} onRequest={() => void location.request()} />
   ) : undefined;
 
   return (
@@ -596,11 +575,5 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[3],
     paddingVertical: spacing[1],
     borderRadius: borderRadius.full,
-  },
-  centerText: {
-    textAlign: 'center',
-  },
-  centerButton: {
-    marginTop: spacing[2],
   },
 });

--- a/packages/mobile/src/components/gym-directory/GymLocationPrompt.tsx
+++ b/packages/mobile/src/components/gym-directory/GymLocationPrompt.tsx
@@ -1,0 +1,78 @@
+import { StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { Text } from '../Text';
+import { Icon } from '../Icon';
+import { Button } from '../Button';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { useTheme } from '../../providers/theme-provider';
+import { canOpenAppSettings, openAppSettings } from '../../lib/open-app-settings';
+import { spacing } from '../../theme/tokens';
+import type { LocationStatus } from '../../lib/use-device-location';
+
+export type GymLocationPromptProps = {
+  status: LocationStatus;
+  /** Kick off (or retry) the permission prompt + one-shot fix. */
+  onRequest: () => void;
+};
+
+/**
+ * Prompt shown in the gym-panel body while there's no location to center the
+ * map on yet. Three states:
+ *  - idle/loading: a spinner while the one-shot request is in flight.
+ *  - denied, and this platform can't deep-link to OS settings (Expo web —
+ *    the browser's permission prompt won't come back and there's no settings
+ *    link to send the user to): explanatory copy only, no button. The header
+ *    search field above this panel is the working path on web, which is what
+ *    the copy tells the user to use instead.
+ *  - anything else (idle/loading fallthrough already handled above, so in
+ *    practice: denied on native, or unavailable): the icon + copy + a button
+ *    that either retries the request or, after a native denial, deep-links to
+ *    Settings (iOS/Android only ever prompt once, so re-requesting after a
+ *    denial would silently re-resolve denied).
+ */
+export function GymLocationPrompt({ status, onRequest }: GymLocationPromptProps) {
+  const { t } = useTranslation('boards');
+  const { systemColors } = useTheme();
+
+  if (status === 'idle' || status === 'loading') {
+    return <ActivityIndicator size="large" />;
+  }
+
+  if (status === 'denied' && !canOpenAppSettings()) {
+    return (
+      <>
+        <Icon name="location" size={40} color={systemColors.tertiaryLabel} />
+        <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.centerText}>
+          {t('mobile.gyms.locationBlocked')}
+        </Text>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Icon name="location" size={40} color={systemColors.tertiaryLabel} />
+      <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.centerText}>
+        {t('mobile.gyms.locationNeeded')}
+      </Text>
+      <Button
+        title={t('mobile.gyms.grantLocation')}
+        variant="outlined"
+        onPress={() => {
+          if (status === 'denied') void openAppSettings();
+          else onRequest();
+        }}
+        style={styles.centerButton}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  centerText: {
+    textAlign: 'center',
+  },
+  centerButton: {
+    marginTop: spacing[2],
+  },
+});

--- a/packages/mobile/src/components/gym-directory/__tests__/gym-location-prompt.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/gym-location-prompt.test.tsx
@@ -60,7 +60,7 @@ describe('GymLocationPrompt', () => {
     expect(queryByRole('button')).toBeNull();
   });
 
-  it('pressing the button in idle/denied-on-native state calls onRequest or openAppSettings appropriately', () => {
+  it('pressing the button in the unavailable state retries via onRequest, not openAppSettings', () => {
     const onRequest = vi.fn();
     const { getByText } = render(<GymLocationPrompt status="unavailable" onRequest={onRequest} />);
 

--- a/packages/mobile/src/components/gym-directory/__tests__/gym-location-prompt.test.tsx
+++ b/packages/mobile/src/components/gym-directory/__tests__/gym-location-prompt.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+type TextProps = { children?: ReactNode };
+type ButtonProps = { title?: string; onPress?: () => void };
+
+const platform = vi.hoisted(() => ({ OS: 'ios' as string }));
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles },
+  Platform: platform,
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children }: TextProps) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }) }));
+vi.mock('../../Button', () => ({
+  Button: ({ title, onPress }: ButtonProps) => createElement('button', { onClick: onPress, type: 'button' }, title),
+}));
+vi.mock('../../ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
+}));
+
+vi.mock('../../../theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+}));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: { tertiaryLabel: '#999', secondaryLabel: '#666' },
+  }),
+}));
+
+// The i18n mock returns the key so assertions pin which copy rendered,
+// independent of catalog text (parity is covered by the catalog tests).
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const openAppSettings = vi.fn();
+vi.mock('../../../lib/open-app-settings', () => ({
+  canOpenAppSettings: () => platform.OS === 'ios' || platform.OS === 'android',
+  openAppSettings: (...args: unknown[]) => openAppSettings(...args),
+}));
+
+import { GymLocationPrompt } from '../GymLocationPrompt';
+
+beforeEach(() => {
+  platform.OS = 'ios';
+  openAppSettings.mockReset();
+});
+
+describe('GymLocationPrompt', () => {
+  it('shows a spinner while idle or loading, without a button', () => {
+    const { getByTestId, queryByRole } = render(<GymLocationPrompt status="idle" onRequest={vi.fn()} />);
+    expect(getByTestId('spinner')).toBeTruthy();
+    expect(queryByRole('button')).toBeNull();
+  });
+
+  it('pressing the button in idle/denied-on-native state calls onRequest or openAppSettings appropriately', () => {
+    const onRequest = vi.fn();
+    const { getByText } = render(<GymLocationPrompt status="unavailable" onRequest={onRequest} />);
+
+    fireEvent.click(getByText('mobile.gyms.grantLocation'));
+
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    expect(openAppSettings).not.toHaveBeenCalled();
+  });
+
+  it('on native (ios/android), denied renders the button and pressing it deep-links to Settings, not onRequest', () => {
+    platform.OS = 'ios';
+    const onRequest = vi.fn();
+    const { getByText } = render(<GymLocationPrompt status="denied" onRequest={onRequest} />);
+
+    fireEvent.click(getByText('mobile.gyms.grantLocation'));
+
+    expect(openAppSettings).toHaveBeenCalledTimes(1);
+    expect(onRequest).not.toHaveBeenCalled();
+  });
+
+  // Regression guard for BOARDSESH-DT: on web there's no settings deep-link and
+  // the browser won't re-prompt, so denied must render explanatory copy and NO
+  // dead button — the header search field above this panel is the working path.
+  it('on web, denied renders explanatory copy and no button', () => {
+    platform.OS = 'web';
+    const { getByText, queryByRole } = render(<GymLocationPrompt status="denied" onRequest={vi.fn()} />);
+
+    expect(getByText('mobile.gyms.locationBlocked')).toBeTruthy();
+    expect(queryByRole('button')).toBeNull();
+  });
+});

--- a/packages/mobile/src/components/integrations/AppleHealthCard.tsx
+++ b/packages/mobile/src/components/integrations/AppleHealthCard.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Linking, Platform, StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Text } from '../Text';
 import { ListRow } from '../ListRow';
 import { SwitchRow } from '../SwitchRow';
 import { useTheme } from '../../providers/theme-provider';
+import { openAppSettings } from '../../lib/open-app-settings';
 import { borderRadius, spacing } from '../../theme/tokens';
 import {
   getAppleHealthAuthorizationStatus,
@@ -98,7 +99,7 @@ export function AppleHealthCard() {
             showChevron
             showSeparator={false}
             onPress={() => {
-              void Linking.openSettings();
+              void openAppSettings();
             }}
           />
         </>

--- a/packages/mobile/src/components/integrations/__tests__/AppleHealthCard.test.tsx
+++ b/packages/mobile/src/components/integrations/__tests__/AppleHealthCard.test.tsx
@@ -120,4 +120,17 @@ describe('AppleHealthCard', () => {
     expect(mocks.requestAppleHealthAuthorization).not.toHaveBeenCalled();
     expect(mocks.trackAppleHealthIntegrationConnected).not.toHaveBeenCalled();
   });
+
+  // Regression guard for the Linking.openSettings -> openAppSettings() migration
+  // (the wrapper is Platform-gated so it never throws on Expo web).
+  it('deep-links to Settings via the shared wrapper when denied', async () => {
+    mocks.getAppleHealthAuthorizationStatus.mockResolvedValue('denied');
+    const { getByText } = render(<AppleHealthCard />);
+
+    await waitFor(() => expect(mocks.getAppleHealthAuthorizationStatus).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(getByText('integrations.appleHealth.openSettings'));
+
+    await waitFor(() => expect(mocks.openSettings).toHaveBeenCalledTimes(1));
+  });
 });

--- a/packages/mobile/src/lib/__tests__/open-app-settings.test.ts
+++ b/packages/mobile/src/lib/__tests__/open-app-settings.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const linking = vi.hoisted(() => ({ openSettings: vi.fn() }));
+const platform = vi.hoisted(() => ({ OS: 'ios' as string }));
+
+vi.mock('react-native', () => ({ Linking: linking, Platform: platform }));
+
+import { canOpenAppSettings, openAppSettings } from '../open-app-settings';
+
+beforeEach(() => {
+  linking.openSettings.mockReset();
+  platform.OS = 'ios';
+});
+
+describe('canOpenAppSettings', () => {
+  it('is true on ios and android', () => {
+    platform.OS = 'ios';
+    expect(canOpenAppSettings()).toBe(true);
+    platform.OS = 'android';
+    expect(canOpenAppSettings()).toBe(true);
+  });
+
+  it('is false on web', () => {
+    platform.OS = 'web';
+    expect(canOpenAppSettings()).toBe(false);
+  });
+});
+
+describe('openAppSettings', () => {
+  it('calls Linking.openSettings on ios and resolves true', async () => {
+    platform.OS = 'ios';
+    linking.openSettings.mockResolvedValue(undefined);
+
+    const opened = await openAppSettings();
+
+    expect(opened).toBe(true);
+    expect(linking.openSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls Linking.openSettings on android and resolves true', async () => {
+    platform.OS = 'android';
+    linking.openSettings.mockResolvedValue(undefined);
+
+    const opened = await openAppSettings();
+
+    expect(opened).toBe(true);
+    expect(linking.openSettings).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression guard for BOARDSESH-DT: react-native-web's Linking has no
+  // openSettings, so it must never even be reached on web.
+  it('returns false on web without touching Linking.openSettings', async () => {
+    platform.OS = 'web';
+
+    const opened = await openAppSettings();
+
+    expect(opened).toBe(false);
+    expect(linking.openSettings).not.toHaveBeenCalled();
+  });
+
+  it('resolves false (does not throw) when openSettings rejects', async () => {
+    platform.OS = 'ios';
+    linking.openSettings.mockRejectedValue(new Error('no settings activity'));
+
+    const opened = await openAppSettings();
+
+    expect(opened).toBe(false);
+  });
+});

--- a/packages/mobile/src/lib/open-app-settings.ts
+++ b/packages/mobile/src/lib/open-app-settings.ts
@@ -1,0 +1,30 @@
+import { Linking, Platform } from 'react-native';
+
+/**
+ * Whether this platform can deep-link into the OS settings app. iOS and
+ * Android both implement `Linking.openSettings()`; the Expo web runtime does
+ * not — react-native-web's `Linking` only implements
+ * `addEventListener`/`removeEventListener`/`canOpenURL`/`getInitialURL`/`openURL`,
+ * so calling `openSettings()` there throws `TypeError: openSettings is not a
+ * function`. That crashed the gyms screen on app.boardsesh.com (BOARDSESH-DT).
+ */
+export function canOpenAppSettings(): boolean {
+  return Platform.OS === 'ios' || Platform.OS === 'android';
+}
+
+/**
+ * Open the OS settings app, Platform-gated so it never throws on web. Returns
+ * whether it actually opened. Mirrors `open-external-link.ts`'s try/catch
+ * shape: a settings deep-link failing is not worth crashing a button handler
+ * over.
+ */
+export async function openAppSettings(): Promise<boolean> {
+  if (!canOpenAppSettings()) return false;
+  try {
+    // oxlint-disable-next-line no-restricted-properties -- the one sanctioned call site; gated by canOpenAppSettings() above
+    await Linking.openSettings();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/shared/i18n/locales/de/boards.json
+++ b/packages/shared/i18n/locales/de/boards.json
@@ -170,6 +170,7 @@
       "subtitle": "Tipp auf eine Halle, um ihr Board zu nutzen",
       "locationNeeded": "Teil deinen Standort, um Hallen in der Nähe zu finden",
       "grantLocation": "Meinen Standort nutzen",
+      "locationBlocked": "Dein Browser gibt deinen Standort nicht raus. Tipp stattdessen einen Ort ins Suchfeld, das geht überall.",
       "empty": "Noch keine Hallen in der Nähe",
       "noBoards": "Hier noch keine Boards",
       "boardCount_one": "{{count}} Board",

--- a/packages/shared/i18n/locales/en-US/boards.json
+++ b/packages/shared/i18n/locales/en-US/boards.json
@@ -170,6 +170,7 @@
       "subtitle": "Tap a gym to use its board",
       "locationNeeded": "Share your location to find gyms nearby",
       "grantLocation": "Use my location",
+      "locationBlocked": "Your browser is keeping your location to itself. Type a town in the search box instead — that works everywhere.",
       "empty": "No gyms nearby yet",
       "noBoards": "No boards here yet",
       "boardCount_one": "{{count}} board",

--- a/packages/shared/i18n/locales/es/boards.json
+++ b/packages/shared/i18n/locales/es/boards.json
@@ -170,6 +170,7 @@
       "subtitle": "Toca un rocódromo para usar su plafón",
       "locationNeeded": "Comparte tu ubicación para encontrar rocódromos cerca",
       "grantLocation": "Usar mi ubicación",
+      "locationBlocked": "Tu navegador no comparte tu ubicación. Escribe una ciudad en el buscador: eso funciona siempre.",
       "empty": "Aún no hay rocódromos cerca",
       "noBoards": "Aún no hay plafones aquí",
       "boardCount_one": "{{count}} plafón",

--- a/packages/shared/i18n/locales/fr/boards.json
+++ b/packages/shared/i18n/locales/fr/boards.json
@@ -170,6 +170,7 @@
       "subtitle": "Touche une salle pour utiliser sa board",
       "locationNeeded": "Partage ta position pour trouver des salles à proximité",
       "grantLocation": "Utiliser ma position",
+      "locationBlocked": "Ton navigateur garde ta position pour lui. Tape une ville dans la recherche : ça marche partout.",
       "empty": "Aucune salle à proximité pour l'instant",
       "noBoards": "Aucune board ici pour l'instant",
       "boardCount_one": "{{count}} board",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -71,6 +71,12 @@ export default defineConfig({
               message:
                 'Hermes does not implement Intl.ListFormat — crashes mobile release builds. Join the parts manually or via i18n.',
             },
+            {
+              object: 'Linking',
+              property: 'openSettings',
+              message:
+                "Linking.openSettings() does not exist in the Expo web runtime (react-native-web's Linking has no such method) — it throws on app.boardsesh.com. Use openAppSettings() from src/lib/open-app-settings, which Platform-gates and never throws.",
+            },
           ],
         },
       },


### PR DESCRIPTION
## Summary

- On the Expo web (browser) build, tapping "Grant Location" on the gyms screen while location is denied called `Linking.openSettings()` — which react-native-web doesn't implement — and threw an unhandled `TypeError`, crashing the screen (Sentry BOARDSESH-DT, 26 events).
- Adds `openAppSettings()` / `canOpenAppSettings()` in `packages/mobile/src/lib/open-app-settings.ts`: a Platform-gated wrapper (iOS/Android only) that never throws, with a try/catch around the native call.
- Extracts the location prompt into `packages/mobile/src/components/gym-directory/GymLocationPrompt.tsx` so it's independently testable. On web, a denied permission now renders explanatory copy and no dead button (reusing the copy already shipped on www's gym directory) instead of a button that goes nowhere — the header search field is the working path there. On iOS/Android, denied still deep-links to Settings via the new wrapper.
- Migrates the other `Linking.openSettings()` call site (`AppleHealthCard.tsx`, iOS-only, unaffected by the crash) to the same wrapper for consistency.
- Adds a `no-restricted-properties` rule banning `Linking.openSettings` directly in `packages/mobile/**` / `packages/shared/**`, pointing callers at the wrapper, so this class of bug can't be reintroduced. This rule is duplicated in both `.oxlintrc.json` and `vite.config.ts`'s `lint.overrides` — only the latter is what `vp check`/CI actually enforces (verified with a scratch probe: 0 errors before the `vite.config.ts` copy, 1 at the exact banned call after). That dual-file duplication is an existing repo convention (see the two `Intl.*` rules right above it), and is itself the subject of #4548, which proposes a single source of truth so a `.oxlintrc.json`-only rule can no longer look like a guard while enforcing nothing.

Closes #4529

## Release Notes

- Fixed the gyms map crashing in the browser when location access is blocked — you'll now see a note pointing you to the search box instead.

## Test plan

- [x] `vp run typecheck:mobile`
- [x] `vp run typecheck` (full)
- [x] `vp run test:mobile` — new `open-app-settings.test.ts`, `gym-location-prompt.test.tsx`, updated `AppleHealthCard.test.tsx`, full mobile suite
- [x] `vp test run --project i18n --reporter=agent` — catalog completeness (four-locale parity for the new `boards.gyms.locationBlocked` key)
- [x] `vp check` (repo-wide) — 0 errors, only pre-existing `no-floating-promises` warnings (#4488), unrelated to this change
- [x] `vp run check:mobile-bundle` — Metro bundle check (ios + android)
- [x] Verified the new rule actually fires under `vp check` (not just raw oxlint): added a scratch `Linking.openSettings()` call, confirmed `vp check` reported it as an error with the expected message, then deleted the scratch file.

## Follow-up (not in this PR)

www keeps its "Use my location" button visible after a browser denial, since a browser permission can flip back at any time (`packages/web/app/gyms/gym-directory-near-me.tsx`). Matching that on Expo web would mean relaxing the sticky `settledRef` in `use-device-location.ts` (which is deliberately one-shot for iOS, which only ever prompts once). Left as a possible follow-up — this PR ships the smallest honest fix for a P3 with 26 events: explanatory copy, no dead button.
