### PR TITLE
chore(web): sweep leftover host-only OAuth cookies on the auth callback

### DIFF
--- a/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
+++ b/packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts
@@ -379,6 +379,11 @@ describe('POST /api/auth/[...nextauth]', () => {
     expect(callbackResponse.headers.getSetCookie()).toContainEqual(
       expect.stringContaining('__Secure-next-auth.session-token=fresh'),
     );
+    // The Expo form-post branch runs its own handler call, so assert the legacy
+    // flow-cookie clears ride that path too and not just the plain callback.
+    expect(callbackResponse.headers.getSetCookie()).toContainEqual(
+      expect.stringMatching(/^__Secure-next-auth\.nonce=; .*Max-Age=0/),
+    );
   });
 
   it('does not bind an untrusted or malformed Expo callback URL', async () => {
@@ -419,5 +424,111 @@ describe('POST /api/auth/[...nextauth]', () => {
     await expect(POST(signInRequest, context)).rejects.toThrow(
       'NEXTAUTH_SECRET is required to bind Expo web OAuth returns',
     );
+  });
+});
+
+describe('legacy host-only OAuth-flow cookie clears', () => {
+  const FLOW_COOKIE_NAMES = [
+    '__Secure-next-auth.callback-url',
+    '__Secure-next-auth.state',
+    '__Secure-next-auth.nonce',
+    '__Secure-next-auth.pkce.code_verifier',
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('VERCEL_ENV', 'production');
+    vi.stubEnv('NEXTAUTH_URL', 'https://www.boardsesh.com');
+    vi.stubEnv('AUTH_COOKIE_DOMAIN', '');
+    vi.stubEnv('NEXTAUTH_SECRET', 'test-nextauth-secret');
+    nextAuthHandlerMock.mockResolvedValue(new Response(null, { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function hostOnlyClears(response: Response): string[] {
+    return response.headers
+      .getSetCookie()
+      .filter((setCookie) => !/;\s*Domain=/i.test(setCookie) && /Max-Age=0/i.test(setCookie))
+      .map((setCookie) => setCookie.split('=', 1)[0] ?? '');
+  }
+
+  it('clears every legacy flow cookie on a GET OAuth callback', async () => {
+    nextAuthHandlerMock.mockResolvedValue(
+      new Response(null, { status: 302, headers: { Location: 'https://www.boardsesh.com/' } }),
+    );
+    const callbackRequest = new NextRequest('https://www.boardsesh.com/api/auth/callback/google?code=provider-code');
+
+    const response = await GET(callbackRequest, context);
+
+    expect(hostOnlyClears(response)).toEqual(expect.arrayContaining(FLOW_COOKIE_NAMES));
+  });
+
+  it('clears every legacy flow cookie on a POST (form_post) OAuth callback', async () => {
+    const callbackRequest = request('/api/auth/callback/apple', { code: 'provider-code', state: 'apple-state' });
+
+    const response = await POST(callbackRequest, context);
+
+    expect(hostOnlyClears(response)).toEqual(expect.arrayContaining(FLOW_COOKIE_NAMES));
+  });
+
+  it('still clears them when the callback FAILED — that is the case needing healing', async () => {
+    nextAuthHandlerMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://www.boardsesh.com/auth/error?error=OAuthCallback' },
+      }),
+    );
+    const callbackRequest = new NextRequest('https://www.boardsesh.com/api/auth/callback/google?code=provider-code');
+
+    const response = await GET(callbackRequest, context);
+
+    expect(hostOnlyClears(response)).toEqual(expect.arrayContaining(FLOW_COOKIE_NAMES));
+  });
+
+  it('does NOT clear them on the /signin redirect that mints the fresh flow cookies', async () => {
+    nextAuthHandlerMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { Location: 'https://accounts.google.com/o/oauth2/v2/auth?state=google-state-9' },
+      }),
+    );
+    const signInRequest = request('/api/auth/signin/google', { csrfToken: 'csrf-token' });
+
+    const response = await POST(signInRequest, context);
+
+    // Whole-set assertion, not "nonce is absent" — the test name says NO flow
+    // cookie is cleared here, so an erroneous clear of state or callback-url has
+    // to fail it too.
+    expect(hostOnlyClears(response)).toEqual([]);
+  });
+
+  it('does NOT clear them on a bare session read', async () => {
+    const sessionRequest = new NextRequest('https://www.boardsesh.com/api/auth/session', { method: 'GET' });
+
+    const response = await GET(sessionRequest, context);
+
+    expect(response.headers.getSetCookie()).toEqual([]);
+  });
+
+  it('never clears the __Host- CSRF cookie', async () => {
+    const callbackRequest = new NextRequest('https://www.boardsesh.com/api/auth/callback/google?code=provider-code');
+
+    const response = await GET(callbackRequest, context);
+
+    expect(response.headers.getSetCookie().some((setCookie) => setCookie.includes('csrf'))).toBe(false);
+  });
+
+  it('is a no-op on a dev host, where the live flow cookies are themselves host-only', async () => {
+    vi.stubEnv('VERCEL_ENV', '');
+    vi.stubEnv('VERCEL_URL', '');
+    vi.stubEnv('NEXTAUTH_URL', 'http://localhost:3000');
+    const callbackRequest = new NextRequest('http://localhost:3000/api/auth/callback/google?code=provider-code');
+
+    const response = await GET(callbackRequest, context);
+
+    expect(response.headers.getSetCookie()).toEqual([]);
   });
 });

