### PR TITLE
fix(mobile): report a terminal event when a board download ends

### DIFF
--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -850,17 +850,17 @@ mid-**bootstrap** would otherwise produce two terminals for one Started — the 
 Issue #4452 widened the removal terminal above to every other ender. The full list, so the next
 person can check it rather than re-derive it:
 
-| How a download ends                                                              | Reports today                                                                                                   |
-| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| it finishes                                                                      | `Offline Board Download Completed`                                                                              |
-| board removed from Storage (`removeBoardScopeData`)                              | `Failed { stage: 'board-removed', reason: 'abandoned-removed' }` (#4406)                                         |
-| explicit sign-out / account deletion (`purgeLocalDataForSignOut`)                | `Failed { stage: 'abandoned', reason: 'abandoned-signed-out' }` — read before the wipe transaction, emitted after |
-| forced 401, proactive token expiry, identity change (`clearUserData` + de-list)  | `Failed { stage: 'abandoned', reason: 'abandoned-signed-out' }` — from `runSignedOutCleanup`, markers then cleared |
-| My Boards toggle-off                                                             | `Failed { stage: 'abandoned', reason: 'abandoned-disabled' }`, plus `Offline Board Toggled { enabled: false }`   |
-| a de-list that crashed before reporting, or a device upgrading into this build   | the launch backstop in `offline-sync-bridge.tsx`, as `abandoned-disabled`                                        |
-| the owner-stamp mismatch wipe (`clearUserData` in the bridge)                    | nothing, and correctly: it de-lists nothing, so the scope keeps downloading                                      |
-| the app is backgrounded, or a sibling board's removal tears the cycle down       | `Failed { aborted: true, reason: 'aborted-background' / 'aborted-wipe' }` — an interruption, the download resumes |
-| process death, uninstall, a climber who never opens the app again                | **nothing, and nothing can.** Per production this is the dominant unterminated bucket                            |
+| How a download ends                                                             | Reports today                                                                                                      |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| it finishes                                                                     | `Offline Board Download Completed`                                                                                 |
+| board removed from Storage (`removeBoardScopeData`)                             | `Failed { stage: 'board-removed', reason: 'abandoned-removed' }` (#4406)                                           |
+| explicit sign-out / account deletion (`purgeLocalDataForSignOut`)               | `Failed { stage: 'abandoned', reason: 'abandoned-signed-out' }` — read before the wipe transaction, emitted after  |
+| forced 401, proactive token expiry, identity change (`clearUserData` + de-list) | `Failed { stage: 'abandoned', reason: 'abandoned-signed-out' }` — from `runSignedOutCleanup`, markers then cleared |
+| My Boards toggle-off                                                            | `Failed { stage: 'abandoned', reason: 'abandoned-disabled' }`, plus `Offline Board Toggled { enabled: false }`     |
+| a de-list that crashed before reporting, or a device upgrading into this build  | the launch backstop in `offline-sync-bridge.tsx`, as `abandoned-disabled`                                          |
+| the owner-stamp mismatch wipe (`clearUserData` in the bridge)                   | nothing, and correctly: it de-lists nothing, so the scope keeps downloading                                        |
+| the app is backgrounded, or a sibling board's removal tears the cycle down      | `Failed { aborted: true, reason: 'aborted-background' / 'aborted-wipe' }` — an interruption, the download resumes  |
+| process death, uninstall, a climber who never opens the app again               | **nothing, and nothing can.** Per production this is the dominant unterminated bucket                              |
 
 The three `abandoned-*` reasons are the once-per-Started ones. The de-list paths also **clear**
 `scope-started:` and `scope-download-started:` (`clearScopeDownloadFunnelMarkers`) once they have
@@ -885,7 +885,7 @@ from the `Logout` half a second earlier, which made all of them unjoinable.
 
 **What this still does not cover.** Started → Completed will not reach 100% and is not meant to. Over
 the funnel's first weeks in production, of the (person, scope) pairs with a Started and no Completed,
-the majority emitted *nothing at all* after the Started — same first and last timestamp, no toggle,
+the majority emitted _nothing at all_ after the Started — same first and last timestamp, no toggle,
 no logout. That is process death, uninstall, or a climber who moved on, and no code change can emit
 an event for it.
 

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -763,8 +763,8 @@ Completed` — so abandonment was structurally unmeasurable and failures went on
 | ---------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `Offline Board Download Started`   | first time any cycle starts pulling a scope, once ever                                 | `scopeKey`, `pathIntent`, `artifactBytes`, `trigger`, `offlineEngineEnabled`          |
 | `Offline Board Download Completed` | both board tables reached the tail, once ever                                          | `scopeKey`, `method`, `durationMs`, `bytes?`, `rowCount?`, `downloadMs?`, `importMs?` |
-| `Offline Board Download Failed`    | a bootstrap attempt ended without succeeding, or a removal ended the download for good | `scopeKey`, `stage`, `attempt`, `expected`, `reason`, `aborted`, `errorMessage`       |
-| `Offline Board Download Cancelled` | the board was switched off mid-download                                                | `scopeKey`, `source`, `stage?`, `fraction?`, `bytesDone?`                             |
+| `Offline Board Download Failed`    | a bootstrap attempt ended without succeeding, or something ended the download for good | `scopeKey`, `stage`, `attempt`, `expected`, `reason`, `aborted`, `errorMessage`       |
+| `Offline Board Download Cancelled` | progress detail when a board is switched off mid-snapshot; 0 events in 180 days        | `scopeKey`, `source`, `stage?`, `fraction?`, `bytesDone?`                             |
 | `Offline Board Toggled`            | the offline switch was flipped, either way                                             | `scopeKey`, `enabled`, `source`                                                       |
 | `Offline Download All Tapped`      | the "download all my boards" switch was TAPPED                                         | `boardCount`                                                                          |
 
@@ -789,6 +789,12 @@ abandonment spike in exactly the window the baseline is read from.
 
 > **If a future change wipes board data on logout** (issue #3621), it must clear both markers in the
 > same transaction as the rows. Otherwise the next sign-in emits Completed with no Started.
+
+**A marker is not the only thing that can orphan a Started.** `pullSync`'s board loop iterates the
+scopes in `syncEnabledBoards` and nothing else, so a board that leaves that list is never visited
+again — its `scope-started:` marker can survive perfectly intact and still describe a download
+nothing will ever finish. Anything that de-lists a board therefore owes the funnel a terminal, even
+when it deletes no rows at all. See "every path that ends a download" below.
 
 **The terminal-event invariant: every Started has exactly one terminal event.** A snapshot bootstrap
 attempt ends in `Offline Board Download Completed` (its scope finished) or `Offline Board Download
@@ -838,6 +844,50 @@ makes "downloads the climber gave up on" a count rather than a subtraction. A re
 mid-**bootstrap** would otherwise produce two terminals for one Started — the phase's own
 `aborted-wipe` and this one — so both claim against the purge generation `beginScopePurge` bumped
 (`sync/download-terminal-registry.ts`), and only the first claim reports.
+
+### Every path that ends a download, and which reports
+
+Issue #4452 widened the removal terminal above to every other ender. The full list, so the next
+person can check it rather than re-derive it:
+
+| How a download ends                                                              | Reports today                                                                                                   |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| it finishes                                                                      | `Offline Board Download Completed`                                                                              |
+| board removed from Storage (`removeBoardScopeData`)                              | `Failed { stage: 'board-removed', reason: 'abandoned-removed' }` (#4406)                                         |
+| explicit sign-out / account deletion (`purgeLocalDataForSignOut`)                | `Failed { stage: 'abandoned', reason: 'abandoned-signed-out' }` — read before the wipe transaction, emitted after |
+| forced 401, proactive token expiry, identity change (`clearUserData` + de-list)  | `Failed { stage: 'abandoned', reason: 'abandoned-signed-out' }` — from `runSignedOutCleanup`, markers then cleared |
+| My Boards toggle-off                                                             | `Failed { stage: 'abandoned', reason: 'abandoned-disabled' }`, plus `Offline Board Toggled { enabled: false }`   |
+| a de-list that crashed before reporting, or a device upgrading into this build   | the launch backstop in `offline-sync-bridge.tsx`, as `abandoned-disabled`                                        |
+| the owner-stamp mismatch wipe (`clearUserData` in the bridge)                    | nothing, and correctly: it de-lists nothing, so the scope keeps downloading                                      |
+| the app is backgrounded, or a sibling board's removal tears the cycle down       | `Failed { aborted: true, reason: 'aborted-background' / 'aborted-wipe' }` — an interruption, the download resumes |
+| process death, uninstall, a climber who never opens the app again                | **nothing, and nothing can.** Per production this is the dominant unterminated bucket                            |
+
+The three `abandoned-*` reasons are the once-per-Started ones. The de-list paths also **clear**
+`scope-started:` and `scope-download-started:` (`clearScopeDownloadFunnelMarkers`) once they have
+reported, and nothing else: the rows and the `checkpoint:` keys stay, so a re-enable still resumes
+instantly. Two Starteds for a toggle-off-then-on is the intended reading — as far as the funnel is
+concerned those are two downloads, and a durable marker outliving its download is what made
+abandonment unmeasurable in the first place.
+
+Sign-out reports through **two** seams for one reason: the explicit wipe runs `deleteAllSyncMeta`, so
+only code inside that function can still see the markers, while the selective sign-outs keep every
+marker and are ended purely by `setSetting('syncEnabledBoards', [])`. The claim in
+`download-terminal-registry.ts` therefore keys on a **composite** `wipeEpoch:purgeEpoch` generation:
+`setSigningOut(true)` moves only the global wipe epoch and `beginScopePurge` only its namespace's, so
+a namespace-only key would let a stale `aborted-wipe` from an unrelated board removal suppress a real
+sign-out terminal. The de-list paths do **not** claim — nothing tore a cycle down for them, and the
+cleared marker is the durable dedup.
+
+`runSignedOutCleanup` also moved `resetAnalytics()` to **after** the offline cleanup. Every sign-out
+event — the discarded outbox, `Offline Data Wiped On Sign Out`, and these terminals — has to land on
+the account that is leaving; production showed every wipe event sitting on a different `person_id`
+from the `Logout` half a second earlier, which made all of them unjoinable.
+
+**What this still does not cover.** Started → Completed will not reach 100% and is not meant to. Over
+the funnel's first weeks in production, of the (person, scope) pairs with a Started and no Completed,
+the majority emitted *nothing at all* after the Started — same first and last timestamp, no toggle,
+no logout. That is process death, uninstall, or a climber who moved on, and no code change can emit
+an event for it.
 
 **A removal also re-arms the scheduler.** A removal latches its namespace for the seconds its delete
 transaction runs, and every purge guard in the pull client reads that latch as "purged" — so a cycle

--- a/docs/board-snapshots.md
+++ b/docs/board-snapshots.md
@@ -862,12 +862,19 @@ person can check it rather than re-derive it:
 | the app is backgrounded, or a sibling board's removal tears the cycle down      | `Failed { aborted: true, reason: 'aborted-background' / 'aborted-wipe' }` — an interruption, the download resumes  |
 | process death, uninstall, a climber who never opens the app again               | **nothing, and nothing can.** Per production this is the dominant unterminated bucket                              |
 
-The three `abandoned-*` reasons are the once-per-Started ones. The de-list paths also **clear**
-`scope-started:` and `scope-download-started:` (`clearScopeDownloadFunnelMarkers`) once they have
-reported, and nothing else: the rows and the `checkpoint:` keys stay, so a re-enable still resumes
-instantly. Two Starteds for a toggle-off-then-on is the intended reading — as far as the funnel is
-concerned those are two downloads, and a durable marker outliving its download is what made
-abandonment unmeasurable in the first place.
+The three `abandoned-*` reasons are the once-per-Started ones. The de-list paths **clear**
+`scope-started:` and `scope-download-started:` (`clearScopeDownloadFunnelMarkers`) and nothing else:
+the rows and the `checkpoint:` keys stay, so a re-enable still resumes instantly. Two Starteds for a
+toggle-off-then-on is the intended reading — as far as the funnel is concerned those are two
+downloads, and a durable marker outliving its download is what made abandonment unmeasurable in the
+first place.
+
+They clear **before** they report, and each scope's close is independently fault-tolerant. The clear
+is the only step that can fail (a locked database); `track()` cannot. Reporting first would emit the
+terminal and then leave the marker behind for the next launch's sweep to report a second time, so a
+failed clear now emits nothing and the sweep becomes the single reporter — exactly one terminal
+either way. Wrapping each scope separately keeps one locked write from silently dropping the rest of
+a sweep.
 
 Sign-out reports through **two** seams for one reason: the explicit wipe runs `deleteAllSyncMeta`, so
 only code inside that function can still see the markers, while the selective sign-outs keep every

--- a/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
+++ b/packages/mobile/app/boards/__tests__/manage-offline.test.tsx
@@ -29,6 +29,7 @@ type ManageRowProps = {
   onRetryFastDownload?: (board: UserBoard) => void;
   onDelete: (board: UserBoard) => void;
   onUnfollow: (board: UserBoard) => void;
+  onToggleOffline: (board: UserBoard) => void;
 };
 
 const routerMock = vi.hoisted(() => ({ push: vi.fn() }));
@@ -40,6 +41,7 @@ const confirmMock = vi.hoisted(() => vi.fn().mockResolvedValue(false));
 const retryFastDownloadMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const estimateScopeDownloadMock = vi.hoisted(() => vi.fn(() => ({ kind: 'unknown' }) as { kind: string }));
 const storedUserIdEnabledMock = vi.hoisted(() => vi.fn());
+const reportAbandonedDownloadOnDisableMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
 
 const state = vi.hoisted(() => ({
   isOffline: false,
@@ -307,6 +309,12 @@ vi.mock('../../../src/offline/use-remember-downloaded-boards', () => ({
   useRememberDownloadedBoards: vi.fn(),
 }));
 vi.mock('../../../src/offline/use-snapshot-manifest', () => ({ useSnapshotManifest: () => null }));
+// The download funnel's terminal for a toggle-off (issue #4452). Nothing is
+// deleted on that path, so there is no teardown to hang it off — the screen has
+// to report it itself.
+vi.mock('../../../src/offline/abandoned-download-terminals', () => ({
+  reportAbandonedDownloadOnDisable: reportAbandonedDownloadOnDisableMock,
+}));
 vi.mock('../../../src/offline/use-snapshot-source', () => ({
   useSnapshotSource: () => (state.snapshotSourceAvailable ? {} : undefined),
 }));
@@ -316,6 +324,7 @@ vi.mock('../../../src/settings', () => ({
   getSetting: () => state.enabledBoards,
   useSetting: () => [state.enabledBoards, vi.fn()],
   setOfflineBoardEnabled: vi.fn(),
+  forgetDownloadTrigger: vi.fn(),
   forgetOfflineBoard: (uuid: string) => forgetOfflineBoardMock(uuid),
   forgetOfflineBoardScope: vi.fn(),
   useOfflineBoards: () => state.offlineCards,
@@ -359,6 +368,7 @@ vi.mock('../../../src/components/board-discovery/BoardManageRow', () => ({
     onRetryFastDownload,
     onDelete,
     onUnfollow,
+    onToggleOffline,
   }: ManageRowProps) =>
     createElement(
       'div',
@@ -374,6 +384,11 @@ vi.mock('../../../src/components/board-discovery/BoardManageRow', () => ({
       rowBoard.name,
       createElement('button', { type: 'button', onClick: () => onDelete(rowBoard) }, `delete ${rowBoard.uuid}`),
       createElement('button', { type: 'button', onClick: () => onUnfollow(rowBoard) }, `unfollow ${rowBoard.uuid}`),
+      createElement(
+        'button',
+        { type: 'button', onClick: () => onToggleOffline(rowBoard) },
+        `toggle-offline ${rowBoard.uuid}`,
+      ),
       canRetryFastDownload && onRetryFastDownload
         ? createElement(
             'button',
@@ -1117,6 +1132,48 @@ describe('My Boards with no usable network list', () => {
     fireEvent.click(screen.getByText('delete net-1'));
 
     await waitFor(() => expect(forgetOfflineBoardMock).toHaveBeenCalledWith('net-1'));
+  });
+
+  // Issue #4452. Turning a board off deletes nothing, so no teardown reports for
+  // it — but the scope leaves `syncEnabledBoards` and pullSync only ever visits
+  // enabled scopes, so the download is over for good and its
+  // `Offline Board Download Started` would otherwise stay open forever.
+  it('closes the download funnel when a board is toggled off', async () => {
+    state.profileId = 'me';
+    state.enabledBoards = ['kilter:8:17'];
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(ManageBoards));
+    await act(async () => {
+      fireEvent.click(screen.getByText('toggle-offline net-1'));
+    });
+
+    await waitFor(() => expect(reportAbandonedDownloadOnDisableMock).toHaveBeenCalledWith({}, 'kilter:8:17'));
+  });
+
+  // The other direction: enabling a board goes through the size-quote confirm,
+  // and there is no download of its own to close.
+  it('reports nothing when a board is toggled ON', async () => {
+    state.profileId = 'me';
+    state.enabledBoards = [];
+    state.myBoards = {
+      data: { boards: [board({ uuid: 'net-1', name: 'Network board' })] },
+      isLoading: false,
+      isError: false,
+      isRefetching: false,
+    };
+
+    render(createElement(ManageBoards));
+    await act(async () => {
+      fireEvent.click(screen.getByText('toggle-offline net-1'));
+    });
+
+    expect(reportAbandonedDownloadOnDisableMock).not.toHaveBeenCalled();
   });
 
   it('forgets an unfollowed board too', async () => {

--- a/packages/mobile/app/boards/manage.tsx
+++ b/packages/mobile/app/boards/manage.tsx
@@ -27,6 +27,7 @@ import {
   getBootstrapMetadataByScope,
   estimateScopeDownload,
 } from '@boardsesh/offline-sync';
+import { reportAbandonedDownloadOnDisable } from '../../src/offline/abandoned-download-terminals';
 import { useBoardDownloads } from '../../src/offline/use-board-downloads';
 import { useSnapshotManifest } from '../../src/offline/use-snapshot-manifest';
 import { useConfirmBoardDownload } from '../../src/offline/use-confirm-board-download';
@@ -235,9 +236,11 @@ export default function ManageBoards() {
       const key = offlineBoardKeyForBoard(board);
       const alreadyEnabled = getSetting('syncEnabledBoards').includes(key);
       if (alreadyEnabled) {
-        // Was this download still in flight? Read BEFORE the setting write, so the
-        // cancel event carries how far it had got (issue #4316) — this is the
-        // abandonment the funnel exists to size, caught at the moment it happens.
+        // How far had it got? Read BEFORE the setting write, so the cancel event
+        // below carries the live progress frame (issue #4316). It needs a
+        // snapshot frame naming this exact scope, so it is silent for a paged
+        // crawl — the funnel terminal further down is the signal that always
+        // fires, this is the extra detail when we happen to have it.
         const liveProgress = boardDownloadProgress({
           scopeKey: key,
           isSyncing: syncStatusRef.current.isSyncing,
@@ -273,12 +276,19 @@ export default function ManageBoards() {
             offlineEngineEnabled: isOfflineEngineEnabled(),
           });
         }
+        // The funnel's terminal (issue #4452). Turning a board off deletes
+        // nothing, so there is no teardown to hang this off — but the scope has
+        // just left `syncEnabledBoards`, and pullSync only ever visits enabled
+        // scopes, so this download is over for good. Reported and its markers
+        // cleared, so a re-enable opens a fresh Started → Completed pair rather
+        // than resuming a funnel this tap ended.
+        await reportAbandonedDownloadOnDisable(db, key);
         return;
       }
       // Size quote + confirm + enable, shared with the discovery-nudge surfaces.
       await confirmAndDownload(board, { trigger: 'toggle', source: 'manage' });
     },
-    [confirmAndDownload],
+    [confirmAndDownload, db],
   );
 
   // The escape from a board that settled onto the slow crawl (issue #4313).

--- a/packages/mobile/src/components/offline-sync-bridge.tsx
+++ b/packages/mobile/src/components/offline-sync-bridge.tsx
@@ -11,6 +11,7 @@ import {
 } from '@boardsesh/offline-sync';
 import { startSyncScheduler, drainMutationQueue, startBackgroundTracking } from '../offline/offline-sync-adapter';
 import { reportOutboxBacklogOnce } from '../offline/outbox-telemetry';
+import { sweepDelistedDownloadTerminals } from '../offline/abandoned-download-terminals';
 import { getSetting } from '../settings';
 import { setupNotificationHandlers } from '../notifications';
 import { getOfflineSyncHttpClient } from '../lib/graphql/client';
@@ -124,6 +125,24 @@ export function OfflineSyncBridge() {
       cancelled = true;
     };
   }, [db, isAuthenticated, localUserId, schemaReady]);
+
+  // The download funnel's launch backstop (issue #4452). Every in-session
+  // de-listing path reports its own terminal now — the My Boards toggle-off and
+  // all three sign-outs — but a `scope-started:` marker whose scope is no longer
+  // in `syncEnabledBoards` is still reachable three ways: a crash between the
+  // de-list and the report, a device upgrading from a build that predates those
+  // reports, and any future de-listing path nobody instruments. Sweeping at
+  // launch makes the invariant structural rather than a list of remembered call
+  // sites (the lesson #4391 wrote down).
+  //
+  // Declared AFTER the owner-stamp effect so a mismatch wipe runs first, and
+  // gated on `isAuthenticated` so a signed-out cold start cannot re-report what
+  // sign-out already reported and cleared. Self-limiting across re-runs: it
+  // clears the markers it reports, so a second pass finds nothing.
+  useEffect(() => {
+    if (!isAuthenticated || !schemaReady) return;
+    void sweepDelistedDownloadTerminals(db);
+  }, [db, isAuthenticated, schemaReady]);
 
   // Unconditional (unlike the scheduler effect below): the offline-sync
   // engine's backgrounding guard must cover ad-hoc drainMutationQueue() calls

--- a/packages/mobile/src/db/__tests__/connection.test.ts
+++ b/packages/mobile/src/db/__tests__/connection.test.ts
@@ -281,6 +281,52 @@ describe('purgeLocalDataForSignOut', () => {
     expect(result).toMatchObject({ pendingDiscarded: 0, deadLettersDiscarded: 0, hadDownloads: false });
     expect(await countRows('board_climbs')).toBe(0);
   });
+
+  // The download funnel's sign-out terminal (issue #4452). `deleteAllSyncMeta`
+  // takes `scope-started:` with everything else, so this wipe is the last code
+  // that can tell an abandoned download from a board that was never downloaded —
+  // hence the read before its transaction and the report after the commit.
+  // `markScopeDownloadStarted` stays package-internal (only the pull client
+  // writes it), so the marker is inserted the way the engine would.
+  const announceDownload = (scopeKey: string) =>
+    db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [`scope-started:${scopeKey}`, '1']);
+
+  describe('the abandoned-download seam', () => {
+    it('calls the hook once per download that had started and never completed', async () => {
+      await seedSignedInDevice();
+      await announceDownload('tension:11:8');
+      // seedSignedInDevice already completed kilter:1:1 — its Started is closed,
+      // so it owes nothing.
+      await announceDownload('kilter:1:1');
+
+      const onDownloadAbandoned = vi.fn();
+      await purgeLocalDataForSignOut(db, { onDownloadAbandoned });
+
+      expect(onDownloadAbandoned).toHaveBeenCalledTimes(1);
+      expect(onDownloadAbandoned).toHaveBeenCalledWith({ scopeKey: 'tension:11:8' });
+    });
+
+    it('stays silent when nothing was downloading', async () => {
+      await seedSignedInDevice();
+      await announceDownload('kilter:1:1');
+
+      const onDownloadAbandoned = vi.fn();
+      await purgeLocalDataForSignOut(db, { onDownloadAbandoned });
+
+      expect(onDownloadAbandoned).not.toHaveBeenCalled();
+    });
+
+    it('wipes exactly the same rows when no hook is supplied', async () => {
+      await seedSignedInDevice();
+      await announceDownload('tension:11:8');
+
+      const result = await purgeLocalDataForSignOut(db);
+
+      expect(result).toMatchObject({ pendingDiscarded: 2, deadLettersDiscarded: 0, hadDownloads: true });
+      expect(await countRows('sync_meta')).toBe(0);
+      expect(await countRows('board_climbs')).toBe(0);
+    });
+  });
 });
 
 // #3646 retired the bundled seed-database import (ATTACH + row copy + cursor

--- a/packages/mobile/src/db/connection.ts
+++ b/packages/mobile/src/db/connection.ts
@@ -16,6 +16,9 @@ import {
   configureMainConnection,
   vacuumDatabase,
   BOARD_DATA_TABLES,
+  getUnfinishedDownloadScopeKeys,
+  claimAbandonedDownloadTerminal,
+  purgeNamespaceForScopeKey,
 } from '@boardsesh/offline-sync';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { reportError } from '../lib/error-reporting';
@@ -476,9 +479,24 @@ export type SignOutPurgeResult = {
  * failure is swallowed: the rows are already gone by then, so a SQLITE_FULL means
  * "the file didn't shrink", never data loss — and failing a sign-out over cosmetics
  * would be the worse bug.
+ *
+ * `onDownloadAbandoned` closes the download funnel for whatever was still
+ * downloading when this ran (issue #4452) — the same seam a board removal uses
+ * (`removeBoardScopeData`). It is called once per scope that had announced a
+ * download and never completed one; see the comments at the read and the call
+ * below for why the read has to precede the transaction and the report follow it.
  */
-export async function purgeLocalDataForSignOut(db: SQLiteDatabase): Promise<SignOutPurgeResult> {
+export async function purgeLocalDataForSignOut(
+  db: SQLiteDatabase,
+  options?: { onDownloadAbandoned?: (info: { scopeKey: string }) => void },
+): Promise<SignOutPurgeResult> {
   const bytesBefore = measureDatabaseBytesQuietly();
+
+  // READ BEFORE THE TRANSACTION, for the reason scope-teardown.ts spells out: the
+  // `deleteAllSyncMeta` at the bottom of it takes `scope-started:` along with
+  // every other row, and once that commits nothing anywhere can tell a download
+  // abandoned mid-flight from a board that was never downloaded at all.
+  const abandonedScopeKeys = options?.onDownloadAbandoned === undefined ? [] : await getUnfinishedDownloadScopeKeys(db);
 
   let pendingDiscarded = 0;
   let deadLettersDiscarded = 0;
@@ -513,6 +531,19 @@ export async function purgeLocalDataForSignOut(db: SQLiteDatabase): Promise<Sign
     }
     await deleteAllSyncMeta(txn);
   });
+
+  // AFTER the commit, for the reason removeBoardScopeData reports after its own:
+  // the cycle this sign-out tore down is still unwinding while the transaction
+  // holds the write lock, and reporting first would race its `aborted-wipe` — the
+  // claim below would then be made before the report it exists to defer to.
+  for (const scopeKey of abandonedScopeKeys) {
+    const namespace = purgeNamespaceForScopeKey(scopeKey);
+    // A key we cannot parse has no namespace to claim against, and the registry
+    // never records one for it either — so nothing can be double-reported and it
+    // is reported unconditionally rather than dropped.
+    if (namespace !== undefined && !claimAbandonedDownloadTerminal(scopeKey, namespace)) continue;
+    options?.onDownloadAbandoned?.({ scopeKey });
+  }
 
   let vacuumed = false;
   try {

--- a/packages/mobile/src/offline/__tests__/abandoned-download-terminals.test.ts
+++ b/packages/mobile/src/offline/__tests__/abandoned-download-terminals.test.ts
@@ -1,0 +1,191 @@
+// The download funnel's terminal on the paths that de-list a board rather than
+// deleting it (issue #4452), against the REAL client DDL.
+//
+// The engine's own suite pins the primitives and the sign-out wipe's shape; this
+// pins the mobile side of the contract: WHICH scope gets a terminal, that the
+// markers are cleared so the funnel closes exactly once, and that a re-enable
+// opens a fresh one instead of resuming a funnel the climber ended.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// The adapter wires AppState and NetInfo at import time, so only the two
+// reporters this module takes from it are stubbed (same trick as #4406's
+// remove-offline-board test).
+const reportScopeDownloadAbandonedOnSignOut = vi.hoisted(() => vi.fn());
+const reportScopeDownloadAbandonedOnDisable = vi.hoisted(() => vi.fn());
+vi.mock('../offline-sync-adapter', () => ({
+  reportScopeDownloadAbandonedOnSignOut,
+  reportScopeDownloadAbandonedOnDisable,
+}));
+
+const enabledScopeKeys = vi.hoisted(() => ({ current: [] as string[] }));
+vi.mock('../../settings', () => ({ getSetting: () => enabledScopeKeys.current }));
+
+import type { SQLiteDatabase } from 'expo-sqlite';
+import { runMigrations, markScopeDownloadComplete, isScopeDownloadStarted } from '@boardsesh/offline-sync';
+import {
+  createTestDatabase,
+  __resetDownloadTerminalRegistryForTests,
+  type TestSqliteDb,
+} from '@boardsesh/offline-sync/testing';
+import {
+  reportAbandonedDownloadsOnSignOut,
+  reportAbandonedDownloadOnDisable,
+  sweepDelistedDownloadTerminals,
+} from '../abandoned-download-terminals';
+
+const DOWNLOADING = 'tension:11:8';
+const DOWNLOADED = 'kilter:1:5';
+
+let workDir: string;
+let db: TestSqliteDb & SQLiteDatabase;
+
+/** `markScopeDownloadStarted` is package-internal — only the pull client writes it. */
+const announceDownload = (scopeKey: string) =>
+  db.runAsync('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)', [`scope-started:${scopeKey}`, '1']);
+
+beforeEach(async () => {
+  workDir = mkdtempSync(join(tmpdir(), 'abandoned-terminals-'));
+  db = createTestDatabase(join(workDir, 'client.db')) as unknown as TestSqliteDb & SQLiteDatabase;
+  await runMigrations(db);
+  enabledScopeKeys.current = [];
+  // The one-terminal-per-teardown claim is process-local, so a suite that closes
+  // several funnels for the same scope has to start each case with a clean one.
+  __resetDownloadTerminalRegistryForTests();
+  reportScopeDownloadAbandonedOnSignOut.mockClear();
+  reportScopeDownloadAbandonedOnDisable.mockClear();
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('reportAbandonedDownloadsOnSignOut', () => {
+  it('closes every open funnel and leaves the finished ones alone', async () => {
+    await announceDownload(DOWNLOADING);
+    await announceDownload(DOWNLOADED);
+    await markScopeDownloadComplete(db, DOWNLOADED);
+
+    await reportAbandonedDownloadsOnSignOut(db);
+
+    expect(reportScopeDownloadAbandonedOnSignOut).toHaveBeenCalledTimes(1);
+    expect(reportScopeDownloadAbandonedOnSignOut).toHaveBeenCalledWith({ scopeKey: DOWNLOADING });
+    // Cleared, so the selective sign-out's surviving markers cannot report twice
+    // — nor make a later re-download emit Completed with no Started.
+    expect(await isScopeDownloadStarted(db, DOWNLOADING)).toBe(false);
+  });
+
+  it('is a no-op when nothing was downloading', async () => {
+    await reportAbandonedDownloadsOnSignOut(db);
+    expect(reportScopeDownloadAbandonedOnSignOut).not.toHaveBeenCalled();
+  });
+
+  it('never fails a sign-out over a database it cannot read', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const brokenDb = {
+      getAllAsync: async () => {
+        throw new Error('database is locked');
+      },
+    } as unknown as SQLiteDatabase;
+
+    await expect(reportAbandonedDownloadsOnSignOut(brokenDb)).resolves.toBeUndefined();
+    expect(reportScopeDownloadAbandonedOnSignOut).not.toHaveBeenCalled();
+  });
+});
+
+describe('reportAbandonedDownloadOnDisable', () => {
+  it('reports the toggled-off scope and closes its funnel', async () => {
+    await announceDownload(DOWNLOADING);
+
+    await reportAbandonedDownloadOnDisable(db, DOWNLOADING);
+
+    expect(reportScopeDownloadAbandonedOnDisable).toHaveBeenCalledWith({ scopeKey: DOWNLOADING });
+    expect(await isScopeDownloadStarted(db, DOWNLOADING)).toBe(false);
+  });
+
+  it('stays silent for a board whose download had already finished', async () => {
+    await announceDownload(DOWNLOADED);
+    await markScopeDownloadComplete(db, DOWNLOADED);
+
+    await reportAbandonedDownloadOnDisable(db, DOWNLOADED);
+
+    expect(reportScopeDownloadAbandonedOnDisable).not.toHaveBeenCalled();
+    // Its Started stays: `scope-complete:` already closed that funnel, and the
+    // marker is what keeps the pair once-ever per download lifecycle.
+    expect(await isScopeDownloadStarted(db, DOWNLOADED)).toBe(true);
+  });
+
+  it('stays silent for a board that never announced a download', async () => {
+    await reportAbandonedDownloadOnDisable(db, DOWNLOADING);
+    expect(reportScopeDownloadAbandonedOnDisable).not.toHaveBeenCalled();
+  });
+
+  it('leaves a sibling board mid-download alone', async () => {
+    await announceDownload(DOWNLOADING);
+    await announceDownload(DOWNLOADED);
+
+    await reportAbandonedDownloadOnDisable(db, DOWNLOADED);
+
+    expect(reportScopeDownloadAbandonedOnDisable).toHaveBeenCalledTimes(1);
+    expect(await isScopeDownloadStarted(db, DOWNLOADING)).toBe(true);
+  });
+
+  it('opens a fresh funnel on re-enable rather than resuming the one it closed', async () => {
+    await announceDownload(DOWNLOADING);
+    await reportAbandonedDownloadOnDisable(db, DOWNLOADING);
+
+    // What `emitScopeDownloadStartOnce` reads. A surviving marker here is exactly
+    // how the re-enabled download would lose its Started.
+    expect(await isScopeDownloadStarted(db, DOWNLOADING)).toBe(false);
+    await announceDownload(DOWNLOADING);
+
+    // …and the second toggle-off gets its own terminal.
+    await reportAbandonedDownloadOnDisable(db, DOWNLOADING);
+    expect(reportScopeDownloadAbandonedOnDisable).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('sweepDelistedDownloadTerminals', () => {
+  it('reports a marker left behind for a board nobody enabled any more', async () => {
+    await announceDownload(DOWNLOADING);
+    enabledScopeKeys.current = [DOWNLOADED];
+
+    await sweepDelistedDownloadTerminals(db);
+
+    expect(reportScopeDownloadAbandonedOnDisable).toHaveBeenCalledWith({ scopeKey: DOWNLOADING });
+  });
+
+  it('reports once, not on every launch', async () => {
+    await announceDownload(DOWNLOADING);
+
+    await sweepDelistedDownloadTerminals(db);
+    await sweepDelistedDownloadTerminals(db);
+
+    expect(reportScopeDownloadAbandonedOnDisable).toHaveBeenCalledTimes(1);
+  });
+
+  it('never touches a board that is still enabled and still downloading', async () => {
+    // A 40k-climb crawl legitimately spans launches; its Started is meant to stay
+    // open across all of them.
+    await announceDownload(DOWNLOADING);
+    enabledScopeKeys.current = [DOWNLOADING];
+
+    await sweepDelistedDownloadTerminals(db);
+
+    expect(reportScopeDownloadAbandonedOnDisable).not.toHaveBeenCalled();
+    expect(await isScopeDownloadStarted(db, DOWNLOADING)).toBe(true);
+  });
+
+  it('ignores a de-listed board whose download had completed', async () => {
+    await announceDownload(DOWNLOADED);
+    await markScopeDownloadComplete(db, DOWNLOADED);
+
+    await sweepDelistedDownloadTerminals(db);
+
+    expect(reportScopeDownloadAbandonedOnDisable).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/src/offline/__tests__/abandoned-download-terminals.test.ts
+++ b/packages/mobile/src/offline/__tests__/abandoned-download-terminals.test.ts
@@ -89,10 +89,10 @@ describe('reportAbandonedDownloadsOnSignOut', () => {
     expect(reportScopeDownloadAbandonedOnSignOut).not.toHaveBeenCalled();
   });
 
-  // One locked write must not silently drop the other scopes from the sweep:
-  // they are independent funnels, and the one that failed still has its marker,
-  // so the next launch's backstop picks it up.
-  it('keeps going when one scope\u2019s clear fails', async () => {
+  // One locked write must not silently drop the other scopes: they are
+  // independent funnels. The one that failed emits nothing and keeps its marker,
+  // so the next launch's backstop reports it — exactly one terminal either way.
+  it('keeps going, and stays quiet, when one scope\u2019s clear fails', async () => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     // The scope keys come back in index order, so the FAILING one has to sort
     // first — otherwise the old whole-loop try/catch would pass this too.
@@ -108,7 +108,12 @@ describe('reportAbandonedDownloadsOnSignOut', () => {
 
     await reportAbandonedDownloadsOnSignOut(db);
 
-    expect(reportScopeDownloadAbandonedOnSignOut).toHaveBeenCalledTimes(2);
+    // The healthy scope still reports; the locked one does not, and keeps its
+    // marker so it is reported once — not twice — on the next launch.
+    expect(reportScopeDownloadAbandonedOnSignOut).toHaveBeenCalledTimes(1);
+    expect(reportScopeDownloadAbandonedOnSignOut).toHaveBeenCalledWith({ scopeKey: DOWNLOADING });
+    vi.mocked(db.runAsync).mockRestore();
+    expect(await getUnfinishedDownloadScopeKeys(db)).toEqual([failing]);
   });
 
   it('never fails a sign-out over a database it cannot read', async () => {

--- a/packages/mobile/src/offline/__tests__/abandoned-download-terminals.test.ts
+++ b/packages/mobile/src/offline/__tests__/abandoned-download-terminals.test.ts
@@ -25,7 +25,12 @@ const enabledScopeKeys = vi.hoisted(() => ({ current: [] as string[] }));
 vi.mock('../../settings', () => ({ getSetting: () => enabledScopeKeys.current }));
 
 import type { SQLiteDatabase } from 'expo-sqlite';
-import { runMigrations, markScopeDownloadComplete, isScopeDownloadStarted } from '@boardsesh/offline-sync';
+import {
+  runMigrations,
+  markScopeDownloadComplete,
+  isScopeDownloadStarted,
+  getUnfinishedDownloadScopeKeys,
+} from '@boardsesh/offline-sync';
 import {
   createTestDatabase,
   __resetDownloadTerminalRegistryForTests,
@@ -82,6 +87,28 @@ describe('reportAbandonedDownloadsOnSignOut', () => {
   it('is a no-op when nothing was downloading', async () => {
     await reportAbandonedDownloadsOnSignOut(db);
     expect(reportScopeDownloadAbandonedOnSignOut).not.toHaveBeenCalled();
+  });
+
+  // One locked write must not silently drop the other scopes from the sweep:
+  // they are independent funnels, and the one that failed still has its marker,
+  // so the next launch's backstop picks it up.
+  it('keeps going when one scope\u2019s clear fails', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // The scope keys come back in index order, so the FAILING one has to sort
+    // first — otherwise the old whole-loop try/catch would pass this too.
+    const failing = 'kilter:1:7';
+    await announceDownload(failing);
+    await announceDownload(DOWNLOADING);
+    expect(await getUnfinishedDownloadScopeKeys(db)).toEqual([failing, DOWNLOADING]);
+    const realRun = db.runAsync.bind(db);
+    vi.spyOn(db, 'runAsync').mockImplementation(async (sql: string, params?: unknown) => {
+      if (JSON.stringify(params ?? null).includes(failing)) throw new Error('database is locked');
+      return realRun(sql, params as never);
+    });
+
+    await reportAbandonedDownloadsOnSignOut(db);
+
+    expect(reportScopeDownloadAbandonedOnSignOut).toHaveBeenCalledTimes(2);
   });
 
   it('never fails a sign-out over a database it cannot read', async () => {

--- a/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
+++ b/packages/mobile/src/offline/__tests__/offline-sync-adapter.test.ts
@@ -95,6 +95,8 @@ import {
   hasUsableInternetConnection,
   subscribeMutationDelivery,
   reportScopeDownloadAbandoned,
+  reportScopeDownloadAbandonedOnSignOut,
+  reportScopeDownloadAbandonedOnDisable,
   __resetCoverageVerdictDedupeForTests,
   __resetCycleErrorDedupeForTests,
   __resetMeteredStateForTests,
@@ -574,6 +576,33 @@ describe('snapshot-bootstrap bindings', () => {
     );
     // A Remove tap is not a defect: `aborted: true` must stop the report at the
     // funnel, or every board removal would land in Sentry as a bootstrap failure.
+    expect(reportHandledError).not.toHaveBeenCalled();
+  });
+
+  // The de-listing terminals (issue #4452). Same permanent contract as the
+  // removal one above, and `stage: 'abandoned'` rather than 'board-removed'
+  // deliberately: nothing was removed on these paths, and 'board-removed'
+  // already ships in dashboards meaning "the rows were deleted".
+  it.each([
+    ['sign-out', reportScopeDownloadAbandonedOnSignOut, 'abandoned-signed-out'],
+    ['a My Boards toggle-off', reportScopeDownloadAbandonedOnDisable, 'abandoned-disabled'],
+  ])('reports a download abandoned by %s as the funnel Failed shape, never to Sentry', (_label, report, reason) => {
+    report({ scopeKey: 'tension:11:8' });
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    expect(trackMock).toHaveBeenCalledWith(
+      SHARED_EVENTS.OfflineBoardDownloadFailed,
+      expect.objectContaining({
+        scopeKey: 'tension:11:8',
+        stage: 'abandoned',
+        reason,
+        aborted: true,
+        expected: true,
+        attempt: 0,
+      }),
+    );
+    // Signing out and turning a board off are both things the climber chose to
+    // do. Neither is a defect, so neither may reach Sentry or a failure rate.
     expect(reportHandledError).not.toHaveBeenCalled();
   });
 

--- a/packages/mobile/src/offline/abandoned-download-terminals.ts
+++ b/packages/mobile/src/offline/abandoned-download-terminals.ts
@@ -52,6 +52,22 @@ async function closeDelistedScopeFunnel(db: SQLiteDatabase, scopeKey: string): P
 }
 
 /**
+ * Run one scope's close without letting it take the rest of a sweep down with
+ * it. A locked database on the first of five scopes must not silently drop the
+ * other four — they are independent funnels, and the one that failed is covered
+ * by the next launch's sweep because its marker is still there.
+ */
+async function closeScopeFunnelQuietly(scopeKey: string, close: () => Promise<void>): Promise<void> {
+  try {
+    await close();
+  } catch (error) {
+    if (__DEV__) {
+      console.warn(`[offline] failed to close the abandoned download funnel for ${scopeKey}:`, error);
+    }
+  }
+}
+
+/**
  * The SELECTIVE sign-out — a forced 401, a proactive token expiry, or an
  * identity change. These keep every marker (`clearUserData` preserves the board
  * checkpoints and never touches `scope-started:`) and keep every downloaded row,
@@ -68,20 +84,23 @@ async function closeDelistedScopeFunnel(db: SQLiteDatabase, scopeKey: string): P
 export async function reportAbandonedDownloadsOnSignOut(db: SQLiteDatabase): Promise<void> {
   try {
     for (const scopeKey of await getUnfinishedDownloadScopeKeys(db)) {
-      // The teardown claim #4406 built, and this path genuinely needs it:
-      // `setSigningOut(true)` bumps the global wipe epoch and tears the running
-      // cycle down, so the bootstrap phase reports its own `aborted-wipe` for
-      // this same scope milliseconds earlier. Two terminals for one Started
-      // would break the funnel invariant. A key we cannot parse belongs to no
-      // namespace, so the registry never records one for it and nothing can
-      // double-report it — those are reported rather than dropped.
-      const namespace = purgeNamespaceForScopeKey(scopeKey);
-      if (namespace === undefined || claimAbandonedDownloadTerminal(scopeKey, namespace)) {
-        reportScopeDownloadAbandonedOnSignOut({ scopeKey });
-      }
-      // Cleared either way: the download is over whether or not this call site
-      // was the one that got to say so.
-      await clearScopeDownloadFunnelMarkers(db, scopeKey);
+      await closeScopeFunnelQuietly(scopeKey, async () => {
+        // The teardown claim #4406 built, and this path genuinely needs it:
+        // `setSigningOut(true)` bumps the global wipe epoch and tears the
+        // running cycle down, so the bootstrap phase reports its own
+        // `aborted-wipe` for this same scope milliseconds earlier. Two terminals
+        // for one Started would break the funnel invariant. A key we cannot
+        // parse belongs to no namespace, so the registry never records one for
+        // it and nothing can double-report it — those are reported rather than
+        // dropped.
+        const namespace = purgeNamespaceForScopeKey(scopeKey);
+        if (namespace === undefined || claimAbandonedDownloadTerminal(scopeKey, namespace)) {
+          reportScopeDownloadAbandonedOnSignOut({ scopeKey });
+        }
+        // Cleared either way: the download is over whether or not this call site
+        // was the one that got to say so.
+        await clearScopeDownloadFunnelMarkers(db, scopeKey);
+      });
     }
   } catch (error) {
     if (__DEV__) {
@@ -138,7 +157,7 @@ export async function sweepDelistedDownloadTerminals(db: SQLiteDatabase): Promis
       // Still enabled means still downloading — a board-data crawl legitimately
       // spans launches, and its Started is meant to stay open across all of them.
       if (enabledScopeKeys.has(scopeKey)) continue;
-      await closeDelistedScopeFunnel(db, scopeKey);
+      await closeScopeFunnelQuietly(scopeKey, () => closeDelistedScopeFunnel(db, scopeKey));
     }
   } catch (error) {
     if (__DEV__) {

--- a/packages/mobile/src/offline/abandoned-download-terminals.ts
+++ b/packages/mobile/src/offline/abandoned-download-terminals.ts
@@ -34,27 +34,20 @@ import { getSetting } from '../settings';
 import { reportScopeDownloadAbandonedOnSignOut, reportScopeDownloadAbandonedOnDisable } from './offline-sync-adapter';
 
 /**
- * Emit the terminal for one scope and close its funnel, unless a torn-down cycle
- * already reported one for this same teardown.
+ * Emit the terminal for a scope that was DE-LISTED without a teardown — the My
+ * Boards toggle-off and the launch backstop — then close its funnel.
  *
- * The claim is the dedup #4406 built: a sign-out bumps the global wipe epoch, so
- * the cycle it tears down reports its own `aborted-wipe` for the same scope
- * milliseconds earlier, and two terminals for one Started would break the funnel
- * invariant. The marker clear is the SECOND dedup, and the durable one — after
- * it, no later path can find an unfinished download for this scope.
+ * No teardown-generation claim here, deliberately, unlike the sign-out path
+ * below. Nothing tore a cycle down, so there is no competing `aborted-wipe` to
+ * defer to, and the claim would actively lose events: it is keyed on a
+ * generation that only a purge or a sign-out moves, so toggling one board off,
+ * back on, and off again in a single session — an ordinary thing to do — would
+ * report the first abandonment and silently swallow the second. The cleared
+ * marker is the dedup that actually holds, and it is durable: once it is gone,
+ * no path anywhere can find an unfinished download for this scope.
  */
-async function closeScopeFunnel(
-  db: SQLiteDatabase,
-  scopeKey: string,
-  report: (info: { scopeKey: string }) => void,
-): Promise<void> {
-  const namespace = purgeNamespaceForScopeKey(scopeKey);
-  // A key we cannot parse belongs to no namespace, so the registry never records
-  // a terminal against it and nothing can double-report it. Report it rather
-  // than dropping it — a malformed key is still an open funnel.
-  if (namespace === undefined || claimAbandonedDownloadTerminal(scopeKey, namespace)) {
-    report({ scopeKey });
-  }
+async function closeDelistedScopeFunnel(db: SQLiteDatabase, scopeKey: string): Promise<void> {
+  reportScopeDownloadAbandonedOnDisable({ scopeKey });
   await clearScopeDownloadFunnelMarkers(db, scopeKey);
 }
 
@@ -75,7 +68,20 @@ async function closeScopeFunnel(
 export async function reportAbandonedDownloadsOnSignOut(db: SQLiteDatabase): Promise<void> {
   try {
     for (const scopeKey of await getUnfinishedDownloadScopeKeys(db)) {
-      await closeScopeFunnel(db, scopeKey, reportScopeDownloadAbandonedOnSignOut);
+      // The teardown claim #4406 built, and this path genuinely needs it:
+      // `setSigningOut(true)` bumps the global wipe epoch and tears the running
+      // cycle down, so the bootstrap phase reports its own `aborted-wipe` for
+      // this same scope milliseconds earlier. Two terminals for one Started
+      // would break the funnel invariant. A key we cannot parse belongs to no
+      // namespace, so the registry never records one for it and nothing can
+      // double-report it — those are reported rather than dropped.
+      const namespace = purgeNamespaceForScopeKey(scopeKey);
+      if (namespace === undefined || claimAbandonedDownloadTerminal(scopeKey, namespace)) {
+        reportScopeDownloadAbandonedOnSignOut({ scopeKey });
+      }
+      // Cleared either way: the download is over whether or not this call site
+      // was the one that got to say so.
+      await clearScopeDownloadFunnelMarkers(db, scopeKey);
     }
   } catch (error) {
     if (__DEV__) {
@@ -100,7 +106,7 @@ export async function reportAbandonedDownloadOnDisable(db: SQLiteDatabase, scope
       isScopeDownloadComplete(db, scopeKey),
     ]);
     if (!started || complete) return;
-    await closeScopeFunnel(db, scopeKey, reportScopeDownloadAbandonedOnDisable);
+    await closeDelistedScopeFunnel(db, scopeKey);
   } catch (error) {
     if (__DEV__) {
       console.warn('[offline] failed to close the abandoned download funnel on toggle-off:', error);
@@ -132,7 +138,7 @@ export async function sweepDelistedDownloadTerminals(db: SQLiteDatabase): Promis
       // Still enabled means still downloading — a board-data crawl legitimately
       // spans launches, and its Started is meant to stay open across all of them.
       if (enabledScopeKeys.has(scopeKey)) continue;
-      await closeScopeFunnel(db, scopeKey, reportScopeDownloadAbandonedOnDisable);
+      await closeDelistedScopeFunnel(db, scopeKey);
     }
   } catch (error) {
     if (__DEV__) {

--- a/packages/mobile/src/offline/abandoned-download-terminals.ts
+++ b/packages/mobile/src/offline/abandoned-download-terminals.ts
@@ -47,8 +47,14 @@ import { reportScopeDownloadAbandonedOnSignOut, reportScopeDownloadAbandonedOnDi
  * no path anywhere can find an unfinished download for this scope.
  */
 async function closeDelistedScopeFunnel(db: SQLiteDatabase, scopeKey: string): Promise<void> {
-  reportScopeDownloadAbandonedOnDisable({ scopeKey });
+  // CLEAR FIRST, report second. The clear is the only step that can fail — a
+  // locked database — and `track()` cannot. Reporting first would emit the
+  // terminal and then leave the marker behind for the next launch's sweep to
+  // report a SECOND time; this way a failed clear emits nothing at all and the
+  // sweep is the one reporter. Exactly one terminal either way, which is the
+  // invariant that matters.
   await clearScopeDownloadFunnelMarkers(db, scopeKey);
+  reportScopeDownloadAbandonedOnDisable({ scopeKey });
 }
 
 /**
@@ -93,13 +99,14 @@ export async function reportAbandonedDownloadsOnSignOut(db: SQLiteDatabase): Pro
         // parse belongs to no namespace, so the registry never records one for
         // it and nothing can double-report it — those are reported rather than
         // dropped.
+        // Cleared FIRST, for the reason closeDelistedScopeFunnel spells out: a
+        // clear that throws must not leave a reported marker behind for the
+        // launch sweep to report again.
+        await clearScopeDownloadFunnelMarkers(db, scopeKey);
         const namespace = purgeNamespaceForScopeKey(scopeKey);
         if (namespace === undefined || claimAbandonedDownloadTerminal(scopeKey, namespace)) {
           reportScopeDownloadAbandonedOnSignOut({ scopeKey });
         }
-        // Cleared either way: the download is over whether or not this call site
-        // was the one that got to say so.
-        await clearScopeDownloadFunnelMarkers(db, scopeKey);
       });
     }
   } catch (error) {

--- a/packages/mobile/src/offline/abandoned-download-terminals.ts
+++ b/packages/mobile/src/offline/abandoned-download-terminals.ts
@@ -1,0 +1,142 @@
+// The download funnel's terminal event for every path that DE-LISTS a board
+// instead of deleting it (issue #4452).
+//
+// `Offline Board Download Started` is emitted once per scope and guarded by the
+// durable `scope-started:` marker, so its terminal is owed by whatever ends the
+// download. Until now exactly one ender reported: `removeBoardScopeData`, which
+// reads the marker before its delete transaction and emits `abandoned-removed`
+// after the commit (issue #4406). Every other ender was silent.
+//
+// The mechanism they share is NOT "the marker was deleted" — it is "the scope
+// left `syncEnabledBoards`". `pullSync`'s board loop iterates only enabled
+// scopes, so a de-listed board is never visited again and its Started stays open
+// forever, even though nothing was deleted and the marker is still sitting in
+// sync_meta. That covers the My Boards toggle-off (which deletes nothing at all)
+// and all three sign-outs (`runSignedOutCleanup` empties the list for the manual,
+// forced-401 and proactive-expiry paths alike).
+//
+// Reporting and CLEARING are one step here, deliberately. The marker is what
+// makes a second report impossible, and it is also what would otherwise make a
+// re-enable's download emit Completed with no Started of its own. Two Starteds
+// for a toggle-off-then-on is the honest reading: as far as the funnel is
+// concerned those are two downloads.
+
+import type { SQLiteDatabase } from 'expo-sqlite';
+import {
+  getUnfinishedDownloadScopeKeys,
+  clearScopeDownloadFunnelMarkers,
+  claimAbandonedDownloadTerminal,
+  purgeNamespaceForScopeKey,
+  isScopeDownloadStarted,
+  isScopeDownloadComplete,
+} from '@boardsesh/offline-sync';
+import { getSetting } from '../settings';
+import { reportScopeDownloadAbandonedOnSignOut, reportScopeDownloadAbandonedOnDisable } from './offline-sync-adapter';
+
+/**
+ * Emit the terminal for one scope and close its funnel, unless a torn-down cycle
+ * already reported one for this same teardown.
+ *
+ * The claim is the dedup #4406 built: a sign-out bumps the global wipe epoch, so
+ * the cycle it tears down reports its own `aborted-wipe` for the same scope
+ * milliseconds earlier, and two terminals for one Started would break the funnel
+ * invariant. The marker clear is the SECOND dedup, and the durable one — after
+ * it, no later path can find an unfinished download for this scope.
+ */
+async function closeScopeFunnel(
+  db: SQLiteDatabase,
+  scopeKey: string,
+  report: (info: { scopeKey: string }) => void,
+): Promise<void> {
+  const namespace = purgeNamespaceForScopeKey(scopeKey);
+  // A key we cannot parse belongs to no namespace, so the registry never records
+  // a terminal against it and nothing can double-report it. Report it rather
+  // than dropping it — a malformed key is still an open funnel.
+  if (namespace === undefined || claimAbandonedDownloadTerminal(scopeKey, namespace)) {
+    report({ scopeKey });
+  }
+  await clearScopeDownloadFunnelMarkers(db, scopeKey);
+}
+
+/**
+ * The SELECTIVE sign-out — a forced 401, a proactive token expiry, or an
+ * identity change. These keep every marker (`clearUserData` preserves the board
+ * checkpoints and never touches `scope-started:`) and keep every downloaded row,
+ * but `runSignedOutCleanup` empties `syncEnabledBoards` for them too, so no
+ * future cycle will ever finish the download.
+ *
+ * The EXPLICIT sign-out does not come through here: its wipe destroys the
+ * markers inside its own transaction, so `purgeLocalDataForSignOut` has to read
+ * them before it commits and report through its own seam.
+ *
+ * Best-effort, like every other sign-out cleanup step: a database that will not
+ * open must never fail a sign-out over a telemetry event.
+ */
+export async function reportAbandonedDownloadsOnSignOut(db: SQLiteDatabase): Promise<void> {
+  try {
+    for (const scopeKey of await getUnfinishedDownloadScopeKeys(db)) {
+      await closeScopeFunnel(db, scopeKey, reportScopeDownloadAbandonedOnSignOut);
+    }
+  } catch (error) {
+    if (__DEV__) {
+      console.warn('[offline] failed to close abandoned download funnels during sign-out:', error);
+    }
+  }
+}
+
+/**
+ * The My Boards toggle-off — the highest-volume de-list the code can still be
+ * responsible for. Nothing is deleted (the rows and checkpoints stay so a
+ * re-enable resumes instantly), which is exactly why nothing reported before:
+ * there is no teardown to hang the terminal off.
+ *
+ * Called with the scope the climber just turned off, so it reads that one key
+ * rather than sweeping — a sibling board mid-download must keep its funnel open.
+ */
+export async function reportAbandonedDownloadOnDisable(db: SQLiteDatabase, scopeKey: string): Promise<void> {
+  try {
+    const [started, complete] = await Promise.all([
+      isScopeDownloadStarted(db, scopeKey),
+      isScopeDownloadComplete(db, scopeKey),
+    ]);
+    if (!started || complete) return;
+    await closeScopeFunnel(db, scopeKey, reportScopeDownloadAbandonedOnDisable);
+  } catch (error) {
+    if (__DEV__) {
+      console.warn('[offline] failed to close the abandoned download funnel on toggle-off:', error);
+    }
+  }
+}
+
+/**
+ * The launch backstop, so this is structural rather than another list of sites
+ * someone has to remember (the lesson #4391 wrote down).
+ *
+ * Any `scope-started:` marker whose scope is NOT in `syncEnabledBoards` is an
+ * open funnel nothing will ever close: the board is de-listed, so no cycle will
+ * visit it. That state is reachable three ways — a crash between the de-list and
+ * the in-session report, a device upgrading from a build that predates this fix,
+ * and any future de-listing path nobody instruments. Sweeping it at launch
+ * covers all three without knowing which happened.
+ *
+ * Attribution is honest but imperfect here: this reports on the NEXT session's
+ * distinct_id. The in-session reports above are the primary path precisely so
+ * this only fires on crashes and upgrades.
+ */
+export async function sweepDelistedDownloadTerminals(db: SQLiteDatabase): Promise<void> {
+  try {
+    const unfinished = await getUnfinishedDownloadScopeKeys(db);
+    if (unfinished.length === 0) return;
+    const enabledScopeKeys = new Set(getSetting('syncEnabledBoards'));
+    for (const scopeKey of unfinished) {
+      // Still enabled means still downloading — a board-data crawl legitimately
+      // spans launches, and its Started is meant to stay open across all of them.
+      if (enabledScopeKeys.has(scopeKey)) continue;
+      await closeScopeFunnel(db, scopeKey, reportScopeDownloadAbandonedOnDisable);
+    }
+  } catch (error) {
+    if (__DEV__) {
+      console.warn('[offline] failed to sweep de-listed download funnels:', error);
+    }
+  }
+}

--- a/packages/mobile/src/offline/offline-sync-adapter.ts
+++ b/packages/mobile/src/offline/offline-sync-adapter.ts
@@ -252,6 +252,48 @@ export const reportScopeDownloadAbandoned = ({ scopeKey }: AbandonedDownloadInfo
   });
 };
 
+/**
+ * The same terminal for every OTHER way a download ends for good (issue #4452):
+ * the paths that de-list a board instead of deleting it.
+ *
+ * `removeBoardScopeData` was the only ender that reported, which left the funnel
+ * blind to every path that empties `syncEnabledBoards` — all three sign-outs and
+ * the My Boards toggle-off. The pull client's board loop iterates only ENABLED
+ * scopes, so a de-listed scope's `Offline Board Download Started` stays open
+ * forever even when nothing was deleted and the marker is still sitting there.
+ *
+ * One shape, one call site, same as #4406's: `stage: 'abandoned'` (no bootstrap
+ * stage produced this, and it is NOT `board-removed` — nothing was removed),
+ * `aborted: true` so it stays out of Sentry and out of any failure rate, and
+ * `attempt: 0` because no retry budget was spent. The reason is the only thing
+ * that varies, and it names which de-listing it was.
+ */
+const reportScopeDownloadAbandonedOnDelist = (
+  scopeKey: string,
+  reason: 'abandoned-signed-out' | 'abandoned-disabled',
+  what: string,
+): void => {
+  reportSnapshotBootstrapError({
+    scopeKey,
+    stage: 'abandoned',
+    attempt: 0,
+    cause: new Error(`Offline download for ${scopeKey} was ${what} before it finished`),
+    expected: true,
+    reason,
+    aborted: true,
+  });
+};
+
+/** Sign-out ended it — the explicit wipe, or any sign-out that de-listed the board. */
+export const reportScopeDownloadAbandonedOnSignOut = ({ scopeKey }: { scopeKey: string }): void => {
+  reportScopeDownloadAbandonedOnDelist(scopeKey, 'abandoned-signed-out', 'signed out from');
+};
+
+/** The climber turned the board off from My Boards, keeping the rows on disk. */
+export const reportScopeDownloadAbandonedOnDisable = ({ scopeKey }: { scopeKey: string }): void => {
+  reportScopeDownloadAbandonedOnDelist(scopeKey, 'abandoned-disabled', 'turned off');
+};
+
 // Fired once per board scope's initial download so the snapshot-bootstrap
 // warm-up can be compared against the plain paged crawl in the field (which
 // path actually got used, and how long it took).

--- a/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/auth-provider.test.tsx
@@ -305,8 +305,19 @@ vi.mock('@boardsesh/offline-sync', () => ({
   getOutboxSummary: (...args: unknown[]) => getOutboxSummaryMock(...args),
   setSigningOut: vi.fn(),
 }));
+// The download funnel's sign-out terminal (issue #4452). The explicit wipe hands
+// its reporter to purgeLocalDataForSignOut — only that transaction can still see
+// the markers it is about to delete — while the selective paths report from the
+// provider, next to the `syncEnabledBoards` reset that is what actually ends
+// those downloads.
+const reportScopeDownloadAbandonedOnSignOutMock = vi.hoisted(() => vi.fn());
 vi.mock('../../offline/offline-sync-adapter', () => ({
   drainMutationQueue: (...args: unknown[]) => drainMutationQueueMock(...args),
+  reportScopeDownloadAbandonedOnSignOut: reportScopeDownloadAbandonedOnSignOutMock,
+}));
+const reportAbandonedDownloadsOnSignOutMock = vi.hoisted(() => vi.fn(async (..._args: unknown[]) => {}));
+vi.mock('../../offline/abandoned-download-terminals', () => ({
+  reportAbandonedDownloadsOnSignOut: reportAbandonedDownloadsOnSignOutMock,
 }));
 // The offline-usage rollup's suppression map is in-memory and not keyed by user,
 // so the sign-out paths reset it (#4317) — otherwise a same-day account switch
@@ -1135,6 +1146,11 @@ describe('AuthProvider sign-out offline data wipe', () => {
       vacuumed: true,
     });
     resetSyncStatusMock.mockClear();
+    resetAnalyticsMock.mockClear();
+    setSettingMock.mockClear();
+    trackMock.mockClear();
+    reportScopeDownloadAbandonedOnSignOutMock.mockClear();
+    reportAbandonedDownloadsOnSignOutMock.mockClear();
     drainMutationQueueMock.mockReset();
     getOutboxSummaryMock.mockReset();
     setOnForcedSignOutMock.mockReset();
@@ -1248,6 +1264,73 @@ describe('AuthProvider sign-out offline data wipe', () => {
     });
 
     expect(trackMock.mock.calls.some((call) => call[0] === 'Offline Data Wiped On Sign Out')).toBe(false);
+  });
+
+  // Issue #4452. Production showed every `Offline Data Wiped On Sign Out` landing
+  // on a DIFFERENT person_id from the `Logout` half a second earlier, because
+  // resetAnalytics() ran first — so the wipe's own event, and every download
+  // terminal emitted beside it, arrived on a fresh anonymous distinct_id that no
+  // funnel query can pair with its `Offline Board Download Started`.
+  it('tracks the wipe before resetting analytics, not after', async () => {
+    purgeLocalDataForSignOutMock.mockResolvedValue({
+      pendingDiscarded: 0,
+      deadLettersDiscarded: 0,
+      hadDownloads: true,
+      vacuumed: true,
+    });
+    const result = await renderSignedIn();
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    const wipeCall = trackMock.mock.calls.findIndex((call) => call[0] === 'Offline Data Wiped On Sign Out');
+    expect(wipeCall).toBeGreaterThanOrEqual(0);
+    expect(resetAnalyticsMock).toHaveBeenCalled();
+    expect(trackMock.mock.invocationCallOrder[wipeCall]).toBeLessThan(resetAnalyticsMock.mock.invocationCallOrder[0]);
+  });
+
+  // The wipe is the only code that can still see the `scope-started:` markers its
+  // own transaction is about to delete, so the terminal has to be reported from
+  // inside it rather than from here.
+  it('hands the explicit wipe the download-abandoned reporter', async () => {
+    const result = await renderSignedIn();
+
+    await act(async () => {
+      await result.current.signOut();
+    });
+
+    expect(purgeLocalDataForSignOutMock).toHaveBeenCalledWith(
+      { tag: 'db' },
+      { onDownloadAbandoned: reportScopeDownloadAbandonedOnSignOutMock },
+    );
+    // The selective sweep would double-report what the wipe already reported —
+    // and the markers are gone by then anyway.
+    expect(reportAbandonedDownloadsOnSignOutMock).not.toHaveBeenCalled();
+  });
+
+  // The selective sign-outs delete nothing and keep every marker, so nothing in
+  // the wipe can report for them — but `setSetting('syncEnabledBoards', [])` runs
+  // on these paths too, and pullSync only ever visits enabled scopes, so the
+  // download is over just the same.
+  it('closes the download funnel on a sign-out that kept the catalogs', async () => {
+    const result = await renderSignedIn();
+
+    deduplicatedRefreshMock.mockResolvedValue({ status: 'rejected', generation: 1 });
+    isTokenExpiringSoonMock.mockResolvedValue(true);
+    await act(async () => {
+      await result.current.refreshAuthState();
+    });
+
+    expect(reportAbandonedDownloadsOnSignOutMock).toHaveBeenCalledWith({ tag: 'db' });
+    // Order is the whole correctness of it, on both sides: after resetAnalytics()
+    // the terminal is unjoinable, and after the enabled-set reset there is no way
+    // to tell which boards were downloading.
+    const reportOrder = reportAbandonedDownloadsOnSignOutMock.mock.invocationCallOrder[0];
+    expect(reportOrder).toBeLessThan(resetAnalyticsMock.mock.invocationCallOrder[0]);
+    const enabledBoardsReset = setSettingMock.mock.calls.findIndex((call) => call[0] === 'syncEnabledBoards');
+    expect(enabledBoardsReset).toBeGreaterThanOrEqual(0);
+    expect(reportOrder).toBeLessThan(setSettingMock.mock.invocationCallOrder[enabledBoardsReset]);
   });
 
   // A wedged SQLite file must not strand someone in a half-signed-out app.

--- a/packages/mobile/src/providers/auth-provider.tsx
+++ b/packages/mobile/src/providers/auth-provider.tsx
@@ -38,7 +38,8 @@ import { clearUserData, purgeLocalDataForSignOut, getDatabaseHandle } from '../d
 import { resetSyncStatus } from '../sync/sync-status';
 import { setSetting, clearOfflineBoards } from '../settings';
 import { getOutboxSummary, setSigningOut } from '@boardsesh/offline-sync';
-import { drainMutationQueue } from '../offline/offline-sync-adapter';
+import { drainMutationQueue, reportScopeDownloadAbandonedOnSignOut } from '../offline/offline-sync-adapter';
+import { reportAbandonedDownloadsOnSignOut } from '../offline/abandoned-download-terminals';
 import { reportOutboxDiscardedOnSignOut } from '../offline/outbox-telemetry';
 import { stopTokenManagement } from '../notifications';
 import { consumeFreshOAuthPending } from '../lib/oauth-pending-store';
@@ -246,7 +247,15 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       if (purgeOfflineBoards) {
         // Reported from here rather than the caller because the counts only exist
         // inside the wipe's own transaction: pending_mutations is emptied by it.
-        const purge = await purgeLocalDataForSignOut(localDb);
+        const purge = await purgeLocalDataForSignOut(localDb, {
+          // The wipe's `deleteAllSyncMeta` is what destroys the download funnel's
+          // `scope-started:` markers, so it is the last code that can close their
+          // funnel (issue #4452). The selective branch below keeps every marker
+          // and is handled in runSignedOutCleanup instead — it needs to run after
+          // this whole cleanup, next to the `syncEnabledBoards` reset that is the
+          // thing actually ending those downloads.
+          onDownloadAbandoned: reportScopeDownloadAbandonedOnSignOut,
+        });
         track(SHARED_EVENTS.OfflineDataWipedOnSignOut, { ...purge });
       } else {
         await clearUserData(localDb);
@@ -288,7 +297,6 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       // paths — manual, forced 401, and proactive expiry.
       const localDb = getDatabaseHandle();
       if (localDb) await reportOutboxDiscardedOnSignOut(localDb);
-      resetAnalytics();
       resetOfflineUsageSignal();
       const stopTokenCleanup = stopTokenManagement(async () => {});
       if (Platform.OS === 'web') await waitForCleanupPhase(stopTokenCleanup);
@@ -301,6 +309,22 @@ export function AuthProvider({ children, onReady }: AuthProviderProps) {
       const offlineUserDataCleanup = clearLocalOfflineUserData(purgeOfflineBoards);
       if (Platform.OS === 'web') await waitForCleanupPhase(offlineUserDataCleanup);
       else await offlineUserDataCleanup;
+      // Close the download funnel for anything that was still downloading (issue
+      // #4452). The SELECTIVE branch only: the explicit wipe already reported
+      // through purgeLocalDataForSignOut's seam and its markers are gone, while
+      // this branch keeps every marker and every row — and still ends the
+      // download for good, because `setSetting('syncEnabledBoards', [])` below
+      // runs on all three sign-out paths and pullSync only ever visits enabled
+      // scopes.
+      if (localDb && !purgeOfflineBoards) await reportAbandonedDownloadsOnSignOut(localDb);
+      // Only NOW. Every sign-out event above — the discarded outbox, the wipe's
+      // own `Offline Data Wiped On Sign Out`, and the abandonment terminals —
+      // has to land on the account that is leaving; after the reset they arrive
+      // on a fresh anonymous distinct_id and no funnel query can pair them with
+      // their `Offline Board Download Started`. Production showed exactly that:
+      // every `Offline Data Wiped On Sign Out` sat on a different person_id from
+      // the `Logout` half a second earlier.
+      resetAnalytics();
       if (!isAuthTransitionCurrent(transitionEpoch)) return false;
       // Reset the per-user "downloaded boards" list so the next account on a shared
       // device doesn't inherit the previous user's offline selection. After a

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -422,8 +422,8 @@ export const SHARED_EVENTS = {
   OfflineBoardDownloadCompleted: 'Offline Board Download Completed',
   // A bootstrap stage failed, or was cut short. Props: { scopeKey, stage:
   // 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import' |
-  // 'board-removed', attempt, expected, reason, aborted, errorMessage,
-  // offlineEngineEnabled }.
+  // 'board-removed' | 'abandoned', attempt, expected, reason, aborted,
+  // errorMessage, offlineEngineEnabled }.
   // `expected: true` is a transport/reachability failure — a phone in a tunnel,
   // not a defect — and is the normal case, not an alarm. These previously went
   // only to Sentry, where they could not be joined to the funnel.
@@ -438,22 +438,44 @@ export const SHARED_EVENTS = {
   // `Failed where aborted = false` over Started.
   //
   // `reason` is a closed, low-cardinality bucket — 'aborted-wipe' |
-  // 'aborted-background' | 'abandoned-removed' | 'database-locked' |
-  // 'schema-stale' | 'watermark-regression' | 'permanent-miss' |
-  // 'artifact-invalid' | 'artifact-truncated' | 'network' | 'unknown' |
-  // 'unknown-exit' — for grouping. The verbatim text stays on `errorMessage`.
-  // Dashboards that ENUMERATE reasons need 'artifact-truncated' (issue #4394's
-  // exact decoded-size gate) and 'abandoned-removed' (#4406) added;
-  // failure-rate queries (`aborted = false`) pick them up on their own.
+  // 'aborted-background' | 'abandoned-removed' | 'abandoned-signed-out' |
+  // 'abandoned-disabled' | 'database-locked' | 'schema-stale' |
+  // 'watermark-regression' | 'permanent-miss' | 'artifact-invalid' |
+  // 'artifact-truncated' | 'network' | 'unknown' | 'unknown-exit' — for
+  // grouping. The verbatim text stays on `errorMessage`. Dashboards that
+  // ENUMERATE reasons need 'artifact-truncated' (issue #4394's exact
+  // decoded-size gate), 'abandoned-removed' (#4406) and the two 'abandoned-*'
+  // de-list reasons (#4452) added; failure-rate queries (`aborted = false`) pick
+  // them up on their own.
   //
-  // 'abandoned-removed' is the one reason that is a COUNT of abandonments rather
-  // than of interruptions (issue #4406): the climber removed the board while its
-  // download was still running, so it fires at most once per Started — from the
-  // teardown, which is the last code that can see the durable start marker — and
-  // always with `stage: 'board-removed'`. Every other abort-shaped reason can
-  // repeat for one download (a pocketed phone, a sibling board's removal), which
-  // is why "downloads given up on" was previously only derivable as
-  // Started-minus-Completed.
+  // The three 'abandoned-*' reasons are the ones that COUNT abandonments rather
+  // than interruptions: each fires at most once per Started, from the last code
+  // that can still see the durable start marker. Every other abort-shaped reason
+  // can repeat many times over one download (a pocketed phone, a sibling board's
+  // removal), which is why "downloads given up on" was previously only derivable
+  // as Started-minus-Completed. They differ only in what ended the download:
+  //   'abandoned-removed'    — the board was removed and its rows deleted
+  //                            (#4406), always with `stage: 'board-removed'`.
+  //   'abandoned-signed-out' — sign-out ended it (#4452). Either the explicit
+  //                            wipe deleted the markers, or a forced-401 /
+  //                            expiry / identity-change sign-out emptied
+  //                            `syncEnabledBoards`, which orphans the Started
+  //                            just as thoroughly: the pull client's board loop
+  //                            only ever visits enabled scopes.
+  //   'abandoned-disabled'   — the climber turned the board off from My Boards,
+  //                            or a launch sweep found a start marker for a
+  //                            board nobody has enabled any more (#4452).
+  //                            Nothing was deleted; a re-enable opens a FRESH
+  //                            Started rather than resuming this one.
+  // Both #4452 reasons carry `stage: 'abandoned'` — deliberately not
+  // 'board-removed', which already ships in dashboards meaning "the rows were
+  // deleted".
+  //
+  // What is still NOT reportable, and per production is the dominant
+  // unterminated bucket: a Started followed by literally nothing — process
+  // death, an uninstall, a climber who never opened the app again. No code
+  // change can emit an event for those, so Started → Completed will not reach
+  // 100% and is not meant to.
   //
   // One pairing changed with #4390: `aborted: true` can now arrive alongside an
   // `Offline Snapshot Retry Scheduled` with `failureKind: 'transport'` — the
@@ -467,15 +489,17 @@ export const SHARED_EVENTS = {
   // rather than the phone went in a pocket. `attempt: 0` on any guard-emitted
   // report: it never spends the scope's retry budget.
   OfflineBoardDownloadFailed: 'Offline Board Download Failed',
-  // The climber turned a board OFF while its first download was still in flight
-  // — the abandonment the funnel exists to size, caught at the moment it
-  // happens. Props: { scopeKey, source: 'manage', stage, fraction, bytesDone,
-  // offlineEngineEnabled }. It needs a live progress frame naming the scope, so
-  // today only the My Boards toggle mid-snapshot fires it: a paged crawl
-  // publishes no such frame, and removing a board from Storage reports its exit
-  // as `Offline Board Toggled { enabled: false, source: 'storage' }` plus the
-  // funnel's own `Offline Board Download Failed { reason: 'abandoned-removed' }`
-  // (issue #4406) instead.
+  // Extra progress detail when the climber turns a board OFF mid-download.
+  // Props: { scopeKey, source: 'manage', stage, fraction, bytesDone,
+  // offlineEngineEnabled }.
+  //
+  // NOT the funnel's terminal, despite what this comment used to claim. It needs
+  // a live SNAPSHOT progress frame naming the exact scope, which a paged crawl
+  // never publishes — and it has fired ZERO times in 180 days of production as a
+  // result. The terminal that always fires is
+  // `Offline Board Download Failed { reason: 'abandoned-disabled' }` (#4452);
+  // this one only adds `fraction` / `bytesDone` on the runs where we happen to
+  // have them. Kept for that detail, not as a count of anything.
   OfflineBoardDownloadCancelled: 'Offline Board Download Cancelled',
   // One artifact transfer that actually moved bytes — the per-download
   // throughput measurement the funnel could not give us (issue #4394). Completed

--- a/packages/shared/offline-sync/src/index.ts
+++ b/packages/shared/offline-sync/src/index.ts
@@ -170,7 +170,12 @@ export {
   getCheckpointKey,
   markScopeDownloadComplete,
   isScopeDownloadComplete,
+  isScopeDownloadStarted,
   getDownloadedScopeKeys,
+  // The download funnel's other half (issue #4452): who still owes a terminal
+  // event, and how to close their funnel once one has been emitted.
+  getUnfinishedDownloadScopeKeys,
+  clearScopeDownloadFunnelMarkers,
   // rewindDeletionsCheckpoint / compareCheckpoints / DELETIONS_CHECKPOINT_KEY
   // stay package-internal (only the bootstrap engine consumes them).
 } from './sync/checkpoints';
@@ -195,6 +200,11 @@ export type { InvalidateKeys } from './sync/invalidate-keys';
 // --- Reclaiming a downloaded board's disk space ----------------------------------
 export { removeBoardScopeData, getScopeUsage, scopeSyncMetaKeys } from './sync/scope-teardown';
 export type { AbandonedDownloadInfo, ScopeTeardownResult, ScopeUsage } from './sync/scope-teardown';
+// Every path that ends a download for good claims its ONE terminal event here —
+// the board removal above, plus the sign-out and de-list paths mobile owns
+// (issue #4452). See download-terminal-registry.ts for why the claim is keyed on
+// a teardown generation rather than a flag.
+export { claimAbandonedDownloadTerminal } from './sync/download-terminal-registry';
 
 // --- Board-snapshot manifest (Phase 2 export ↔ Phase 3 bootstrap) ----------------
 export { parseSnapshotManifest, SNAPSHOT_MANIFEST_FORMAT_VERSION } from './sync/snapshot-manifest';

--- a/packages/shared/offline-sync/src/sync/__tests__/abandoned-download-signout.test.ts
+++ b/packages/shared/offline-sync/src/sync/__tests__/abandoned-download-signout.test.ts
@@ -1,0 +1,231 @@
+// The download funnel's terminal on the paths that DE-LIST a board rather than
+// deleting it (issue #4452), replayed against the REAL client DDL.
+//
+// #4450 closed the removal case: `removeBoardScopeData` reads `scope-started:`
+// before its delete transaction and emits `abandoned-removed` after the commit.
+// Every other ender stayed silent — and the mechanism they share is not "the
+// marker was deleted", it is "the scope left `syncEnabledBoards`", which
+// `pullSync`'s board loop only ever iterates. So:
+//
+//   - the EXPLICIT sign-out wipes sync_meta wholesale (`deleteAllSyncMeta`), so
+//     the markers have to be read before the transaction and reported after it,
+//     exactly like the teardown;
+//   - the SELECTIVE sign-outs (forced 401, proactive expiry, identity change)
+//     keep every marker and every row, and still end the download for good;
+//   - the My Boards toggle-off deletes nothing whatsoever.
+//
+// The wipe wiring itself lives in mobile's `purgeLocalDataForSignOut` (this
+// package is platform-free and never sees expo-sqlite), so the shape is modelled
+// here — read before, wipe, claim, emit after — while
+// `packages/mobile/src/db/__tests__/connection.test.ts` pins the real call site
+// against the same contract.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  markScopeDownloadStarted,
+  markScopeDownloadComplete,
+  isScopeDownloadStarted,
+  isScopeDownloadComplete,
+  getUnfinishedDownloadScopeKeys,
+  clearScopeDownloadFunnelMarkers,
+  ensureScopeDownloadStartedAt,
+  deleteAllSyncMeta,
+  setCheckpoint,
+  getCheckpoint,
+  getCheckpointKey,
+} from '../checkpoints';
+import {
+  claimAbandonedDownloadTerminal,
+  noteScopeDownloadTerminal,
+  __resetDownloadTerminalRegistryForTests,
+} from '../download-terminal-registry';
+import { runMigrations } from '../../db/migrations';
+import { ensureMutationQueueTable } from '../../mutation-queue/schema';
+import { beginScopePurge, setSigningOut, __resetDrainerStateForTests } from '../../mutation-queue/drainer';
+import { purgeNamespaceForScopeKey } from '../../offline-board-key';
+import { createTestDatabase, type TestSqliteDb } from '../../testing/sqlite-test-db';
+
+const DOWNLOADING = 'tension:11:8';
+const DOWNLOADED = 'kilter:1:5';
+const DOWNLOADING_NAMESPACE = 'tension:11';
+
+let workDir: string;
+let db: TestSqliteDb;
+
+beforeEach(async () => {
+  workDir = mkdtempSync(join(tmpdir(), 'abandoned-signout-'));
+  db = createTestDatabase(join(workDir, 'client.db'));
+  await runMigrations(db);
+  await ensureMutationQueueTable(db);
+  __resetDrainerStateForTests();
+  __resetDownloadTerminalRegistryForTests();
+});
+
+afterEach(() => {
+  db.close();
+  __resetDrainerStateForTests();
+  __resetDownloadTerminalRegistryForTests();
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+/**
+ * The shape `purgeLocalDataForSignOut` implements: read the open funnels BEFORE
+ * the transaction that destroys them, wipe, then claim-and-emit after the commit.
+ */
+async function signOutWipe(onDownloadAbandoned: (info: { scopeKey: string }) => void): Promise<void> {
+  const abandoned = await getUnfinishedDownloadScopeKeys(db);
+  await db.withExclusiveTransactionAsync(async (txn) => {
+    await deleteAllSyncMeta(txn);
+  });
+  for (const scopeKey of abandoned) {
+    const namespace = purgeNamespaceForScopeKey(scopeKey);
+    if (namespace !== undefined && !claimAbandonedDownloadTerminal(scopeKey, namespace)) continue;
+    onDownloadAbandoned({ scopeKey });
+  }
+}
+
+describe('getUnfinishedDownloadScopeKeys', () => {
+  it('names only the scopes with a Started and no Completed', async () => {
+    await markScopeDownloadStarted(db, DOWNLOADING);
+    await markScopeDownloadStarted(db, DOWNLOADED);
+    await markScopeDownloadComplete(db, DOWNLOADED);
+
+    expect(await getUnfinishedDownloadScopeKeys(db)).toEqual([DOWNLOADING]);
+  });
+
+  it('is empty when nothing ever announced a download', async () => {
+    await markScopeDownloadComplete(db, DOWNLOADED);
+    expect(await getUnfinishedDownloadScopeKeys(db)).toEqual([]);
+  });
+
+  it('does not confuse the start STAMP with the start MARKER', async () => {
+    // `scope-download-started:` is the wall-clock stamp; only `scope-started:`
+    // opens a funnel. A GLOB on the wrong prefix would return this scope.
+    await ensureScopeDownloadStartedAt(db, DOWNLOADING, 1_700_000_000_000);
+    expect(await getUnfinishedDownloadScopeKeys(db)).toEqual([]);
+  });
+});
+
+describe('clearScopeDownloadFunnelMarkers', () => {
+  it('closes the funnel without touching the rows it describes', async () => {
+    await markScopeDownloadStarted(db, DOWNLOADING);
+    await ensureScopeDownloadStartedAt(db, DOWNLOADING, 1_700_000_000_000);
+    const checkpointKey = getCheckpointKey('board_climbs', DOWNLOADING);
+    await setCheckpoint(db, checkpointKey, { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' });
+    await markScopeDownloadComplete(db, DOWNLOADED);
+
+    await clearScopeDownloadFunnelMarkers(db, DOWNLOADING);
+
+    expect(await isScopeDownloadStarted(db, DOWNLOADING)).toBe(false);
+    // The checkpoint is what makes a re-enable resume instantly rather than
+    // re-crawl 40k climbs, and `scope-complete:` is what tells local-first search
+    // a catalog is on disk. Neither is the funnel's business.
+    expect(await getCheckpoint(db, checkpointKey)).not.toBeNull();
+    expect(await isScopeDownloadComplete(db, DOWNLOADED)).toBe(true);
+  });
+});
+
+describe('a sign-out landing mid-download (issue #4452)', () => {
+  it('closes the in-flight Started, and only that one, with exactly one terminal', async () => {
+    await markScopeDownloadStarted(db, DOWNLOADING);
+    await markScopeDownloadStarted(db, DOWNLOADED);
+    await markScopeDownloadComplete(db, DOWNLOADED);
+
+    const terminals: string[] = [];
+    setSigningOut(true);
+    await signOutWipe(({ scopeKey }) => terminals.push(scopeKey));
+    setSigningOut(false);
+
+    expect(terminals).toEqual([DOWNLOADING]);
+    // And the evidence really is gone by then — which is why the read has to
+    // happen before the transaction rather than after it.
+    expect(await getUnfinishedDownloadScopeKeys(db)).toEqual([]);
+  });
+
+  it('stays silent when nothing was downloading', async () => {
+    await markScopeDownloadStarted(db, DOWNLOADED);
+    await markScopeDownloadComplete(db, DOWNLOADED);
+
+    const onDownloadAbandoned = vi.fn();
+    setSigningOut(true);
+    await signOutWipe(onDownloadAbandoned);
+    setSigningOut(false);
+
+    expect(onDownloadAbandoned).not.toHaveBeenCalled();
+  });
+
+  it('emits ONE terminal, not two, when the torn-down cycle already reported aborted-wipe', async () => {
+    await markScopeDownloadStarted(db, DOWNLOADING);
+
+    const terminals: string[] = [];
+    // setSigningOut bumps the global wipe epoch and tears the cycle down; the
+    // bootstrap phase reports its own `aborted-wipe` for the attempt it just
+    // abandoned, which the pull client notes in the registry.
+    setSigningOut(true);
+    noteScopeDownloadTerminal(DOWNLOADING);
+    await signOutWipe(({ scopeKey }) => terminals.push(scopeKey));
+    setSigningOut(false);
+
+    expect(terminals).toEqual([]);
+  });
+
+  it('still reports when an EARLIER removal noted a terminal for the same scope', async () => {
+    await markScopeDownloadStarted(db, DOWNLOADING);
+
+    // A sibling board in this namespace was removed earlier in the session, and
+    // the cycle it tore down reported `aborted-wipe` for our scope. That removal
+    // is not this sign-out.
+    const release = beginScopePurge(DOWNLOADING_NAMESPACE);
+    noteScopeDownloadTerminal(DOWNLOADING);
+    release();
+
+    // Under the namespace-only generation #4406 shipped, the stale note IS the
+    // current generation, so the sign-out below would be suppressed.
+    expect(claimAbandonedDownloadTerminal(DOWNLOADING, DOWNLOADING_NAMESPACE)).toBe(false);
+
+    const terminals: string[] = [];
+    setSigningOut(true);
+    await signOutWipe(({ scopeKey }) => terminals.push(scopeKey));
+    setSigningOut(false);
+
+    // The composite generation moves with the wipe epoch, so the sign-out gets
+    // its own claim.
+    expect(terminals).toEqual([DOWNLOADING]);
+  });
+
+  it('gives a second sign-out in the same session its own claim', async () => {
+    setSigningOut(true);
+    expect(claimAbandonedDownloadTerminal(DOWNLOADING, DOWNLOADING_NAMESPACE)).toBe(true);
+    // Same sign-out, same generation: no second terminal.
+    expect(claimAbandonedDownloadTerminal(DOWNLOADING, DOWNLOADING_NAMESPACE)).toBe(false);
+    setSigningOut(false);
+
+    setSigningOut(true);
+    expect(claimAbandonedDownloadTerminal(DOWNLOADING, DOWNLOADING_NAMESPACE)).toBe(true);
+    setSigningOut(false);
+  });
+});
+
+describe('a de-listed scope keeps its rows and opens a fresh funnel (issue #4452)', () => {
+  it('lets the next download emit its own Started after a toggle-off', async () => {
+    await markScopeDownloadStarted(db, DOWNLOADING);
+    const checkpointKey = getCheckpointKey('board_climbs', DOWNLOADING);
+    await setCheckpoint(db, checkpointKey, { updatedAt: '2026-05-02T00:00:00Z', syncSeq: '20' });
+
+    // The toggle-off: report, then close the funnel. Nothing else is deleted.
+    await clearScopeDownloadFunnelMarkers(db, DOWNLOADING);
+    expect(await getUnfinishedDownloadScopeKeys(db)).toEqual([]);
+
+    // The re-enable. `emitScopeDownloadStartOnce` gates on this exact read, so a
+    // surviving marker would have made the next download's Started disappear —
+    // and its eventual Completed unmatched.
+    expect(await isScopeDownloadStarted(db, DOWNLOADING)).toBe(false);
+    await markScopeDownloadStarted(db, DOWNLOADING);
+    expect(await getUnfinishedDownloadScopeKeys(db)).toEqual([DOWNLOADING]);
+    // The crawl still resumes from where the abandoned one stopped.
+    expect(await getCheckpoint(db, checkpointKey)).not.toBeNull();
+  });
+});

--- a/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
+++ b/packages/shared/offline-sync/src/sync/bootstrap-failure-reason.ts
@@ -33,6 +33,24 @@ export type SnapshotBootstrapFailureReason =
    * funnel is trying to size rather than another interruption.
    */
   | 'abandoned-removed'
+  /**
+   * Sign-out ended the download (issue #4452). Either the explicit sign-out's
+   * wipe deleted the marker along with every other sync_meta row, or a selective
+   * sign-out (forced 401, proactive expiry, identity change) emptied
+   * `syncEnabledBoards` — which orphans the Started just as thoroughly, because
+   * the pull client's board loop only ever visits ENABLED scopes. Same
+   * once-per-Started contract as `abandoned-removed`.
+   */
+  | 'abandoned-signed-out'
+  /**
+   * The climber turned the board OFF while its download was still running
+   * (issue #4452), from My Boards. Nothing is deleted — the rows and checkpoints
+   * stay so a re-enable resumes instantly — but the scope leaves
+   * `syncEnabledBoards`, so no future cycle will finish THIS download. A
+   * re-enable opens a fresh funnel rather than resuming this one, which is the
+   * only reading that keeps Started → Completed a real ratio.
+   */
+  | 'abandoned-disabled'
   /** The app went to the background mid-cycle. Resumes on the next foreground. */
   | 'aborted-background'
   /** SQLITE_BUSY / SQLITE_LOCKED — contention, not a broken database. */

--- a/packages/shared/offline-sync/src/sync/checkpoints.ts
+++ b/packages/shared/offline-sync/src/sync/checkpoints.ts
@@ -204,6 +204,55 @@ export async function getDownloadedScopeKeys(db: SqlExecutor): Promise<string[]>
   return rows.map((row) => row.key.slice(SCOPE_COMPLETE_PREFIX.length));
 }
 
+/**
+ * The scopes with an OPEN download funnel: a `scope-started:` marker and no
+ * `scope-complete:` twin (issue #4452).
+ *
+ * `removeBoardScopeData` can ask this question one scope at a time because it
+ * already knows which board is going away. The paths this exists for cannot: a
+ * sign-out ends EVERY download at once, and the launch backstop is looking for
+ * markers whose board nobody named at the time. Both need the whole open set
+ * before they act, because the act is what destroys the evidence — the sign-out
+ * wipe deletes sync_meta wholesale, and de-listing a board means the pull
+ * client's `boardScopes` loop never visits that scope again.
+ *
+ * Two GLOB reads and a set difference rather than a `NOT EXISTS` subquery, so it
+ * keeps the literal-prefix index range-scan `getDownloadedScopeKeys` relies on
+ * (SQLite's default case-insensitive LIKE would scan the table instead).
+ */
+export async function getUnfinishedDownloadScopeKeys(db: SqlExecutor): Promise<string[]> {
+  const startedRows = await db.getAllAsync<{ key: string }>('SELECT key FROM sync_meta WHERE key GLOB ?', [
+    `${SCOPE_STARTED_PREFIX}*`,
+  ]);
+  if (startedRows.length === 0) return [];
+  const completedScopeKeys = new Set(await getDownloadedScopeKeys(db));
+  return startedRows
+    .map((row) => row.key.slice(SCOPE_STARTED_PREFIX.length))
+    .filter((scopeKey) => !completedScopeKeys.has(scopeKey));
+}
+
+/**
+ * Close one scope's funnel without touching anything else it owns (issue #4452).
+ *
+ * The de-listing paths — the My Boards toggle-off, and the selective sign-out
+ * that empties `syncEnabledBoards` — delete no catalog rows at all: the rows and
+ * their checkpoints stay so a re-enable resumes instantly. Only the funnel's own
+ * bookkeeping has to go, and only once a terminal event has been emitted for it.
+ * Left behind, the marker is what makes abandonment unmeasurable: this
+ * download's Started stays open forever, and the NEXT download emits Completed
+ * with no Started of its own.
+ *
+ * `scope-complete:` is deliberately NOT here — it describes rows that still
+ * exist, and dropping it would make `isBoardDownloadedLocally` deny a catalog
+ * sitting on disk. Neither is any `checkpoint:` key, for the same reason. An
+ * exact key list, like scope-teardown's `clearScopeSyncMeta`, never a prefix
+ * sweep.
+ */
+export async function clearScopeDownloadFunnelMarkers(db: SqlExecutor, scopeKey: string): Promise<void> {
+  const keys = [`${SCOPE_STARTED_PREFIX}${scopeKey}`, `${SCOPE_DOWNLOAD_STARTED_PREFIX}${scopeKey}`];
+  await db.runAsync(`DELETE FROM sync_meta WHERE key IN (${keys.map(() => '?').join(', ')})`, keys);
+}
+
 export async function getCheckpoint(db: SqlExecutor, key: string): Promise<SyncCheckpoint | null> {
   const row = await db.getFirstAsync<{ value: string }>('SELECT value FROM sync_meta WHERE key = ?', [key]);
   if (!row) return null;

--- a/packages/shared/offline-sync/src/sync/download-terminal-registry.ts
+++ b/packages/shared/offline-sync/src/sync/download-terminal-registry.ts
@@ -14,27 +14,41 @@
 //
 // Both can be true at once (a purge that lands mid-bootstrap runs the teardown
 // milliseconds later), and two terminals for one Started would break the funnel
-// invariant #4391 states. So the two agree through the purge GENERATION: the
-// epoch `beginScopePurge` bumped is the removal's identity, and a terminal is
+// invariant #4391 states. So the two agree through the teardown GENERATION: the
+// epoch the teardown bumped is that teardown's identity, and a terminal is
 // claimed against it exactly once.
 //
-// Keyed on the epoch rather than a plain "already reported" flag on purpose. A
-// scope collects `aborted-wipe` terminals routinely — every sibling size of a
+// The generation is COMPOSITE — `${globalWipeEpoch}:${purgeEpoch(namespace)}` —
+// because two different teardowns can end a download and they move different
+// counters (issue #4452). `beginScopePurge` bumps only its namespace's epoch;
+// `setSigningOut(true)` bumps only the global wipe epoch. Keying on the
+// namespace epoch alone made a sign-out invisible to the registry: an
+// `aborted-wipe` recorded earlier in the session, from an unrelated board
+// removal, would still be the current generation and would falsely suppress the
+// sign-out's terminal, and two sign-outs in one session would collide with each
+// other.
+//
+// Keyed on a generation rather than a plain "already reported" flag on purpose.
+// A scope collects `aborted-wipe` terminals routinely — every sibling size of a
 // removed layout gets one, and none of those removals is its own — so a flag
 // would let one stale report suppress a real abandonment months later. The
-// epoch makes the claim specific to the removal in progress.
+// generation makes the claim specific to the teardown in progress.
 //
 // Process-local, like every other purge-generation fact. A Started that survives
 // a relaunch is covered by the durable markers instead: the teardown reads
 // `scope-started:` / `scope-complete:` before its transaction, so a download
 // abandoned in an earlier launch still reports exactly one terminal when the
-// board is finally removed.
+// board is finally removed — and the launch backstop sweeps the de-listed ones.
 
-import { getPurgeEpoch } from '../mutation-queue/drainer';
+import { getPurgeEpoch, getWipeEpoch } from '../mutation-queue/drainer';
 import { purgeNamespaceForScopeKey } from '../offline-board-key';
 
-/** scopeKey → the purge epoch a terminal event was last reported against. */
-const terminalByScope = new Map<string, number>();
+/** scopeKey → the teardown generation a terminal event was last reported against. */
+const terminalByScope = new Map<string, string>();
+
+function teardownGeneration(namespace: string): string {
+  return `${getWipeEpoch()}:${getPurgeEpoch(namespace)}`;
+}
 
 /**
  * A terminal event was just emitted for `scopeKey` by a torn-down cycle. Only
@@ -47,17 +61,18 @@ export function noteScopeDownloadTerminal(scopeKey: string): void {
   // A malformed key belongs to no namespace we can name, so there is no
   // generation to record it against — and nothing will ever claim against it.
   if (namespace === undefined) return;
-  terminalByScope.set(scopeKey, getPurgeEpoch(namespace));
+  terminalByScope.set(scopeKey, teardownGeneration(namespace));
 }
 
 /**
- * Claim the abandoned terminal for the removal currently in progress. False when
- * the cycle this removal tore down already reported one for the same generation.
+ * Claim the abandoned terminal for the teardown currently in progress — a board
+ * removal or a sign-out. False when the cycle this teardown tore down already
+ * reported one for the same generation.
  */
 export function claimAbandonedDownloadTerminal(scopeKey: string, namespace: string): boolean {
-  const epoch = getPurgeEpoch(namespace);
-  if (terminalByScope.get(scopeKey) === epoch) return false;
-  terminalByScope.set(scopeKey, epoch);
+  const generation = teardownGeneration(namespace);
+  if (terminalByScope.get(scopeKey) === generation) return false;
+  terminalByScope.set(scopeKey, generation);
   return true;
 }
 

--- a/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
+++ b/packages/shared/offline-sync/src/sync/snapshot-bootstrap.ts
@@ -201,13 +201,22 @@ export interface SnapshotSource {
 export type SnapshotBootstrapErrorReport = {
   scopeKey: string;
   /**
-   * How far the attempt got. `board-removed` is the one value no bootstrap stage
-   * produces: it is reported by the teardown when a board is removed mid-download
-   * (issue #4406), which can happen at any stage — including the paged delta
-   * crawl that runs long after the bootstrap phase has finished — so naming a
-   * bootstrap stage there would invent a precision the teardown does not have.
+   * How far the attempt got. `board-removed` and `abandoned` are the two values
+   * no bootstrap stage produces.
+   *
+   * `board-removed` is reported by the teardown when a board is removed
+   * mid-download (issue #4406), which can happen at any stage — including the
+   * paged delta crawl that runs long after the bootstrap phase has finished — so
+   * naming a bootstrap stage there would invent a precision the teardown does
+   * not have.
+   *
+   * `abandoned` is the same story for the de-listing paths (issue #4452):
+   * sign-out, and the My Boards toggle-off. It is a SEPARATE value rather than
+   * more `board-removed` on purpose — `board-removed` already ships in
+   * dashboards and means "the rows were deleted", which is exactly what these
+   * paths do NOT do. The `reason` says which de-listing it was.
    */
-  stage: 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import' | 'board-removed';
+  stage: 'manifest' | 'download' | 'import' | 'grades-download' | 'grades-import' | 'board-removed' | 'abandoned';
   attempt: number;
   cause: unknown;
   /**

--- a/packages/shared/offline-sync/src/testing/index.ts
+++ b/packages/shared/offline-sync/src/testing/index.ts
@@ -3,3 +3,7 @@ export { createTestDatabase, listTables, tableColumns, primaryKeyColumns, type T
 // (not on the main entry) so app code never sees the escape hatches.
 export { __resetDrainerStateForTests } from '../mutation-queue/drainer';
 export { __resetSyncSchedulerStateForTests } from '../sync/sync-scheduler';
+// The download funnel's one-terminal-per-teardown claim (issues #4406, #4452).
+// Process-local by design, so a suite that closes more than one funnel has to
+// clear it between cases or the second claim is refused.
+export { __resetDownloadTerminalRegistryForTests } from '../sync/download-terminal-registry';


### PR DESCRIPTION
## Summary

Closes #4452.

`Offline Board Download Started` is emitted once per scope and guarded by a durable
`scope-started:` sync_meta marker, so its terminal is owed by whatever ends the download. After
#4450 exactly **one** ender reported: `removeBoardScopeData`, which reads the marker before its
delete transaction and emits `abandoned-removed` after the commit. Every other way a download can
end for good was silent.

The issue names the sign-out wipe, and that is real — but the hole is wider, and on a different
axis. The mechanism is **not** "the wipe deleted the marker". It is "the board left
`syncEnabledBoards`". `pullSync`'s board loop iterates only enabled scopes
(`pull-client.ts:2712`), so a de-listed board is never visited again and its Started stays open
forever *even when nothing was deleted and the marker is still sitting in sync_meta*. That covers
the My Boards toggle-off, which deletes nothing at all, and all three sign-outs —
`runSignedOutCleanup` runs `setSetting('syncEnabledBoards', [])` unconditionally, including the
forced-401, proactive-expiry and identity-change paths that only ever ran the selective
`clearUserData`.

### Every path that ends a download, and which reports one now

The list, so the next person can check it rather than re-derive it. **NEW** marks what this PR adds.

| How a download ends | Reports | Terminal |
| --- | --- | --- |
| It finishes | before | `Offline Board Download Completed` |
| Board removed from Storage (`removeBoardScopeData`) | #4450 | `Failed { stage: 'board-removed', reason: 'abandoned-removed' }` |
| Explicit sign-out / account deletion (`purgeLocalDataForSignOut`) | **NEW** | `Failed { stage: 'abandoned', reason: 'abandoned-signed-out' }` — markers read before the wipe transaction, emitted after the commit |
| Forced 401 (`handleForcedSignOut`) | **NEW** | `Failed { … reason: 'abandoned-signed-out' }` — from `runSignedOutCleanup`, markers then cleared |
| Proactive token expiry (`checkAuth`) | **NEW** | same as above |
| Identity change / owner mismatch sign-out | **NEW** | same as above |
| My Boards toggle-off (`manage.tsx` `handleToggleOffline`) | **NEW** | `Failed { stage: 'abandoned', reason: 'abandoned-disabled' }` |
| A de-list that crashed before reporting, or a device upgrading into this build | **NEW** | launch backstop in `offline-sync-bridge.tsx`, as `abandoned-disabled` |
| Owner-stamp mismatch wipe (`clearUserData` in the bridge) | n/a | **nothing, correctly** — it de-lists nothing and keeps every board checkpoint, so the scope keeps downloading |
| App backgrounded / a sibling board's removal tears the cycle down | before | `Failed { aborted: true, reason: 'aborted-background' / 'aborted-wipe' }` — an interruption, not an ending; the download resumes |
| Process death, uninstall, a climber who never opens the app again | n/a | **nothing, and nothing can** |

That last row is not a caveat, it is the dominant bucket. Over the 30 days the funnel has existed:
145 (person, scope) Starteds, 44 with no Completed (30%), and **25 of those 44 emitted literally
nothing after the Started** — same first and last timestamp, no toggle, no logout. This PR does not
close the funnel gap; it closes every gap the code can still be responsible for.

### What changed

**Shared engine** (`packages/shared/offline-sync`)

- `getUnfinishedDownloadScopeKeys(db)` — every `scope-started:` with no `scope-complete:` twin. Two
  GLOB reads and a set difference, keeping the literal-prefix index range-scan
  `getDownloadedScopeKeys` relies on. The de-list paths need the whole open set before they act,
  because the act is what destroys the evidence.
- `clearScopeDownloadFunnelMarkers(db, scopeKey)` — deletes `scope-started:` and
  `scope-download-started:` and *nothing else*. Not `scope-complete:` (it describes rows that still
  exist), not any `checkpoint:` key (a re-enable must still resume instantly). Exact key list, like
  `scope-teardown`'s `clearScopeSyncMeta`, never a prefix sweep.
- Two new closed-union reasons, `abandoned-signed-out` and `abandoned-disabled`, and **one new
  stage, `abandoned`**. Deliberately not more `board-removed`: that value already ships in
  dashboards and means "the rows were deleted", which is exactly what these paths do not do.
- `download-terminal-registry.ts` now keys its claim on a **composite**
  `${wipeEpoch}:${purgeEpoch(namespace)}` generation. `setSigningOut(true)` moves only the global
  wipe epoch and `beginScopePurge` only its namespace's, so the shipped namespace-only key made a
  sign-out invisible to the registry: a stale `aborted-wipe` from an unrelated sibling-board removal
  earlier in the session would falsely suppress a real sign-out terminal, and two sign-outs in one
  session collided. Covered by a test that is red on the old key.

**Mobile**

- `purgeLocalDataForSignOut` takes an optional `onDownloadAbandoned`, reads the open funnels
  **before** its transaction (its `deleteAllSyncMeta` is what destroys them) and reports **after**
  the commit — same ordering, and the same reason, as `removeBoardScopeData`.
- `reportScopeDownloadAbandonedOnSignOut` / `…OnDisable` route through the single
  `reportSnapshotBootstrapError` call site, so the Failed leg can never disagree with itself.
  `aborted: true`, `expected: true`, `attempt: 0` — out of Sentry and out of every failure rate.
- New `abandoned-download-terminals.ts` owns the three de-list entry points (selective sign-out,
  toggle-off, launch sweep). Clear **then** report, per scope: the cleared marker is the durable
  dedup and is also what lets a re-enable open a fresh Started → Completed pair, and the clear is
  the only step that can fail — so a locked write emits nothing and leaves the launch sweep as the
  single reporter, rather than emitting now and again next launch. Each scope's close is
  independently fault-tolerant, so one locked write cannot drop the rest of a sweep.
- Launch backstop in `offline-sync-bridge.tsx`: any `scope-started:` whose scope is not in
  `syncEnabledBoards` is an open funnel nothing will ever close. Makes the invariant structural
  rather than a list of remembered call sites (the lesson #4391 wrote down), and covers crashes and
  devices upgrading from a build that predates this fix.
- `runSignedOutCleanup` moves `resetAnalytics()` to **after** the offline cleanup. This is not a
  nice-to-have: production shows *every* `Offline Data Wiped On Sign Out` landing on a different
  `person_id` from the `Logout` half a second earlier (e.g. Logout `2cd8132e` @12:38:16.950Z vs wipe
  `77a77835` @12:38:17.538Z). Without this, the new terminals would be equally unjoinable to their
  Started, and the pre-existing mis-attribution of the wipe event itself stays broken.

### Decisions worth flagging

- **The toggle-off clears `scope-started:`.** A toggle-off-then-on gets two Starteds. That is the
  honest reading — as far as the funnel is concerned they are two downloads — and a durable marker
  outliving its download is what caused this bug in the first place. The rows and checkpoints stay,
  so the re-enable still resumes instantly.
- **The de-list paths do not claim against the terminal registry; the sign-out paths do.** Sign-out
  genuinely races a torn-down cycle's own `aborted-wipe` (`setSigningOut(true)` tears it down), so
  it needs the claim. Nothing tears a cycle down for a toggle-off, and using the claim there
  actively loses events: it is keyed on a generation only a purge or sign-out moves, so toggling one
  board off, on, and off again in a session would swallow the second terminal. There is a test for
  exactly that.
- **`Offline Board Download Cancelled` is kept, and its doc corrected.** It has fired **zero times
  in 180 days** — it is absent from the project's event taxonomy entirely — because it needs a live
  snapshot progress frame naming the exact scope, which a paged crawl never publishes. Its
  `events.ts` doc claimed it was "the abandonment the funnel exists to size"; it is now documented
  as progress detail on the runs where we happen to have it, with the new terminal as the signal
  that always fires. Retaining it costs nothing and forecloses nothing.
- **Not built:** a durable "owed terminal" record so the launch backstop could attribute to the
  right account. Bigger than this issue warrants; the in-session reports are primary so the backstop
  only bites on crashes and upgrades.

No BLE, native config, plugin or `packages/mobile/modules` changes, so the native fingerprint is
unaffected and this ships OTA.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run test:offline-sync` — 33 files / 726 tests green, including the new
  `abandoned-download-signout.test.ts` against the real client DDL: read-before/emit-after over a
  `deleteAllSyncMeta`-shaped wipe reports exactly one terminal for the incomplete scope only; a
  sign-out landing mid-bootstrap dedups against the phase's own `aborted-wipe`; a sign-out after an
  earlier sibling removal still reports (**confirmed red** on the namespace-only generation key, along
  with the two-sign-outs-in-one-session case).
- `vp run test:mobile` — includes new/extended coverage:
  - `offline/__tests__/abandoned-download-terminals.test.ts` (new, real DDL): which scope is
    reported, markers cleared, sibling mid-download untouched, re-enable gets a fresh funnel and its
    own second terminal, the launch sweep reports once and never touches a still-enabled scope,
    a broken database never fails a sign-out, and one scope's locked clear neither drops the other
    scopes nor double-reports itself (**confirmed red** without the per-scope guard).
  - `offline/__tests__/offline-sync-adapter.test.ts`: both new reporters emit the funnel Failed
    shape with `stage: 'abandoned'` and never reach Sentry.
  - `db/__tests__/connection.test.ts`: `purgeLocalDataForSignOut` calls the hook once per
    started-and-incomplete scope, zero times for a completed one, and wipes identically with no hook.
  - `providers/__tests__/auth-provider.test.tsx`: the wipe event is tracked strictly **before**
    `resetAnalytics()`; the explicit sign-out is handed the reporter and does not double-report; the
    selective sign-out reports before both `resetAnalytics()` and the `syncEnabledBoards` reset.
  - `app/boards/__tests__/manage-offline.test.tsx`: toggling a board off closes its funnel, toggling
    one on does not.
- `vp run typecheck` and `vp check` green.
- `vp run check:mobile-bundle` green.
- **Post-merge PostHog check** (project 412845), once the OTA lands: `abandoned-signed-out` and
  `abandoned-disabled` appear in the `Offline Board Download Failed` reason breakdown, and the
  per-(person_id, scopeKey) no-Completed share falls from its current 30%. It will not reach zero —
  the silent-process class is not reportable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016552Be7ctNKKH8QM9rkryN
