### PR TITLE
fix(web): stop the climb view redirecting to itself for non-Latin names

### DIFF
--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/redirect.test.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/__tests__/redirect.test.tsx
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from 'vite-plus/test';
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+// Real (unmocked) slug builders, used to compute the expected self-redirect
+// URL the same way `constructClimbViewUrlWithSlugs` does — rather than
+// hardcoding a slug string that would silently drift from the real formatter.
+import { generateLayoutSlug, generateSizeSlug, generateSetSlug } from '@/app/lib/url-utils';
 
 // Regression for the legacy layout hijacking numeric climb-view URLs: the
 // board `[angle]` layout used to 308 every numeric URL to the bare slug LIST
@@ -7,6 +11,10 @@ import { describe, expect, it, vi } from 'vite-plus/test';
 // the slug VIEW URL that preserves the climb uuid — is the one that runs.
 
 const CLIMB_UUID = 'abcdef1234567890abcdef1234567890';
+// Distinct uuid for the self-redirect regression: a bare-uuid request whose
+// climb name is entirely non-Latin, so it never collides with the real
+// `board-constants` lookups the numeric-format test above exercises.
+const SELF_REDIRECT_UUID = 'ffffffff000011112222333344445555';
 
 // `permanentRedirect` throws a NEXT_REDIRECT error whose `digest` the page's
 // catch block re-throws (rather than swallowing into a 404). Mirror that shape