--- a/packages/web/app/api/auth/[...nextauth]/route.ts
+++ b/packages/web/app/api/auth/[...nextauth]/route.ts
@@ -3,6 +3,7 @@ import { getToken } from 'next-auth/jwt';
 import { type NextRequest, NextResponse } from 'next/server';
 import { authOptions } from '@/app/lib/auth/auth-options';
 import {
+  appendLegacyHostOnlyOAuthFlowCookieClears,
   appendLegacyHostOnlySessionCookieClear,
   isSecureCookieContext,
   responseSetsSessionCookie,
@@ -30,6 +31,9 @@ type ExpectedSignOutIdentity = {
 const handler = NextAuth(authOptions) as NextAuthHandler;
 const OAUTH_SIGNIN_PATH_PATTERN = /\/api\/auth\/signin\/(apple|google)\/?$/;
 const OAUTH_CALLBACK_PATH_PATTERN = /\/api\/auth\/callback\/(apple|google)\/?$/;
+// Any provider's callback, not just the OIDC ones — `callback-url` is consumed
+// by the credentials and email callbacks too.
+const ANY_CALLBACK_PATH_PATTERN = /\/api\/auth\/callback\/[^/]+\/?$/;
 
 function oauthProviderForPath(pathname: string, action: 'signin' | 'callback'): ExpoWebOAuthProvider | null {
   const pattern = action === 'signin' ? OAUTH_SIGNIN_PATH_PATTERN : OAUTH_CALLBACK_PATH_PATTERN;
@@ -70,6 +74,12 @@ async function handleExpoOAuthPost(
   context: NextAuthRouteContext,
   pathname: string,
 ): Promise<Response | null> {
+  // The /signin/* branch below deliberately does NOT call
+  // clearLegacyOAuthFlowCookiesOnCallback. Not because the clears would be
+  // unsafe here — host-only and Domain-scoped are separate storage entries, so a
+  // Domain-less deletion next to a Domain-scoped write of the same name is
+  // well-defined — but because one placement is enough and the callback is the
+  // one every provider's flow reaches, GET and form_post alike.
   const signInProvider = oauthProviderForPath(pathname, 'signin');
   if (signInProvider) {
     const form = await readOAuthForm(request);
@@ -91,7 +101,10 @@ async function handleExpoOAuthPost(
   if (typeof state !== 'string' || !state) return null;
   const descriptor = readExpoReturnForState(request, state, callbackProvider);
   if (!descriptor) return null;
-  const response = clearLegacyCookieIfSessionWritten(await handler(request, context));
+  const response = clearLegacyOAuthFlowCookiesOnCallback(
+    clearLegacyCookieIfSessionWritten(await handler(request, context)),
+    pathname,
+  );
   return redirectExpoOAuthResponse(response, request, state, descriptor.returnUrl);
 }
 
@@ -144,6 +157,22 @@ function clearLegacyCookieIfSessionWritten(response: Response): Response {
   return response;
 }
 
+// Sweep the pre-#3775 host-only duplicates of the OAuth-flow cookies out of the
+// jar. This is hygiene, not a sign-in fix — a duplicate loses the read
+// deterministically; see appendLegacyHostOnlyOAuthFlowCookieClears for why.
+//
+// The callback response is the natural place for it: by the time we hold it,
+// NextAuth has already read state/pkce/callback-url off the REQUEST and expired
+// its own copies on this same response, so the flow is over and the deletion
+// cannot interact with it. Unconditional on outcome — an errored callback ends
+// the flow just as definitively as a successful one.
+function clearLegacyOAuthFlowCookiesOnCallback(response: Response, pathname: string): Response {
+  if (ANY_CALLBACK_PATH_PATTERN.test(pathname)) {
+    appendLegacyHostOnlyOAuthFlowCookieClears(response);
+  }
+  return response;
+}
+
 export async function POST(request: NextRequest, context: NextAuthRouteContext): Promise<Response> {
   const pathname = request.nextUrl.pathname.endsWith('/')
     ? request.nextUrl.pathname.slice(0, -1)
@@ -151,7 +180,10 @@ export async function POST(request: NextRequest, context: NextAuthRouteContext):
   const expoOAuthResponse = await handleExpoOAuthPost(request, context, pathname);
   if (expoOAuthResponse) return expoOAuthResponse;
   if (!pathname.endsWith('/api/auth/signout')) {
-    return clearLegacyCookieIfSessionWritten(await handler(request, context));
+    return clearLegacyOAuthFlowCookiesOnCallback(
+      clearLegacyCookieIfSessionWritten(await handler(request, context)),
+      pathname,
+    );
   }
 
   const expectedIdentity = await readExpectedSignOutIdentity(request);
@@ -185,14 +217,21 @@ export async function POST(request: NextRequest, context: NextAuthRouteContext):
 }
 
 export async function GET(request: NextRequest, context: NextAuthRouteContext): Promise<Response> {
-  const callbackProvider = oauthProviderForPath(request.nextUrl.pathname, 'callback');
+  const pathname = request.nextUrl.pathname;
+  const callbackProvider = oauthProviderForPath(pathname, 'callback');
   const state = request.nextUrl.searchParams.get('state');
   if (callbackProvider && state) {
     const descriptor = readExpoReturnForState(request, state, callbackProvider);
     if (descriptor) {
-      const response = clearLegacyCookieIfSessionWritten(await handler(request, context));
+      const response = clearLegacyOAuthFlowCookiesOnCallback(
+        clearLegacyCookieIfSessionWritten(await handler(request, context)),
+        pathname,
+      );
       return redirectExpoOAuthResponse(response, request, state, descriptor.returnUrl);
     }
   }
-  return clearLegacyCookieIfSessionWritten(await handler(request, context));
+  return clearLegacyOAuthFlowCookiesOnCallback(
+    clearLegacyCookieIfSessionWritten(await handler(request, context)),
+    pathname,
+  );
 }

--- a/packages/web/app/lib/auth/__tests__/secure-cookies.test.ts
+++ b/packages/web/app/lib/auth/__tests__/secure-cookies.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  appendLegacyHostOnlyOAuthFlowCookieClears,
   appendLegacyHostOnlySessionCookieClear,
+  domainScopedCookieNames,
   isSecureCookieContext,
+  oauthFlowCookieNames,
   responseSetsSessionCookie,
   sessionCookieDomain,
   sessionCookieName,
@@ -185,5 +188,146 @@ describe('appendLegacyHostOnlySessionCookieClear', () => {
     const response = new Response(null);
     appendLegacyHostOnlySessionCookieClear(response);
     expect(response.headers.getSetCookie()).toEqual([]);
+  });
+});
+
+describe('oauthFlowCookieNames', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('matches the NextAuth names for every Domain-scoped flow cookie in a secure context', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    expect(oauthFlowCookieNames()).toEqual([
+      '__Secure-next-auth.callback-url',
+      '__Secure-next-auth.state',
+      '__Secure-next-auth.nonce',
+      // NextAuth stores the PKCE verifier under `pkce.code_verifier`, NOT
+      // `pkceCodeVerifier` (next-auth/core/lib/cookie.js).
+      '__Secure-next-auth.pkce.code_verifier',
+    ]);
+  });
+
+  it('drops the prefix in a non-secure context', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'http://localhost:3000' });
+    expect(oauthFlowCookieNames()).toEqual([
+      'next-auth.callback-url',
+      'next-auth.state',
+      'next-auth.nonce',
+      'next-auth.pkce.code_verifier',
+    ]);
+  });
+
+  it('never targets the __Host- CSRF cookie, which cannot carry a Domain', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    expect(oauthFlowCookieNames().some((name) => name.includes('csrf'))).toBe(false);
+    expect(oauthFlowCookieNames().some((name) => name.startsWith('__Host-'))).toBe(false);
+  });
+
+  it('never targets the session token, which has its own clear', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    expect(oauthFlowCookieNames()).not.toContain(sessionCookieName());
+  });
+
+  // The sweep and auth-options' `cookies` block both read
+  // domainScopedCookieNames(), so a rename lands in both at once. This pins the
+  // relationship: the flow names are exactly that set minus the session token.
+  it('is exactly the Domain-scoped cookie set minus the session token', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    const { sessionToken, ...flowCookies } = domainScopedCookieNames();
+    expect(sessionToken).toBe(sessionCookieName());
+    expect([...oauthFlowCookieNames()].sort()).toEqual(Object.values(flowCookies).sort());
+  });
+});
+
+describe('appendLegacyHostOnlyOAuthFlowCookieClears', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  function clearedCookieNames(response: Response): string[] {
+    return response.headers.getSetCookie().map((setCookie) => setCookie.split('=', 1)[0] ?? '');
+  }
+
+  it('emits one Domain-less, Max-Age=0 deletion per Domain-scoped flow cookie in prod', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    const response = new Response(null);
+    appendLegacyHostOnlyOAuthFlowCookieClears(response);
+
+    const setCookies = response.headers.getSetCookie();
+    expect(setCookies).toHaveLength(4);
+    expect(clearedCookieNames(response)).toEqual([
+      '__Secure-next-auth.callback-url',
+      '__Secure-next-auth.state',
+      '__Secure-next-auth.nonce',
+      '__Secure-next-auth.pkce.code_verifier',
+    ]);
+    for (const setCookie of setCookies) {
+      // No Domain attribute is the whole mechanism: it targets the legacy
+      // host-only entry and cannot touch the Domain-scoped cookie.
+      expect(setCookie).not.toMatch(/;\s*Domain=/i);
+      expect(setCookie).toMatch(/Max-Age=0/i);
+      expect(setCookie).toMatch(/HttpOnly/);
+      expect(setCookie).toMatch(/Secure/);
+      // Empty value — a deletion, never a fresh write.
+      expect(setCookie.split(';', 1)[0]).toMatch(/=$/);
+    }
+  });
+
+  it('clears callback-url, the only flow cookie whose legacy copy can still be in the jar', () => {
+    // state and pkce.code_verifier get a 15-minute `expires` from NextAuth's
+    // signCookie (core/lib/oauth/checks.js) — auth-options drops the
+    // defaultCookies maxAge, signCookie's STATE_MAX_AGE/PKCE_MAX_AGE fallback
+    // supplies the bound — so any pre-#3775 host-only copy expired long ago.
+    // nonce is never written by this deployment (no provider enables the nonce
+    // check). callback-url gets neither, so it is the one leftover a sweep can
+    // actually find.
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    const response = new Response(null);
+    appendLegacyHostOnlyOAuthFlowCookieClears(response);
+    expect(clearedCookieNames(response)).toContain('__Secure-next-auth.callback-url');
+  });
+
+  it('never touches the __Host- CSRF cookie', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    const response = new Response(null);
+    appendLegacyHostOnlyOAuthFlowCookieClears(response);
+    expect(response.headers.getSetCookie().some((setCookie) => setCookie.includes('csrf'))).toBe(false);
+    expect(response.headers.getSetCookie().some((setCookie) => setCookie.startsWith('__Host-'))).toBe(false);
+  });
+
+  it('never touches the session cookie, whose clear is gated on a fresh write', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    const response = new Response(null);
+    appendLegacyHostOnlyOAuthFlowCookieClears(response);
+    expect(clearedCookieNames(response)).not.toContain('__Secure-next-auth.session-token');
+  });
+
+  it('is a no-op in dev, where the live flow cookies are themselves host-only', () => {
+    // Same load-bearing guard as the session clear: with no cookie domain the
+    // deletion would target the LIVE state/pkce/callback-url and break sign-in.
+    stubAuthEnv({ NEXTAUTH_URL: 'http://localhost:3000' });
+    const response = new Response(null);
+    appendLegacyHostOnlyOAuthFlowCookieClears(response);
+    expect(response.headers.getSetCookie()).toEqual([]);
+  });
+
+  it('is a no-op on a Vercel preview even though the context is secure', () => {
+    stubAuthEnv({ VERCEL_ENV: 'preview', VERCEL_URL: 'boardsesh-abc123-marcodejonghs-projects.vercel.app' });
+    const response = new Response(null);
+    appendLegacyHostOnlyOAuthFlowCookieClears(response);
+    expect(response.headers.getSetCookie()).toEqual([]);
+  });
+
+  it('is a no-op on a homelab preview host', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://42.preview.boardsesh.com' });
+    const response = new Response(null);
+    appendLegacyHostOnlyOAuthFlowCookieClears(response);
+    expect(response.headers.getSetCookie()).toEqual([]);
+  });
+
+  it('appends alongside an existing session-cookie clear without replacing it', () => {
+    stubAuthEnv({ NEXTAUTH_URL: 'https://www.boardsesh.com', VERCEL_ENV: 'production' });
+    const response = new Response(null);
+    appendLegacyHostOnlySessionCookieClear(response);
+    appendLegacyHostOnlyOAuthFlowCookieClears(response);
+    expect(response.headers.getSetCookie()).toHaveLength(5);
+    expect(clearedCookieNames(response)).toContain('__Secure-next-auth.session-token');
   });
 });

