### PR TITLE
fix(mobile): stop a busy database dropping a tick you just logged

### DIFF
--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -12,6 +12,7 @@ import {
   deleteUserCheckpoints,
   deleteAllSyncMeta,
   applyBusyTimeout,
+  beginImmediateWrite,
   classifySqliteLockError,
   configureMainConnection,
   vacuumDatabase,
@@ -487,7 +488,14 @@ export async function purgeLocalDataForSignOut(db: SQLiteDatabase): Promise<Sign
     // Same lock guard as clearUserData: this runs on its own connection alongside
     // in-flight sync reads/writes, so wait for the write lock rather than failing
     // instantly with SQLITE_BUSY (BOARDSESH-A9).
-    await applyBusyTimeout(txn);
+    //
+    // IMMEDIATE, not just a timeout (#4332): the two reads below run before the
+    // first DELETE, and expo's `BEGIN` is deferred — so a deferred transaction
+    // would open for READING here, and SQLite never consults `busy_timeout` when
+    // upgrading a read transaction to a write. A contended sign-out would fail in
+    // about a millisecond and leave the previous account's rows on disk, which is
+    // the exact hazard the owner stamp exists to defend against.
+    await beginImmediateWrite(txn);
     // Counted here, inside the transaction and immediately before the DELETE, because
     // this is the only place the number is both post-drain and exact. The count the
     // confirmation dialog showed was taken before sign-out's bounded 3s drain, so it

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -14,6 +14,7 @@ import {
   applyBusyTimeout,
   beginImmediateWrite,
   classifySqliteLockError,
+  OFFLINE_DB_BUSY_TIMEOUT_MS,
   configureMainConnection,
   vacuumDatabase,
   BOARD_DATA_TABLES,
@@ -495,7 +496,7 @@ export async function purgeLocalDataForSignOut(db: SQLiteDatabase): Promise<Sign
     // upgrading a read transaction to a write. A contended sign-out would fail in
     // about a millisecond and leave the previous account's rows on disk, which is
     // the exact hazard the owner stamp exists to defend against.
-    await beginImmediateWrite(txn);
+    await beginImmediateWrite(txn, OFFLINE_DB_BUSY_TIMEOUT_MS);
     // Counted here, inside the transaction and immediately before the DELETE, because
     // this is the only place the number is both post-drain and exact. The count the
     // confirmation dialog showed was taken before sign-out's bounded 3s drain, so it

--- a/packages/mobile/src/hooks/use-offline-mutations.ts
+++ b/packages/mobile/src/hooks/use-offline-mutations.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
-  applyBusyTimeout,
+  beginImmediateWrite,
   enqueue,
   getLocalUserId,
   runLocalWriteWithRetry,
-  OFFLINE_DB_BUSY_TIMEOUT_MS,
+  OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS,
   OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS,
   OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS,
   type EnqueueResult,
@@ -45,8 +45,16 @@ function scheduleDrain(
  * Every write in this file is a single `withExclusiveTransactionAsync` task, so
  * losing the single-writer lock rolls back both the data row and the outbox row
  * it would have queued — the whole write vanishes and, for a tick, the send is
- * gone. Attempt 1 keeps the shipped 5s `busy_timeout`; a retry gets the shorter
- * one, because a first-attempt failure already means a five-second holder.
+ * gone.
+ *
+ * The task opens IMMEDIATE rather than just arming `busy_timeout` (#4332). These
+ * tasks read before they write — `getLocalUserId` for the owner stamp — and a
+ * deferred transaction that reads first never reaches SQLite's busy handler when
+ * it upgrades to a write, so the timeout was set and then ignored and a contended
+ * tick died in about a millisecond. `beginImmediateWrite` takes the write lock up
+ * front, which is the only way the wait below is real. Keep using it even in a
+ * task that happens to write first today: the next person to add a read above the
+ * INSERT would silently bring the bug back.
  *
  * Every statement inside `task` MUST be safe to re-run: a `SQLITE_BUSY` can
  * surface at COMMIT, so a retry can follow an attempt that actually landed.
@@ -65,9 +73,13 @@ function runLocalWrite(
         if (injectedFault) throw injectedFault;
       }
       await db.withExclusiveTransactionAsync(async (txn) => {
-        // Own connection, busy_timeout defaults to 0 — wait for a held write lock
-        // instead of failing this offline write instantly (BOARDSESH-AB/AX).
-        await applyBusyTimeout(txn, attempt === 1 ? OFFLINE_DB_BUSY_TIMEOUT_MS : OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS);
+        // Own connection, busy_timeout defaults to 0, and expo's `BEGIN` is
+        // DEFERRED — arm the timeout and take the write lock in one step, or a
+        // held lock fails this offline write instantly (BOARDSESH-AB/AX, #4332).
+        await beginImmediateWrite(
+          txn,
+          attempt === 1 ? OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS : OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS,
+        );
         await task(txn);
       });
       if (__DEV__) {
@@ -149,7 +161,8 @@ export async function writeTickLocal(
  * self-contained — the drainer replays it from the payload alone — so an
  * outbox-only row is enough for the send to reach the server. It is also a
  * strictly smaller target than the full write: one `INSERT OR IGNORE`, no owner
- * read, at a later instant with its own (shorter) `busy_timeout`.
+ * read, at a later instant with its own (shorter) `busy_timeout`. It still opens
+ * IMMEDIATE — `enqueue` reads the existing row before it decides what to write.
  *
  * No owner stamp is needed: the server derives ownership from the authenticated
  * call. What the user gives up is documented at the call site — no local tick
@@ -168,7 +181,7 @@ export async function enqueueTickOutboxOnly(
   await runLocalWriteWithRetry(
     async () => {
       await db.withExclusiveTransactionAsync(async (txn) => {
-        await applyBusyTimeout(txn, OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS);
+        await beginImmediateWrite(txn, OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS);
         await enqueue(txn, 'boardsesh_ticks', 'create', input, tickUuid);
       });
     },

--- a/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
@@ -244,11 +244,13 @@ describe('ephemeral transaction connection', () => {
 // checked "the contended write throws" passes in both worlds, which is exactly how
 // this shipped.
 describe('beginImmediateWrite', () => {
-  // Short enough to keep the suite fast, long enough that "failed instantly" and
-  // "waited out the timeout" cannot be confused on a loaded CI box.
-  const CONTENDED_TIMEOUT_MS = 400;
-  const FAILED_INSTANTLY_MS = 200;
-  const WAITED_MS = 300;
+  // Short enough to keep the suite fast, wide enough that "failed instantly" and
+  // "waited out the timeout" cannot be confused on a loaded CI box: a failure has
+  // 400ms of scheduling jitter to spend before it reads as a wait, and a wait has
+  // 200ms of slack under the timeout it is supposed to sit out.
+  const CONTENDED_TIMEOUT_MS = 1000;
+  const FAILED_INSTANTLY_MS = 400;
+  const WAITED_MS = 800;
 
   /** Runs a transaction task and hands back what escaped, or null if it committed. */
   async function captureFailure(task: (txn: TestSqliteDb) => Promise<void>): Promise<unknown> {
@@ -334,7 +336,7 @@ describe('beginImmediateWrite', () => {
 
   it('commits the write when nothing contends', async () => {
     await db.withExclusiveTransactionAsync(async (txn) => {
-      await beginImmediateWrite(txn);
+      await beginImmediateWrite(txn, OFFLINE_DB_BUSY_TIMEOUT_MS);
       await txn.getFirstAsync('SELECT id FROM probe LIMIT 1');
       await txn.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [4, 'landed']);
     });
@@ -367,7 +369,7 @@ describe('beginImmediateWrite', () => {
       expect(Date.now() - startedAt).toBeLessThan(FAILED_INSTANTLY_MS);
 
       await db.withExclusiveTransactionAsync(async (txn) => {
-        await beginImmediateWrite(txn);
+        await beginImmediateWrite(txn, OFFLINE_DB_BUSY_TIMEOUT_MS);
         await txn.getFirstAsync('SELECT id FROM probe LIMIT 1');
         // Same interleaving, opposite outcome: the interloper is the one that loses.
         await expect(

--- a/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
+++ b/packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts
@@ -9,12 +9,15 @@ import { join } from 'node:path';
 
 import {
   OFFLINE_DB_BUSY_TIMEOUT_MS,
+  OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS,
   OFFLINE_DB_WAL_SWITCH_TIMEOUT_MS,
   OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS,
   OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS,
   applyBusyTimeout,
+  beginImmediateWrite,
   configureMainConnection,
 } from '../pragmas';
+import { isDatabaseLockedError } from '../lock-errors';
 import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
 
 let workDir: string;
@@ -57,6 +60,14 @@ describe('applyBusyTimeout', () => {
 
     const after = await db.getFirstAsync<{ timeout: number }>('PRAGMA busy_timeout');
     expect(after?.timeout).toBe(OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS);
+    expect(OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS).toBeLessThan(OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS);
+  });
+
+  // The ladder shortens each rung, and a user-facing first attempt is shorter than
+  // the background default because somebody is holding a phone waiting for it.
+  it('orders the ladder from the foreground attempt down to the fallback', () => {
+    expect(OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS).toBeLessThan(OFFLINE_DB_BUSY_TIMEOUT_MS);
+    expect(OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS).toBeLessThan(OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS);
     expect(OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS).toBeLessThan(OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS);
   });
 });
@@ -221,5 +232,154 @@ describe('ephemeral transaction connection', () => {
 
     expect(insideDefault).toBe(0);
     expect(insideAfterApply).toBe(OFFLINE_DB_BUSY_TIMEOUT_MS);
+  });
+});
+
+// #4332: expo's `withExclusiveTransactionAsync` opens a DEFERRED `BEGIN`, so a task
+// that reads before it writes — every tick and favorite does, for the owner stamp —
+// opens for READING and then has to upgrade. SQLite does not run the busy handler on
+// that upgrade, which made `busy_timeout` dead code on every user-facing offline
+// write: the pragma said "wait five seconds" and the tick died in about a
+// millisecond. These tests assert the WAIT, not the pragma's value. A test that only
+// checked "the contended write throws" passes in both worlds, which is exactly how
+// this shipped.
+describe('beginImmediateWrite', () => {
+  // Short enough to keep the suite fast, long enough that "failed instantly" and
+  // "waited out the timeout" cannot be confused on a loaded CI box.
+  const CONTENDED_TIMEOUT_MS = 400;
+  const FAILED_INSTANTLY_MS = 200;
+  const WAITED_MS = 300;
+
+  /** Runs a transaction task and hands back what escaped, or null if it committed. */
+  async function captureFailure(task: (txn: TestSqliteDb) => Promise<void>): Promise<unknown> {
+    try {
+      await db.withExclusiveTransactionAsync(task);
+      return null;
+    } catch (error) {
+      return error;
+    }
+  }
+
+  beforeEach(async () => {
+    // WAL, exactly as the device runs it — the snapshot semantics below only exist there.
+    await configureMainConnection(db);
+    await db.execAsync('CREATE TABLE probe (id INTEGER PRIMARY KEY, note TEXT)');
+    await db.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [1, 'seed']);
+  });
+
+  describe('with another connection holding the write lock', () => {
+    let holder: TestSqliteDb;
+
+    beforeEach(async () => {
+      // A snapshot import, a scope teardown, a VACUUM. It never releases inside a
+      // test: node:sqlite is synchronous, so a holder cannot let go while another
+      // connection blocks the same thread. Elapsed time is therefore the assertion.
+      holder = createTestDatabase(dbPath);
+      await holder.execAsync('BEGIN IMMEDIATE');
+      await holder.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [2, 'held']);
+    });
+
+    afterEach(async () => {
+      await holder.execAsync('ROLLBACK').catch(() => {});
+      holder.close();
+    });
+
+    it('pins the bug: a read-first deferred task never consults busy_timeout', async () => {
+      const startedAt = Date.now();
+      const error = await captureFailure(async (txn) => {
+        await applyBusyTimeout(txn, CONTENDED_TIMEOUT_MS);
+        // The owner-stamp read every tick and favorite write starts with.
+        await txn.getFirstAsync('SELECT id FROM probe LIMIT 1');
+        await txn.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [3, 'tick']);
+      });
+
+      expect((error as Error | null)?.message).toMatch(/database is locked/i);
+      expect(Date.now() - startedAt).toBeLessThan(FAILED_INSTANTLY_MS);
+    });
+
+    it('waits out the whole busy_timeout once the transaction opens IMMEDIATE', async () => {
+      const startedAt = Date.now();
+      const error = await captureFailure(async (txn) => {
+        await beginImmediateWrite(txn, CONTENDED_TIMEOUT_MS);
+        await txn.getFirstAsync('SELECT id FROM probe LIMIT 1');
+        await txn.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [3, 'tick']);
+      });
+
+      expect((error as Error | null)?.message).toMatch(/database is locked/i);
+      expect(Date.now() - startedAt).toBeGreaterThanOrEqual(WAITED_MS);
+    });
+
+    // The catch inside beginImmediateWrite is load-bearing, not defensive dressing.
+    it("lets the ORIGINAL lock error escape expo's unconditional ROLLBACK", async () => {
+      // Without the guard: a losing `BEGIN IMMEDIATE` leaves no open transaction, so
+      // the wrapper's ROLLBACK throws over the top of the lock error. The retry
+      // ladder would then see a broken database rather than contention, stop
+      // retrying, and file the failure under a brand-new Sentry aggregate.
+      const unguarded = await captureFailure(async (txn) => {
+        await applyBusyTimeout(txn, CONTENDED_TIMEOUT_MS);
+        await txn.execAsync('COMMIT');
+        await txn.execAsync('BEGIN IMMEDIATE');
+      });
+      expect((unguarded as Error | null)?.message).toMatch(/no transaction is active/i);
+      expect(isDatabaseLockedError(unguarded)).toBe(false);
+
+      // With the guard: the lock error survives intact and still classifies.
+      const guarded = await captureFailure(async (txn) => {
+        await beginImmediateWrite(txn, CONTENDED_TIMEOUT_MS);
+      });
+      expect((guarded as Error | null)?.message).toMatch(/database is locked/i);
+      expect(isDatabaseLockedError(guarded)).toBe(true);
+    });
+  });
+
+  it('commits the write when nothing contends', async () => {
+    await db.withExclusiveTransactionAsync(async (txn) => {
+      await beginImmediateWrite(txn);
+      await txn.getFirstAsync('SELECT id FROM probe LIMIT 1');
+      await txn.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [4, 'landed']);
+    });
+
+    const row = await db.getFirstAsync<{ note: string }>('SELECT note FROM probe WHERE id = 4');
+    expect(row?.note).toBe('landed');
+  });
+
+  // The case no `busy_timeout` can survive at any value: SQLITE_BUSY_SNAPSHOT (517,
+  // which prints as a plain "database is locked"). A deferred task takes its WAL read
+  // snapshot at the SELECT, and if any other connection commits before the task's
+  // INSERT the upgrade is refused OUTRIGHT — not waited on, not retried. Opening
+  // IMMEDIATE takes the write lock first, so nothing can move the snapshot underneath.
+  it('cannot lose a WAL snapshot race, because the write lock is taken up front', async () => {
+    const interloper = createTestDatabase(dbPath);
+    // Fail fast rather than block: node:sqlite is synchronous, so an interloper that
+    // waited would deadlock the test thread against the transaction it is racing.
+    await interloper.execAsync('PRAGMA busy_timeout = 0');
+
+    try {
+      const startedAt = Date.now();
+      const deferredError = await captureFailure(async (txn) => {
+        // The FULL five seconds armed, and it still buys nothing.
+        await applyBusyTimeout(txn, OFFLINE_DB_BUSY_TIMEOUT_MS);
+        await txn.getFirstAsync('SELECT id FROM probe LIMIT 1');
+        await interloper.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [5, 'moved the snapshot']);
+        await txn.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [6, 'tick']);
+      });
+      expect((deferredError as Error | null)?.message).toMatch(/database is locked/i);
+      expect(Date.now() - startedAt).toBeLessThan(FAILED_INSTANTLY_MS);
+
+      await db.withExclusiveTransactionAsync(async (txn) => {
+        await beginImmediateWrite(txn);
+        await txn.getFirstAsync('SELECT id FROM probe LIMIT 1');
+        // Same interleaving, opposite outcome: the interloper is the one that loses.
+        await expect(
+          interloper.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [7, 'interloper']),
+        ).rejects.toThrow(/database is locked/i);
+        await txn.runAsync('INSERT INTO probe (id, note) VALUES (?, ?)', [8, 'tick']);
+      });
+
+      const row = await db.getFirstAsync<{ note: string }>('SELECT note FROM probe WHERE id = 8');
+      expect(row?.note).toBe('tick');
+    } finally {
+      interloper.close();
+    }
   });
 });

--- a/packages/shared/offline-sync/src/db/pragmas.ts
+++ b/packages/shared/offline-sync/src/db/pragmas.ts
@@ -103,6 +103,12 @@ export async function applyBusyTimeout(db: SqlExecutor, timeoutMs = OFFLINE_DB_B
  * `busy_timeout` armed. Call it as the task's first statement instead of
  * `applyBusyTimeout` whenever the task writes — always, if the task reads first.
  *
+ * `timeoutMs` is REQUIRED rather than defaulted: this helper serves both a
+ * foreground write somebody is watching (OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS)
+ * and a background one nobody is (OFFLINE_DB_BUSY_TIMEOUT_MS), and there is no
+ * default that is right for both. Whichever it defaulted to, half the future call
+ * sites would silently get the wrong wait.
+ *
  * Why this exists (#4332). expo's wrapper opens a plain deferred `BEGIN`, and a
  * deferred transaction picks its lock from whatever statement runs first. When
  * that is a SELECT — every tick and favorite write starts with a `sync_meta` read
@@ -126,7 +132,7 @@ export async function applyBusyTimeout(db: SqlExecutor, timeoutMs = OFFLINE_DB_B
  * retry helper goes out of its way to keep intact. Restoring a deferred `BEGIN`
  * first gives the wrapper something to roll back so the original error survives.
  */
-export async function beginImmediateWrite(db: SqlExecutor, timeoutMs = OFFLINE_DB_BUSY_TIMEOUT_MS): Promise<void> {
+export async function beginImmediateWrite(db: SqlExecutor, timeoutMs: number): Promise<void> {
   // Connection-local, takes no lock, cannot fail — safe inside the empty transaction.
   await applyBusyTimeout(db, timeoutMs);
 

--- a/packages/shared/offline-sync/src/db/pragmas.ts
+++ b/packages/shared/offline-sync/src/db/pragmas.ts
@@ -5,9 +5,10 @@
 // connection per `withExclusiveTransactionAsync` task (`useNewConnection: true`).
 // That task connection opens a plain deferred `BEGIN` — expo-sqlite's "exclusive"
 // means one JS task owns the connection, NOT SQLite's `BEGIN EXCLUSIVE` — so it
-// takes no lock until its first real statement, which is why applying the timeout
-// as the task's first statement is early enough. Two settings keep these from
-// colliding:
+// takes no lock until its first real statement. Applying the timeout as the task's
+// first statement SETS it early enough; it does not follow that SQLite will ever
+// CONSULT it, which is what `beginImmediateWrite` below exists to fix. Two settings
+// keep these from colliding:
 //
 // - `journal_mode = WAL` PERSISTS in the database file header, so it is set ONCE
 //   on the main connection (configureMainConnection) and every later connection —
@@ -27,8 +28,27 @@ import type { SqlExecutor } from '../database';
  * seconds comfortably covers the longest offline write (a snapshot import or a
  * teardown delete on a large layout) without hanging a foreground interaction if
  * something is genuinely wedged.
+ *
+ * This is the BACKGROUND default — engine writers (pull, teardown, sign-out purge)
+ * have nobody waiting on a tap. A user-facing write takes the shorter
+ * OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS instead.
  */
 export const OFFLINE_DB_BUSY_TIMEOUT_MS = 5000;
+
+/**
+ * The `busy_timeout` for the FIRST attempt of a write a user is waiting on — a
+ * tick from the log-ascent sheet, a favorite, a follow.
+ *
+ * Shorter than the background default on purpose. Until #4332 the timeout was
+ * never consulted at all on this path (see `beginImmediateWrite`), so the real
+ * contention windows were finally measurable only from the retry ladder's own
+ * telemetry: `Offline Local Write Attempt Failed` over 30 days is 17 events with
+ * `elapsedMs` between 174ms and 342ms for a two-attempt ladder — i.e. every
+ * observed holder released inside ~340ms, and 14 of 16 recovered on attempt 2.
+ * 2.5s is a 7x margin over the worst window ever seen, while halving how long a
+ * genuinely wedged file (a VACUUM mid-rebuild) can freeze the sheet.
+ */
+export const OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS = 2500;
 
 /**
  * The `busy_timeout` in force *only* while the one-shot WAL switch is attempted.
@@ -47,7 +67,7 @@ export const OFFLINE_DB_WAL_SWITCH_TIMEOUT_MS = 250;
 
 /**
  * The `busy_timeout` for a RETRY of a local write whose first attempt already
- * waited out the full five seconds. Shorter on purpose: measured import windows
+ * waited out its whole window. Shorter on purpose: measured import windows
  * (`Offline Board Download Completed.importMs`, p50 806ms / max 3.2s over 60
  * days) all fit inside attempt 1, so a second full wait buys almost nothing —
  * this attempt asks "did the lock clear in the retry gap?" and gets out of the
@@ -69,10 +89,58 @@ export const OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS = 1000;
  * connection, which starts at `busy_timeout = 0`.
  *
  * `timeoutMs` exists for the retry ladder, which shortens the wait on later
- * attempts (see the two constants above). Everything else takes the default.
+ * attempts (see the constants above). Everything else takes the default.
+ *
+ * Setting the timeout is NOT sufficient on its own for a task that reads before
+ * it writes — use `beginImmediateWrite` for those. See its docblock.
  */
 export async function applyBusyTimeout(db: SqlExecutor, timeoutMs = OFFLINE_DB_BUSY_TIMEOUT_MS): Promise<void> {
   await db.execAsync(`PRAGMA busy_timeout = ${timeoutMs}`);
+}
+
+/**
+ * Open a `withExclusiveTransactionAsync` task as a WRITE transaction, with
+ * `busy_timeout` armed. Call it as the task's first statement instead of
+ * `applyBusyTimeout` whenever the task writes — always, if the task reads first.
+ *
+ * Why this exists (#4332). expo's wrapper opens a plain deferred `BEGIN`, and a
+ * deferred transaction picks its lock from whatever statement runs first. When
+ * that is a SELECT — every tick and favorite write starts with a `sync_meta` read
+ * for the owner stamp — SQLite opens a READ transaction, and the later INSERT has
+ * to upgrade it. SQLite does not run the busy handler on that upgrade (btree.c's
+ * retry loop is gated on there being no transaction yet), and under WAL a snapshot
+ * conflict (SQLITE_BUSY_SNAPSHOT, 517, which prints as plain code 5) is not
+ * retryable at any timeout. So `busy_timeout` was set and then never consulted:
+ * measured against real SQLite with a second connection holding the write lock,
+ * `BEGIN; PRAGMA busy_timeout=5000; SELECT; INSERT` threw in 1ms, while the
+ * sequence below waited the full 5,049ms and then succeeded once the holder let go.
+ *
+ * The shape mirrors what the snapshot importer already does: close the wrapper's
+ * empty deferred transaction, then re-open it IMMEDIATE so the write lock is taken
+ * (and the busy handler engaged) up front, on a fresh snapshot.
+ *
+ * The catch is MANDATORY, not defensive dressing. expo runs an unconditional
+ * `ROLLBACK` on its error path, and a `ROLLBACK` with no open transaction throws —
+ * that error would REPLACE the lock error, breaking `isDatabaseLockedError`
+ * classification, defeating the retry ladder, and forking the Sentry aggregate the
+ * retry helper goes out of its way to keep intact. Restoring a deferred `BEGIN`
+ * first gives the wrapper something to roll back so the original error survives.
+ */
+export async function beginImmediateWrite(db: SqlExecutor, timeoutMs = OFFLINE_DB_BUSY_TIMEOUT_MS): Promise<void> {
+  // Connection-local, takes no lock, cannot fail — safe inside the empty transaction.
+  await applyBusyTimeout(db, timeoutMs);
+
+  try {
+    // The wrapper's `BEGIN` has taken no locks yet, so this commits nothing.
+    await db.execAsync('COMMIT');
+    await db.execAsync('BEGIN IMMEDIATE');
+  } catch (error) {
+    // Leave a transaction open for expo's unconditional ROLLBACK, whichever of the
+    // two statements failed. If COMMIT was the one that threw we are still inside
+    // the wrapper's transaction and this BEGIN fails harmlessly.
+    await db.execAsync('BEGIN').catch(() => {});
+    throw error;
+  }
 }
 
 /**

--- a/packages/shared/offline-sync/src/db/write-retry.ts
+++ b/packages/shared/offline-sync/src/db/write-retry.ts
@@ -8,17 +8,23 @@
 // saves.
 //
 // SIZING, from measurement rather than assertion:
-//   - Attempt 1 keeps the shipped 5s `busy_timeout` (OFFLINE_DB_BUSY_TIMEOUT_MS),
-//     so a first-attempt failure already means a real holder sat on the file for
-//     five seconds.
+//   - Attempt 1 of a user-facing write takes 2.5s
+//     (OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS). NOTE what a first-attempt failure
+//     did and did not mean: until #4332 the busy handler was never reached on this
+//     path at all, because the task opened a deferred transaction with a SELECT.
+//     Every one of the 17 `Offline Local Write Attempt Failed` events over 30 days
+//     ran the WHOLE two-attempt ladder — a 150ms sleep included — in 174-342ms,
+//     which an honoured 5s timeout makes arithmetically impossible. With
+//     `beginImmediateWrite` the wait is real for the first time, and 2.5s carries
+//     a 7x margin over the longest window ever observed.
 //   - Attempt 2 gets a shortened 1.5s timeout after a 150ms gap. Measured
 //     `Offline Board Download Completed.importMs` over 60 days is p50 806ms,
 //     p90 2.3s, max 3.2s — every observed import fits inside attempt 1's window,
-//     so a second FULL 5s wait buys almost nothing. Attempt 2 is a "did the lock
+//     so a second full wait buys almost nothing. Attempt 2 is a "did the lock
 //     clear in the gap" probe.
 //   - A caller may then run a smaller fallback write (mobile's outbox-only tick
 //     degrade) on the remaining budget.
-// Worst case 5000 + 150 + 1500 + 1000 + 150 + 1000 = 8.8s, under the hard
+// Worst case 2500 + 150 + 1500 + 1000 + 150 + 1000 = 6.3s, under the hard
 // OFFLINE_LOCAL_WRITE_BUDGET_MS wall-clock cap, so no composition of per-attempt
 // timeouts can overrun it.
 //
@@ -27,7 +33,8 @@
 // db/vacuum.ts), and it is reachable from the UI (remove a downloaded board).
 // Waiting that out would freeze the log-ascent sheet for twenty seconds. That
 // case exits as a localized error instead, and `onSettled`'s `elapsedMs` is what
-// will finally measure how long these locks really are.
+// measures how long these locks really are — it is the number that refuted the
+// "holders are minutes long" theory in #4332.
 
 import { isDatabaseLockedError } from './lock-errors';
 

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -238,9 +238,11 @@ export { runMigrations, MIGRATIONS, LATEST_SCHEMA_VERSION } from './db/migration
 export type { Migration } from './db/migrations';
 export {
   OFFLINE_DB_BUSY_TIMEOUT_MS,
+  OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS,
   OFFLINE_DB_RETRY_BUSY_TIMEOUT_MS,
   OFFLINE_DB_FALLBACK_BUSY_TIMEOUT_MS,
   applyBusyTimeout,
+  beginImmediateWrite,
   configureMainConnection,
 } from './db/pragmas';
 


### PR DESCRIPTION
## Summary

Closes #4332.

A tick logged while the offline database is busy could be dropped. The fix is one line
of SQL semantics: open the transaction `IMMEDIATE` instead of letting expo open it
deferred.

### The issue's premise was wrong, and that is why two previous passes missed this

#4332 reasoned: `busy_timeout` is 5000 on every connection, therefore every surviving
failure is by construction a lock held ≥5s, therefore the culprit must be the snapshot
importer's minutes-long `BEGIN EXCLUSIVE` and no bounded retry can ever help. Both
halves are false.

**`busy_timeout` was set and then never consulted.** expo's
`withExclusiveTransactionAsync` runs a plain deferred `BEGIN` — its "exclusive" means
one JS task owns the connection, not SQLite's `BEGIN EXCLUSIVE`
(`expo-sqlite/build/SQLiteDatabase.js:162`). A deferred transaction picks its lock from
whatever statement runs first, and every user-facing offline write starts with a SELECT:
`getLocalUserId` reads `sync_meta` for the owner stamp before the INSERT. So the
transaction opens for **reading**, and the INSERT has to upgrade it. SQLite does not
invoke the busy handler on that upgrade (btree.c's retry loop is gated on there being no
transaction yet), and under WAL a snapshot conflict (`SQLITE_BUSY_SNAPSHOT`, 517, which
prints as a plain code 5) is not retryable at any timeout at all.

Measured against real SQLite with a second connection holding the write lock:

| statement order | outcome |
| --- | --- |
| `BEGIN; PRAGMA busy_timeout=5000; SELECT; INSERT` (what shipped) | threw after **1ms** |
| `BEGIN; PRAGMA busy_timeout=5000; INSERT` (write first) | threw after **5108ms** |
| `BEGIN; PRAGMA; COMMIT; BEGIN IMMEDIATE; SELECT; INSERT` (this PR) | threw after **5049ms**, and **succeeded** once the holder let go |

A snapshot-conflict variant threw in 1ms with extended code 517 despite the same 5s
timeout.

**Production says the same thing.** The retry-ladder telemetry #4402 shipped on
2026-08-14 — the data #4332 says it is blocked on — has 17 `Offline Local Write Attempt
Failed` events over 30 days, all `isLockError: true`, with `elapsedMs` between **174ms
and 342ms**. That ladder is attempt 1 at `busy_timeout=5000`, a **150ms sleep**, then
attempt 2 at 1500. An honoured 5s timeout makes a 342ms total arithmetically impossible.
Both attempts died in tens of milliseconds, and 14 of 16 recovered on attempt 2 — the
holders are releasing almost immediately.

There is also no minutes-long lock to outlast. `importMs` measures the entire
`bootstrapScopeFromSnapshot` call including its exclusive transaction and reads p50 806ms
/ max 3.2s over 60 days. The p50 2m55s figure #4332 quotes from #4310 is whole-download
wall time (network + gunzip), which happens outside any transaction.

### What changed

- New `beginImmediateWrite(txn, timeoutMs)` in `@boardsesh/offline-sync`: arm
  `busy_timeout`, `COMMIT` expo's empty deferred transaction, re-open `BEGIN IMMEDIATE`.
  Same shape the snapshot importer has already been running in production
  (`snapshot-bootstrap.ts:1015-1053`); the user-write path never got it.
- The tick / favorite / follow writes, the outbox-only tick fallback, and
  `purgeLocalDataForSignOut` now use it. The sign-out purge had the identical read-first
  shape — two reads before the first DELETE — so a contended sign-out failed in ~1ms and
  left the previous account's rows on disk.
- Attempt 1 of a **user-facing** write drops from 5000ms to
  `OFFLINE_DB_FOREGROUND_WRITE_TIMEOUT_MS = 2500`. Now that the wait is real for the
  first time, a genuinely wedged file (a VACUUM mid-rebuild) can block the log-ascent
  sheet for the whole window. 2.5s is a 7x margin over the longest window ever observed
  (342ms) while halving that worst case. Engine writers keep the 5s background default.
  Worst-case ladder is now 2500 + 150 + 1500 + 1000 + 150 + 1000 = 6.3s, still under the
  9s `OFFLINE_LOCAL_WRITE_BUDGET_MS` cap.
- Corrected three comment blocks that asserted the thing the measurements contradict —
  they are why the last two attempts at this reached for retry windows instead of the
  lock mode.

**The catch in `beginImmediateWrite` is load-bearing, not defensive dressing.** expo runs
an unconditional `ROLLBACK` on its error path, and a `ROLLBACK` with no open transaction
throws `cannot rollback - no transaction is active` — which *replaces* the lock error.
That would break `isDatabaseLockedError` classification (so the retry ladder stops
retrying), and fork the 90-day Sentry aggregate `runLocalWriteWithRetry` deliberately
preserves by rethrowing the original error by identity. Restoring a deferred `BEGIN`
before rethrowing gives the wrapper something to roll back. There is a test that pins
both sides of this.

### Closing out #4332's "designs worth considering"

None of the three are needed, and leaving them open invites someone to build them:

- **In-memory hand-off / defer the tick until the import releases the lock** — there is
  nothing to defer around. The lock windows are 174-342ms, not minutes, and after this
  change the write simply waits them out.
- **Retry-later buffer** — same reason; #4402 already shipped the bounded ladder, and
  this makes its premise true for the first time.
- **Shrink the EXCLUSIVE window in the snapshot import** — still worth doing for download
  duration (#4310), but it is not this bug. The import transaction is p50 806ms.

Worth recording: the last 30 days contain **zero actually-lost ticks**. Every
`Offline Tick Local Write Failed` event carries `wasOffline: false`, and both post-#4402
events read `outcome: queued`. This was a latent data-loss bug whose only reason for not
firing is that users happened to be online. The residual harm today is the degraded
outbox-only row (no local `boardsesh_ticks` row, so the climb reads as unticked in
offline search) plus a first-attempt failure rate that is ~100% avoidable.

## Release Notes

- Log a tick while a board is downloading and it sticks — the app now waits its turn for the database instead of quietly dropping the send.

## Test plan

- New tests in `packages/shared/offline-sync/src/db/__tests__/pragmas.test.ts`, against
  real SQLite with a second connection holding the write lock. They assert the **wait**,
  not the pragma's value — the only existing coverage checked that `busy_timeout` read
  back as 5000 inside the task, which passes in both worlds and is exactly how this
  shipped:
  - the old read-first deferred shape fails in <200ms with a 400ms timeout armed;
  - `beginImmediateWrite` waits ≥300ms of that same 400ms before giving up;
  - the original `database is locked` error escapes expo's unconditional ROLLBACK and
    still classifies, while the unguarded variant surfaces
    `cannot rollback - no transaction is active` instead;
  - a WAL snapshot race (`SQLITE_BUSY_SNAPSHOT`) kills the deferred shape instantly even
    with the full 5s armed, and cannot touch the IMMEDIATE one.
- `vp run test:mobile`, `vp run typecheck:mobile`, full `vp run typecheck`, `vp check`,
  `vp run check:mobile-bundle`.

Device QA (needs a build or the OTA preview): More → Development → Offline Writes, hold
the write lock for 3s, then log a tick. It should wait and then write a real
`boardsesh_ticks` row plus its outbox row, with no `Offline Local Write Attempt Failed`
event. The 10s hold should still exit inside the 9s budget with a localized error rather
than hanging the sheet. Worth repeating on Android, where the lock-error string carries a
raw U+0005 control byte (BOARDSESH-6V) and must still classify.

Post-release gate, ~7 days after the OTA lands: `Offline Local Write Attempt Failed`
should collapse toward zero, and any survivor should carry `elapsedMs` in the thousands
rather than ~200ms. A survivor still showing ~200ms means the `BEGIN IMMEDIATE` is not
taking effect.

JS/TS only — no native module, plugin, or `package.json` change, so the fingerprint is
unmoved and this rides OTA to the shipped 2.3.1 binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016552Be7ctNKKH8QM9rkryN