@@ -22,35 +30,80 @@ const notFound = vi.fn(() => {
 
 vi.mock('next/navigation', () => ({ permanentRedirect, notFound }));
 
+// Branches on the requested climb_uuid so a single mock can drive both the
+// legacy-numeric-format redirect test and the self-redirect regression below
+// without needing per-test module resets.
 vi.mock('@/app/lib/url-utils.server', () => ({
-  parseRouteParams: vi.fn(async () => ({
-    parsedParams: {
-      board_name: 'kilter',
-      layout_id: 1,
-      size_id: 10,
-      set_ids: [1, 20],
-      angle: 40,
-      climb_uuid: CLIMB_UUID,
-    },
-    isNumericFormat: true,
-  })),
+  parseRouteParams: vi.fn(async (params: { climb_uuid?: string }) => {
+    if (params.climb_uuid === SELF_REDIRECT_UUID) {
+      // Slug-format layout/size/set segments (not numeric), and ids that
+      // don't resolve against the real `board-constants` tables — so
+      // `tryConstructSlugViewUrl` falls through to the name-based builder,
+      // whose fallback for a non-Latin name is the bare uuid this route was
+      // already requested with.
+      return {
+        parsedParams: {
+          board_name: 'kilter',
+          layout_id: 424242,
+          size_id: 424242,
+          set_ids: [424242],
+          angle: 40,
+          climb_uuid: SELF_REDIRECT_UUID,
+        },
+        isNumericFormat: false,
+      };
+    }
+    return {
+      parsedParams: {
+        board_name: 'kilter',
+        layout_id: 1,
+        size_id: 10,
+        set_ids: [1, 20],
+        angle: 40,
+        climb_uuid: CLIMB_UUID,
+      },
+      isNumericFormat: true,
+    };
+  }),
 }));
 
 vi.mock('server-only', () => ({}));
 
 vi.mock('@/app/lib/data/queries', () => ({
-  getClimb: vi.fn(async () => ({ name: 'My Test Climb', frames: 'p1r12' })),
+  getClimb: vi.fn(async (parsedParams: { climb_uuid?: string }) =>
+    parsedParams.climb_uuid === SELF_REDIRECT_UUID
+      ? { name: 'Скала', frames: 'p1r12' } // Cyrillic: generateSlugFromText's ASCII-only `\w` slugs this to ''
+      : { name: 'My Test Climb', frames: 'p1r12' },
+  ),
   getClimbStatsForAllAngles: vi.fn(async () => []),
-  getLayouts: vi.fn(async () => [{ id: 1, name: 'Kilter Board Original' }]),
-  getSizes: vi.fn(async () => [{ id: 10, name: '12 x 12', description: 'Commercial' }]),
+  getLayouts: vi.fn(async (board_name: string) =>
+    board_name === 'kilter'
+      ? [
+          { id: 1, name: 'Kilter Board Original' },
+          { id: 424242, name: 'Kilter Board Original' },
+        ]
+      : [],
+  ),
+  getSizes: vi.fn(async () => [
+    { id: 10, name: '12 x 12', description: 'Commercial' },
+    { id: 424242, name: '12 x 12', description: 'Commercial' },
+  ]),
   getSets: vi.fn(async () => [
     { id: 1, name: 'Bolt Ons' },
     { id: 20, name: 'Screw Ons' },
+    { id: 424242, name: 'Bolt Ons' },
   ]),
 }));
 
 vi.mock('@/app/lib/board-utils', () => ({
-  getBoardDetailsForBoard: vi.fn(() => ({ board_name: 'kilter' })),
+  getBoardDetailsForBoard: vi.fn(
+    (params: { board_name: string; layout_id: number; size_id: number; set_ids: number[] }) => ({
+      board_name: params.board_name,
+      layout_id: params.layout_id,
+      size_id: params.size_id,
+      set_ids: params.set_ids,
+    }),
+  ),
 }));
 
 // Body/metadata imports pulled in at module load but never exercised on the
@@ -70,6 +123,11 @@ vi.mock('@/app/lib/data/front-door-data.server', () => ({
 vi.mock('@/app/components/climb-front-door/climb-front-door', () => ({ default: () => null }));
 
 const pageModule = await import('../page');
+
+beforeEach(() => {
+  permanentRedirect.mockClear();
+  notFound.mockClear();
+});
 
 describe('legacy numeric climb-view redirect', () => {
   it('redirects a numeric view URL to the slug VIEW URL preserving the climb uuid', async () => {
@@ -95,5 +153,36 @@ describe('legacy numeric climb-view redirect', () => {
     expect(target).toContain('/view/');
     expect(target).toContain(CLIMB_UUID);
     expect(target).not.toContain('/list');
+  });
+});
+
+describe('non-Latin climb name self-redirect', () => {
+  it('renders instead of 308ing to itself when the slug target equals the request', async () => {
+    // `generateSlugFromText` is ASCII-only, so a Cyrillic-only climb name
+    // slugs to '' and both slug builders fall back to the bare uuid — the
+    // exact URL this page was requested with when the board/layout/size/set
+    // segments are already slugs. This is the requested path built the same
+    // way `constructClimbViewUrlWithSlugs` builds its target, so an unguarded
+    // `permanentRedirect` here would 308 the page to itself forever.
+    const layoutSlug = generateLayoutSlug('Kilter Board Original');
+    const sizeSlug = generateSizeSlug('12 x 12', 'Commercial');
+    const setSlug = generateSetSlug(['Bolt Ons']);
+
+    const result = await pageModule.default({
+      params: Promise.resolve({
+        board_name: 'kilter',
+        layout_id: layoutSlug,
+        size_id: sizeSlug,
+        set_ids: setSlug,
+        angle: '40',
+        climb_uuid: SELF_REDIRECT_UUID,
+      }),
+    });
+
+    // No redirect fired, and the page rendered instead of throwing NOT_FOUND
+    // or NEXT_REDIRECT.
+    expect(permanentRedirect).not.toHaveBeenCalled();
+    expect(notFound).not.toHaveBeenCalled();
+    expect(result).toBeTruthy();
   });
 });

--- a/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
+++ b/packages/web/app/[board_name]/[layout_id]/[size_id]/[set_ids]/[angle]/view/[climb_uuid]/page.tsx
@@ -123,7 +123,18 @@ export default async function ClimbViewPage(props: { params: Promise<BoardRouteP
           parsedParams.climb_uuid,
           currentClimb.name,
         );
-      permanentRedirect(newUrl);
+      // `generateSlugFromText` (shared/play-view) is ASCII-only (`\w` doesn't
+      // match Cyrillic/CJK/emoji), so a climb whose name is entirely
+      // non-Latin slugs to '' and both builders above fall back to the bare
+      // uuid — the same value this route may already have been requested
+      // with. Compare against the RAW request path (not `parsedParams`, which
+      // normalises slugs/ids and would never match) so we only redirect when
+      // the target actually differs; otherwise `permanentRedirect(newUrl)`
+      // would 308 the page to itself forever.
+      const requestedPath = `/${params.board_name}/${params.layout_id}/${params.size_id}/${params.set_ids}/${params.angle}/view/${params.climb_uuid}`;
+      if (newUrl !== requestedPath) {
+        permanentRedirect(newUrl);
+      }
     }
 
     const boardDetails = getBoardDetailsForBoard(parsedParams);


### PR DESCRIPTION
## Summary

`ClimbViewPage` (config-tuple `/[board_name]/.../view/[climb_uuid]`) always called `permanentRedirect(newUrl)` when `needsSlugRedirect` was true, without ever checking whether `newUrl` was actually different from the URL that was requested.

`generateSlugFromText` (`@boardsesh/play-view`) strips non-word characters with `/[^\w\s-]/g`, and JS `\w` is ASCII-only. A climb whose name is entirely Cyrillic/CJK/emoji slugs to `''`, so both `tryConstructSlugViewUrl` and its `constructClimbViewUrlWithSlugs` fallback emit the bare uuid instead of a `slug-uuid` segment. For a bare-uuid request (`isUuidOnly` true) to such a climb, the redirect target ends up identical to the request path, so the page 308s to itself — `ERR_TOO_MANY_REDIRECTS` for the visitor and, at sitemap scale, a redirect loop Google will never resolve into an index.

Fixed by comparing the built `newUrl` against the raw requested path (built from `params`, not the normalised `parsedParams`) and only calling `permanentRedirect` when they differ; otherwise the page falls through and renders normally. This is the general fix — not an empty-slug special case — so it also covers any other way the two builders could land on the request's own path.

I checked the other view route, `/b/[board_slug]/[angle]/view/[climb_uuid]/page.tsx`, for the same bug. It does **not** have this issue: that page never redirects at all — it renders directly for whatever `board_slug`/`climb_uuid` it's given, and only points *other* pages' canonicals into the config-tuple tree (see its `generateMetadata` A1 comment). No change needed there.

Deliberately **not** making `generateSlugFromText` Unicode-aware here — that would change the canonical slug for already-indexed climbs with non-Latin names, which is an SEO regression out of scope for this fix. Filed as a follow-up: #4590.

Closes #4410

## Release Notes

- [x] No release note needed (internal / technical change)

Only affects a climb view URL that was already broken (an infinite-redirect 500-adjacent error page); nothing a climber would describe as a feature getting better.

## Test plan

- Added a regression test (`non-Latin climb name self-redirect`) that requests a bare-uuid URL for a climb named `Скала` (Cyrillic) with slug-format layout/size/set segments matching what the builders would themselves produce, and asserts `permanentRedirect` is never called and the page renders.
- Kept and extended the existing `legacy numeric climb-view redirect` test, which still asserts the *normal* redirect path fires for a climb with a real (Latin) name/slug — confirming the equality guard doesn't suppress genuine redirects.
- `vp test run --project web redirect.test.tsx --reporter=agent` — 11 tests / 3 files passed.
- `vp check --fix` — clean.
- `vp run typecheck` — clean.