--- a/packages/web/app/lib/auth/auth-options.ts
+++ b/packages/web/app/lib/auth/auth-options.ts
@@ -10,7 +10,7 @@ import * as schema from '@/app/lib/db/schema';
 import { and, eq, isNull } from 'drizzle-orm';
 import { compare } from 'bcryptjs';
 import { verifyNativeOAuthTransferToken } from '@/app/lib/auth/native-oauth-transfer';
-import { isSecureCookieContext, sessionCookieDomain } from '@/app/lib/auth/secure-cookies';
+import { domainScopedCookieNames, isSecureCookieContext, sessionCookieDomain } from '@/app/lib/auth/secure-cookies';
 import { isAllowedAppOrigin } from '@/app/lib/auth/app-origin-allowlist';
 import { applyCanonicalAuthUrl } from '@/app/lib/auth/canonical-auth-url';
 
@@ -182,6 +182,9 @@ const useSecureCookies = isSecureCookieContext();
 // logged-in user's HttpOnly session — keep untrusted/third-party content off
 // *.boardsesh.com hosts.
 const cookieDomain = sessionCookieDomain();
+// Cookie names come from secure-cookies so the legacy host-only clears there
+// can never drift from what NextAuth actually writes here.
+const domainScopedCookieName = domainScopedCookieNames();
 
 export const authOptions: NextAuthOptions = {
   adapter: DrizzleAdapter(getDb(), {
@@ -199,7 +202,7 @@ export const authOptions: NextAuthOptions = {
     // stays true in secure contexts and the `__Secure-` prefix (which permits a
     // Domain attribute) is kept so the name still matches what getToken reads.
     sessionToken: {
-      name: `${useSecureCookies ? '__Secure-' : ''}next-auth.session-token`,
+      name: domainScopedCookieName.sessionToken,
       options: {
         httpOnly: true,
         sameSite: 'lax',
@@ -209,7 +212,7 @@ export const authOptions: NextAuthOptions = {
       },
     },
     callbackUrl: {
-      name: `${useSecureCookies ? '__Secure-' : ''}next-auth.callback-url`,
+      name: domainScopedCookieName.callbackUrl,
       options: {
         httpOnly: true,
         sameSite: useSecureCookies ? 'none' : 'lax',
@@ -219,7 +222,7 @@ export const authOptions: NextAuthOptions = {
       },
     },
     state: {
-      name: `${useSecureCookies ? '__Secure-' : ''}next-auth.state`,
+      name: domainScopedCookieName.state,
       options: {
         httpOnly: true,
         sameSite: useSecureCookies ? 'none' : 'lax',
@@ -229,7 +232,7 @@ export const authOptions: NextAuthOptions = {
       },
     },
     nonce: {
-      name: `${useSecureCookies ? '__Secure-' : ''}next-auth.nonce`,
+      name: domainScopedCookieName.nonce,
       options: {
         httpOnly: true,
         sameSite: useSecureCookies ? 'none' : 'lax',
@@ -239,7 +242,7 @@ export const authOptions: NextAuthOptions = {
       },
     },
     pkceCodeVerifier: {
-      name: `${useSecureCookies ? '__Secure-' : ''}next-auth.pkce.code_verifier`,
+      name: domainScopedCookieName.pkceCodeVerifier,
       options: {
         httpOnly: true,
         sameSite: useSecureCookies ? 'none' : 'lax',

--- a/packages/web/app/lib/auth/secure-cookies.ts
+++ b/packages/web/app/lib/auth/secure-cookies.ts
@@ -70,9 +70,107 @@ export function appendLegacyHostOnlySessionCookieClear(response: Response): void
   // that was just written. There is no legacy Domain-cookie migration to do in
   // those environments, so skipping is strictly correct.
   if (sessionCookieDomain() === undefined) return;
+  appendHostOnlyCookieClear(response, sessionCookieName());
+}
+
+// Single source of truth for every cookie name `auth-options.ts` gives a
+// `Domain`. auth-options builds its `cookies` block from this and the legacy
+// clears below read the same values, so a rename cannot leave the sweep
+// pointing at a name nothing writes. The dependency runs one way only —
+// auth-options imports secure-cookies, never the reverse — so no import cycle.
+//
+// Names are NextAuth's own (next-auth/core/lib/cookie.js): `pkceCodeVerifier`
+// is stored as `next-auth.pkce.code_verifier`, not `next-auth.pkceCodeVerifier`.
+// `csrfToken` is deliberately absent — it uses the `__Host-` prefix, which
+// forbids a Domain attribute, so it has no second cookie identity.
+export function domainScopedCookieNames(): {
+  sessionToken: string;
+  callbackUrl: string;
+  state: string;
+  nonce: string;
+  pkceCodeVerifier: string;
+} {
+  const cookiePrefix = isSecureCookieContext() ? '__Secure-' : '';
+  return {
+    sessionToken: sessionCookieName(),
+    callbackUrl: `${cookiePrefix}next-auth.callback-url`,
+    state: `${cookiePrefix}next-auth.state`,
+    nonce: `${cookiePrefix}next-auth.nonce`,
+    pkceCodeVerifier: `${cookiePrefix}next-auth.pkce.code_verifier`,
+  };
+}
+
+// The flow-cookie subset of the above — the names the legacy host-only sweep
+// targets. `next-auth.nonce` is here because auth-options declares it with a
+// Domain, not because this deployment writes it: `checks.nonce.create`
+// early-returns unless the provider's `checks` include `'nonce'`
+// (next-auth/core/lib/oauth/checks.js), and both configured OIDC providers are
+// `['pkce', 'state']` — Google's built-in default, Apple's explicit override in
+// auth-options. Its clear is inert today; mirroring the declaration rather than
+// the current provider config means enabling the nonce check later cannot
+// silently leave a gap.
+export function oauthFlowCookieNames(): string[] {
+  const { callbackUrl, state, nonce, pkceCodeVerifier } = domainScopedCookieNames();
+  return [callbackUrl, state, nonce, pkceCodeVerifier];
+}
+
+// Cookie-jar hygiene, NOT a sign-in fix — read this before extending it.
+//
+// The flow cookies were host-only before app.boardsesh.com shared the login, so
+// a browser that signed in before #3775 (2026-07-20) can still carry a host-only
+// copy of each alongside the Domain-scoped one NextAuth writes now: `(name,
+// domain, path)` is the storage key, so both entries coexist and both ride every
+// www request.
+//
+// A duplicate does NOT shadow the fresh cookie on the read path. Next's
+// `parseCookie` (next/dist/compiled/@edge-runtime/cookies) does `map.set(key,
+// value)` per pair, so the LAST occurrence in the Cookie header wins, and RFC
+// 6265 §5.4 orders equal-path cookies by ascending creation time — the older
+// host-only copy is sent first, the Domain-scoped one last. The fresh cookie
+// wins deterministically, and so does the one `getToken({ req })` reads.
+//
+// What is left is leftovers, not breakage. `state` and `pkceCodeVerifier` are
+// bounded to 15 minutes — though NOT by the `maxAge: 60 * 15` in NextAuth's
+// `defaultCookies()`, which this app never sees: next-auth merges the `cookies`
+// map one level deep (`{...defaultCookies(), ...authOptions.cookies}`,
+// core/init.js), so auth-options' entries replace the defaults' `options`
+// wholesale and drop the maxAge. The real ceiling is `signCookie`
+// (core/lib/oauth/checks.js), which takes `cookies[type].options.maxAge ??
+// STATE_MAX_AGE | PKCE_MAX_AGE` (both `60 * 15`) and stamps `expires` on the
+// Set-Cookie. That applied identically before #3775 — the cookies block already
+// overrode those entries — so every pre-#3775 host-only copy expired 15 minutes
+// after its owner's last sign-in. `nonce` was never written at all (see the name
+// list above). Only `callback-url` gets neither maxAge nor expires, so a legacy
+// copy can sit in the jar for the life of a browser session — losing every read,
+// and neutered anyway by the `callbacks.redirect` allow-list in auth-options.
+// Deleting the host-only entries keeps the jar honest; no user-visible failure
+// depends on it.
+//
+// Unlike the session clear above, which IS load-bearing: after sign-out only the
+// Domain-scoped session cookie is deleted, so a surviving host-only copy would
+// be the only one left and would win by default — a logout bypass.
+export function appendLegacyHostOnlyOAuthFlowCookieClears(response: Response): void {
+  // Identical load-bearing guard to the session clear: with no cookie domain in
+  // play (local dev, previews) the cookies NextAuth writes are THEMSELVES
+  // host-only, so this "legacy" deletion would target the live flow cookies and
+  // break the sign-in it is meant to protect.
+  if (sessionCookieDomain() === undefined) return;
+  for (const cookieName of oauthFlowCookieNames()) {
+    appendHostOnlyCookieClear(response, cookieName);
+  }
+}
+
+// A `Set-Cookie` with NO Domain attribute: that is what targets the legacy
+// host-only entry, and it cannot touch the Domain-scoped cookie of the same
+// name. `__Secure-` permits a Domain-less cookie (unlike `__Host-`), so the
+// deletion is valid for the secure-context names too. Cookie removal matches on
+// name + domain + path only, so SameSite here is inert.
+function appendHostOnlyCookieClear(response: Response, cookieName: string): void {
   const secure = isSecureCookieContext();
-  const clearedCookie = `${sessionCookieName()}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`;
-  response.headers.append('Set-Cookie', clearedCookie);
+  response.headers.append(
+    'Set-Cookie',
+    `${cookieName}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`,
+  );
 }
 
 // True when the response installs a fresh (non-empty) value for the session


### PR DESCRIPTION
> **Recommendation: close this.** The bug it was written to fix does not exist. The branch has been reworked so it is honest about what it actually does — leftover-cookie hygiene — but the honest version is thin enough that closing is the better call. Details below; the branch is here if you disagree.

Rewritten after the QA review. The original version of this PR claimed a stale host-only cookie could shadow the fresh `Domain=.boardsesh.com` one and break Google/Apple sign-in for a whole browser session. **That claim was false and is retracted.** The false mechanism is gone from the code comments, the commit message, this body, and the Release Notes.

## What I verified

Every claim below was re-checked against the installed packages in this worktree, not from memory.

**A duplicate cookie loses the read, deterministically.**

- `parseCookie` in `next@16.2.12` (`next/dist/compiled/@edge-runtime/cookies/index.js:48-65`) builds a Map with `map.set(key, decodeURIComponent(value))` walking the Cookie header left to right. The **last** occurrence of a name wins.
- RFC 6265 §5.4 orders equal-path cookies by ascending creation time. Both copies are `Path=/`; the host-only one predates the widening, so it is sent **first** and the Domain-scoped one **last**.

Last-wins parse + older-first ordering = the fresh Domain-scoped cookie is what NextAuth reads, and what `getToken({ req })` reads. There is no shadowing and no sign-in loop.

**`next-auth.nonce` is never written by this deployment.** `checks.nonce.create` and `checks.nonce.use` both early-return unless the provider's `checks` include `'nonce'` (`next-auth/core/lib/oauth/checks.js:120-153`). Google's built-in default is `checks: ["pkce", "state"]` (`next-auth/providers/google.js:19`) and Apple is explicitly overridden to `['pkce', 'state']` in `auth-options.ts:52`. There has never been a host-only `next-auth.nonce` to clean up.

**The other three, against the timeline.** The widening landed 2026-07-20 in #3775 (`04153617a`), a month ago.

| Cookie | Lifetime as written by this app | State of a pre-#3775 host-only copy today |
| --- | --- | --- |
| `next-auth.state` | 15 min (`expires`, via `signCookie`) | Expired 15 min after its owner's last pre-#3775 sign-in |
| `next-auth.pkce.code_verifier` | 15 min (same) | Same |
| `next-auth.nonce` | never written | Never existed |
| `next-auth.callback-url` | session cookie | **Can still be in the jar** for the life of a browser session |

One correction to the earlier draft of this body, which cited the wrong mechanism for that 15-minute bound. It is **not** the `maxAge: 60 * 15` in NextAuth's `defaultCookies()` (`core/lib/cookie.js:47-66`) — this app never sees it. next-auth merges the cookie map one level deep, `{...defaultCookies(...), ...authOptions.cookies}` (`core/init.js:59-61`), so `auth-options.ts` replacing the `state` and `pkceCodeVerifier` entries replaces their `options` wholesale and drops the maxAge. The bound actually comes from `signCookie` (`core/lib/oauth/checks.js:13-41`), which takes `cookies[type].options.maxAge ?? STATE_MAX_AGE | PKCE_MAX_AGE` (both `60 * 15`) and stamps `expires` on the Set-Cookie. `git show 04153617a^:…/auth-options.ts` confirms the cookies block already overrode those entries before #3775, so the same 15-minute ceiling applied to the legacy copies. The conclusion is unchanged; the citation was wrong and is fixed in the code comment, the test comment, the commit message and here.

So `callback-url` is the only real leftover. It loses every read per the above, and even if it won, `callbacks.redirect` (`auth-options.ts:265-289`) collapses anything outside the base origin / app allow-list to `baseUrl` — it cannot produce the localhost redirect from #4227.

**The rolling-deploy window does not rescue it either.** The scenario would be an old instance writing a host-only cookie *after* a new instance wrote the domain-scoped one, making the stale copy newer and therefore last. `sessionCookieDomain()` is keyed on env, not on instance identity, so this can only happen while a deploy that changes cookie-domain behaviour is being promoted — i.e. during #3775's promotion, once, a month ago, over a window of seconds, and only for a user whose signin and callback straddled it. Walking that case through: the user has no domain-scoped copy yet, so there is no ambiguity to resolve and the flow completes normally. It leaves an orphan, not a failure.

## What this PR therefore is

Deleting leftovers that nothing depends on. On the OAuth callback response only, it emits four Domain-less `Max-Age=0` `Set-Cookie` headers so any pre-#3775 host-only copies leave the jar.

The cost is four extra `Set-Cookie` headers per OAuth callback — not per request. The benefit is a tidier cookie jar and one less thing to reason about the next time someone looks at duplicate-name cookies here.

`next-auth.nonce` stays in the swept list even though it is never written: the list mirrors what `auth-options.ts` **declares** with a `Domain`, not what the current provider config happens to write, so turning on the nonce check later cannot silently leave a gap.

The dev/preview guard is the load-bearing part and is unchanged: `sessionCookieDomain() === undefined` short-circuits both clears, because in local dev and previews the fresh cookies are themselves host-only and the "legacy" deletion would delete the live ones.

## Also fixed from the reviews

**Duplicated source of truth for the cookie names.** `secure-cookies.ts` had its own copy of the four names, unlinked from the `authOptions.cookies` declaration — rename one and the sweep would silently target nothing with every test still green. Now `domainScopedCookieNames()` in `secure-cookies.ts` is the single source and `auth-options.ts` builds its `cookies` block from it. The dependency runs one way only (auth-options → secure-cookies), so there is no import cycle. A test pins that the swept set is exactly that set minus the session token.

**The self-contradictory placement rationale** at `route.ts:77-80`. It justified skipping the `/signin/*` response with the same same-name-ambiguity argument the fix's own premise depends on rejecting. Replaced: host-only and Domain-scoped are separate storage entries, so the clears would be well-defined at `/signin/*` too — the callback is chosen because one placement is enough and it is the point every provider's flow reaches, GET and form_post alike.

**Test names encoding the false mechanism.** The `"clears the no-Max-Age nonce, the cookie that breaks sign-in for a whole browser session"` case now asserts the one cookie a sweep can actually find (`callback-url`) and says why the other three cannot be found.

**The `/signin` negative assertion** (claude-review's note). `expect(hostOnlyClears(response)).not.toEqual(expect.arrayContaining(['…nonce']))` only proved nonce was absent, so a partial clear of `state` or `callback-url` would still have passed a test named "does NOT clear them". Now `toEqual([])`.

## What is unchanged, and is not mine to decide

`Domain=.boardsesh.com` sends the session JWT to **every** `boardsesh.com` subdomain, including `updates.boardsesh.com`, which runs the third-party `mercuretechnologies/expo-open-ota` server. The four OAuth-flow cookies ride along too. `auth-options.ts` documents the widening as intentional with the instruction to keep untrusted content off `*.boardsesh.com` — and the OTA host sits inside that scope. Two options if you want it closed: move the OTA server off the parent domain (touches `updates.url` in shipped binaries), or replace the shared parent-domain cookie with an explicit handoff to `app.boardsesh.com` and return the session cookie to host-only. Owner call, not touched here.

## Tests

`packages/web/app/lib/auth/__tests__/secure-cookies.test.ts` + `packages/web/app/api/auth/[...nextauth]/__tests__/route.test.ts`:

```
Test Files  2 passed (2)
     Tests  59 passed (59)
```

`vp run typecheck:web` exits 0. `vp check` reports the same 2 errors / 324 warnings it reports on `main` (#4488 — both in `packages/db`), with zero diagnostics in any of the five files touched here. The pre-commit hook ran `vp check --fix` scoped to the staged files and came back clean.

## Release Notes

none
