### PR TITLE
fix(web): make MoonBoard set slugs resolve to the sets they name

### DIFF
--- a/packages/shared/play-view/src/__tests__/readable-url-utils.test.ts
+++ b/packages/shared/play-view/src/__tests__/readable-url-utils.test.ts
@@ -31,6 +31,13 @@ const CLIMB_UUID = '0A1B2C3D4E5F60718293A4B5C6D7E8F9';
  */
 const HEX_RUN_CLIMB_NAME_SLUG = 'beefcafe0ff1cedeadbeefcafe0ff1ce';
 
+/**
+ * A real MoonBoard uuid, copied off the dev image. MoonBoard is the one board
+ * whose climbs carry the dashed 36-character RFC-4122 form; every Aurora board
+ * carries the 32-character unbroken form above.
+ */
+const MOONBOARD_CLIMB_UUID = '9fe54099-6fdd-5adb-b82f-2d7bcb10d4ad';
+
 describe('extractUuidFromClimbSegment', () => {
   it('pulls the uuid out of a name-slugged segment', () => {
     expect(extractUuidFromClimbSegment(`crimpy-thing-${CLIMB_UUID}`)).toBe(CLIMB_UUID);
@@ -55,6 +62,29 @@ describe('extractUuidFromClimbSegment', () => {
 
   it('takes the uuid at the end even when the name runs longer than a uuid', () => {
     expect(extractUuidFromClimbSegment(`${HEX_RUN_CLIMB_NAME_SLUG}deadbeef-${CLIMB_UUID}`)).toBe(CLIMB_UUID);
+  });
+
+  it('pulls a dashed MoonBoard uuid out of a name-slugged segment', () => {
+    expect(extractUuidFromClimbSegment(`to-dokids-yuito-${MOONBOARD_CLIMB_UUID}`)).toBe(MOONBOARD_CLIMB_UUID);
+  });
+
+  it('passes a bare dashed MoonBoard uuid through', () => {
+    expect(extractUuidFromClimbSegment(MOONBOARD_CLIMB_UUID)).toBe(MOONBOARD_CLIMB_UUID);
+  });
+
+  it('carries a dashed MoonBoard uuid through a whole route parse', () => {
+    expect(
+      parseClimbRoutePath(`/moonboard/2016/standard/hold-set-a/40/view/to-dokids-yuito-${MOONBOARD_CLIMB_UUID}`)
+        ?.climbUuid,
+    ).toBe(MOONBOARD_CLIMB_UUID);
+  });
+
+  it('does not let the dashed shape steal the tail of an Aurora uuid', () => {
+    // The dashed alternative must end at the segment end and its final group is
+    // preceded by a `-`; the character twelve back from the end of a 32-hex uuid
+    // is always a hex digit, so it can never match here. A name slug that looks
+    // like the head of a dashed uuid is the adversarial case.
+    expect(extractUuidFromClimbSegment(`deadbeef-cafe-babe-face-${CLIMB_UUID}`)).toBe(CLIMB_UUID);
   });
 
   it('carries the hex-named climb through a whole route parse', () => {

--- a/packages/shared/play-view/src/readable-url-utils.ts
+++ b/packages/shared/play-view/src/readable-url-utils.ts
@@ -443,8 +443,21 @@ const numericSegmentRegex = /^\d+$/;
  * perfectly valid shared link queried a uuid nobody has and rendered
  * not-found. A bare uuid still matches: the whole segment is then the run at
  * the end.
+ *
+ * Two shapes, because the catalogue holds two. Aurora climbs carry a 32-char
+ * unbroken hex uuid; every MoonBoard climb carries a dashed 36-char RFC-4122
+ * uuid (`9fe54099-6fdd-5adb-b82f-2d7bcb10d4ad`) — measured on the dev image:
+ * 142,566 MoonBoard rows, all dashed, and no other board has one. With only the
+ * 32-char form, no MoonBoard climb URL parsed: the whole `<name>-<uuid>` segment
+ * was handed on as the uuid, so the climb query missed and the page 404'd, while
+ * the same page reached by its bare uuid rendered a `<link rel="canonical">`
+ * pointing straight at that 404.
+ *
+ * The dashed alternative cannot steal a match from an Aurora segment: its final
+ * group must be preceded by a `-`, and the character 12 back from the end of a
+ * 32-hex uuid is always a hex digit.
  */
-const climbUuidRegex = /[0-9A-F]{32}$/i;
+const climbUuidRegex = /(?:[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}|[0-9A-F]{32})$/i;
 
 function isNumericSegment(value: string): boolean {
   return numericSegmentRegex.test(value);

--- a/packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts
+++ b/packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts
@@ -280,6 +280,11 @@ function nonEmptySetSubsets(setIds: readonly number[]): number[][] {
 
 const moonBoardLayoutKeys = Object.keys(MOONBOARD_LAYOUTS) as MoonBoardLayoutKey[];
 
+/** 32 hex characters in the dashed 8-4-4-4-12 form MoonBoard climbs actually use. */
+function toDashedUuid(hex: string): string {
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 describe('MoonBoard catalogue round-trip (the static tables, through the same www resolver)', () => {
   it.each(moonBoardLayoutKeys)(
     '%s: every emitted set-slug subset parses back to the ids it was built from',
@@ -292,7 +297,13 @@ describe('MoonBoard catalogue round-trip (the static tables, through the same ww
 
       for (const setIds of subsets) {
         const label = `${layoutKey} / sets [${setIds.join(',')}]`;
-        const climbUuid = `${layout.id}${setIds.join('')}`.padStart(32, '0');
+        // Dashed, because that is the only shape MoonBoard has: every one of the
+        // 142,566 MoonBoard rows on the dev image carries a 36-character
+        // RFC-4122 uuid, and no other board does. An Aurora-shaped 32-hex uuid
+        // here would leave the climb segment untested — the uuid extractor
+        // matched only the unbroken form, so a real MoonBoard climb URL parsed
+        // back with its whole `<name>-<uuid>` segment as the uuid and 404'd.
+        const climbUuid = toDashedUuid(`${layout.id}${setIds.join('')}`.padStart(32, '0'));
 
         const emittedPath = tryConstructSlugViewUrl(
           'moonboard',

--- a/packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts
+++ b/packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts
@@ -41,6 +41,7 @@ import {
 import { getLayoutBySlug, getSetsBySlug, getSizeBySlug } from '@/app/lib/slug-utils';
 import { tryConstructSlugViewUrl } from '@/app/lib/url-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
+import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE, type MoonBoardLayoutKey } from '@/app/lib/moonboard-config';
 
 /**
  * The acceptance criterion for #4362: a round-trip over the WHOLE catalogue
@@ -72,6 +73,15 @@ import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
  * the repo's SQL-stub testing convention) and is out of scope here.
  */
 
+/**
+ * MoonBoard is walked by its own suite at the bottom of this file rather than by
+ * the loop below. It carries no rows in `@boardsesh/board-constants`' layout and
+ * product-size tables — its catalogue is the static `MOONBOARD_LAYOUTS` /
+ * `MOONBOARD_SETS` objects — so `getAllLayouts('moonboard')` is empty and this
+ * loop would walk zero tuples for it while still reporting green. The split is
+ * which TABLE each arm reads, not which board is covered; the coverage assertion
+ * below pins that the two arms together cover `SUPPORTED_BOARDS`.
+ */
 const auroraBoards = SUPPORTED_BOARDS.filter((boardName) => boardName !== 'moonboard');
 
 /**
@@ -245,5 +255,153 @@ describe('the pinned PERMANENT_SIZE_SLUG_ALIASES strings resolve through getSize
     }
 
     expect(resolvedAliases).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The MoonBoard arm. Until this shipped, MoonBoard was filtered out of this file
+ * entirely — which is exactly why `getMoonBoardSetsBySlug`'s `-`-splitting
+ * substring matcher survived: nothing ever fed a MoonBoard path it emitted back
+ * through `parseBoardRouteParamsWithSlugs`.
+ *
+ * Every non-empty subset, not just the full set: a MoonBoard URL names whichever
+ * hold sets are installed on that wall, `getMoonBoardDetails` turns the parsed
+ * ids into the hold-set background images the board renders, and a parser that
+ * resolves `hold-set-a` to all three 2016 sets draws holds the URL never asked
+ * for. 291 tuples across the seven layouts.
+ */
+function nonEmptySetSubsets(setIds: readonly number[]): number[][] {
+  const subsets: number[][] = [];
+  for (let mask = 1; mask < 1 << setIds.length; mask += 1) {
+    subsets.push(setIds.filter((_, index) => (mask & (1 << index)) !== 0));
+  }
+  return subsets;
+}
+
+const moonBoardLayoutKeys = Object.keys(MOONBOARD_LAYOUTS) as MoonBoardLayoutKey[];
+
+describe('MoonBoard catalogue round-trip (the static tables, through the same www resolver)', () => {
+  it.each(moonBoardLayoutKeys)(
+    '%s: every emitted set-slug subset parses back to the ids it was built from',
+    async (layoutKey) => {
+      const layout = MOONBOARD_LAYOUTS[layoutKey];
+      const allSetIds = MOONBOARD_SETS[layoutKey].map((set) => set.id);
+      const subsets = nonEmptySetSubsets(allSetIds);
+
+      expect(subsets.length, `${layoutKey}: no set subsets to walk`).toBe(2 ** allSetIds.length - 1);
+
+      for (const setIds of subsets) {
+        const label = `${layoutKey} / sets [${setIds.join(',')}]`;
+        const climbUuid = `${layout.id}${setIds.join('')}`.padStart(32, '0');
+
+        const emittedPath = tryConstructSlugViewUrl(
+          'moonboard',
+          layout.id,
+          MOONBOARD_SIZE.id,
+          setIds,
+          ROUND_TRIP_ANGLE,
+          climbUuid,
+          'Round Trip',
+        );
+        expect(emittedPath, `${label}: tryConstructSlugViewUrl returned null`).not.toBeNull();
+
+        const [, emittedBoard, emittedLayout, emittedSize, emittedSets, emittedAngle, surface, emittedClimb] =
+          emittedPath!.split('/');
+        expect(surface, `${label}: emitted path ${emittedPath}`).toBe('view');
+
+        const parsed = await parseBoardRouteParamsWithSlugs({
+          board_name: emittedBoard,
+          layout_id: emittedLayout,
+          size_id: emittedSize,
+          set_ids: emittedSets,
+          angle: emittedAngle,
+          climb_uuid: emittedClimb,
+        });
+
+        expect(
+          {
+            board_name: parsed.board_name,
+            layout_id: parsed.layout_id,
+            size_id: parsed.size_id,
+            set_ids: [...parsed.set_ids].sort((left, right) => left - right),
+            angle: parsed.angle,
+            climb_uuid: parsed.climb_uuid,
+          },
+          `${label}: ${emittedPath} did not parse back to its own ids`,
+        ).toEqual({
+          board_name: 'moonboard',
+          layout_id: layout.id,
+          size_id: MOONBOARD_SIZE.id,
+          set_ids: [...setIds].sort((left, right) => left - right),
+          angle: ROUND_TRIP_ANGLE,
+          climb_uuid: climbUuid,
+        });
+      }
+    },
+  );
+
+  it('walks all 291 subsets, and the two arms together cover every supported board', () => {
+    const walked = moonBoardLayoutKeys.reduce(
+      (total, layoutKey) => total + 2 ** MOONBOARD_SETS[layoutKey].length - 1,
+      0,
+    );
+    expect(walked).toBe(291);
+    expect([...auroraBoards, 'moonboard'].sort()).toEqual([...SUPPORTED_BOARDS].sort());
+  });
+});
+
+/**
+ * The other half of the parser's contract, which the round-trip above cannot
+ * reach: what happens to a set slug this app never emitted.
+ *
+ * The round-trip only ever feeds back slugs `generateSetSlug` built, and those
+ * rebuild by construction — so it stays green with the rebuild check deleted.
+ * These cases are what that check is for. A reordered or repeated slug is not a
+ * form www or the Expo app mints, so it is not authoritative about which sets
+ * are on the wall; it falls through to the layout's full set rather than
+ * silently deciding the URL meant a subset.
+ */
+describe('MoonBoard set slugs this app never emits', () => {
+  const layoutsWithSeveralSets = moonBoardLayoutKeys.filter((layoutKey) => MOONBOARD_SETS[layoutKey].length >= 2);
+
+  async function parseSetSlug(layoutKey: MoonBoardLayoutKey, setSlug: string): Promise<number[]> {
+    const parsed = await parseBoardRouteParamsWithSlugs({
+      board_name: 'moonboard',
+      layout_id: generateLayoutSlug(MOONBOARD_LAYOUTS[layoutKey].name),
+      size_id: 'standard-11x18-grid',
+      set_ids: setSlug,
+      angle: String(ROUND_TRIP_ANGLE),
+    });
+    return [...parsed.set_ids].sort((left, right) => left - right);
+  }
+
+  it.each(layoutsWithSeveralSets)('%s: a reordered two-set slug falls back to every set', async (layoutKey) => {
+    const pair = MOONBOARD_SETS[layoutKey].slice(0, 2);
+    const canonical = generateSetSlug(pair.map((set) => set.name));
+    const reordered = canonical.split('_').reverse().join('_');
+
+    // Without this the case is vacuous: a symmetric slug would prove nothing.
+    expect(reordered, `${layoutKey}: reversing '${canonical}' changed nothing`).not.toBe(canonical);
+
+    expect(await parseSetSlug(layoutKey, canonical)).toEqual(pair.map((set) => set.id).sort((a, b) => a - b));
+    expect(await parseSetSlug(layoutKey, reordered)).toEqual(
+      MOONBOARD_SETS[layoutKey].map((set) => set.id).sort((a, b) => a - b),
+    );
+  });
+
+  it.each(layoutsWithSeveralSets)('%s: a repeated part falls back to every set', async (layoutKey) => {
+    const [firstSet] = MOONBOARD_SETS[layoutKey];
+    const onePart = generateSetSlug([firstSet.name]);
+
+    expect(await parseSetSlug(layoutKey, onePart)).toEqual([firstSet.id]);
+    expect(await parseSetSlug(layoutKey, `${onePart}_${onePart}`)).toEqual(
+      MOONBOARD_SETS[layoutKey].map((set) => set.id).sort((a, b) => a - b),
+    );
+  });
+
+  it.each(moonBoardLayoutKeys)('%s: an unrecognised slug still renders the whole layout', async (layoutKey) => {
+    expect(await parseSetSlug(layoutKey, 'holds-that-do-not-exist')).toEqual(
+      MOONBOARD_SETS[layoutKey].map((set) => set.id).sort((a, b) => a - b),
+    );
   });
 });

--- a/packages/web/app/lib/__tests__/url-utils.test.ts
+++ b/packages/web/app/lib/__tests__/url-utils.test.ts
@@ -1056,6 +1056,20 @@ describe('Utility functions', () => {
       expect(isUuidOnly('ABC123')).toBe(false);
       expect(isUuidOnly('')).toBe(false);
     });
+
+    it('stays false for a dashed MoonBoard uuid, on purpose', () => {
+      // `extractUuidFromSlug` DOES understand the dashed form, so it is tempting
+      // to widen this too. Do not: the only caller that gains anything is the
+      // slug-redirect branch in `/[board_name]/…/view/[climb_uuid]`, which
+      // resolves its layout through `getLayouts(board_name)` — the Aurora
+      // `board-constants` tables, which carry no MoonBoard rows at all
+      // (`getAllLayouts('moonboard')` is `[]`). Returning true here sends every
+      // bare-uuid MoonBoard climb URL into that branch, where `layout` is
+      // undefined and the page calls `notFound()`. Today those URLs render and
+      // carry a canonical pointing at their slug form, which is the consolidation
+      // Google needs; a 308 would cost a working page to gain nothing.
+      expect(isUuidOnly('9fe54099-6fdd-5adb-b82f-2d7bcb10d4ad')).toBe(false);
+    });
   });
 
   describe('isNumericId', () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/moonboard-canonical-identity.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/moonboard-canonical-identity.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+// Same trap as `slug-utils-catalogue-round-trip.test.ts`: `url-utils.server`
+// pulls in `@/app/lib/db/db`, whose module body opens a pool at load time. The
+// stub throws rather than returning rows, so "MoonBoard resolves entirely off
+// the static tables" is an assertion of this file rather than an assumption.
+vi.mock('server-only', () => ({}));
+vi.mock('@/app/lib/db/db', () => ({
+  dbz: {
+    select: () => {
+      throw new Error('a MoonBoard sitemap URL fell through to the database');
+    },
+  },
+}));
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new Error('notFound(): a URL this sitemap emitted did not parse back');
+  },
+  permanentRedirect: (target: string) => {
+    throw new Error(`permanentRedirect('${target}'): the emitted path was not already canonical`);
+  },
+}));
+
+import { ANGLES } from '@boardsesh/board-config';
+import type { PopularBoardConfig } from '@boardsesh/shared-schema';
+import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
+import { MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE, type MoonBoardLayoutKey } from '@/app/lib/moonboard-config';
+import { resolveClimbDisplayName } from '@/app/lib/string-utils';
+import { buildCanonicalClimbListUrl, buildCanonicalClimbViewUrl, popularConfigListUrl } from '@/app/lib/url-utils';
+import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
+import { climbRowsToItems, type ClimbConfigGroup } from '../climb-entries';
+
+/**
+ * The property the whole MoonBoard sitemap turns on: a URL the shard submits is
+ * byte-identical to the `<link rel="canonical">` the page it points at renders.
+ *
+ * Not three per-segment comparisons — the composition. `climbRowsToItems` builds
+ * the path, `parseBoardRouteParamsWithSlugs` is what the route handler runs on
+ * it, `getBoardDetailsForBoard` is what `generateMetadata` calls on the result,
+ * and `buildCanonicalClimbViewUrl` is the builder that emits the canonical. Any
+ * disagreement anywhere along that chain — a set slug that parses back to a
+ * different id list, a segment reordered, a display name resolved on one side
+ * only — shows up here as two different strings.
+ *
+ * It goes red on the parser this replaced for masters-2017 and masters-2019,
+ * whose full-set slugs lost `Screw-on Feet` on the way back in, which is the
+ * proof it is not vacuous.
+ */
+
+const MOONBOARD_LAYOUT_KEYS = Object.keys(MOONBOARD_LAYOUTS) as MoonBoardLayoutKey[];
+
+/** The full-set group per layout — exactly what the sitemap config source emits. */
+function fullSetGroup(layoutKey: MoonBoardLayoutKey): ClimbConfigGroup {
+  return {
+    boardType: 'moonboard',
+    layoutId: MOONBOARD_LAYOUTS[layoutKey].id,
+    sizeId: MOONBOARD_SIZE.id,
+    setIds: MOONBOARD_SETS[layoutKey].map((set) => set.id),
+  };
+}
+
+function syntheticConfig(layoutKey: MoonBoardLayoutKey): PopularBoardConfig {
+  const group = fullSetGroup(layoutKey);
+  return {
+    boardType: 'moonboard',
+    layoutId: group.layoutId,
+    layoutName: MOONBOARD_LAYOUTS[layoutKey].name,
+    sizeId: group.sizeId,
+    sizeName: MOONBOARD_SIZE.name,
+    sizeDescription: MOONBOARD_SIZE.description,
+    setIds: group.setIds,
+    setNames: MOONBOARD_SETS[layoutKey].map((set) => set.name),
+    boardCount: 0,
+    climbCount: 1,
+    totalAscents: 0,
+    displayName: MOONBOARD_LAYOUTS[layoutKey].name,
+  };
+}
+
+/** `/moonboard/{layout}/{size}/{sets}/{angle}/view/{slug-uuid}` → the parsed tuple. */
+async function parseViewPath(path: string) {
+  const [, boardName, layoutSlug, sizeSlug, setSlug, angle, surface, climbSegment] = path.split('/');
+  expect(surface, `expected a /view/ path, got ${path}`).toBe('view');
+  return parseBoardRouteParamsWithSlugs({
+    board_name: boardName,
+    layout_id: layoutSlug,
+    size_id: sizeSlug,
+    set_ids: setSlug,
+    angle,
+    climb_uuid: climbSegment,
+  });
+}
+
+/** `/moonboard/{layout}/{size}/{sets}/{angle}/list` → the parsed tuple. */
+async function parseListPath(path: string) {
+  const [, boardName, layoutSlug, sizeSlug, setSlug, angle, surface] = path.split('/');
+  expect(surface, `expected a /list path, got ${path}`).toBe('list');
+  return parseBoardRouteParamsWithSlugs({
+    board_name: boardName,
+    layout_id: layoutSlug,
+    size_id: sizeSlug,
+    set_ids: setSlug,
+    angle,
+  });
+}
+
+describe('MoonBoard sitemap URLs are self-canonical', () => {
+  it.each(MOONBOARD_LAYOUT_KEYS)(
+    '%s: every emitted climb URL rebuilds itself through the page’s own canonical builder',
+    async (layoutKey) => {
+      const group = fullSetGroup(layoutKey);
+
+      // Two rows so an unnamed climb — the one whose canonical carries the
+      // `-moonboard-climb-` display-name slug — is covered alongside a named one.
+      const rows = [
+        { uuid: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', name: 'Slab Dancer', angle: 0, updatedAt: new Date(0) },
+        { uuid: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', name: null, angle: 0, updatedAt: new Date(0) },
+      ];
+
+      for (const angle of ANGLES.moonboard) {
+        const { items, dropped } = climbRowsToItems(
+          rows.map((row) => ({ ...row, angle })),
+          group,
+        );
+        expect(dropped, `${layoutKey} @ ${angle}: rows dropped`).toBe(0);
+        expect(items).toHaveLength(rows.length);
+
+        for (const [index, item] of items.entries()) {
+          const parsed = await parseViewPath(item.path);
+
+          // The tuple the page resolves must be the tuple the sitemap named —
+          // otherwise the canonical below could still match while the page
+          // renders a different set of holds.
+          expect(
+            [...parsed.set_ids].sort((left, right) => left - right),
+            `${layoutKey} @ ${angle}: ${item.path}`,
+          ).toEqual([...group.setIds].sort((left, right) => left - right));
+          expect(parsed.layout_id).toBe(group.layoutId);
+          expect(parsed.size_id).toBe(group.sizeId);
+          expect(parsed.angle).toBe(angle);
+
+          const canonical = buildCanonicalClimbViewUrl(
+            getBoardDetailsForBoard(parsed),
+            parsed.angle,
+            parsed.climb_uuid,
+            resolveClimbDisplayName(rows[index].name, group.boardType),
+          );
+          expect(canonical, `${layoutKey} @ ${angle}: sitemap emitted ${item.path}`).toBe(item.path);
+        }
+      }
+    },
+  );
+
+  it.each(MOONBOARD_LAYOUT_KEYS)('%s: the boards-shard list URL is self-canonical too', async (layoutKey) => {
+    const config = syntheticConfig(layoutKey);
+
+    for (const angle of ANGLES.moonboard) {
+      const listPath = popularConfigListUrl(config, angle);
+
+      // The `//` guard is the empty-path-segment shape `popularConfigListUrl`
+      // falls into when its name branch is reached with an empty `setNames` —
+      // a 404 handed straight to Google.
+      expect(listPath, `${layoutKey} @ ${angle}`).not.toContain('//');
+      expect(listPath.endsWith(`/${angle}/list`), `${layoutKey} @ ${angle}: ${listPath}`).toBe(true);
+
+      const parsed = await parseListPath(listPath);
+      expect(buildCanonicalClimbListUrl(getBoardDetailsForBoard(parsed), parsed.angle)).toBe(listPath);
+    }
+  });
+
+  it('the full-set tuples are the ones the shared render-board resolver already names', () => {
+    // Literal, not re-derived: an expectation computed by calling the same
+    // function the source calls would assert `f(x) === f(x)`.
+    expect(MOONBOARD_LAYOUT_KEYS.map((layoutKey) => fullSetGroup(layoutKey))).toEqual([
+      { boardType: 'moonboard', layoutId: 1, sizeId: 1, setIds: [1] },
+      { boardType: 'moonboard', layoutId: 2, sizeId: 1, setIds: [2, 3, 4] },
+      { boardType: 'moonboard', layoutId: 3, sizeId: 1, setIds: [5, 6, 7, 8, 9, 10] },
+      { boardType: 'moonboard', layoutId: 4, sizeId: 1, setIds: [11, 12, 13, 14, 15, 16] },
+      { boardType: 'moonboard', layoutId: 5, sizeId: 1, setIds: [17, 18, 19, 20, 21, 22, 23] },
+      { boardType: 'moonboard', layoutId: 6, sizeId: 1, setIds: [24, 25, 26, 27] },
+      { boardType: 'moonboard', layoutId: 7, sizeId: 1, setIds: [28, 29, 30, 31] },
+    ]);
+  });
+});

--- a/packages/web/app/lib/seo/sitemap/__tests__/moonboard-canonical-identity.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/moonboard-canonical-identity.test.ts
@@ -113,9 +113,15 @@ describe('MoonBoard sitemap URLs are self-canonical', () => {
 
       // Two rows so an unnamed climb — the one whose canonical carries the
       // `-moonboard-climb-` display-name slug — is covered alongside a named one.
+      //
+      // Both uuids are real MoonBoard uuids off the dev image, and the shape is
+      // load-bearing: MoonBoard is the only board whose climbs carry the dashed
+      // 36-character form (142,566 of them; every Aurora board is 32 unbroken
+      // hex). An `'aaaa…'` fixture matches the uuid extractor's 32-hex rule and
+      // therefore proves nothing about the segment a real MoonBoard row emits.
       const rows = [
-        { uuid: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', name: 'Slab Dancer', angle: 0, updatedAt: new Date(0) },
-        { uuid: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', name: null, angle: 0, updatedAt: new Date(0) },
+        { uuid: '9fe54099-6fdd-5adb-b82f-2d7bcb10d4ad', name: 'Slab Dancer', angle: 0, updatedAt: new Date(0) },
+        { uuid: '28510d27-9e46-5f30-8d6b-4c9dbb2d1f70', name: null, angle: 0, updatedAt: new Date(0) },
       ];
 
       for (const angle of ANGLES.moonboard) {
@@ -139,6 +145,12 @@ describe('MoonBoard sitemap URLs are self-canonical', () => {
           expect(parsed.layout_id).toBe(group.layoutId);
           expect(parsed.size_id).toBe(group.sizeId);
           expect(parsed.angle).toBe(angle);
+
+          // The uuid the route hands `getClimb`. Without this the canonical
+          // below still matches — `buildCanonicalClimbViewUrl` re-slugs whatever
+          // it is given, so a segment that failed to yield its uuid rebuilds the
+          // same string — while the page itself 404s on a climb nobody has.
+          expect(parsed.climb_uuid, `${layoutKey} @ ${angle}: ${item.path}`).toBe(rows[index].uuid);
 
           const canonical = buildCanonicalClimbViewUrl(
             getBoardDetailsForBoard(parsed),

--- a/packages/web/app/lib/url-utils.server.ts
+++ b/packages/web/app/lib/url-utils.server.ts
@@ -16,6 +16,7 @@ import {
   parseBoardRouteParams,
   getMoonBoardLayoutBySlug,
 } from './url-utils';
+import { generateSetNameSlug, generateSetSlug } from '@boardsesh/play-view/readable-url-utils';
 import { type MoonBoardLayoutKey, MOONBOARD_LAYOUTS, MOONBOARD_SETS, MOONBOARD_SIZE } from './moonboard-config';
 
 // Helper to parse MoonBoard size slug (always returns the single size)
@@ -23,16 +24,38 @@ function getMoonBoardSizeBySlug(): { id: number; name: string } {
   return { id: MOONBOARD_SIZE.id, name: MOONBOARD_SIZE.name };
 }
 
-// Helper to parse MoonBoard set slugs
+/**
+ * A MoonBoard set slug back to the exact set ids it was built from.
+ *
+ * Generate-and-compare, the same rule the Expo app already ships
+ * (`resolveMoonBoardSegmentsToIds`, `readable-url-utils.ts`): split the slug on
+ * `_` — the separator `generateSetSlug` joins with — pick the layout's sets
+ * whose `generateSetNameSlug` is one of those parts, then accept only if
+ * re-emitting the selection rebuilds the incoming slug byte for byte.
+ *
+ * The rule this replaces split on `-` and substring-matched the pieces against
+ * set names, so it could not tell one subset from another. Two concrete
+ * failures it produced on every www MoonBoard URL: `generateSetNameSlug('Screw-on
+ * Feet')` is `screw`, which a `-`-split never yields as a standalone part, so
+ * masters-2017's own full-set slug parsed back WITHOUT set 15 and masters-2019's
+ * without set 20 — and `generateMetadata` then emitted a `<link rel="canonical">`
+ * pointing at a different URL than the one requested. It also matched far too
+ * much: `hold-set-a` contains the part `set`, which is a substring of every
+ * `Hold Set *` name on the layout.
+ *
+ * Returning an empty array is the caller's signal to fall back to every set on
+ * the layout, which keeps a hand-edited or pre-slug link rendering instead of
+ * 404ing. That fallback is now the only lenient path.
+ */
 function getMoonBoardSetsBySlug(layoutKey: MoonBoardLayoutKey, setSlug: string): { id: number; name: string }[] {
   const sets = MOONBOARD_SETS[layoutKey] || [];
-  const slugParts = setSlug.split('-').map((s) => s.toLowerCase());
+  const slugParts = new Set(setSlug.split('_'));
 
-  // Try to match sets by name
-  return sets.filter((set) => {
-    const setNameLower = set.name.toLowerCase().replace(/\s+/g, '-');
-    return slugParts.some((part) => setNameLower.includes(part) || set.name.toLowerCase().includes(part));
-  });
+  const selectedSets = sets.filter((set) => slugParts.has(generateSetNameSlug(set.name)));
+  if (selectedSets.length === 0) return [];
+  if (generateSetSlug(selectedSets.map((set) => set.name)) !== setSlug) return [];
+
+  return selectedSets.map((set) => ({ id: set.id, name: set.name }));
 }
 
 // Enhanced route parsing function that handles both slug and numeric formats


### PR DESCRIPTION
## Summary

Every MoonBoard climb URL on www is broken, in two independent ways — and the first of them is **not MoonBoard-only**. This is the parser half of #4493, and both bugs are live in production right now, independent of the sitemap work.

### The uuid: 6,355 URLs in production's own sitemap 404 today

`extractUuidFromClimbSegment` matched a 32-character unbroken hex run at the end of the `<name-slug>-<uuid>` segment. With no match the extractor falls back to the whole segment, so `getClimb` was asked for `half-past-thirteen-42359a66-…` — a uuid nobody has — and the route called `notFound()`.

That was written up as a MoonBoard problem. It is not. Measured against production today:

| board | 32-hex uuids | dashed 36-char uuids |
|---|---|---|
| moonboard | 86 | **281,241** |
| kilter | 360,513 | **48,416** |
| tension / decoy / grasshopper / soill / touchstone | all | 0 |

So **Kilter carries 48,416 dashed-uuid climbs**, and 6,614 of them clear the tier-2 bar. Counting the URLs actually in the live sitemap right now:

```
/sitemaps/climbs/1.xml   1,466 dashed-uuid URLs
/sitemaps/climbs/2.xml   2,240
/sitemaps/climbs/3.xml   2,223
/sitemaps/climbs/4.xml     426
                        ------
                         6,355 URLs www submits to Google and then 404s
```

Fetched live, three at random, all from `climbs/2.xml`:

```
GET /kilter/original/12x12-square/screw_bolt/40/view/half-past-thirteen-42359a66-48e0-4368-ade2-2626af7b9def   404
GET /kilter/original/12x12-square/screw_bolt/60/view/how-do-i-delete-holds-4238fe4e-9183-4053-9266-bf8e99296821 404
GET /kilter/original/12x12-square/screw_bolt/40/view/gold-ship-4242747c-a60d-4eb8-8c30-520d733ca2f7             404
```

The same climb reached by its **bare** uuid renders, which is what isolates the extractor as the cause rather than the data:

```
GET /kilter/original/12x12-square/screw_bolt/40/view/42359a66-48e0-4368-ade2-2626af7b9def                       200
GET /decoy/.../view/numerous-goose-00377e6917e848eaa0b35e2c7704ffec  (32-hex control, same sitemap)            200
```

And the 404 page's own `<link rel="canonical">` points straight at that 404.

The regex now accepts either shape. The dashed alternative cannot steal a match from an Aurora segment, because it has to end at the segment end with its final twelve-hex group preceded by a `-`, and the character twelve back from the end of a 32-hex uuid is always a hex digit.

`isUuidOnly` deliberately does **not** gain the dashed form, and a test pins that with the reason. Its only caller that would change behaviour is the slug-redirect branch of `/[board_name]/…/view/[climb_uuid]`, which resolves its layout through `getLayouts(board_name)` — the Aurora `board-constants` tables, which carry no MoonBoard rows at all (`getAllLayouts('moonboard')` returns `[]`, verified). Returning true there would send every bare-uuid MoonBoard climb URL into a branch that ends in `notFound()`, costing a working page to gain a 308 the canonical already achieves. The `/play` → `/view` redirect pages 404 MoonBoard for the same reason; that is unchanged here and filed rather than widened.

### The set slug

`generateSetSlug` (the emitter, in `@boardsesh/play-view`) joins set-name slugs with `_`. `getMoonBoardSetsBySlug` (the parser, `packages/web/app/lib/url-utils.server.ts`) split the incoming slug on `-` and substring-matched the pieces against set names, so it could not tell one subset of hold sets from another.

Two consequences, both reproduced by the tests in this PR:

- `generateSetNameSlug('Screw-on Feet')` is `screw`, and a `-`-split never yields `screw` as a standalone part. So the **Masters 2017** full-set URL parsed back without set 15 and the **Masters 2019** one without set 20 — the tuple every link, share card and OG render for those layouts uses. `generateMetadata` builds its canonical from the *parsed* params, so the page canonicalised itself onto a URL nobody asked for.
- In the other direction it matched far too much: `hold-set-a` contains the part `set`, a substring of every `Hold Set *` name on the layout, so a single-set URL resolved to all of them and `getMoonBoardDetails` drew hold-set art the URL never named.

The fix is generate-and-compare — the rule the Expo app has already shipped in `resolveMoonBoardSegmentsToIds`, whose comment names web's parser as the deliberately-different one. Split on `_`, select the layout's sets whose `generateSetNameSlug` is one of those parts, accept only if re-emitting the selection rebuilds the incoming slug byte for byte. www was the outlier producing a third reading of the same URL; now it agrees with app.boardsesh.com.

The all-sets fallback stays for a slug that does not rebuild, so a hand-edited or pre-slug link renders the whole layout instead of 404ing. It is now the only lenient path, and it is pinned by a test rather than left implicit.

No new redirect — a legacy partial slug keeps serving 200, so there is nothing needing `es`/`fr`/`de` siblings.

### Verified end to end

Rebased onto current `main` and re-run against a full dev image through `vp run dev`. All three shapes render 200 with a `<link rel="canonical">` byte-identical to the requested path:

```
/moonboard/2016/standard-11x18-grid/original-school-holds_hold-set-b_hold-set-a/40/view/can-you-do-it-dcb417f0-225f-59a6-8758-60d123532dc5
  200 · <h1>Can you do it? — 7c+/V10</h1> · canonical identical
/moonboard/masters-2017/standard-11x18-grid/wooden-holds_screw_original-school-holds_hold-set-c_hold-set-b_hold-set-a/40/view/for-finn-663d3df8-…
  200 · canonical identical  (the `screw` part the old parser could never produce)
/moonboard/masters-2019/standard-11x18-grid/wooden-holds-c_wooden-holds-b_wooden-holds_screw_original-school-holds_hold-set-b_hold-set-a/40/view/ganan-las-negras-00087864-…
  200 · canonical identical
```

The dev image has no dashed-uuid *Kilter* tier-2 climb to demonstrate the 6,355-URL repair on, so that arm is evidenced by the production 404/200 pair above plus the `parseClimbRoutePath` unit case — same extractor, same segment shape, only the board prefix differs.

Part of #4493. Stacked below #4578, which must not merge first — dropping the sitemap's MoonBoard hold-out ahead of this parser fix would submit tens of thousands of URLs that canonicalise elsewhere.

**Production targets:** `www.boardsesh.com`, `app.boardsesh.com`, **and the native store fleet**. The set-slug fix is web-only, but the uuid fix is in `packages/shared/play-view`, which is in the mobile graph — so merging to `main` auto-publishes a production OTA. It is JS only, no native fingerprint move. The Expo app has the same deep-link bug today (`board-route-target.ts` calls the same extractor), so this fixes it there too — for MoonBoard and for those 48,416 Kilter climbs. No BLE code, so no Fable review.

## Release Notes

- Shared climb links open the climb again instead of a not-found page, on the web and in the app. Every MoonBoard link was affected, and so were about 48,000 Kilter climbs.
- MoonBoard links now light exactly the hold sets named in the URL. Masters 2017 and Masters 2019 links were quietly dropping Screw-on Feet, and a single-hold-set link lit the whole layout.

## Test plan

Every oracle below was mutation-tested on the rebased branch: the mutation applied, the test watched go red, then reverted, tree verified clean.

**`packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts`** — MoonBoard joins the suite it was explicitly filtered out of (`SUPPORTED_BOARDS.filter((b) => b !== 'moonboard')`, which is exactly why this bug survived). Walks all **291** tuples: every one of the 7 layouts × every non-empty subset of its hold sets, emitted through `tryConstructSlugViewUrl` and fed back through `parseBoardRouteParamsWithSlugs`. The file's `dbz` stub throws, so "MoonBoard resolves off the static tables" is asserted, not assumed.

- Mutation — restore the `-`-splitting substring matcher: **6 of 7 layouts red** (only `moonboard-2010`, which has a single hold set, passes trivially).
- Mutation — drop just the `generateSetSlug(...) === setSlug` rebuild check: **12 red** in this file. (The 291-tuple round-trip arm alone cannot see it — every slug it feeds back was built by the emitter and rebuilds by construction — which is what the second suite in the same file is for.)

**`MoonBoard set slugs this app never emits`** (same file) — the strict/fallback contract: a reordered two-set slug and a repeated part both fall through to the layout's full set; an unrecognised slug still renders the whole layout rather than 404ing. The reorder case asserts the reversal actually differs from the canonical first, so it cannot go vacuous on a symmetric slug.

**`packages/web/app/lib/seo/sitemap/__tests__/moonboard-canonical-identity.test.ts`** (new) — the property the whole issue turns on, tested as a composition rather than three per-segment comparisons: `climbRowsToItems` builds the path, `parseBoardRouteParamsWithSlugs` parses it the way the route handler does, `getBoardDetailsForBoard` is what `generateMetadata` calls on the result, and `buildCanonicalClimbViewUrl` emits the canonical — asserted byte-identical to the emitted path, for both angles and for a named and an unnamed climb. Same for the boards-shard `/list` URL through `popularConfigListUrl` vs `buildCanonicalClimbListUrl`, including a `//` guard. Set tuples are written as literals, not re-derived by calling the source's own helper. It also asserts `parsed.climb_uuid` equals the uuid the sitemap emitted — without that the canonical still matches (it re-slugs whatever it is handed) while the page it names 404s.

- Mutation — restore the old parser: **masters-2017 and masters-2019 red on both surfaces**, 4 tests. That is the shape of the production bug, reproduced.

**`packages/shared/play-view/src/__tests__/readable-url-utils.test.ts`** — the uuid extractor. Cases: a dashed uuid out of a name-slugged segment, a bare dashed uuid, a dashed uuid through a whole `parseClimbRoutePath`, and an adversarial no-steal case (`deadbeef-cafe-babe-face-<32hex>`).

- Mutation — restore `/[0-9A-F]{32}$/i`: **2 red here, and 14 red across the two web suites.**
- Mutation — a plausible-looking loose fix, `/[0-9A-F-]{36}$|[0-9A-F]{32}$/i`: **4 red**, including the no-steal case, which is why that case exists.

**`packages/web/app/lib/__tests__/url-utils.test.ts`** — pins `isUuidOnly` as false for a dashed uuid, with the `getAllLayouts('moonboard') === []` reason in the comment, so the tempting "widen this too" change has to argue with a test.

Gates, all from the rebased branch:

- `vp run typecheck` — pass (full, including the web `next build`)
- `vp test run --reporter=agent --project web` — **362 files, 4,069 tests**; one unrelated `waitFor` flake in `gym-settings-panel.test.tsx` under full-suite load, green on its own
- `vp run test:mobile` — **693 files, 6,725 tests**; one failure, `board-detail-fields.test.ts > resolves the size from the bundled tables when the server sends null`, which **reproduces identically on `main` at 25322da86** and is untouched by this branch
- `vp test run --reporter=agent --project i18n` — 101 pass
- `vp run check:i18n` / `vp run check:i18n:orphans` — OK
- `vp check` — the only 2 errors are the known local `@gorhom/bottom-sheet` artefact (`packages/mobile/web-runtime` nested install missing on this box; CI installs it), untouched here
- pre-commit hook — pass, no `--no-verify`

No user-facing strings added, so no catalog work and no Spanish/French/German glossary exposure.

Production counts here are from a read-only `SELECT` against the production database and from fetching `www.boardsesh.com` directly, both on 2026-08-22; the round-trip and canonical numbers are from the dev image. Canonical `<link>` was checked in `en-US` only, not in `es`/`fr`/`de`.
