### PR TITLE
feat(mobile): a read-only climb surface for signed-out readers

### DIFF
--- a/packages/mobile/src/components/AnonymousClimbView.tsx
+++ b/packages/mobile/src/components/AnonymousClimbView.tsx
@@ -24,7 +24,7 @@
 // Native never renders this. The whole anonymous branch sits behind
 // `RELAXES_ANONYMOUS_ROUTES`, whose native fork is a literal `false`.
 
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { Stack, useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
@@ -70,15 +70,20 @@ export const AnonymousClimbView = memo(function AnonymousClimbView({
   // without a fresh nonce the anonymous drawer would fall back to the queue's
   // current climb, which is empty here, and blank itself.
   const [openNonce, setOpenNonce] = useState(1);
+  // The current angle again, in a ref, purely so the "did it actually move?"
+  // check can happen OUTSIDE a state updater. Bumping the nonce from inside
+  // `setAngle`'s updater read naturally but broke React's contract that updaters
+  // are pure: Strict Mode runs them twice, so every angle change moved the nonce
+  // by two in development and by one in production — the kind of difference that
+  // makes a re-open bug reproduce on a device and not on a desk.
+  const angleRef = useRef(boardConfig.angle);
   const handleAngleChange = useCallback((nextAngle: number) => {
-    // Both writes are conditional on the angle actually moving. Re-opening the
-    // drawer for an angle it is already on would rebuild the preview item for
-    // nothing.
-    setAngle((currentAngle) => {
-      if (currentAngle === nextAngle) return currentAngle;
-      setOpenNonce((nonce) => nonce + 1);
-      return nextAngle;
-    });
+    // Re-opening the drawer for the angle it is already on would rebuild the
+    // preview item for nothing, so both writes are conditional on the move.
+    if (angleRef.current === nextAngle) return;
+    angleRef.current = nextAngle;
+    setAngle(nextAngle);
+    setOpenNonce((nonce) => nonce + 1);
   }, []);
 
   const paneBoardConfig = useMemo<BoardConfig>(() => ({ ...boardConfig, angle }), [boardConfig, angle]);

--- a/packages/mobile/src/components/AnonymousClimbView.tsx
+++ b/packages/mobile/src/components/AnonymousClimbView.tsx
@@ -67,8 +67,14 @@ export const AnonymousClimbView = memo(function AnonymousClimbView({
   // current climb, which is empty here, and blank itself.
   const [openNonce, setOpenNonce] = useState(1);
   const handleAngleChange = useCallback((nextAngle: number) => {
-    setAngle((currentAngle) => (currentAngle === nextAngle ? currentAngle : nextAngle));
-    setOpenNonce((nonce) => nonce + 1);
+    // Both writes are conditional on the angle actually moving. Re-opening the
+    // drawer for an angle it is already on would rebuild the preview item for
+    // nothing.
+    setAngle((currentAngle) => {
+      if (currentAngle === nextAngle) return currentAngle;
+      setOpenNonce((nonce) => nonce + 1);
+      return nextAngle;
+    });
   }, []);
 
   const paneBoardConfig = useMemo<BoardConfig>(() => ({ ...boardConfig, angle }), [boardConfig, angle]);

--- a/packages/mobile/src/components/AnonymousClimbView.tsx
+++ b/packages/mobile/src/components/AnonymousClimbView.tsx
@@ -1,0 +1,149 @@
+// The read-only climb view a signed-out visitor gets on app.boardsesh.com.
+//
+// www links every indexed climb page into this app at the same path. Until now
+// that arrival hit a login form — 209 characters of body copy where the SEO
+// funnel was supposed to end — because the board routes are redirectors: they
+// adopt the URL's board (a write that needs an account) and hand off to the
+// Climbs tab plus the `/play` modal.
+//
+// Neither half was necessary to DRAW the climb. Every render input is in the
+// URL: the tuple carries the whole board config, board art is a local catalogue
+// lookup, and the `climb` resolver takes no viewer at all. So this screen skips
+// adoption and, crucially, skips the navigation: `PlayDrawer` renders here in
+// its existing `presentation="pane"` mode, in place, on the canonical
+// `/…/{angle}/view/{segment}` URL.
+//
+// Staying put is not a style choice. `/(tabs)/climbs` and `/play` are both
+// outside the anonymous allow-set, and `AuthProvider` re-reads
+// `window.location.pathname` on every navigation — so a hand-off would bounce
+// the visitor back to the login wall the moment the drawer opened. Anything
+// added here that navigates off the allow-set does the same thing silently; see
+// `PlayDrawerActionBar`'s `viewer` prop for the affordances that were removed
+// for exactly that reason.
+//
+// Native never renders this. The whole anonymous branch sits behind
+// `RELAXES_ANONYMOUS_ROUTES`, whose native fork is a literal `false`.
+
+import { memo, useCallback, useMemo, useState } from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import type { Climb } from '@boardsesh/shared-schema';
+import { PlayDrawer } from './play-drawer/PlayDrawer';
+import { Button } from './Button';
+import { Text } from './Text';
+import { climbToQueueItem } from '../lib/climb-to-queue-item';
+import { buildLoginHrefWithReturn } from '../lib/routing/anonymous-auth-gate';
+import { useTheme } from '../providers/theme-provider';
+import type { BoardConfig } from '../providers/drawer-host-provider';
+import { spacing } from '../theme/tokens';
+
+/** Nothing to open: the queue button is hidden for an anonymous viewer. */
+function noop() {}
+
+export const AnonymousClimbView = memo(function AnonymousClimbView({
+  climb,
+  boardConfig,
+}: {
+  climb: Climb;
+  boardConfig: BoardConfig;
+}) {
+  const { t } = useTranslation('session');
+  const router = useRouter();
+  const { systemColors } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  // The angle pill stays live, and the drawer's board config is the only thing
+  // it moves — exactly what the signed-in deep-link path does, where an angle
+  // change rewrites `boardConfigOverride` and leaves the climb object alone.
+  // The URL is not rewritten for the same reason it is not there either.
+  const [angle, setAngle] = useState(boardConfig.angle);
+
+  // Bumped alongside the angle so the open target re-applies. PlayDrawer clears
+  // its preview item on every angle change and then re-reads `openTarget`
+  // (whose effect is declared after that one, so it wins in the same commit) —
+  // without a fresh nonce the anonymous drawer would fall back to the queue's
+  // current climb, which is empty here, and blank itself.
+  const [openNonce, setOpenNonce] = useState(1);
+  const handleAngleChange = useCallback((nextAngle: number) => {
+    setAngle((currentAngle) => (currentAngle === nextAngle ? currentAngle : nextAngle));
+    setOpenNonce((nonce) => nonce + 1);
+  }, []);
+
+  const paneBoardConfig = useMemo<BoardConfig>(() => ({ ...boardConfig, angle }), [boardConfig, angle]);
+
+  // `previewQueueItem` is what keeps the queue untouched: with it set, the
+  // drawer renders the climb without dispatching `setCurrentClimb`. The deep
+  // link already opens this way for a signed-in visitor.
+  const openTarget = useMemo(
+    () => ({ climb, options: { previewQueueItem: climbToQueueItem(climb) }, nonce: openNonce }),
+    [climb, openNonce],
+  );
+
+  // Always the builder, never a hand-rolled `/auth/login`: it validates the
+  // current path against the same allow-set the gate produced it from and
+  // encodes it as `?next=`, which is what brings the visitor back to THIS climb
+  // instead of Home once they sign in.
+  const handleSignIn = useCallback(() => {
+    router.push(buildLoginHrefWithReturn());
+  }, [router]);
+
+  return (
+    <View style={[styles.root, { backgroundColor: systemColors.secondaryBackground }]}>
+      {/* Headerless, like the redirector it replaces: these routes mount at the
+          root stack, and a back chevron here would point at nothing. */}
+      <Stack.Screen options={{ headerShown: false }} />
+      <PlayDrawer
+        presentation="pane"
+        viewer="anonymous"
+        boardConfig={paneBoardConfig}
+        onAngleChange={handleAngleChange}
+        onOpenQueue={noop}
+        openTarget={openTarget}
+        onSignIn={handleSignIn}
+      />
+      {/* The standing invitation, below the drawer rather than over it: the
+          board art and the below-fold reads are the reason someone followed the
+          link, and covering them to ask for an account is how a read-only view
+          ends up feeling worse than the wall it replaced. */}
+      <View
+        style={[
+          styles.signInBar,
+          { borderTopColor: systemColors.separator, paddingBottom: insets.bottom + spacing[3] },
+        ]}
+      >
+        <View style={styles.signInCopy}>
+          <Text variant="subheadline" style={styles.signInHeadline}>
+            {t('mobile.anonymous.signInHeadline')}
+          </Text>
+          <Text variant="caption1" color={systemColors.secondaryLabel}>
+            {t('mobile.anonymous.signInSubtitle')}
+          </Text>
+        </View>
+        <Button title={t('mobile.anonymous.signInAction')} onPress={handleSignIn} variant="filled" />
+      </View>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  signInBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingTop: spacing[3],
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  signInCopy: {
+    flex: 1,
+    gap: spacing[1],
+  },
+  signInHeadline: {
+    fontWeight: '600',
+  },
+});

--- a/packages/mobile/src/components/AnonymousClimbView.tsx
+++ b/packages/mobile/src/components/AnonymousClimbView.tsx
@@ -34,6 +34,7 @@ import { PlayDrawer } from './play-drawer/PlayDrawer';
 import { Button } from './Button';
 import { Text } from './Text';
 import { climbToQueueItem } from '../lib/climb-to-queue-item';
+import { useClimb } from '../lib/graphql/hooks';
 import { buildLoginHrefWithReturn } from '../lib/routing/anonymous-auth-gate';
 import { useTheme } from '../providers/theme-provider';
 import type { BoardConfig } from '../providers/drawer-host-provider';
@@ -45,19 +46,22 @@ function noop() {}
 export const AnonymousClimbView = memo(function AnonymousClimbView({
   climb,
   boardConfig,
+  isAngleAdjustable = true,
 }: {
   climb: Climb;
   boardConfig: BoardConfig;
+  /** False for a board bolted at a fixed angle — hides the angle pill, the same
+   *  rule the signed-in chrome reads off `activeBoard.isAngleAdjustable`. The
+   *  tuple URL carries no board record, so it keeps the create path's default. */
+  isAngleAdjustable?: boolean;
 }) {
   const { t } = useTranslation('session');
   const router = useRouter();
   const { systemColors } = useTheme();
   const insets = useSafeAreaInsets();
 
-  // The angle pill stays live, and the drawer's board config is the only thing
-  // it moves — exactly what the signed-in deep-link path does, where an angle
-  // change rewrites `boardConfigOverride` and leaves the climb object alone.
-  // The URL is not rewritten for the same reason it is not there either.
+  // The angle pill stays live. The URL is not rewritten — the signed-in
+  // deep-link path doesn't either.
   const [angle, setAngle] = useState(boardConfig.angle);
 
   // Bumped alongside the angle so the open target re-applies. PlayDrawer clears
@@ -79,12 +83,29 @@ export const AnonymousClimbView = memo(function AnonymousClimbView({
 
   const paneBoardConfig = useMemo<BoardConfig>(() => ({ ...boardConfig, angle }), [boardConfig, angle]);
 
+  // Grade, stars and ascent count are baked into the climb row at the angle it
+  // was fetched for — `getClimbByUuid` joins the stats tables ON angle — and the
+  // route's query is frozen at the URL's angle. The signed-in header survives an
+  // angle change because `useEffectiveClimbStats` re-reads canonical stats per
+  // (climb, angle); that read is `requireAuthenticated`, so anonymously it never
+  // fires and the header keeps the URL angle's numbers. Meanwhile the Boardsesh
+  // grade, the crowd-grade bar and the angle sheet's own per-angle stats all move
+  // — two different grades for the same angle, on the same screen.
+  //
+  // So the climb itself is refetched at the live angle. The URL angle is left to
+  // the route's query (same key, one request); while a moved angle is in flight
+  // the previous climb keeps rendering, so the drawer never blanks mid-swap.
+  const movedAngleClimb = useClimb(
+    angle === boardConfig.angle ? null : { ...boardConfig, angle, climbUuid: climb.uuid },
+  );
+  const climbAtAngle = movedAngleClimb.data ?? climb;
+
   // `previewQueueItem` is what keeps the queue untouched: with it set, the
   // drawer renders the climb without dispatching `setCurrentClimb`. The deep
   // link already opens this way for a signed-in visitor.
   const openTarget = useMemo(
-    () => ({ climb, options: { previewQueueItem: climbToQueueItem(climb) }, nonce: openNonce }),
-    [climb, openNonce],
+    () => ({ climb: climbAtAngle, options: { previewQueueItem: climbToQueueItem(climbAtAngle) }, nonce: openNonce }),
+    [climbAtAngle, openNonce],
   );
 
   // Always the builder, never a hand-rolled `/auth/login`: it validates the
@@ -104,6 +125,7 @@ export const AnonymousClimbView = memo(function AnonymousClimbView({
         presentation="pane"
         viewer="anonymous"
         boardConfig={paneBoardConfig}
+        isAngleAdjustable={isAngleAdjustable}
         onAngleChange={handleAngleChange}
         onOpenQueue={noop}
         openTarget={openTarget}

--- a/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
+++ b/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
@@ -85,6 +85,27 @@ describe('AnonymousClimbView', () => {
     expect(props.onSwitchBoard).toBeUndefined();
   });
 
+  // THE LOOP GUARD. `openTarget` is an object literal, and PlayDrawer's
+  // apply-the-target effect keys on its IDENTITY — so an unmemoised one is a new
+  // target on every render, which re-opens the drawer, which renders again. The
+  // page never settles, and every other assertion in this file passes just as
+  // happily inside that loop: they all read the LAST render's props. Only the
+  // render count and the target's identity across a re-render can tell the
+  // difference.
+  it('settles — one render, and the same open-target object across a re-render', () => {
+    const { rerender } = render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+
+    expect(drawerProps.calls).toHaveLength(1);
+    const firstTarget = lastDrawerProps().openTarget;
+
+    // A fresh board-config object carrying the same values — what an ordinary
+    // parent re-render looks like, and enough to defeat the outer `memo`.
+    rerender(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: { ...BOARD_CONFIG } }));
+
+    expect(drawerProps.calls).toHaveLength(2);
+    expect(lastDrawerProps().openTarget).toBe(firstTarget);
+  });
+
   it('opens the climb as a preview so the queue is never written', () => {
     render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
     const openTarget = lastDrawerProps().openTarget as { climb: Climb; options: { previewQueueItem: unknown } };

--- a/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
+++ b/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+// The read-only climb surface a signed-out visitor gets on app.boardsesh.com.
+//
+// Three claims are load-bearing enough to pin here, because each has a failure
+// mode that looks fine in a screenshot:
+//
+// 1. The sign-in control uses the GATE's href, not a hand-rolled `/auth/login`.
+//    A bare login route drops the `?next=`, so the visitor signs in and lands on
+//    Home having lost the climb they followed a search result to reach — the
+//    exact regression the round trip was built to prevent.
+// 2. The drawer opens with a `previewQueueItem`, which is what leaves the queue
+//    untouched.
+// 3. An angle change bumps the open target's nonce. PlayDrawer clears its
+//    preview on every angle change and re-reads `openTarget` afterwards; without
+//    a fresh nonce the anonymous drawer falls back to a queue that is empty here
+//    and blanks itself.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { act, createElement, type ReactNode } from 'react';
+import type { Climb } from '@boardsesh/shared-schema';
+
+// The gate's return, as a sentinel: this suite asserts the view forwards that
+// value verbatim. Whether the value is right for a given location is
+// `anonymous-auth-gate.web.test.ts`'s job.
+const LOGIN_HREF = vi.hoisted(() => '/auth/login?next=%2Fkilter%2F1%2F10%2F1%2C20%2F40%2Fview%2Fcrimpy-thing-0A1B');
+const buildLoginHrefWithReturn = vi.hoisted(() => vi.fn(() => LOGIN_HREF));
+const router = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn() }));
+const drawerProps = vi.hoisted(() => ({ calls: [] as Record<string, unknown>[] }));
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode } & Record<string, unknown>) => createElement('div', null, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Platform: { OS: 'web' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('expo-router', () => ({ Stack: { Screen: () => null }, useRouter: () => router }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
+vi.mock('../../providers/theme-provider', () => ({
+  useTheme: () => ({ systemColors: { secondaryBackground: '#111', secondaryLabel: '#888', separator: '#333' } }),
+}));
+vi.mock('../Text', () => ({ Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children) }));
+vi.mock('../Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    createElement('button', { 'data-testid': 'sign-in', onClick: onPress }, title),
+}));
+vi.mock('../../lib/climb-to-queue-item', () => ({
+  climbToQueueItem: (climb: Climb) => ({ uuid: 'queue-item-uuid', climb }),
+}));
+vi.mock('../../lib/routing/anonymous-auth-gate', () => ({ buildLoginHrefWithReturn }));
+vi.mock('../play-drawer/PlayDrawer', () => ({
+  PlayDrawer: (props: Record<string, unknown>) => {
+    drawerProps.calls.push(props);
+    return createElement('div', { 'data-testid': 'play-drawer' });
+  },
+}));
+
+const { AnonymousClimbView } = await import('../AnonymousClimbView');
+
+const BOARD_CONFIG = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 };
+const CLIMB = { uuid: '0A1B2C3D4E5F60718293A4B5C6D7E8F9', name: 'Crimpy Thing' } as unknown as Climb;
+
+function lastDrawerProps(): Record<string, unknown> {
+  const props = drawerProps.calls.at(-1);
+  if (!props) throw new Error('PlayDrawer never rendered');
+  return props;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  drawerProps.calls = [];
+  buildLoginHrefWithReturn.mockReturnValue(LOGIN_HREF);
+});
+
+describe('AnonymousClimbView', () => {
+  it('renders the drawer in place as an anonymous pane — never as the /play route', () => {
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+    const props = lastDrawerProps();
+
+    expect(props.presentation).toBe('pane');
+    expect(props.viewer).toBe('anonymous');
+    // `/boards` is outside the read-only allow-set, so a switch-board scrim
+    // would bounce the visitor to login the moment they tapped it.
+    expect(props.boardMismatch).toBeUndefined();
+    expect(props.onSwitchBoard).toBeUndefined();
+  });
+
+  it('opens the climb as a preview so the queue is never written', () => {
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+    const openTarget = lastDrawerProps().openTarget as { climb: Climb; options: { previewQueueItem: unknown } };
+
+    expect(openTarget.climb).toBe(CLIMB);
+    expect(openTarget.options.previewQueueItem).toEqual({ uuid: 'queue-item-uuid', climb: CLIMB });
+  });
+
+  it('sends the sign-in bar to the href the gate builds, not a bare login route', () => {
+    const { getByTestId } = render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+
+    act(() => getByTestId('sign-in').click());
+
+    expect(router.push).toHaveBeenCalledWith(LOGIN_HREF);
+    expect(router.push).not.toHaveBeenCalledWith('/auth/login');
+  });
+
+  it('sends the drawer’s own sign-in prompt to the same gate href', () => {
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+    const onSignIn = lastDrawerProps().onSignIn as () => void;
+
+    act(() => onSignIn());
+
+    expect(router.push).toHaveBeenCalledWith(LOGIN_HREF);
+  });
+
+  it('re-applies the open target when the angle moves so the drawer cannot blank', () => {
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+    const beforeTarget = lastDrawerProps().openTarget as { nonce: number };
+    const onAngleChange = lastDrawerProps().onAngleChange as (angle: number) => void;
+
+    act(() => onAngleChange(25));
+
+    const afterProps = lastDrawerProps();
+    expect((afterProps.boardConfig as { angle: number }).angle).toBe(25);
+    expect((afterProps.openTarget as { nonce: number }).nonce).toBeGreaterThan(beforeTarget.nonce);
+  });
+});

--- a/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
+++ b/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
@@ -26,6 +26,11 @@ const LOGIN_HREF = vi.hoisted(() => '/auth/login?next=%2Fkilter%2F1%2F10%2F1%2C2
 const buildLoginHrefWithReturn = vi.hoisted(() => vi.fn(() => LOGIN_HREF));
 const router = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn() }));
 const drawerProps = vi.hoisted(() => ({ calls: [] as Record<string, unknown>[] }));
+// The per-angle climb read. `null` variables mean "not armed" — the view leaves
+// the URL angle to the route's own query rather than issuing a second one.
+const useClimb = vi.hoisted(() =>
+  vi.fn((_variables: Record<string, unknown> | null): { data: unknown } => ({ data: undefined })),
+);
 
 vi.mock('react-native', () => ({
   View: ({ children }: { children?: ReactNode } & Record<string, unknown>) => createElement('div', null, children),
@@ -48,6 +53,7 @@ vi.mock('../../lib/climb-to-queue-item', () => ({
   climbToQueueItem: (climb: Climb) => ({ uuid: 'queue-item-uuid', climb }),
 }));
 vi.mock('../../lib/routing/anonymous-auth-gate', () => ({ buildLoginHrefWithReturn }));
+vi.mock('../../lib/graphql/hooks', () => ({ useClimb }));
 vi.mock('../play-drawer/PlayDrawer', () => ({
   PlayDrawer: (props: Record<string, unknown>) => {
     drawerProps.calls.push(props);
@@ -70,6 +76,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   drawerProps.calls = [];
   buildLoginHrefWithReturn.mockReturnValue(LOGIN_HREF);
+  useClimb.mockImplementation(() => ({ data: undefined }));
 });
 
 describe('AnonymousClimbView', () => {
@@ -154,5 +161,65 @@ describe('AnonymousClimbView', () => {
     const afterProps = lastDrawerProps();
     expect((afterProps.boardConfig as { angle: number }).angle).toBe(25);
     expect((afterProps.openTarget as { nonce: number }).nonce).toBeGreaterThan(beforeTarget.nonce);
+  });
+
+  // Grade, stars and ascent count are baked into the climb row at the angle it
+  // was fetched for. The route's query is frozen at the URL angle and
+  // `useEffectiveClimbStats` — which is what keeps the SIGNED-IN header honest
+  // across an angle change — never fires anonymously, so without this the header
+  // would keep the URL angle's numbers while the Boardsesh grade, the crowd-grade
+  // bar and the angle sheet all moved. Two grades for one angle, same screen.
+  it('refetches the climb at the angle the reader moved to', () => {
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+
+    // The URL angle is the route's query, not a second one.
+    expect(useClimb).toHaveBeenLastCalledWith(null);
+
+    const onAngleChange = lastDrawerProps().onAngleChange as (angle: number) => void;
+    act(() => onAngleChange(25));
+
+    expect(useClimb).toHaveBeenLastCalledWith({ ...BOARD_CONFIG, angle: 25, climbUuid: CLIMB.uuid });
+  });
+
+  it('keeps the climb on screen while the moved angle is still in flight', () => {
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+    const onAngleChange = lastDrawerProps().onAngleChange as (angle: number) => void;
+
+    act(() => onAngleChange(25));
+
+    // A blank drawer is worse than one frame of the previous angle's numbers.
+    expect((lastDrawerProps().openTarget as { climb: Climb }).climb).toBe(CLIMB);
+  });
+
+  it('opens the moved angle’s climb once it lands, not the URL angle’s', () => {
+    const CLIMB_AT_25 = { uuid: CLIMB.uuid, name: 'Crimpy Thing', difficulty: '6C+' } as unknown as Climb;
+    useClimb.mockImplementation((variables) => ({
+      data: (variables as { angle?: number } | null)?.angle === 25 ? CLIMB_AT_25 : undefined,
+    }));
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+    const onAngleChange = lastDrawerProps().onAngleChange as (angle: number) => void;
+
+    act(() => onAngleChange(25));
+
+    const openTarget = lastDrawerProps().openTarget as { climb: Climb; options: { previewQueueItem: unknown } };
+    expect(openTarget.climb).toBe(CLIMB_AT_25);
+    // The preview item is rebuilt from the same climb, so the board the drawer
+    // draws and the header above it cannot disagree about the angle.
+    expect(openTarget.options.previewQueueItem).toEqual({ uuid: 'queue-item-uuid', climb: CLIMB_AT_25 });
+  });
+
+  // A gym board bolted at a fixed angle resolves with `isAngleAdjustable: false`;
+  // the signed-in chrome reads the same flag off the active board. Dropping it
+  // here offers an anonymous reader an angle pill for a wall that cannot tilt.
+  it('hides the angle pill for a board that cannot tilt', () => {
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG, isAngleAdjustable: false }));
+
+    expect(lastDrawerProps().isAngleAdjustable).toBe(false);
+  });
+
+  it('keeps it for an adjustable board', () => {
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+
+    expect(lastDrawerProps().isAngleAdjustable).toBe(true);
   });
 });

--- a/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
+++ b/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
@@ -111,6 +111,18 @@ describe('AnonymousClimbView', () => {
     expect(router.push).toHaveBeenCalledWith(LOGIN_HREF);
   });
 
+  // The angle selector can hand back the angle already showing. Re-opening for
+  // it would rebuild the preview item for nothing.
+  it('leaves the open target alone when the angle has not actually moved', () => {
+    render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
+    const beforeTarget = lastDrawerProps().openTarget as { nonce: number };
+    const onAngleChange = lastDrawerProps().onAngleChange as (angle: number) => void;
+
+    act(() => onAngleChange(BOARD_CONFIG.angle));
+
+    expect((lastDrawerProps().openTarget as { nonce: number }).nonce).toBe(beforeTarget.nonce);
+  });
+
   it('re-applies the open target when the angle moves so the drawer cannot blank', () => {
     render(createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG }));
     const beforeTarget = lastDrawerProps().openTarget as { nonce: number };

--- a/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
+++ b/packages/mobile/src/components/__tests__/anonymous-climb-view.test.tsx
@@ -16,7 +16,7 @@
 //    and blanks itself.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { act, createElement, type ReactNode } from 'react';
+import { act, createElement, StrictMode, type ReactNode } from 'react';
 import type { Climb } from '@boardsesh/shared-schema';
 
 // The gate's return, as a sentinel: this suite asserts the view forwards that
@@ -149,6 +149,24 @@ describe('AnonymousClimbView', () => {
     act(() => onAngleChange(BOARD_CONFIG.angle));
 
     expect((lastDrawerProps().openTarget as { nonce: number }).nonce).toBe(beforeTarget.nonce);
+  });
+
+  // Strict Mode is the oracle for the nonce, not a style check. React runs state
+  // updaters twice under it, so bumping the nonce from inside `setAngle`'s
+  // updater — which read perfectly well — advanced it by two in development and
+  // by one in production. Anything that later keys off the nonce's VALUE rather
+  // than its identity would then behave differently on a desk than on a device.
+  it('advances the open target by exactly one under Strict Mode', () => {
+    const { getByTestId } = render(
+      createElement(StrictMode, null, createElement(AnonymousClimbView, { climb: CLIMB, boardConfig: BOARD_CONFIG })),
+    );
+    expect(getByTestId('play-drawer')).not.toBeNull();
+    const before = (lastDrawerProps().openTarget as { nonce: number }).nonce;
+    const onAngleChange = lastDrawerProps().onAngleChange as (angle: number) => void;
+
+    act(() => onAngleChange(25));
+
+    expect((lastDrawerProps().openTarget as { nonce: number }).nonce).toBe(before + 1);
   });
 
   it('re-applies the open target when the angle moves so the drawer cannot blank', () => {

--- a/packages/mobile/src/components/play-drawer/DeferredSections.tsx
+++ b/packages/mobile/src/components/play-drawer/DeferredSections.tsx
@@ -113,7 +113,8 @@ export const DeferredSections = memo(function DeferredSections({
   // only tried at (a send always leads; 3+ angles collapse to a count).
   const logbookSummary = useMemo(() => {
     // Logged-out visitors have no logbook, so "not tried yet" would be a lie —
-    // show no subtitle at all (the section still expands to the sign-in prompt).
+    // show no subtitle at all. The section body carries the sign-in line instead
+    // (LogbookSection's signed-out branch).
     if (!isAuthenticated) return null;
     const sends = climb.userAscents ?? 0;
     const attempts = climb.userAttempts ?? 0;

--- a/packages/mobile/src/components/play-drawer/LogbookSection.tsx
+++ b/packages/mobile/src/components/play-drawer/LogbookSection.tsx
@@ -8,6 +8,7 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { LogbookEntryRow } from './LogbookEntryRow';
 import { useLocalPendingTicks } from '../../hooks/use-local-ticks';
+import { useAuth } from '../../providers/auth-provider';
 import { iosSystemColors } from '../../theme/ios-colors';
 import { spacing } from '../../theme/tokens';
 
@@ -25,6 +26,7 @@ export const LogbookSection = memo(function LogbookSection({
   userAttempts,
 }: LogbookSectionProps) {
   const { t } = useTranslation('session');
+  const { isAuthenticated } = useAuth();
   const { logbook, isLoading } = useLogbook(boardName as BoardName, [climbUuid]);
   const { data: pendingTicks = 0 } = useLocalPendingTicks(climbUuid, boardName);
 
@@ -61,6 +63,25 @@ export const LogbookSection = memo(function LogbookSection({
   // their own angle chip. Sessions = distinct days, matching the logbook's
   // day-scoped grouping.
   const angleSections = useMemo(() => groupEntriesByAngle(entries), [entries]);
+
+  // A reader with no account has no logbook, so every string below would be a
+  // lie about them: `useLogbook` is disabled signed-out (so `entries` is empty
+  // and `isLoading` false), and `userAscents` / `userAttempts` are viewer-scoped
+  // and arrive null — which lands squarely on "No tries yet. Get on it." for
+  // someone who has never had a try to record. Ahead of every other branch,
+  // because the emptiness that reaches them is not the empty state.
+  if (!isAuthenticated) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.emptyContainer}>
+          <Icon name="history" size={20} color={iosSystemColors.systemGray} />
+          <Text variant="subheadline" color={iosSystemColors.systemGray}>
+            {t('mobile.logbook.signedOut')}
+          </Text>
+        </View>
+      </View>
+    );
+  }
 
   if (entries.length > 0) {
     return (

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -76,7 +76,7 @@ import { getBoardRenderData } from '../../lib/board-details';
 import { hapticSuccess } from '../../lib/haptics';
 import { usePlayDrawerWakeLock } from './use-play-drawer-wake-lock';
 import { resolveFavoriteRollback } from './favorite-rollback';
-import { getViewOnlyPreviewNavigationTarget } from './play-drawer-navigation';
+import { getSimilarClimbTapMode, getViewOnlyPreviewNavigationTarget } from './play-drawer-navigation';
 import { useLightbulbControl } from '../ble/use-lightbulb-control';
 import { track } from '../../lib/analytics';
 import { iosSystemColors } from '../../theme/ios-colors';
@@ -796,6 +796,18 @@ export function PlayDrawer({
   const handleSimilarClimbPress = useCallback(
     async (similarClimb: Climb) => {
       const queueItem = climbToQueueItem(similarClimb);
+      // A signed-out reader swaps what the drawer is showing and writes nothing:
+      // no queue entry they cannot carry anywhere, and no `setCurrentClimb`,
+      // which is what re-arms the BLE auto-sender. Similar Climbs is the only
+      // affordance in the anonymous view that could otherwise still drive a
+      // wall, so it takes the preview path the wrong-board drawer already uses.
+      if (getSimilarClimbTapMode(viewer) === 'preview') {
+        setDrawerPreviewItem(queueItem);
+        setDrawerPreviewSuggestionSource(null);
+        setIsMirrored(false);
+        setIsTickBarActive(false);
+        return;
+      }
       // A similar climb can be set on another board, so this add may raise the
       // cross-board prompt. Wait for it: backing out has to leave the drawer on
       // the climb they were already looking at, not activate the one they just
@@ -810,7 +822,7 @@ export function PlayDrawer({
       setIsTickBarActive(false);
       setCurrentClimb(queueItem, { playlistSuggestionSource: null });
     },
-    [addToQueue, setCurrentClimb],
+    [addToQueue, setCurrentClimb, viewer],
   );
 
   // The first screen is sized so the action bar stays visible and the Logbook
@@ -1039,13 +1051,16 @@ export function PlayDrawer({
                           lightbulbPending={lightbulbPending}
                           autoDisconnectWarning={bluetooth?.autoDisconnectWarning ?? false}
                           lightbulbLongPressEnabled={bluetoothConnected}
-                          // Web Bluetooth IS mounted on the browser export, so the
-                          // bulb would otherwise render for a signed-out visitor —
-                          // board presence binds on an active board uuid they do not
-                          // have, and a pairing prompt on a first-ever visit is a
-                          // hostile opening. Anonymous wall lighting is its own
-                          // feature, not a v1 side effect.
-                          showLightbulb={bluetooth !== null && !isAnonymous}
+                          // Whether a Bluetooth transport exists at all, and only
+                          // that. The anonymous suppression lives in the bar, with
+                          // the rest of the `viewer` rules and the test that pins
+                          // them — Web Bluetooth IS mounted on the browser export,
+                          // so without it the bulb would render for a signed-out
+                          // visitor, whose board presence binds on an active board
+                          // uuid they do not have and whose first-ever visit would
+                          // open with a pairing prompt. Anonymous wall lighting is
+                          // its own feature (#4606), not a v1 side effect.
+                          showLightbulb={bluetooth !== null}
                           // The on-wall banner owns the driver's face in the header
                           // when it's up; suppress the lightbulb pip so the same
                           // avatar never shows twice in the drawer.

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -167,6 +167,18 @@ type PlayDrawerProps = {
    *  when a WallStrip is docked above the pane and already owns that inset. Ignored
    *  in route mode (the modal always owns the top inset). */
   paneTopInset?: boolean;
+  /**
+   * Who is looking. `'anonymous'` is the signed-out reader that
+   * `AnonymousClimbView` renders on the web export's read-only climb URL: the
+   * board, header, grade and every below-fold read stay, and every write
+   * affordance is removed (see PlayDrawerActionBar's `viewer` prop for the full
+   * list and why removal beats disabling). Never reachable on native — the whole
+   * anonymous branch sits behind `RELAXES_ANONYMOUS_ROUTES`, a literal `false`
+   * in the native fork.
+   */
+  viewer?: 'member' | 'anonymous';
+  /** Anonymous only: hand this URL to login. Wired to the tick prompt. */
+  onSignIn?: () => void;
 };
 
 // Fallback used for the first-screen reserve before the Logbook header has
@@ -195,7 +207,11 @@ export function PlayDrawer({
   openTarget,
   presentation = 'route',
   paneTopInset = true,
+  viewer = 'member',
+  onSignIn,
 }: PlayDrawerProps) {
+  // The signed-out reader on app.boardsesh.com's read-only climb URL.
+  const isAnonymous = viewer === 'anonymous';
   // The iPad right-column pane is persistent — it has no dismiss. Suppresses the
   // pull-down dismiss gesture, the close chevron, the grabber, and router.dismiss.
   const isPane = presentation === 'pane';
@@ -392,8 +408,11 @@ export function PlayDrawer({
   // server's truth — so the heart reflects whether the climb is already a favorite
   // on open, and a single tap can't invert reality (the previous always-false
   // local state silently un-favorited already-favorited climbs).
+  // `favorites` is `requireAuthenticated` on the backend, and the heart is hidden
+  // anonymously anyway — arming it would fire a query that can only 401 on every
+  // read-only open. The hook re-checks the session itself; this is the local half.
   const { data: serverFavorited } = useFavoriteStatus(boardName, displayedClimb?.uuid ?? null, angle, {
-    enabled: isSheetOpen,
+    enabled: isSheetOpen && !isAnonymous,
   });
   const isFavorited = favoriteOverride ?? serverFavorited ?? false;
   // Lit visual, pending pulse, and the connect/disconnect tap — shared with the
@@ -1010,7 +1029,13 @@ export function PlayDrawer({
                           lightbulbPending={lightbulbPending}
                           autoDisconnectWarning={bluetooth?.autoDisconnectWarning ?? false}
                           lightbulbLongPressEnabled={bluetoothConnected}
-                          showLightbulb={bluetooth !== null}
+                          // Web Bluetooth IS mounted on the browser export, so the
+                          // bulb would otherwise render for a signed-out visitor —
+                          // board presence binds on an active board uuid they do not
+                          // have, and a pairing prompt on a first-ever visit is a
+                          // hostile opening. Anonymous wall lighting is its own
+                          // feature, not a v1 side effect.
+                          showLightbulb={bluetooth !== null && !isAnonymous}
                           // The on-wall banner owns the driver's face in the header
                           // when it's up; suppress the lightbulb pip so the same
                           // avatar never shows twice in the drawer.
@@ -1027,6 +1052,8 @@ export function PlayDrawer({
                           onShare={handleShare}
                           onTickPress={handleTickFabPress}
                           onTickLongPress={handleTickFabLongPress}
+                          viewer={viewer}
+                          onSignInPress={onSignIn}
                           currentAngle={angle}
                           onOpenAngleSelector={isAngleAdjustable ? handleOpenAngleSelector : undefined}
                         />

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -969,10 +969,18 @@ export function PlayDrawer({
                       }
                     />
 
-                    {isPreview && !drawerPreviewIsWallClimb ? (
+                    {isPreview && !drawerPreviewIsWallClimb && !isAnonymous ? (
                       // Cross-board previews use the switch-board overlay instead, so
                       // hide "Set active" there — promoting a foreign-board climb would
                       // only spill it into the queue.
+                      //
+                      // The anonymous drawer is ALWAYS a preview — that is what keeps
+                      // the queue untouched — so an ungated banner would put a live
+                      // "Set active" on every read-only open, and its press is
+                      // `setCurrentClimb`: the same queue write and the same BLE
+                      // auto-sender re-arm that `getSimilarClimbTapMode` blocks a few
+                      // lines up. "Preview" also means nothing to a reader who has no
+                      // active climb to promote it over.
                       <PlayDrawerPreviewBanner showSetActive={!boardMismatch} onSetActive={handleSetActive} />
                     ) : null}
 

--- a/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawer.tsx
@@ -44,7 +44,12 @@ import { SwitchBoardOverlay } from './SwitchBoardOverlay';
 import { LogAscentSheet } from '../LogAscentSheet';
 import { DeferredSections } from './DeferredSections';
 import { PanePlaceholder } from './PanePlaceholder';
-import { computeFirstScreenHeight, computeLogbookScrollTarget, shouldShowPanePlaceholder } from './play-drawer-layout';
+import {
+  computeFirstScreenHeight,
+  computeLogbookScrollTarget,
+  initialDrawerPreviewItem,
+  shouldShowPanePlaceholder,
+} from './play-drawer-layout';
 import { useBelowFoldContentRequest } from './use-below-fold-content-request';
 import { useDrawerDismissGesture } from './use-drawer-dismiss-gesture';
 import { AngleSelectorSheet } from './AngleSelectorSheet';
@@ -234,7 +239,12 @@ export function PlayDrawer({
     const measured = event.nativeEvent.layout.height;
     setSheetViewportHeight((prev) => (Math.abs(prev - measured) > 2 ? Math.round(measured) : prev));
   }, []);
-  const [drawerPreviewItem, setDrawerPreviewItem] = useState<ClimbQueueItem | null>(null);
+  // Seeded from the open target rather than left null: the effect that applies
+  // the target runs after the first commit, so a pane that already has its climb
+  // would otherwise paint one frame of the "Pick a climb" placeholder first.
+  const [drawerPreviewItem, setDrawerPreviewItem] = useState<ClimbQueueItem | null>(() =>
+    initialDrawerPreviewItem(openTarget),
+  );
   const [drawerPreviewSuggestionSource, setDrawerPreviewSuggestionSource] = useState<PlaylistSuggestionSource | null>(
     null,
   );

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -36,7 +36,11 @@ type PlayDrawerActionBarProps = {
   lightbulbAccessibilityLabel?: string;
   lightbulbLongPressAccessibilityHint?: string;
   lightbulbLongPressEnabled?: boolean;
-  /** Hide the BLE action when the host platform has no Bluetooth provider. */
+  /**
+   * Whether the host platform has a Bluetooth provider at all. Only that — an
+   * anonymous viewer never gets the bulb regardless, and that rule lives here
+   * rather than at the call site (see `viewer`).
+   */
   showLightbulb?: boolean;
   /** Show the holder avatar pip on the lightbulb. Suppressed when the on-wall
    *  banner already carries the driver's face in the header, so the same face

--- a/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
+++ b/packages/mobile/src/components/play-drawer/PlayDrawerActionBar.tsx
@@ -44,6 +44,25 @@ type PlayDrawerActionBarProps = {
   showHolderBadge?: boolean;
   ascentCount: number;
   currentAngle?: number;
+  /**
+   * Who is looking.
+   *
+   * `'anonymous'` is the signed-out reader on the web export's read-only climb
+   * view (`AnonymousClimbView`). Every affordance that writes is REMOVED rather
+   * than disabled — a dead button a visitor taps and nothing happens is worse
+   * than the login wall this view replaced — and the tick becomes the one
+   * conversion prompt in the bar.
+   *
+   * Two of the removals are about navigation, not writes: the drawer is rendered
+   * IN PLACE on the canonical `/…/view/{segment}` URL, and the anonymous gate
+   * re-reads `window.location.pathname` on every navigation. Anything that
+   * pushes a route outside the read-only allow-set (`/boards`, `/play`,
+   * `/climbs/{uuid}`) bounces the visitor to login mid-session, so the queue and
+   * climb-actions entries have to go whether or not their targets would 401.
+   */
+  viewer?: 'member' | 'anonymous';
+  /** Anonymous only: what the tick button does instead of opening the tick sheet. */
+  onSignInPress?: () => void;
   onPrevClick: () => void;
   onNextClick: () => void;
   onMirror: () => void;
@@ -76,6 +95,8 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
   showHolderBadge = true,
   ascentCount,
   currentAngle,
+  viewer = 'member',
+  onSignInPress,
   onPrevClick,
   onNextClick,
   onMirror,
@@ -93,6 +114,12 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
   const { t: tClimbs } = useTranslation('climbs');
   const { t: tSettings } = useTranslation('settings');
   const theme = useTheme();
+  const isAnonymous = viewer === 'anonymous';
+
+  const handleSignIn = useCallback(() => {
+    hapticMedium();
+    onSignInPress?.();
+  }, [onSignInPress]);
 
   const handlePrev = useCallback(() => {
     hapticMedium();
@@ -127,6 +154,9 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
   return (
     <View style={drawerActionBarStyles.container}>
       <View style={drawerActionBarStyles.rowPrimary}>
+        {/* Mirror, or the heart where a board can't mirror. An anonymous reader
+            gets neither fallback — a favourite needs an account — so the slot
+            stays empty and the row keeps its five-slot spacing either way. */}
         <View style={drawerActionBarStyles.primarySlot}>
           {supportsMirroring ? (
             <ActionButton
@@ -139,7 +169,7 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
                 isMirrored ? t('playView.actionBar.unmirrorAria') : t('playView.actionBar.mirrorAria')
               }
             />
-          ) : (
+          ) : isAnonymous ? null : (
             // On boards without mirror support, the favorite (heart) takes the
             // first slot — keeps the row visually balanced and gives heart a
             // bigger tap target. It is removed from Row 2 below in that case.
@@ -164,12 +194,17 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
           />
         </View>
         <View style={drawerActionBarStyles.primarySlot}>
+          {/* The one prompt in the anonymous bar. It stays the hero slot and
+              keeps its glyph — a visitor who came to log a send should not have
+              to hunt for the way in — but it opens login carrying this URL
+              instead of the tick sheet, and drops the ascent badge, which counts
+              a logbook they do not have. */}
           <TickButton
             size="lg"
-            ascentCount={ascentCount}
-            onPress={onTickPress}
-            onLongPress={onTickLongPress}
-            accessibilityLabel={t('playView.tickFab.logAscentAria')}
+            ascentCount={isAnonymous ? 0 : ascentCount}
+            onPress={isAnonymous ? handleSignIn : onTickPress}
+            onLongPress={isAnonymous ? undefined : onTickLongPress}
+            accessibilityLabel={isAnonymous ? t('mobile.anonymous.tickAria') : t('playView.tickFab.logAscentAria')}
           />
         </View>
         <View style={drawerActionBarStyles.primarySlot}>
@@ -182,7 +217,7 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
           />
         </View>
         <View style={drawerActionBarStyles.primarySlot}>
-          {showLightbulb ? (
+          {showLightbulb && !isAnonymous ? (
             <>
               <BleLightbulbButton
                 isConnected={lightbulbActive}
@@ -237,7 +272,7 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
             </Text>
           </Pressable>
         )}
-        {supportsMirroring && (
+        {supportsMirroring && !isAnonymous && (
           <ActionButton
             size="sm"
             iconName={isFavorited ? 'favorite.fill' : 'favorite'}
@@ -248,22 +283,32 @@ export const PlayDrawerActionBar = memo(function PlayDrawerActionBar({
             }
           />
         )}
-        <ActionButton
-          size="sm"
-          iconName="more"
-          onPress={onOpenActions}
-          accessibilityLabel={t('playView.actionBar.climbActionsAria')}
-        />
+        {/* The ellipsis opens queue / favourite / tick / playlist rows — every
+            one of them an account action. */}
+        {!isAnonymous && (
+          <ActionButton
+            size="sm"
+            iconName="more"
+            onPress={onOpenActions}
+            accessibilityLabel={t('playView.actionBar.climbActionsAria')}
+          />
+        )}
 
         <View style={drawerActionBarStyles.spacer} />
 
+        {/* Share is a pure client action and the whole point of a read-only
+            climb page, so it stays. */}
         <ShareButton size="sm" onPress={handleShare} accessibilityLabel={tClimbs('mobile.climbRow.share')} />
-        <ActionButton
-          size="sm"
-          iconName="queue"
-          onPress={onOpenQueue}
-          accessibilityLabel={t('playView.actionBar.queueCountAria', { count: remainingQueueCount })}
-        />
+        {/* A queue means nothing without a wall or a session, and the sheet it
+            opens is a write surface. */}
+        {!isAnonymous && (
+          <ActionButton
+            size="sm"
+            iconName="queue"
+            onPress={onOpenQueue}
+            accessibilityLabel={t('playView.actionBar.queueCountAria', { count: remainingQueueCount })}
+          />
+        )}
       </View>
     </View>
   );

--- a/packages/mobile/src/components/play-drawer/__tests__/logbook-section-angles.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/logbook-section-angles.test.tsx
@@ -57,6 +57,10 @@ vi.mock('@boardsesh/board-react', () => ({
 // hook; mock it so the test doesn't need a QueryClientProvider.
 vi.mock('../../../hooks/use-local-ticks', () => ({ useLocalPendingTicks: () => ({ data: 0 }) }));
 
+// The section's first branch is the signed-out prompt; every case here is about
+// a member's own entries, so the session is signed in.
+vi.mock('../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: true }) }));
+
 import { LogbookSection } from '../LogbookSection';
 
 function makeEntry(overrides: Partial<LogbookEntry>): LogbookEntry {

--- a/packages/mobile/src/components/play-drawer/__tests__/logbook-section-signed-out.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/logbook-section-signed-out.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+// The play drawer now renders for a signed-out reader on app.boardsesh.com's
+// read-only climb URLs. Everything that reaches the Logbook section in that
+// state looks identical to a member who has never touched the climb — the
+// logbook query is disabled, so it lands empty, and `userAscents` /
+// `userAttempts` are viewer-scoped and arrive null — which used to fall through
+// to "No tries yet. Get on it." That line is a claim about the reader's history,
+// and for someone who has never had an account it is simply false.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode } & Record<string, unknown>) => createElement('div', null, children),
+  ActivityIndicator: () => createElement('i', null),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Platform: { OS: 'web' },
+  PlatformColor: (name: string) => name,
+}));
+vi.mock('../../Text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => createElement('span', null, children),
+}));
+vi.mock('../../Icon', () => ({ Icon: () => createElement('i', null) }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('../LogbookEntryRow', () => ({ LogbookEntryRow: () => createElement('div', null) }));
+
+const logbookState = vi.hoisted(() => ({ logbook: [] as unknown[], isLoading: false }));
+vi.mock('@boardsesh/board-react', () => ({ useLogbook: () => logbookState }));
+vi.mock('../../../hooks/use-local-ticks', () => ({ useLocalPendingTicks: () => ({ data: 0 }) }));
+
+const authState = vi.hoisted(() => ({ current: { isAuthenticated: false } }));
+vi.mock('../../../providers/auth-provider', () => ({ useAuth: () => authState.current }));
+
+import { LogbookSection } from '../LogbookSection';
+
+beforeEach(() => {
+  logbookState.logbook = [];
+  logbookState.isLoading = false;
+  authState.current = { isAuthenticated: false };
+});
+
+describe('LogbookSection for a signed-out reader', () => {
+  it('offers the sign-in line instead of claiming they have no tries yet', () => {
+    const { container } = render(
+      createElement(LogbookSection, {
+        climbUuid: 'climb-1',
+        boardName: 'kilter',
+        userAscents: undefined,
+        userAttempts: undefined,
+      }),
+    );
+
+    expect(container.textContent).toContain('mobile.logbook.signedOut');
+    // The negative half is the load-bearing one: asserting only that the prompt
+    // renders would stay green if the empty state rendered underneath it too.
+    expect(container.textContent).not.toContain('mobile.logbook.noEntries');
+  });
+
+  // The branch has to sit ahead of the count fallbacks, not just ahead of the
+  // empty state: a stale denormalised count on the climb payload must not be
+  // narrated as this reader's history either.
+  it('does not narrate somebody else’s counts as the reader’s own', () => {
+    const { container } = render(
+      createElement(LogbookSection, {
+        climbUuid: 'climb-1',
+        boardName: 'kilter',
+        userAscents: 3,
+        userAttempts: 9,
+      }),
+    );
+
+    expect(container.textContent).toContain('mobile.logbook.signedOut');
+    expect(container.textContent).not.toContain('mobile.logbook.sendCount');
+    expect(container.textContent).not.toContain('mobile.logbook.attemptCount');
+  });
+
+  // A member on the same empty climb still gets the real empty state — the fix
+  // must not swallow it for everyone.
+  it('leaves a signed-in member on the real empty state', () => {
+    authState.current = { isAuthenticated: true };
+
+    const { container } = render(
+      createElement(LogbookSection, {
+        climbUuid: 'climb-1',
+        boardName: 'kilter',
+        userAscents: 0,
+        userAttempts: 0,
+      }),
+    );
+
+    expect(container.textContent).toContain('mobile.logbook.noEntries');
+    expect(container.textContent).not.toContain('mobile.logbook.signedOut');
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-action-bar.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-action-bar.test.tsx
@@ -108,6 +108,21 @@ const baseProps = {
   onOpenAngleSelector: vi.fn(),
 };
 
+/** The `data-action` iconName each ActionButton renders under (see the mock). */
+const ACTION_ICONS = {
+  mirror: 'mirror',
+  previous: 'skip.previous',
+  next: 'skip.next',
+  favorite: 'favorite',
+  favoriteFilled: 'favorite.fill',
+  ellipsis: 'more',
+  queue: 'queue',
+} as const;
+
+function actions(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('[data-action]')].map((node) => node.getAttribute('data-action') ?? '');
+}
+
 describe('PlayDrawerActionBar', () => {
   it('renders the tick as a green glyph (colour on the icon, not a solid fill)', () => {
     const { container } = render(createElement(PlayDrawerActionBar, baseProps));
@@ -207,5 +222,82 @@ describe('PlayDrawerActionBar', () => {
 
     expect(activeLongPressBulb.getAttribute('data-long-press-enabled')).toBe('true');
     expect(activeLongPressBulb.getAttribute('data-long-press-hint')).toBe('ble.holdForControls');
+  });
+});
+
+// The signed-out reader on app.boardsesh.com's read-only climb URL. Every
+// affordance is asserted individually rather than as one "renders no write
+// buttons" sweep: flipping a single gate is a distinct product regression (a
+// heart that 401s; a missing tick that turns the surface into a dead end), and a
+// blanket assertion could not tell them apart.
+describe('PlayDrawerActionBar (anonymous viewer)', () => {
+  const anonymousProps = { ...baseProps, viewer: 'anonymous' as const, onSignInPress: vi.fn() };
+
+  it('removes the queue, favourite, lightbulb and climb-actions affordances', () => {
+    const { container } = render(createElement(PlayDrawerActionBar, anonymousProps));
+    const rendered = actions(container);
+
+    expect(rendered).not.toContain(ACTION_ICONS.queue);
+    expect(rendered).not.toContain(ACTION_ICONS.favorite);
+    expect(rendered).not.toContain(ACTION_ICONS.favoriteFilled);
+    expect(rendered).not.toContain(ACTION_ICONS.ellipsis);
+    expect(container.querySelector('[data-ble="true"]')).toBeNull();
+    expect(container.querySelector('[data-lightbulb-holder-badge="true"]')).toBeNull();
+  });
+
+  // On a board with no mirror support the heart normally takes the first primary
+  // slot; anonymously that fallback has to go too, or the removal above is only
+  // half true.
+  it('does not fall back to the heart in the first slot on a fixed-mirror board', () => {
+    const { container } = render(createElement(PlayDrawerActionBar, { ...anonymousProps, supportsMirroring: false }));
+
+    expect(actions(container)).not.toContain(ACTION_ICONS.favorite);
+  });
+
+  it('keeps the reads: mirror, prev/next, share and the angle pill', () => {
+    const { container } = render(createElement(PlayDrawerActionBar, anonymousProps));
+    const rendered = actions(container);
+
+    expect(rendered).toContain(ACTION_ICONS.mirror);
+    expect(rendered).toContain(ACTION_ICONS.previous);
+    expect(rendered).toContain(ACTION_ICONS.next);
+    expect(container.querySelector('[data-icon="share"]')).toBeTruthy();
+    expect(container.querySelector('[data-label="mobile.angleSelector.title"]')).toBeTruthy();
+  });
+
+  // The tick is the ONLY prompt in the anonymous bar. Hiding it would leave the
+  // visitor no way in; wiring it to onTickPress would open a tick sheet that
+  // cannot save.
+  it('keeps the tick button and routes it to the sign-in handler, not the tick sheet', () => {
+    const onSignInPress = vi.fn();
+    const onTickPress = vi.fn();
+    const { container } = render(createElement(PlayDrawerActionBar, { ...anonymousProps, onSignInPress, onTickPress }));
+    const tick = container.querySelector('[data-label="mobile.anonymous.tickAria"]') as HTMLElement;
+
+    expect(tick).toBeTruthy();
+    expect(container.querySelector('[data-icon="tick.outline"]')).toBeTruthy();
+    tick.click();
+    expect(onSignInPress).toHaveBeenCalledTimes(1);
+    expect(onTickPress).not.toHaveBeenCalled();
+  });
+
+  // `ascentCount` is the viewer's own send count. Anonymously it is somebody
+  // else's number, so the badge must not render.
+  it('drops the ascent badge, which counts a logbook the reader does not have', () => {
+    const { container } = render(createElement(PlayDrawerActionBar, { ...anonymousProps, ascentCount: 7 }));
+
+    expect(container.textContent).not.toContain('7');
+  });
+
+  // The member bar is the invariant half: nothing above may leak into it.
+  it('leaves the member bar untouched', () => {
+    const { container } = render(createElement(PlayDrawerActionBar, baseProps));
+    const rendered = actions(container);
+
+    expect(rendered).toContain(ACTION_ICONS.queue);
+    expect(rendered).toContain(ACTION_ICONS.favorite);
+    expect(rendered).toContain(ACTION_ICONS.ellipsis);
+    expect(container.querySelector('[data-ble="true"]')).toBeTruthy();
+    expect(container.querySelector('[data-label="playView.tickFab.logAscentAria"]')).toBeTruthy();
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-anonymous.test.tsx
@@ -1,0 +1,318 @@
+// @vitest-environment jsdom
+// The one test that actually RENDERS PlayDrawer.
+//
+// Every anonymous rule in this component was previously pinned one hop away —
+// `play-drawer-action-bar.test.tsx` renders the bar with a `viewer` handed
+// straight in, `play-drawer-navigation.test.ts` calls `getSimilarClimbTapMode`
+// as a pure function, `play-drawer-layout.test.ts` calls
+// `initialDrawerPreviewItem` as a pure function. All three oracles are sound and
+// none of them can see whether PlayDrawer *uses* them: hardcoding
+// `viewer="member"` at the action-bar call site, or deleting the
+// similar-climb guard outright, left the whole 6576-test mobile suite green.
+//
+// So this file renders the real component with its children recorded, and
+// asserts the joins:
+//
+//   1. `viewer` and `onSignInPress` reach PlayDrawerActionBar.
+//   2. A similar-climb tap writes nothing anonymously — no `addToQueue`, no
+//      `setCurrentClimb` (which is what re-arms the BLE auto-sender) — and still
+//      does both for a member.
+//   3. No "Preview / Set active" banner anonymously. `Set active` calls
+//      `setCurrentClimb`, so it is the same queue write and the same BLE re-arm
+//      wearing a different button.
+//   4. The favourite query is disarmed anonymously (`favorites` is
+//      `requireAuthenticated`, so an armed one can only 401).
+//   5. The pane never paints its "Pick a climb" placeholder when the open target
+//      already carries the climb — not even on the first commit.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { Climb } from '@boardsesh/shared-schema';
+
+type Props = Record<string, unknown>;
+
+const recorded = vi.hoisted(() => ({
+  actionBar: [] as Props[],
+  previewBanner: [] as Props[],
+  deferredSections: [] as Props[],
+  favoriteStatus: [] as Props[],
+  panePlaceholder: 0,
+}));
+const queueActions = vi.hoisted(() => ({
+  setCurrentClimb: vi.fn(),
+  nextClimb: vi.fn(),
+  previousClimb: vi.fn(),
+  addToQueue: vi.fn(async () => 'added'),
+}));
+
+// --- Host platform -----------------------------------------------------------
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  Pressable: ({ children, onPress }: { children?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { onClick: onPress }, children),
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1, absoluteFillObject: {} },
+  Platform: { OS: 'web', select: (spec: Record<string, unknown>) => spec.web ?? spec.default },
+  useWindowDimensions: () => ({ width: 390, height: 844 }),
+}));
+vi.mock('react-native-gesture-handler', () => ({
+  ScrollView: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  GestureDetector: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
+  useAnimatedStyle: () => ({}),
+  useAnimatedReaction: () => undefined,
+  useSharedValue: (initial: unknown) => ({ value: initial }),
+  runOnJS: (fn: unknown) => fn,
+}));
+vi.mock('expo-router', () => ({ router: { dismiss: vi.fn() } }));
+vi.mock('expo-crypto', () => ({ randomUUID: () => 'random-uuid' }));
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) }));
+
+// --- Shared packages ---------------------------------------------------------
+vi.mock('@boardsesh/play-view', () => ({
+  computeNavigationStateWithSuggestions: () => ({
+    nextItem: null,
+    prevItem: null,
+    canNext: false,
+    canPrevious: false,
+  }),
+  boardSupportsMirroring: () => true,
+}));
+vi.mock('@boardsesh/analytics', () => ({
+  SHARED_EVENTS: {
+    ClimbShared: 'Climb Shared',
+    FavoriteToggle: 'Favorite Toggle',
+    QuickTickOpened: 'Quick Tick Opened',
+  },
+}));
+vi.mock('../../../lib/analytics', () => ({ track: vi.fn() }));
+
+// --- Children ----------------------------------------------------------------
+// Recorded rather than stubbed: these three carry the props under test.
+vi.mock('../PlayDrawerActionBar', () => ({
+  PlayDrawerActionBar: (props: Props) => {
+    recorded.actionBar.push(props);
+    return createElement('div', { 'data-testid': 'action-bar' });
+  },
+}));
+vi.mock('../PlayDrawerPreviewBanner', () => ({
+  PlayDrawerPreviewBanner: (props: Props) => {
+    recorded.previewBanner.push(props);
+    return createElement('div', { 'data-testid': 'preview-banner' });
+  },
+}));
+vi.mock('../DeferredSections', () => ({
+  DeferredSections: (props: Props) => {
+    recorded.deferredSections.push(props);
+    return createElement('div', { 'data-testid': 'deferred-sections' });
+  },
+}));
+vi.mock('../PanePlaceholder', () => ({
+  PanePlaceholder: () => {
+    recorded.panePlaceholder += 1;
+    return createElement('div', { 'data-testid': 'pane-placeholder' });
+  },
+}));
+vi.mock('../DeferredBoard', () => ({ DeferredBoard: () => createElement('div', { 'data-testid': 'board' }) }));
+vi.mock('../BoardRenderUnavailable', () => ({ BoardRenderUnavailable: () => null }));
+vi.mock('../PlaybackControls', () => ({ PlaybackControls: () => null }));
+vi.mock('../PlayDrawerHeader', () => ({ LivePlayDrawerHeader: () => createElement('div', null) }));
+vi.mock('../SwipeableHeader', () => ({
+  SwipeableHeader: ({ current }: { current?: ReactNode }) => createElement('div', null, current),
+}));
+vi.mock('../PlayDrawerOnWallBanner', () => ({ PlayDrawerOnWallBanner: () => null }));
+vi.mock('../SwitchBoardOverlay', () => ({ SwitchBoardOverlay: () => null }));
+vi.mock('../AngleSelectorSheet', () => ({ AngleSelectorSheet: () => null }));
+vi.mock('../../LogAscentSheet', () => ({ LogAscentSheet: () => null }));
+vi.mock('../../ClimbActionsSheet', () => ({ ClimbActionsSheet: () => null }));
+vi.mock('../../AddBetaVideoSheet', () => ({ AddBetaVideoSheet: () => null }));
+vi.mock('../../ble/BleControlSheetHost', () => ({ BleControlSheetHost: () => null }));
+vi.mock('../../Icon', () => ({ Icon: () => null }));
+
+// --- Hooks / providers -------------------------------------------------------
+vi.mock('../../../providers/queue-provider', () => ({
+  useQueueData: () => ({ queue: [], currentClimbQueueItem: null }),
+  useQueueActions: () => queueActions,
+  useQueueSessionId: () => ({ sessionId: null }),
+  usePlaylistSuggestionSource: () => null,
+}));
+vi.mock('../../../providers/bluetooth-provider', () => ({ useOptionalBluetoothContext: () => null }));
+vi.mock('../../../providers/auth-provider', () => ({ useAuth: () => ({ isAuthenticated: false }) }));
+vi.mock('../../../providers/toast-provider', () => ({ useToast: () => ({ showToast: vi.fn() }) }));
+vi.mock('../../../lib/graphql/hooks', () => ({
+  useToggleFavorite: () => ({ mutate: vi.fn() }),
+  useFavoriteStatus: (_boardName: string, _uuid: string | null, _angle: number, options?: Props) => {
+    recorded.favoriteStatus.push(options ?? {});
+    return { data: undefined };
+  },
+}));
+vi.mock('../../../hooks/use-display-grade', () => ({ useDisplayGrade: () => ({ boardseshActive: false }) }));
+vi.mock('../../../hooks/use-share-climb', () => ({ useShareClimb: () => vi.fn() }));
+vi.mock('../../../hooks/use-mounted-on-first-open', () => ({ useMountedOnFirstOpen: (open: boolean) => open }));
+vi.mock('../use-mobile-playback', () => ({ useMobilePlayback: () => ({ isAnimatable: false }) }));
+vi.mock('../use-below-fold-content-request', () => ({
+  useBelowFoldContentRequest: () => ({ requested: false, request: vi.fn(), requestFromScrollOffset: vi.fn() }),
+}));
+vi.mock('../use-drawer-dismiss-gesture', () => ({
+  useDrawerDismissGesture: () => ({ gesture: { enabled: () => ({}) }, translateY: { value: 0 } }),
+}));
+vi.mock('../use-play-drawer-wake-lock', () => ({ usePlayDrawerWakeLock: () => undefined }));
+vi.mock('../../ble/use-lightbulb-control', () => ({
+  useLightbulbControl: () => ({ lit: false, localConnected: false, pending: false, onPress: vi.fn() }),
+}));
+vi.mock('../copy-climb-name', () => ({ copyClimbName: vi.fn() }));
+vi.mock('../../../lib/haptics', () => ({ hapticSuccess: vi.fn() }));
+vi.mock('../../../lib/board-details', () => ({
+  getBoardRenderData: () => ({ boardWidth: 100, boardHeight: 100, holdsData: [], imagesToHolds: {} }),
+}));
+
+// `play-drawer-navigation`, `play-drawer-layout`, `boardsesh-grade-display` and
+// `favorite-rollback` stay REAL — the wiring of those helpers into the render is
+// exactly what this file exists to measure.
+
+const { PlayDrawer } = await import('../PlayDrawer');
+
+const BOARD_CONFIG = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 };
+const CLIMB = {
+  uuid: '0A1B2C3D4E5F60718293A4B5C6D7E8F9',
+  name: 'Crimpy Thing',
+  frames: 'p1145r15',
+  difficulty: '7A',
+} as unknown as Climb;
+const SIMILAR_CLIMB = {
+  uuid: 'FFEE0011223344556677889900AABBCC',
+  name: 'Neighbour',
+  frames: 'p1200r15',
+} as unknown as Climb;
+
+function openTargetFor(climb: Climb) {
+  return { climb, options: { previewQueueItem: { uuid: 'queue-item-uuid', climb } }, nonce: 1 };
+}
+
+function renderDrawer(viewer: 'member' | 'anonymous', onSignIn?: () => void) {
+  return render(
+    createElement(PlayDrawer, {
+      presentation: 'pane' as const,
+      viewer,
+      boardConfig: BOARD_CONFIG,
+      openTarget: openTargetFor(CLIMB),
+      onOpenQueue: vi.fn(),
+      onSignIn,
+    }),
+  );
+}
+
+function lastActionBarProps(): Props {
+  const props = recorded.actionBar.at(-1);
+  if (!props) throw new Error('PlayDrawerActionBar never rendered');
+  return props;
+}
+
+function lastSimilarClimbHandler(): (climb: Climb) => Promise<void> {
+  const props = recorded.deferredSections.at(-1);
+  if (!props) throw new Error('DeferredSections never rendered');
+  return props.onSimilarClimbPress as (climb: Climb) => Promise<void>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recorded.actionBar = [];
+  recorded.previewBanner = [];
+  recorded.deferredSections = [];
+  recorded.favoriteStatus = [];
+  recorded.panePlaceholder = 0;
+  queueActions.addToQueue.mockResolvedValue('added');
+});
+
+describe('PlayDrawer — the anonymous joins', () => {
+  it('hands its own viewer and sign-in prompt to the action bar', () => {
+    const onSignIn = vi.fn();
+    renderDrawer('anonymous', onSignIn);
+
+    const props = lastActionBarProps();
+    // Hardcoding `viewer="member"` here is invisible to every action-bar test,
+    // which passes `viewer` in directly: it would restore the queue button, the
+    // heart, the lightbulb, the ellipsis and the tick sheet for a signed-out
+    // reader with the whole suite green.
+    expect(props.viewer).toBe('anonymous');
+    // The tick is the only conversion prompt on the surface. With the prop
+    // dropped in the middle, the bar calls `onSignInPress?.()` on undefined and
+    // the tap silently does nothing.
+    expect(typeof props.onSignInPress).toBe('function');
+    (props.onSignInPress as () => void)();
+    expect(onSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the member viewer through unchanged', () => {
+    renderDrawer('member');
+    expect(lastActionBarProps().viewer).toBe('member');
+  });
+
+  it('writes nothing when a signed-out reader taps a similar climb', async () => {
+    renderDrawer('anonymous');
+    const onSimilarClimbPress = lastSimilarClimbHandler();
+
+    await act(async () => {
+      await onSimilarClimbPress(SIMILAR_CLIMB);
+    });
+
+    // Both halves matter. `addToQueue` is a queue a signed-out visitor cannot
+    // carry anywhere; `setCurrentClimb` re-arms the BLE auto-sender, and the
+    // browser export is the one surface where Web Bluetooth is mounted.
+    expect(queueActions.addToQueue).not.toHaveBeenCalled();
+    expect(queueActions.setCurrentClimb).not.toHaveBeenCalled();
+    // It still swaps what the drawer shows — Similar Climbs is the best reason
+    // a visitor has to keep looking, so a dead tap would be its own regression.
+    expect((recorded.deferredSections.at(-1)?.climb as Climb).uuid).toBe(SIMILAR_CLIMB.uuid);
+  });
+
+  it('still queues and activates a similar climb for a member', async () => {
+    renderDrawer('member');
+    const onSimilarClimbPress = lastSimilarClimbHandler();
+
+    await act(async () => {
+      await onSimilarClimbPress(SIMILAR_CLIMB);
+    });
+
+    expect(queueActions.addToQueue).toHaveBeenCalledTimes(1);
+    expect(queueActions.setCurrentClimb).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers no "Set active" banner to a signed-out reader', () => {
+    renderDrawer('anonymous');
+    // The anonymous drawer is ALWAYS a preview (that is what keeps the queue
+    // untouched), so an ungated banner renders an orange PREVIEW chip plus a
+    // live "Set active" button whose press is `setCurrentClimb` — the same
+    // queue write and BLE re-arm the similar-climb guard above blocks.
+    expect(recorded.previewBanner).toHaveLength(0);
+  });
+
+  it('still offers it to a member previewing a climb', () => {
+    renderDrawer('member');
+    expect(recorded.previewBanner.length).toBeGreaterThan(0);
+    expect(recorded.previewBanner.at(-1)?.showSetActive).toBe(true);
+  });
+
+  it('disarms the favourite query for a signed-out reader', () => {
+    renderDrawer('anonymous');
+    // `favorites` is `requireAuthenticated` server-side, so an armed query has
+    // exactly one possible outcome on every anonymous open.
+    expect(recorded.favoriteStatus.at(-1)?.enabled).toBe(false);
+  });
+
+  it('arms it for a member', () => {
+    renderDrawer('member');
+    expect(recorded.favoriteStatus.at(-1)?.enabled).toBe(true);
+  });
+
+  it('never paints the "Pick a climb" placeholder when the target already carries one', () => {
+    renderDrawer('anonymous');
+    // Counted across every commit, not just the last: the open target is applied
+    // by an effect that runs after the first commit, so a pane seeded only there
+    // shows the placeholder for one frame — a lie on a surface the visitor
+    // reached by following a link to one specific climb.
+    expect(recorded.panePlaceholder).toBe(0);
+  });
+});

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-layout.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-layout.test.ts
@@ -4,6 +4,7 @@ import {
   computeContainedBoardSize,
   computeFirstScreenHeight,
   computeLogbookScrollTarget,
+  initialDrawerPreviewItem,
   shouldShowPanePlaceholder,
 } from '../play-drawer-layout';
 
@@ -113,5 +114,29 @@ describe('CAROUSEL_LAYER_Z', () => {
 
   it('keeps the reset-zoom button tappable above the pan overlay', () => {
     expect(CAROUSEL_LAYER_Z.resetZoom).toBeGreaterThan(CAROUSEL_LAYER_Z.zoomPan);
+  });
+});
+
+// The open target is applied by an effect, which runs after the first commit —
+// so without this seed a pane that already has its climb paints one frame of the
+// "Pick a climb / Tap a climb to see it here" placeholder first. True on the
+// iPad, where the pane really is waiting on a list selection; a lie on the
+// anonymous climb view, where there is no list to tap and the visitor followed a
+// link to one specific climb.
+describe('initialDrawerPreviewItem', () => {
+  const previewQueueItem = { uuid: 'queue-item', climb: { uuid: 'climb-1' } } as never;
+
+  it('seeds a preview open so the pane placeholder never paints', () => {
+    expect(initialDrawerPreviewItem({ options: { previewQueueItem } })).toBe(previewQueueItem);
+  });
+
+  // A commit open carries queue side effects (`setCurrentClimb`) that belong in
+  // the effect, not in a state initialiser — so it seeds nothing.
+  it('seeds nothing for a commit open, or no target at all', () => {
+    expect(initialDrawerPreviewItem({ options: { previewQueueItem: null } })).toBeNull();
+    expect(initialDrawerPreviewItem({ options: {} })).toBeNull();
+    expect(initialDrawerPreviewItem({})).toBeNull();
+    expect(initialDrawerPreviewItem(null)).toBeNull();
+    expect(initialDrawerPreviewItem(undefined)).toBeNull();
   });
 });

--- a/packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts
+++ b/packages/mobile/src/components/play-drawer/__tests__/play-drawer-navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ClimbQueueItem, PlaylistSuggestionSource } from '@boardsesh/queue';
-import { getViewOnlyPreviewNavigationTarget } from '../play-drawer-navigation';
+import { getSimilarClimbTapMode, getViewOnlyPreviewNavigationTarget } from '../play-drawer-navigation';
 
 function makeItem(id: string): ClimbQueueItem {
   return {
@@ -79,5 +79,22 @@ describe('getViewOnlyPreviewNavigationTarget', () => {
         targetItem: makeItem('previous'),
       }),
     ).toEqual({ viewOnly: false });
+  });
+});
+
+describe('getSimilarClimbTapMode', () => {
+  it('queues and activates for a signed-in member', () => {
+    expect(getSimilarClimbTapMode('member')).toBe('queue');
+  });
+
+  // The affordance the anonymous drawer keeps that could still write. Similar
+  // Climbs is a read worth keeping, but its member tap does two things a
+  // signed-out reader must not get: it writes the local queue (a list they
+  // cannot carry anywhere, next to a queue button that is hidden) and it calls
+  // `setCurrentClimb`, which re-arms the BLE auto-sender and pushes the climb to
+  // a connected board. The lightbulb is hidden for exactly that reason; this is
+  // the back door into the same behaviour.
+  it('only swaps the preview for a signed-out reader — no queue write, no BLE re-arm', () => {
+    expect(getSimilarClimbTapMode('anonymous')).toBe('preview');
   });
 });

--- a/packages/mobile/src/components/play-drawer/play-drawer-layout.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-layout.ts
@@ -4,6 +4,8 @@
  * aspect ratios and screen sizes (the board catalog has many variants).
  */
 
+import type { ClimbQueueItem } from '@boardsesh/queue';
+
 export type BoardBox = { width: number; height: number };
 
 /**
@@ -30,6 +32,27 @@ export function computeContainedBoardSize(boxWidth: number, boxHeight: number, a
  */
 export function computeFirstScreenHeight(windowHeight: number, reserve: number, minFraction = 0.5): number {
   return Math.max(windowHeight - reserve, windowHeight * minFraction);
+}
+
+/**
+ * The preview item a drawer should already be showing on its FIRST render.
+ *
+ * The open target is normally applied by an effect, which does not run until
+ * after the first commit — so a pane opened with a climb in hand still paints
+ * one frame of the "Pick a climb / Tap a climb to see it here" placeholder
+ * before the climb appears. Harmless on the iPad, where that copy is true and
+ * the pane really is waiting on a list selection. Wrong on the anonymous climb
+ * view, where there is no list to tap and the visitor followed a link to one
+ * specific climb — the first thing they would read is an instruction they
+ * cannot follow.
+ *
+ * Only a PREVIEW target seeds anything. A commit open has queue side effects
+ * (`setCurrentClimb`) that belong in the effect, not in a state initialiser.
+ */
+export function initialDrawerPreviewItem(
+  openTarget: { options?: { previewQueueItem?: ClimbQueueItem | null } } | null | undefined,
+): ClimbQueueItem | null {
+  return openTarget?.options?.previewQueueItem ?? null;
 }
 
 /** A persistent detail pane needs an explicit empty state; a modal route does not. */

--- a/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
+++ b/packages/mobile/src/components/play-drawer/play-drawer-navigation.ts
@@ -19,3 +19,29 @@ export function getViewOnlyPreviewNavigationTarget({
   if (!previewSuggestionSource || !previewItem) return { viewOnly: false };
   return { viewOnly: true, targetItem };
 }
+
+/**
+ * What a tap on a Similar Climbs card does, by viewer.
+ *
+ * `'queue'` is the long-standing behaviour: add the climb to the queue (which
+ * may raise the cross-board prompt) and make it the current climb.
+ *
+ * `'preview'` is the signed-out reader on the web export's read-only climb view.
+ * Similar Climbs stays — it is a READ, and the best reason a visitor has to keep
+ * looking — but its tap must not take the queue path, for two reasons that are
+ * not about permissions:
+ *
+ *  - `addToQueue` writes the local queue, which for an anonymous reader is a
+ *    list they cannot carry anywhere. Hidden queue button, live queue writes is
+ *    the worst of both.
+ *  - `setCurrentClimb` re-arms the BLE auto-sender, which pushes the new climb
+ *    to a connected board. The anonymous view hides the lightbulb precisely so
+ *    nothing here drives a wall; a similar-climb tap must not be the back door
+ *    that does.
+ *
+ * The preview swap is the same mechanism `getViewOnlyPreviewNavigationTarget`
+ * already uses above — show the climb, commit nothing.
+ */
+export function getSimilarClimbTapMode(viewer: 'member' | 'anonymous'): 'queue' | 'preview' {
+  return viewer === 'anonymous' ? 'preview' : 'queue';
+}

--- a/packages/mobile/src/lib/graphql/hooks/__tests__/use-favorite-status.test.tsx
+++ b/packages/mobile/src/lib/graphql/hooks/__tests__/use-favorite-status.test.tsx
@@ -17,6 +17,14 @@ vi.mock('../../client', () => ({
   getHttpClient: () => ({ request: requestMock }),
 }));
 
+// `favorites` is `requireAuthenticated` server-side, so the hook reads the
+// session off the board adapter and refuses to fire without one. Mutable so the
+// signed-out case can be exercised without re-mocking.
+const adapterAuth = vi.hoisted(() => ({ isAuthenticated: true }));
+vi.mock('@boardsesh/board-react', () => ({
+  useBoardAdapter: () => adapterAuth,
+}));
+
 // The hooks barrel re-exports sibling hooks that transitively pull in
 // react-native / expo-router (auth provider, you-data, social, session-detail).
 // useFavoriteStatus + useToggleFavorite are pure React Query and touch none of
@@ -62,6 +70,7 @@ function makeWrapper() {
 
 beforeEach(() => {
   requestMock.mockReset();
+  adapterAuth.isAuthenticated = true;
 });
 
 describe('useFavoriteStatus', () => {
@@ -105,6 +114,34 @@ describe('useFavoriteStatus', () => {
     // Give React Query a tick; nothing should fire while disabled.
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  // The anonymous read-only climb view opens the play drawer with
+  // `enabled: isSheetOpen` for a visitor who has no account. Without this gate
+  // every such open fired a GET_FAVORITES that `requireAuthenticated` rejects.
+  it('does not fetch for a signed-out reader even when the caller enables it', async () => {
+    adapterAuth.isAuthenticated = false;
+    requestMock.mockResolvedValue({ favorites: ['climb-1'] });
+    const { Wrapper } = makeWrapper();
+
+    renderHook(() => useFavoriteStatus('kilter', 'climb-1', 40, { enabled: true }), { wrapper: Wrapper });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  // The other half of the gate: the fix must not be "never fetch". A member on
+  // the same climb still gets exactly one request, so the heart keeps working.
+  it('still fetches once for a signed-in member on the same arguments', async () => {
+    requestMock.mockResolvedValue({ favorites: ['climb-1'] });
+    const { Wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useFavoriteStatus('kilter', 'climb-1', 40, { enabled: true }), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(requestMock).toHaveBeenCalledTimes(1);
   });
 
   it('does not fetch before a climb is selected (null uuid)', async () => {

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -984,6 +984,11 @@ export function useToggleFavorite() {
  * opens with `enabled: isSheetOpen` and fires a guaranteed rejection on every
  * open. Gating here rather than only at the call site means a future consumer
  * cannot reintroduce it by forgetting.
+ *
+ * The cost is a provider dependency this hook did not used to have: it reads the
+ * session off `useBoardAdapter()`, so it must be called under a
+ * `BoardAdapterProvider` — mounted app-wide in `app/_layout.tsx` — and throws at
+ * the hook rather than at query time outside one.
  */
 export function useFavoriteStatus(
   boardName: string,

--- a/packages/mobile/src/lib/graphql/hooks/index.ts
+++ b/packages/mobile/src/lib/graphql/hooks/index.ts
@@ -38,6 +38,7 @@ import {
   type FavoritesQueryResponse,
 } from '@boardsesh/graphql/operations/favorites';
 import { BOULDER_GRADES } from '@boardsesh/board-config';
+import { useBoardAdapter } from '@boardsesh/board-react';
 import { myBoardsQueryKey } from '../query-keys';
 import { getDatabaseHandle } from '../../../db';
 import { offlineAwareRequest } from '../offline-request';
@@ -974,6 +975,15 @@ export function useToggleFavorite() {
  * angle matters — favoriting at 40° is distinct from 25°. Disabled until a
  * `climbUuid` is supplied (and via `enabled`, so callers can gate it on a sheet
  * being open). Returns `true` when the climb is favorited at this angle.
+ *
+ * The session is part of the gate, not just the caller's `enabled`. `favorites`
+ * is `requireAuthenticated` server-side, so for a signed-out reader this query
+ * has exactly one outcome: an error. That used to be theoretical — nothing
+ * signed-out could open the play drawer — and stopped being so when the web
+ * export began rendering read-only climb URLs anonymously, where the drawer
+ * opens with `enabled: isSheetOpen` and fires a guaranteed rejection on every
+ * open. Gating here rather than only at the call site means a future consumer
+ * cannot reintroduce it by forgetting.
  */
 export function useFavoriteStatus(
   boardName: string,
@@ -981,6 +991,7 @@ export function useFavoriteStatus(
   angle: number,
   options?: { enabled?: boolean },
 ) {
+  const { isAuthenticated } = useBoardAdapter();
   return useQuery({
     queryKey: ['favoriteStatus', boardName, climbUuid, angle],
     queryFn: () =>
@@ -990,7 +1001,7 @@ export function useFavoriteStatus(
         angle,
       }),
     select: (data) => data.favorites.includes(climbUuid!),
-    enabled: (options?.enabled ?? true) && !!climbUuid,
+    enabled: (options?.enabled ?? true) && !!climbUuid && isAuthenticated,
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/packages/shared/i18n/locales/de/session.json
+++ b/packages/shared/i18n/locales/de/session.json
@@ -196,7 +196,14 @@
       "lifetimeSends_one": "{{count}} Begehung",
       "lifetimeSends_other": "{{count}} Begehungen",
       "lifetimeRecap": "{{tries}} {{sessions}}",
-      "lifetimeRecapWithSends": "{{tries}} {{sessions}} · {{sends}}"
+      "lifetimeRecapWithSends": "{{tries}} {{sessions}} · {{sends}}",
+      "signedOut": "Melde dich an, um deine Versuche an diesem Boulder zu sehen."
+    },
+    "anonymous": {
+      "signInHeadline": "Begehung eintragen",
+      "signInSubtitle": "Melde dich an, um Versuche, Begehungen und Beta an einem Ort zu behalten.",
+      "signInAction": "Anmelden",
+      "tickAria": "Melde dich an, um diese Begehung einzutragen"
     },
     "similarClimbs": {
       "title": "Ähnliche Boulder",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -196,7 +196,14 @@
       "lifetimeSends_one": "{{count}} send",
       "lifetimeSends_other": "{{count}} sends",
       "lifetimeRecap": "{{tries}} {{sessions}}",
-      "lifetimeRecapWithSends": "{{tries}} {{sessions}} · {{sends}}"
+      "lifetimeRecapWithSends": "{{tries}} {{sessions}} · {{sends}}",
+      "signedOut": "Sign in to see your tries on this climb."
+    },
+    "anonymous": {
+      "signInHeadline": "Log this send",
+      "signInSubtitle": "Sign in to keep your tries, sends and beta in one place.",
+      "signInAction": "Sign in",
+      "tickAria": "Sign in to log this send"
     },
     "similarClimbs": {
       "title": "Similar Climbs",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -196,7 +196,14 @@
       "lifetimeSends_one": "{{count}} encadene",
       "lifetimeSends_other": "{{count}} encadenes",
       "lifetimeRecap": "{{tries}} {{sessions}}",
-      "lifetimeRecapWithSends": "{{tries}} {{sessions}} · {{sends}}"
+      "lifetimeRecapWithSends": "{{tries}} {{sessions}} · {{sends}}",
+      "signedOut": "Inicia sesión para ver tus intentos en este bloque."
+    },
+    "anonymous": {
+      "signInHeadline": "Registra este encadene",
+      "signInSubtitle": "Inicia sesión para guardar tus intentos, encadenes y beta en un solo sitio.",
+      "signInAction": "Iniciar sesión",
+      "tickAria": "Inicia sesión para registrar este encadene"
     },
     "similarClimbs": {
       "title": "Escaladas similares",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -196,7 +196,14 @@
       "lifetimeRecap": "{{tries}} {{sessions}}",
       "lifetimeRecapWithSends": "{{tries}} {{sessions}} · {{sends}}",
       "pendingSync_one": "{{count}} en attente de synchronisation",
-      "pendingSync_other": "{{count}} en attente de synchronisation"
+      "pendingSync_other": "{{count}} en attente de synchronisation",
+      "signedOut": "Connecte-toi pour voir tes essais sur ce bloc."
+    },
+    "anonymous": {
+      "signInHeadline": "Fais la croix",
+      "signInSubtitle": "Connecte-toi pour garder tes essais, tes croix et ton beta au même endroit.",
+      "signInAction": "Se connecter",
+      "tickAria": "Connecte-toi pour enregistrer cette croix"
     },
     "similarClimbs": {
       "title": "Voies similaires",


### PR DESCRIPTION
## Summary

Part 1 of 2 for #4478. Adds the pieces a signed-out reader needs to **read** a climb, without wiring anything to them yet. Nothing routes here, so this ships behaviourally inert on both platforms — the routing switch is the stacked PR.

Splitting this way keeps each reviewable unit honest: this PR alone would ship dead buttons if it were the routing PR, and the routing PR alone would ship a login wall if it were the surface PR.

- **`AnonymousClimbView`** hosts `PlayDrawer` in its existing `presentation="pane"` mode — the seam `IpadPlayPane` already proves — with a standing sign-in bar whose href comes from `buildLoginHrefWithReturn()`, never a hand-rolled `/auth/login`. The climb opens as a `previewQueueItem`, so the queue is never written.
- **`viewer: 'member' | 'anonymous'`** through `PlayDrawer` and `PlayDrawerActionBar`. Write affordances are **removed rather than disabled** — queue, favourite, lightbulb, climb actions — because a dead button a visitor taps and nothing happens is worse than the login wall this replaces. The tick stays as the one conversion prompt, relabelled and pointed at login. Mirror, prev/next, share and the angle pill are reads and stay live.
- **Similar Climbs stays, but its tap changes.** It is the best reason a visitor has to keep looking, so removing it would be the wrong trade — but the member tap does two things a signed-out reader must not get. It writes the local queue (a list they cannot carry anywhere, sitting next to a queue button that is hidden), and it calls `setCurrentClimb`, which **re-arms the BLE auto-sender** and pushes the new climb to a connected board. Anonymously it takes the preview path the wrong-board drawer already uses: the drawer shows the climb, nothing is committed, nothing reaches a wall.
- **The "Preview · Set active" banner is hidden too.** The anonymous view always opens with a preview item, so the banner rendered every time — and its one button calls `setCurrentClimb`, i.e. a queue write plus a BLE re-arm, which is the exact affordance the rest of this PR removes. It also asks a question a signed-out reader has no answer to: there is no active climb and no wall.
- **`PlayDrawer` is now rendered in a unit test** (`play-drawer-anonymous.test.tsx`). It never had been — both existing suites mock it — so the props it hands its children were unmeasured, and six mutations survived the entire 6,500-test suite. They do not any more.

- Two of the removals are about **navigation**, not writes. The anonymous gate re-reads `window.location.pathname` on every navigation, so anything pushing `/boards`, `/play` or `/climbs/{uuid}` bounces the visitor to login mid-session. The reasoning is in a code comment, because this is the failure mode that will bite a later change.
- **The lightbulb is hidden.** Web Bluetooth *is* mounted on the browser export, so it would otherwise render for an anonymous visitor — board presence binds on an active board uuid they do not have, and a pairing prompt on a first-ever visit is a hostile opening. Anonymous wall lighting deserves its own thought; filed as #4606. The suppression lives in **one** place, `PlayDrawerActionBar`'s `viewer` rules, next to the test that pins it; `showLightbulb` went back to meaning only "a Bluetooth transport exists".

### Two real bugs fixed on the way

- **`useFavoriteStatus` had no session gate.** It was armed on `enabled: isSheetOpen` alone, and `favorites` is `requireAuthenticated` server-side — so every anonymous drawer open would have fired a query with exactly one possible outcome. Gated in the hook, not only at the call site, so a future consumer cannot reintroduce it by forgetting.
- **The Logbook told first-time visitors they had "No tries yet. Get on it."** Everything reaching that section signed-out looks like a member with no history: the logbook query is disabled so it lands empty, and `userAscents`/`userAttempts` are viewer-scoped and arrive null. A comment in `DeferredSections.tsx` claimed the section "still expands to the sign-in prompt" — no such branch existed (`DeferredSections.tsx:117` gates the summary *string*, and `LogbookSection` had no auth gate at all). Now the branch exists and the comment is correct.

### A third one, found while building it

**The pane painted "Pick a climb. Tap a climb to see it here." as its first frame.** The open target is applied by an effect, which runs after the first commit — so a pane that already has its climb shows the placeholder for one frame first. True on the iPad, where the pane really is waiting on a list selection; a lie on the anonymous view, where there is no list to tap and the visitor followed a link to one specific climb. The preview item is now seeded in the state initialiser. Only a *preview* target seeds anything — a commit open has queue side effects that belong in the effect.

### Three more, from the adversarial review

**The anonymous drawer offered a live "Set active".** It is always in preview mode — that is what keeps the queue untouched — so the "Preview / Set active" banner rendered on every read-only open, and its press is `setCurrentClimb`: the same queue write and the same BLE auto-sender re-arm the similar-climb guard above was written to block, wearing a different button. Gated on the viewer now. "Preview" also means nothing to a reader with no active climb to promote it over.

**The angle pill was cosmetic where it mattered.** Grade, stars and ascent count are baked into the climb row at the angle it was fetched for (`getClimbByUuid` joins the stats tables ON angle), the route's query is frozen at the URL angle, and `useEffectiveClimbStats` — what keeps the signed-in header honest across an angle change — is `requireAuthenticated` and never fires here. So the header held the URL angle's numbers while the Boardsesh grade, the crowd-grade bar and the angle sheet's own per-angle stats all moved: two grades for one angle, on one screen. The climb is refetched at the live angle, and the one already on screen keeps rendering while that is in flight, so the drawer never blanks mid-swap.

Known gap, left as-is: the URL is not rewritten when the angle moves, so `buildLoginHrefWithReturn()` sends the reader back to the URL's angle rather than the one they were looking at. The signed-in deep-link path behaves the same way, and rewriting the address bar mid-read is its own decision.

**A board that cannot tilt can now say so.** `isAngleAdjustable` rides through to the drawer instead of defaulting to an angle pill for a bolted wall. The stacked PR resolves it from the `/b/{slug}` board record.

Copy added to all four locales, following the glossaries (es *encadene*, fr *faire la croix*, de *Begehung* / informal *du*).

Closes nothing on its own. Refs #4478.

## Review gates

- **`ble-needs-fable-review`.** This suppresses the lightbulb and stops a similar-climb tap re-arming the BLE auto-sender. Web Bluetooth is live on the browser export, so this touches the BLE surface — **Fable review required before merge** (repo rule), on top of the standing Fable review every `packages/mobile` PR gets under epic #4358.
- **Needs Marco's explicit nod on epic #4358's standing rules** before merge — this is a W-06 follow-up and it publishes to the native fleet as an inert OTA (below).
- Not auto-mergeable.

### Production targets

**The native store fleet, via auto-OTA** — this touches `packages/mobile/**` and `packages/shared/i18n`, so merging to `main` auto-publishes a production OTA that reaches every installed binary within hours. It is behaviourally inert there (nothing renders `viewer="anonymous"` until the stacked PR), but the diff does ship. Also **app.boardsesh.com** for the same reason. Not `www.boardsesh.com`.

**No native fingerprint inputs changed** — no `app.config.ts`, `plugins/**`, `modules/**`, `locales/**`, `patches/**` or dependency edits — so `main` stays OTA-compatible with the store binaries and the OTA-compatibility check reports both platforms matching `main`.

## Release Notes

- [x] No release note needed (internal / technical change)

Nothing is reachable yet — the user-facing note ships with the stacked routing PR.

## Test plan

- `vp run typecheck:mobile` — green.
- `vp run test:mobile` — green.
- `vp test run --project i18n catalog-completeness --reporter=agent` — green (four-locale parity; `--project web` does not run it).
- `vp run check:i18n`, `vp run check:i18n:orphans` — clean.
- `vp check` — 0 errors, formatted.
- `vp run check:mobile-bundle`, `vp run check:mobile-web-bundle` — both OK.

**Every new oracle was mutation-tested** — the mutation applied, the test watched go red, reverted:

| Mutation | Caught by |
| --- | --- |
| `useFavoriteStatus` loses the session gate | `use-favorite-status.test.tsx` |
| ...or becomes "never fetch" (breaks the member heart) | same file, the signed-in half |
| Logbook signed-out branch deleted | `logbook-section-signed-out.test.tsx` |
| ...or ordered after the count fallbacks | same file |
| Favourite / queue / ellipsis / lightbulb rendered anonymously | `play-drawer-action-bar.test.tsx`, one assertion each |
| Tick FAB hidden anonymously (removes the only way in) | same file |
| Tick wired to `onTickPress` instead of sign-in | same file |
| Heart falls back into slot 1 on a fixed-mirror board | same file |
| Ascent badge kept anonymously | same file |
| Sign-in href hard-coded to `/auth/login` | `anonymous-climb-view.test.tsx` |
| **`openTarget` left unmemoised (infinite re-open loop)** | `anonymous-climb-view.test.tsx`, the settle test |
| Nonce bumped from inside a state updater (double-advances under Strict Mode) | same file, the Strict Mode test |
| Open target's nonce not bumped on angle change (drawer blanks) | same file |
| `presentation="route"` instead of `"pane"` | same file |
| `previewQueueItem` dropped (queue would be written) | same file |
| Nonce bumped for an angle that did not move | same file |
| Similar-climb tap queues + commits for an anonymous reader | `play-drawer-navigation.test.ts` |
| Pane preview seed always null (placeholder paints again) | `play-drawer-layout.test.ts` |
| ...or a commit open seeded too (queue side effects bypassed) | same file |
| Angle refetch never armed / armed at the URL angle | `anonymous-climb-view.test.tsx` |
| Fresh climb ignored, open target keeps the URL angle's numbers | same file |
| In-flight fallback dropped (drawer blanks mid-swap) | same file |
| `isAngleAdjustable` not forwarded, or forced true | same file |
| The six `PlayDrawer` call-site mutations in the table below | `play-drawer-anonymous.test.tsx` |

Per-affordance assertions rather than one "renders no write buttons" sweep: a heart that 401s and a missing tick are different product regressions and a blanket assertion could not tell them apart.

The **settle test** deserves a note: every other assertion in that file reads the *last* render's props, so all of them stay green inside an infinite re-render loop. Only the render count plus the open target's identity across a re-render can tell a memoised target from a fresh object.

### `PlayDrawer` is now rendered in a test

It never had been — both existing suites mock it — so every anonymous rule was pinned one hop away from the code that ships it, and the hop is where the bugs were. Six mutations survived the whole mobile suite before `play-drawer-anonymous.test.tsx` existed:

| Mutation at the call site | Consequence | Now caught by |
| --- | --- | --- |
| `viewer={viewer}` → `viewer="member"` | queue button, heart, lightbulb, ellipsis and tick sheet all return for a signed-out reader | the viewer join |
| similar-climb preview guard deleted | `addToQueue` + `setCurrentClimb` return — the BLE auto-sender re-arms on the one surface where Web Bluetooth is mounted | the write assertions, both directions |
| `onSignInPress={onSignIn}` dropped | the only conversion prompt on the surface becomes a dead button | the same viewer join |
| preview banner ungated anonymously | a live "Set active" — same write, same re-arm | the banner assertion, both directions |
| `enabled: isSheetOpen && !isAnonymous` → `enabled: isSheetOpen` | an auth-only `favorites` query on every anonymous open | the enabled assertion, both directions |
| `initialDrawerPreviewItem(openTarget)` → `null` | the pane paints "Pick a climb" for one frame | the placeholder count across every commit |

The oracles inside `PlayDrawerActionBar` were all sound; only their connection to the shipped render was unmeasured.

Also not verified here: how the pane-presentation drawer reads as a full-width browser surface. It has only ever been exercised as an iPad right column — a real-device gate, and the most likely source of a second iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016552Be7ctNKKH8QM9rkryN


