### PR TITLE
feat(mobile): render the climb, not the login form, for signed-out readers

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -4,6 +4,8 @@ Two kinds, and they fail in different ways.
 
 **Client flags** (`FEATURE_FLAG_KEYS` in `packages/web/app/flags.ts`) resolve in the browser via `FeatureFlagsProvider`. They hide a control. If PostHog is slow or unreachable the control stays hidden and nothing else happens.
 
+**Kill switches invert that default, deliberately.** A flag named `*-kill` gates a shipped feature and an unresolved read means _not killed_, i.e. the feature is on — the opposite of the rule above. The reason is the same asynchrony: a positive flag reads as OFF for the first frames of a cold open, which for a surface whose off-state is a redirect means the visitor watches a redirect flash before the flag lands. `anonymous-climb-view-kill` (mobile, `useAnonymousClimbViewEnabled`) is the worked example — its off-state is the login wall the feature exists to remove, so a flash of it on arrival would defeat the whole surface. Read a kill switch as `useFeatureFlag(key) !== true`, never `=== false`, so a missing key and an unresolved one both mean on.
+
 **Server flags** (`SERVER_FEATURE_FLAG_KEYS`) resolve during SSR via `getServerFeatureFlag` and decide whether a route renders at all — with one off, its route is a plain `notFound()`. A client-resolved flag could not do this: by the time the browser knows the answer the HTML has already shipped.
 
 The registry is **empty today**. `gyms-directory` was the only server flag; `/gyms` and its three facet routes now render for everyone and the flag is gone. The machinery below stays for the next route that needs it — and the diagnostics endpoint still answers any key you name.

--- a/packages/mobile/src/components/BoardRouteRedirect.tsx
+++ b/packages/mobile/src/components/BoardRouteRedirect.tsx
@@ -113,8 +113,15 @@ export function BoardRouteRedirect({ status }: { status: BoardRouteStatus }) {
       <Stack.Screen options={{ headerShown: false }} />
       {/* A handed-off screen keeps this spinner on its way out — nothing flips it
           to the not-found, because the board and climb it handed off with are
-          both still there. */}
-      {status === 'resolving' ? (
+          both still there.
+
+          `anonymous-climb` reaching HERE means the caller had the status but not
+          the climb — a state `resolveStatus` refuses to produce today (it only
+          says `anonymous-climb` once the climb has landed). It waits on the
+          spinner rather than falling through, because the alternative reading of
+          "the climb has not arrived yet" is "Not found" plus a Back-to-home
+          button, on a URL that is about to resolve. */}
+      {status === 'resolving' || status === 'anonymous-climb' ? (
         <ActivityIndicator size="large" />
       ) : (
         <>
@@ -145,7 +152,11 @@ export function BoardRouteHandoff({ target, mode }: { target: BoardRouteTarget |
   // `RELAXES_ANONYMOUS_ROUTES` is false, so the flag cannot reach a decision
   // there however it resolves.
   const anonymousClimbEnabled = useAnonymousClimbViewEnabled();
-  const { status, climb, boardConfig } = useBoardRouteTarget(target, { mode, onHandedOff, anonymousClimbEnabled });
+  const { status, climb, boardConfig, isAngleAdjustable } = useBoardRouteTarget(target, {
+    mode,
+    onHandedOff,
+    anonymousClimbEnabled,
+  });
 
   const renderedStatus = RENDERED_EVENT_STATUS[status as keyof typeof RENDERED_EVENT_STATUS];
   const parsedUrl = target !== null;
@@ -165,7 +176,7 @@ export function BoardRouteHandoff({ target, mode }: { target: BoardRouteTarget |
   // right here, on the URL the visitor arrived at, because every route the
   // hand-off would navigate to is behind the login gate.
   if (status === 'anonymous-climb' && climb && boardConfig) {
-    return <AnonymousClimbView climb={climb} boardConfig={boardConfig} />;
+    return <AnonymousClimbView climb={climb} boardConfig={boardConfig} isAngleAdjustable={isAngleAdjustable} />;
   }
 
   return <BoardRouteRedirect status={status} />;

--- a/packages/mobile/src/components/BoardRouteRedirect.tsx
+++ b/packages/mobile/src/components/BoardRouteRedirect.tsx
@@ -13,9 +13,11 @@ import { useTranslation } from 'react-i18next';
 import { onlineManager } from '@tanstack/react-query';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { ActivityIndicator } from './ActivityIndicator';
+import { AnonymousClimbView } from './AnonymousClimbView';
 import { Button } from './Button';
 import { Icon } from './Icon';
 import { Text } from './Text';
+import { useAnonymousClimbViewEnabled } from '../providers/feature-flags-provider';
 import { useTheme } from '../providers/theme-provider';
 import { track } from '../lib/analytics';
 import { buildLoginHrefWithReturn } from '../lib/routing/anonymous-auth-gate';
@@ -25,8 +27,16 @@ import { useBoardRouteTarget, type BoardRouteMode, type BoardRouteStatus } from 
 /** Where `app/+not-found.tsx` sends people; the dead end below has to match it. */
 const HOME_TAB = '/(tabs)/home' as const;
 
-/** How a board-route open ended, in the wire spelling. */
-type HandoffEventStatus = 'resolved' | 'not_found' | 'auth_required';
+/**
+ * How a board-route open ended, in the wire spelling.
+ *
+ * `anonymous` is a signed-out reader who got the climb rather than the login
+ * wall. A new VALUE rather than a new event on purpose: the funnel is
+ * `Climb Handoff Clicked` ÷ `Board Route Handoff`, both stamped
+ * `environment: production-web`, and a second event name would have split it.
+ * Anonymous-vs-signed-in arrivals are a breakdown of the same ratio.
+ */
+type HandoffEventStatus = 'resolved' | 'not_found' | 'auth_required' | 'anonymous';
 
 /**
  * The terminal statuses the screen SITS on, in the wire spelling.
@@ -38,6 +48,7 @@ type HandoffEventStatus = 'resolved' | 'not_found' | 'auth_required';
 const RENDERED_EVENT_STATUS = {
   'not-found': 'not_found',
   'auth-required': 'auth_required',
+  'anonymous-climb': 'anonymous',
 } as const satisfies Partial<Record<BoardRouteStatus, HandoffEventStatus>>;
 
 /** The URL a report is about, so two different climbs each get their own event. */
@@ -130,7 +141,11 @@ export function BoardRouteRedirect({ status }: { status: BoardRouteStatus }) {
 export function BoardRouteHandoff({ target, mode }: { target: BoardRouteTarget | null; mode?: BoardRouteMode }) {
   const report = useBoardRouteHandoffReporter(target, mode);
   const onHandedOff = useCallback(() => report('resolved'), [report]);
-  const status = useBoardRouteTarget(target, { mode, onHandedOff });
+  // Read unconditionally, applied only where the gate already relaxes: on native
+  // `RELAXES_ANONYMOUS_ROUTES` is false, so the flag cannot reach a decision
+  // there however it resolves.
+  const anonymousClimbEnabled = useAnonymousClimbViewEnabled();
+  const { status, climb, boardConfig } = useBoardRouteTarget(target, { mode, onHandedOff, anonymousClimbEnabled });
 
   const renderedStatus = RENDERED_EVENT_STATUS[status as keyof typeof RENDERED_EVENT_STATUS];
   const parsedUrl = target !== null;
@@ -145,6 +160,13 @@ export function BoardRouteHandoff({ target, mode }: { target: BoardRouteTarget |
     if (renderedStatus === 'not_found' && parsedUrl && !onlineManager.isOnline()) return;
     report(renderedStatus);
   }, [parsedUrl, renderedStatus, report]);
+
+  // The one status this component does not redirect for: the climb is drawn
+  // right here, on the URL the visitor arrived at, because every route the
+  // hand-off would navigate to is behind the login gate.
+  if (status === 'anonymous-climb' && climb && boardConfig) {
+    return <AnonymousClimbView climb={climb} boardConfig={boardConfig} />;
+  }
 
   return <BoardRouteRedirect status={status} />;
 }

--- a/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
+++ b/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
@@ -4,6 +4,7 @@ import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SHARED_EVENTS } from '@boardsesh/analytics';
 import type { BoardRouteTarget } from '../../lib/routing/board-route-target';
+import type { Climb } from '@boardsesh/shared-schema';
 import type { BoardRouteStatus } from '../../lib/routing/use-board-route-target';
 
 // What the gate hands back, as a sentinel. This suite asserts the component
@@ -13,6 +14,10 @@ const LOGIN_HREF = vi.hoisted(() => '/auth/login?next=%2Fb%2Fthe-gym%2F40%2Flist
 
 const analytics = vi.hoisted(() => ({ track: vi.fn() }));
 const routeStatus = vi.hoisted(() => ({ current: 'resolving' as BoardRouteStatus }));
+// The kill switch, as the component reads it. `true` = feature on.
+const anonymousClimbView = vi.hoisted(() => ({ enabled: true, seen: [] as (boolean | undefined)[] }));
+// What the anonymous branch renders instead of a redirect.
+const anonymousView = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
 const redirect = vi.hoisted(() => ({ hrefs: [] as string[] }));
 const router = vi.hoisted(() => ({ replace: vi.fn() }));
 // The hand-off callback the hook holds. A successful hand-off never becomes a
@@ -55,12 +60,27 @@ vi.mock('../../lib/routing/anonymous-auth-gate', () => ({
   buildLoginHrefWithReturn: () => LOGIN_HREF,
 }));
 vi.mock('@tanstack/react-query', () => ({ onlineManager: { isOnline: () => connectivity.isOnline } }));
-vi.mock('../../lib/routing/use-board-route-target', () => ({
-  useBoardRouteTarget: (_target: unknown, options?: { onHandedOff?: () => void }) => {
-    handoff.current = options?.onHandedOff ?? null;
-    return routeStatus.current;
+vi.mock('../../providers/feature-flags-provider', () => ({
+  useAnonymousClimbViewEnabled: () => anonymousClimbView.enabled,
+}));
+vi.mock('../AnonymousClimbView', () => ({
+  AnonymousClimbView: (props: Record<string, unknown>) => {
+    anonymousView.props.push(props);
+    return createElement('div', { 'data-testid': 'anonymous-climb-view' });
   },
 }));
+vi.mock('../../lib/routing/use-board-route-target', () => ({
+  useBoardRouteTarget: (_target: unknown, options?: { onHandedOff?: () => void; anonymousClimbEnabled?: boolean }) => {
+    handoff.current = options?.onHandedOff ?? null;
+    anonymousClimbView.seen.push(options?.anonymousClimbEnabled);
+    return routeStatus.current === 'anonymous-climb'
+      ? { status: routeStatus.current, climb: ANONYMOUS_CLIMB, boardConfig: ANONYMOUS_BOARD_CONFIG }
+      : { status: routeStatus.current, climb: null, boardConfig: null };
+  },
+}));
+
+const ANONYMOUS_CLIMB = { uuid: '0A1B2C3D4E5F60718293A4B5C6D7E8F9', name: 'Crimpy Thing' } as unknown as Climb;
+const ANONYMOUS_BOARD_CONFIG = { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 };
 
 const { BoardRouteHandoff, BoardRouteRedirect } = await import('../BoardRouteRedirect');
 
@@ -82,6 +102,9 @@ beforeEach(() => {
   routeStatus.current = 'resolving';
   handoff.current = null;
   connectivity.isOnline = true;
+  anonymousClimbView.enabled = true;
+  anonymousClimbView.seen = [];
+  anonymousView.props = [];
 });
 
 describe('BoardRouteRedirect', () => {
@@ -257,5 +280,45 @@ describe('Board Route Handoff event', () => {
       status: 'not_found',
       source: 'deep-link',
     });
+  });
+});
+
+// The signed-out reader who gets the climb instead of the login wall. The
+// hand-off telemetry is the same funnel — a status VALUE, not a new event — so
+// `Climb Handoff Clicked` ÷ `Board Route Handoff` keeps counting the whole hop.
+describe('BoardRouteHandoff anonymous climb', () => {
+  it('draws the climb in place rather than redirecting', () => {
+    routeStatus.current = 'anonymous-climb';
+
+    const { queryByTestId } = render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+
+    expect(queryByTestId('anonymous-climb-view')).not.toBeNull();
+    expect(redirect.hrefs).toEqual([]);
+    expect(anonymousView.props.at(-1)).toMatchObject({
+      climb: ANONYMOUS_CLIMB,
+      boardConfig: ANONYMOUS_BOARD_CONFIG,
+    });
+  });
+
+  it('reports the arrival on the existing funnel as a status value', () => {
+    routeStatus.current = 'anonymous-climb';
+
+    render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+    expect(analytics.track).toHaveBeenCalledWith(SHARED_EVENTS.BoardRouteHandoff, {
+      kind: 'climb',
+      status: 'anonymous',
+      source: 'deep-link',
+    });
+  });
+
+  // The kill switch has to reach the decision, not just exist.
+  it('passes the kill switch through to the gate', () => {
+    anonymousClimbView.enabled = false;
+
+    render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+
+    expect(anonymousClimbView.seen.at(-1)).toBe(false);
   });
 });

--- a/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
+++ b/packages/mobile/src/components/__tests__/BoardRouteRedirect.test.tsx
@@ -18,6 +18,8 @@ const routeStatus = vi.hoisted(() => ({ current: 'resolving' as BoardRouteStatus
 const anonymousClimbView = vi.hoisted(() => ({ enabled: true, seen: [] as (boolean | undefined)[] }));
 // What the anonymous branch renders instead of a redirect.
 const anonymousView = vi.hoisted(() => ({ props: [] as Record<string, unknown>[] }));
+// The resolved board's tilt setting, and whether the climb has landed yet.
+const anonymousResult = vi.hoisted(() => ({ isAngleAdjustable: true, climbHasLanded: true }));
 const redirect = vi.hoisted(() => ({ hrefs: [] as string[] }));
 const router = vi.hoisted(() => ({ replace: vi.fn() }));
 // The hand-off callback the hook holds. A successful hand-off never becomes a
@@ -73,9 +75,14 @@ vi.mock('../../lib/routing/use-board-route-target', () => ({
   useBoardRouteTarget: (_target: unknown, options?: { onHandedOff?: () => void; anonymousClimbEnabled?: boolean }) => {
     handoff.current = options?.onHandedOff ?? null;
     anonymousClimbView.seen.push(options?.anonymousClimbEnabled);
-    return routeStatus.current === 'anonymous-climb'
-      ? { status: routeStatus.current, climb: ANONYMOUS_CLIMB, boardConfig: ANONYMOUS_BOARD_CONFIG }
-      : { status: routeStatus.current, climb: null, boardConfig: null };
+    return routeStatus.current === 'anonymous-climb' && anonymousResult.climbHasLanded
+      ? {
+          status: routeStatus.current,
+          climb: ANONYMOUS_CLIMB,
+          boardConfig: ANONYMOUS_BOARD_CONFIG,
+          isAngleAdjustable: anonymousResult.isAngleAdjustable,
+        }
+      : { status: routeStatus.current, climb: null, boardConfig: null, isAngleAdjustable: true };
   },
 }));
 
@@ -105,6 +112,8 @@ beforeEach(() => {
   anonymousClimbView.enabled = true;
   anonymousClimbView.seen = [];
   anonymousView.props = [];
+  anonymousResult.isAngleAdjustable = true;
+  anonymousResult.climbHasLanded = true;
 });
 
 describe('BoardRouteRedirect', () => {
@@ -311,6 +320,42 @@ describe('BoardRouteHandoff anonymous climb', () => {
       status: 'anonymous',
       source: 'deep-link',
     });
+  });
+
+  // Only the slug branch resolves a board, and the flag lives on the board
+  // record. Dropping it here is invisible in the view, whose own default is an
+  // angle pill — so a gym wall bolted at one angle would still offer one.
+  it('hands a fixed-angle board’s no-tilt setting to the view', () => {
+    routeStatus.current = 'anonymous-climb';
+    anonymousResult.isAngleAdjustable = false;
+
+    render(createElement(BoardRouteHandoff, { target: SLUG_CLIMB_TARGET }));
+
+    expect(anonymousView.props.at(-1)?.isAngleAdjustable).toBe(false);
+  });
+
+  it('keeps the pill for a board that tilts', () => {
+    routeStatus.current = 'anonymous-climb';
+
+    render(createElement(BoardRouteHandoff, { target: SLUG_CLIMB_TARGET }));
+
+    expect(anonymousView.props.at(-1)?.isAngleAdjustable).toBe(true);
+  });
+
+  // `resolveStatus` refuses to say `anonymous-climb` before the climb lands, so
+  // this state is unreachable today. It is pinned because the fall-through is
+  // not benign: the redirector's only spinner used to be `resolving`, so a
+  // loosened guard upstream would paint "Not found" + Back-to-home over a URL
+  // that is one network round trip from rendering.
+  it('waits on the spinner rather than a dead end when the climb has not landed', () => {
+    routeStatus.current = 'anonymous-climb';
+    anonymousResult.climbHasLanded = false;
+
+    const { queryByTestId } = render(createElement(BoardRouteHandoff, { target: CLIMB_TARGET }));
+
+    expect(queryByTestId('spinner')).not.toBeNull();
+    expect(queryByTestId('error-icon')).toBeNull();
+    expect(queryByTestId('back-home')).toBeNull();
   });
 
   // The kill switch has to reach the decision, not just exist.

--- a/packages/mobile/src/lib/routing/__tests__/read-only-routes.test.ts
+++ b/packages/mobile/src/lib/routing/__tests__/read-only-routes.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { isReadOnlyAnonymousPath, isSafeReturnPath, MAX_RETURN_HREF_LENGTH } from '../read-only-routes';
-import { CLIMB_SEGMENT, GATED_PATHS, READ_ONLY_PATHS, TUPLE } from './read-only-route-corpus';
+import { CLIMB_SEGMENT, CLIMB_UUID, GATED_PATHS, READ_ONLY_PATHS, TUPLE } from './read-only-route-corpus';
 
 describe('isReadOnlyAnonymousPath', () => {
   it.each(READ_ONLY_PATHS)('relaxes %s', (path) => {
@@ -23,6 +23,21 @@ describe('isReadOnlyAnonymousPath', () => {
 
   it('tolerates a trailing slash', () => {
     expect(isReadOnlyAnonymousPath('/b/the-gym/40/list/')).toBe(true);
+  });
+
+  // Named, literal, corpus-independent: the player route stays gated.
+  //
+  // The anonymous climb renders IN PLACE on its `/…/{angle}/view/{segment}` URL
+  // precisely so `/play` never has to open anonymously. The cheap way to "fix"
+  // a future bug in that flow is to move `/play` from GATED_PATHS into
+  // READ_ONLY_PATHS — and every corpus-driven suite here, in both fork suites
+  // and in both AuthProvider gate suites, is an `it.each` over whichever array
+  // now holds it, so all of them would stay green while the whole player route
+  // became reachable from a typed URL. Only a named literal goes red.
+  it('never relaxes the player route or the legacy climb redirector', () => {
+    expect(isReadOnlyAnonymousPath('/play')).toBe(false);
+    expect(isReadOnlyAnonymousPath(`/climbs/${CLIMB_UUID}`)).toBe(false);
+    expect(isReadOnlyAnonymousPath('/(tabs)/climbs')).toBe(false);
   });
 
   // The locale has to be a whole segment — `stripLocalePrefix`'s rule. Chopping

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -152,16 +152,34 @@ function Harness({
   target,
   mode,
   onHandedOff,
+  anonymousClimbEnabled,
 }: {
   target: BoardRouteTarget | null;
   mode?: 'deep-link' | 'in-app';
   onHandedOff?: () => void;
+  anonymousClimbEnabled?: boolean;
 }) {
-  return createElement('span', { 'data-status': useBoardRouteTarget(target, { mode, onHandedOff }) });
+  const { status, climb, boardConfig } = useBoardRouteTarget(target, { mode, onHandedOff, anonymousClimbEnabled });
+  return createElement('span', {
+    'data-status': status,
+    'data-climb': climb?.uuid ?? '',
+    'data-board-config': boardConfig ? JSON.stringify(boardConfig) : '',
+  });
 }
 
 function statusOf(container: HTMLElement): string | null {
   return container.querySelector('span')?.getAttribute('data-status') ?? null;
+}
+
+/** The climb the hook hands the route to draw — only ever set anonymously. */
+function climbOf(container: HTMLElement): string | null {
+  return container.querySelector('span')?.getAttribute('data-climb') ?? null;
+}
+
+/** The board config it draws against, parsed back from the harness. */
+function boardConfigOf(container: HTMLElement): unknown {
+  const serialised = container.querySelector('span')?.getAttribute('data-board-config');
+  return serialised ? JSON.parse(serialised) : null;
 }
 
 beforeEach(() => {
@@ -786,11 +804,14 @@ describe('useBoardRouteTarget signed-out on web', () => {
     expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
   });
 
-  // The tuple form is the half that carries its whole board config in the URL,
-  // so nothing has to resolve before the climb query could arm itself. Leaving
-  // it armed would have a signed-out visitor pulling a climb from the server on
-  // the way to a login redirect.
-  it('asks the server for nothing on a tuple climb URL either', async () => {
+  // A tuple climb URL is the one shape that renders with no account: it carries
+  // the whole board config, so the climb query can arm without resolving
+  // anything, and the board it would have adopted is not a render input.
+  //
+  // The positive assertions are the point. `status !== 'auth-required'` would
+  // stay green for a silently blank render, which is the failure this branch is
+  // most likely to produce.
+  it('renders a tuple climb URL in place for a signed-out reader, adopting nothing', async () => {
     gateState.relaxesRoutes = true;
     authState.current = { isAuthenticated: false, isLoading: false };
     climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
@@ -801,10 +822,95 @@ describe('useBoardRouteTarget signed-out on web', () => {
       }),
     );
 
+    await waitFor(() => expect(statusOf(container)).toBe('anonymous-climb'));
+    // The climb the route hands the drawer, and the config it draws it against —
+    // both straight off the URL.
+    expect(climbOf(container)).toBe(CLIMB_UUID);
+    expect(boardConfigOf(container)).toEqual(KILTER_BOARD);
+    expect(climbQueryVariables.current).toContainEqual({ ...KILTER_BOARD, climbUuid: CLIMB_UUID });
+    // Nothing was minted, walked, stored or navigated on their behalf.
+    expect(resolveBoardForSession).not.toHaveBeenCalled();
+    expect(fetchAllMyBoards).not.toHaveBeenCalled();
+    expect(createBoardMutateAsync).not.toHaveBeenCalled();
+    expect(setActiveBoard).not.toHaveBeenCalled();
+    // `/climbs` and `/play` are both behind the login gate, and AuthProvider
+    // re-reads the location on every navigation — so a hand-off here IS the
+    // bounce back to login.
+    expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  // THE FLEET-SAFETY ORACLE. Every merge to main touching packages/mobile
+  // auto-publishes a production OTA, and a JS-only diff keeps the fingerprint,
+  // so this lands on every installed binary within hours. One constant stands
+  // between the store fleet and an anonymous route tree.
+  //
+  // Phrased positively on purpose: the pre-existing `not.toBe('auth-required')`
+  // assertion stays GREEN under exactly the mutation it looks like it catches,
+  // because the anonymous branch is not 'auth-required' either.
+  it('still adopts and hands off on the native fork, byte for byte', async () => {
+    gateState.relaxesRoutes = false;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(setActiveBoard).toHaveBeenCalledWith(RESOLVED_BOARD));
+    await waitFor(() => expect(openClimbInPlayDrawer).toHaveBeenCalledTimes(1));
+    expect(statusOf(container)).not.toBe('anonymous-climb');
+  });
+
+  // The kill switch. Flipping it in PostHog restores the login wall without a
+  // new binary or a new OTA.
+  it('falls back to the login wall when the anonymous view is killed', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+        anonymousClimbEnabled: false,
+      }),
+    );
+
     await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
     expect(climbQueryVariables.current.every((variables) => variables === null)).toBe(true);
-    expect(resolveBoardForSession).not.toHaveBeenCalled();
     expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
+  });
+
+  // A climb URL relaxes; a list URL does not. The list surface needs a board,
+  // and minting one is `requireAuthenticated`.
+  it('still hands a list URL to login', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+
+    const { container } = render(
+      createElement(Harness, { target: { kind: 'list', board: KILTER_BOARD } as BoardRouteTarget }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
+    expect(resolveBoardForSession).not.toHaveBeenCalled();
+  });
+
+  // A dead climb uuid is a dead link for a signed-out reader too — the anonymous
+  // branch must not paper over it with a permanent spinner.
+  it('reports a missing climb as not-found rather than spinning anonymously', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: undefined, isError: false, isSuccess: true };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('not-found'));
   });
 
   // The same URL signed IN still loads its climb — the gate above must not be a

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -788,10 +788,14 @@ describe('useBoardRouteTarget signed-out on web', () => {
     expect(router.replace).not.toHaveBeenCalled();
   });
 
-  it('short-circuits a slug climb URL the same way', async () => {
+  // A shared gym-board link is the same kind of arrival as a search result. It
+  // carries no config, so unlike the tuple form it does resolve — but by the
+  // public `boardBySlug` read, with nothing minted and nothing stored.
+  it('renders a slug climb URL anonymously off one public board read', async () => {
     gateState.relaxesRoutes = true;
     authState.current = { isAuthenticated: false, isLoading: false };
     climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+    fetchBoardBySlug.mockResolvedValue(board({ uuid: 'gym-board', slug: 'the-gym', angle: 25 }));
 
     const { container } = render(
       createElement(Harness, {
@@ -799,9 +803,84 @@ describe('useBoardRouteTarget signed-out on web', () => {
       }),
     );
 
+    await waitFor(() => expect(statusOf(container)).toBe('anonymous-climb'));
+    expect(fetchBoardBySlug).toHaveBeenCalledWith('the-gym');
+    // The URL's angle wins over the board's stored 25°.
+    expect(boardConfigOf(container)).toEqual({ ...KILTER_BOARD, angle: 40 });
+    expect(createBoardMutateAsync).not.toHaveBeenCalled();
+    expect(setActiveBoard).not.toHaveBeenCalled();
+    expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  // The board's own stored angle when the URL carries none.
+  it('falls back to the board’s stored angle on a bare /b/{slug} climb URL', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+    fetchBoardBySlug.mockResolvedValue(board({ uuid: 'gym-board', slug: 'the-gym', angle: 25 }));
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'slug-climb', slug: 'the-gym', angle: null, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('anonymous-climb'));
+    expect(boardConfigOf(container)).toEqual({ ...KILTER_BOARD, angle: 25 });
+  });
+
+  // `boardBySlug` returns null for a board a signed-out viewer may not see —
+  // indistinguishable from one that does not exist. That has to surface as the
+  // route's own not-found, never as a permanent spinner or a leaked board.
+  it('reports a board a signed-out viewer may not see as not-found', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+    fetchBoardBySlug.mockResolvedValue(null);
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'slug-climb', slug: 'private-gym', angle: 40, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('not-found'));
+    expect(climbOf(container)).toBe('');
+  });
+
+  // The device's stored board belongs to whoever last signed in on this browser.
+  // Matching a slug against it would show an anonymous reader someone else's
+  // board, so the anonymous read is server-only.
+  it('never resolves an anonymous slug against the device’s stored boards', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+    getStoredActiveBoard.mockResolvedValue(board({ uuid: 'someone-elses', slug: 'the-gym' }));
+    fetchBoardBySlug.mockResolvedValue(null);
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'slug-climb', slug: 'the-gym', angle: 40, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('not-found'));
+  });
+
+  // A slug LIST URL still needs a board it can adopt, so it keeps the login wall.
+  it('still hands a slug list URL to login', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'slug-list', slug: 'the-gym', angle: 40 } as BoardRouteTarget,
+      }),
+    );
+
     await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
     expect(fetchBoardBySlug).not.toHaveBeenCalled();
-    expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
   });
 
   // A tuple climb URL is the one shape that renders with no account: it carries

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -868,6 +868,27 @@ describe('useBoardRouteTarget signed-out on web', () => {
     await waitFor(() => expect(statusOf(container)).toBe('not-found'));
   });
 
+  // A transport failure and a board that isn't there resolve to the SAME
+  // not-found, on purpose: there is no offline healing on this path (it only
+  // exists on the web export, where a reload is the retry). Pinned because it is
+  // a deliberate dead end rather than an oversight — anyone adding a retry here
+  // should have to change a test that says so.
+  it('treats a failed slug lookup as not-found rather than spinning', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+    fetchBoardBySlug.mockRejectedValue(new Error('network down'));
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'slug-climb', slug: 'the-gym', angle: 40, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('not-found'));
+    expect(climbOf(container)).toBe('');
+  });
+
   // A slug LIST URL still needs a board it can adopt, so it keeps the login wall.
   it('still hands a slug list URL to login', async () => {
     gateState.relaxesRoutes = true;

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, render, waitFor } from '@testing-library/react';
 import { createElement, useLayoutEffect, useState } from 'react';
 import type { UserBoard } from '@boardsesh/shared-schema';
-import type { BoardRouteTarget } from '../board-route-target';
+import { buildBoardClimbTarget, type BoardRouteTarget } from '../board-route-target';
 
 const router = vi.hoisted(() => ({ replace: vi.fn(), back: vi.fn(), canGoBack: vi.fn(() => true), push: vi.fn() }));
 const openPlayDrawer = vi.hoisted(() => vi.fn());
@@ -840,10 +840,14 @@ describe('useBoardRouteTarget signed-out on web', () => {
     expect(boardConfigOf(container)).toEqual({ ...KILTER_BOARD, angle: 25 });
   });
 
-  // `boardBySlug` returns null for a board a signed-out viewer may not see —
-  // indistinguishable from one that does not exist. That has to surface as the
-  // route's own not-found, never as a permanent spinner or a leaked board.
-  it('reports a board a signed-out viewer may not see as not-found', async () => {
+  // A PRIVATE board must not turn into a dead link. `boardBySlug` masks "you may
+  // not see this board" and "there is no such board" to the same null, so
+  // not-found here would tell a gym member their own board does not exist — on a
+  // URL that, before this branch existed, simply asked them to sign in and then
+  // showed them the climb. Sign-in is the only answer that is right either way,
+  // and the only one that resolves the ambiguity: signed in, the same URL either
+  // renders or reaches the route's own not-found.
+  it('asks a signed-out reader to sign in when the slug resolves to nothing', async () => {
     gateState.relaxesRoutes = true;
     authState.current = { isAuthenticated: false, isLoading: false };
     climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
@@ -855,7 +859,7 @@ describe('useBoardRouteTarget signed-out on web', () => {
       }),
     );
 
-    await waitFor(() => expect(statusOf(container)).toBe('not-found'));
+    await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
     expect(climbOf(container)).toBe('');
   });
 
@@ -875,15 +879,19 @@ describe('useBoardRouteTarget signed-out on web', () => {
       }),
     );
 
-    await waitFor(() => expect(statusOf(container)).toBe('not-found'));
+    // The login wall, not the stranger's board: the stored one is never read on
+    // this path, so the server's null is the whole answer.
+    await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
+    expect(boardConfigOf(container)).toBeNull();
   });
 
-  // A transport failure and a board that isn't there resolve to the SAME
-  // not-found, on purpose: there is no offline healing on this path (it only
-  // exists on the web export, where a reload is the retry). Pinned because it is
-  // a deliberate dead end rather than an oversight — anyone adding a retry here
-  // should have to change a test that says so.
-  it('treats a failed slug lookup as not-found rather than spinning', async () => {
+  // A transport failure lands in the same place as a masked board, on purpose:
+  // there is no offline healing on this path (it only exists on the web export,
+  // where a reload is the retry), and a failed read says nothing about whether
+  // the climb is there. What it must never be is a permanent spinner. Pinned
+  // because it is a deliberate choice — anyone adding a retry here should have to
+  // change a test that says so.
+  it('sends a failed slug lookup to the login wall rather than spinning', async () => {
     gateState.relaxesRoutes = true;
     authState.current = { isAuthenticated: false, isLoading: false };
     climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
@@ -895,7 +903,7 @@ describe('useBoardRouteTarget signed-out on web', () => {
       }),
     );
 
-    await waitFor(() => expect(statusOf(container)).toBe('not-found'));
+    await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
     expect(climbOf(container)).toBe('');
   });
 
@@ -1023,6 +1031,36 @@ describe('useBoardRouteTarget signed-out on web', () => {
     await waitFor(() => expect(climbQueryVariables.current.length).toBeGreaterThan(0));
     expect(statusOf(container)).toBe('resolving');
     expect(climbOf(container)).toBe('');
+  });
+
+  // `/…/{angle}/play/{segment}` opens anonymously too, and that is a decision
+  // rather than an accident. The two route files differ only in the surface they
+  // pass to `buildBoardClimbTarget`, which drops it — so both produce the same
+  // `kind: 'climb'` target and the predicate here cannot tell them apart. Left
+  // that way on purpose: `/play/…` is in the read-only allow-set, older shares
+  // and the web app's play view still emit it, and a reader who followed one
+  // would otherwise be the only arrival still meeting the login form.
+  //
+  // Built through the real builder rather than a literal, because the claim is
+  // about the ROUTE, not about a target shape a test made up. What stays gated is
+  // the app's own `/play` MODAL route — `read-only-routes.test.ts` pins that.
+  it('renders a /play climb URL anonymously as well, by the same target', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+
+    const playTarget = buildBoardClimbTarget(
+      { boardName: 'kilter', layoutId: 'original', sizeId: '12x12-square', setIds: 'screw_bolt', angle: '40' },
+      'play',
+      CLIMB_UUID,
+    );
+
+    const { container } = render(createElement(Harness, { target: playTarget }));
+
+    await waitFor(() => expect(statusOf(container)).toBe('anonymous-climb'));
+    expect(climbOf(container)).toBe(CLIMB_UUID);
+    expect(boardConfigOf(container)).toEqual(KILTER_BOARD);
+    expect(router.replace).not.toHaveBeenCalled();
   });
 
   // THE FLEET-SAFETY ORACLE. Every merge to main touching packages/mobile

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -159,11 +159,16 @@ function Harness({
   onHandedOff?: () => void;
   anonymousClimbEnabled?: boolean;
 }) {
-  const { status, climb, boardConfig } = useBoardRouteTarget(target, { mode, onHandedOff, anonymousClimbEnabled });
+  const { status, climb, boardConfig, isAngleAdjustable } = useBoardRouteTarget(target, {
+    mode,
+    onHandedOff,
+    anonymousClimbEnabled,
+  });
   return createElement('span', {
     'data-status': status,
     'data-climb': climb?.uuid ?? '',
     'data-board-config': boardConfig ? JSON.stringify(boardConfig) : '',
+    'data-angle-adjustable': String(isAngleAdjustable),
   });
 }
 
@@ -174,6 +179,11 @@ function statusOf(container: HTMLElement): string | null {
 /** The climb the hook hands the route to draw — only ever set anonymously. */
 function climbOf(container: HTMLElement): string | null {
   return container.querySelector('span')?.getAttribute('data-climb') ?? null;
+}
+
+/** Whether the drawer should offer the angle pill for this board. */
+function angleAdjustableOf(container: HTMLElement): string | null {
+  return container.querySelector('span')?.getAttribute('data-angle-adjustable') ?? null;
 }
 
 /** The board config it draws against, parsed back from the harness. */
@@ -938,6 +948,81 @@ describe('useBoardRouteTarget signed-out on web', () => {
     // bounce back to login.
     expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
     expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  // A gym board bolted at a fixed angle resolves with `isAngleAdjustable: false`.
+  // The flag only exists on a board record, so the slug branch is the only place
+  // the anonymous view can learn it — dropping it at this boundary is invisible
+  // downstream, because the drawer's own default is an angle pill.
+  it('carries a fixed-angle gym board’s no-tilt setting through to the view', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+    fetchBoardBySlug.mockResolvedValue(board({ uuid: 'gym-board', slug: 'the-gym', isAngleAdjustable: false }));
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'slug-climb', slug: 'the-gym', angle: 40, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('anonymous-climb'));
+    expect(angleAdjustableOf(container)).toBe('false');
+  });
+
+  it('keeps the angle pill for a gym board that does tilt', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+    fetchBoardBySlug.mockResolvedValue(board({ uuid: 'gym-board', slug: 'the-gym', isAngleAdjustable: true }));
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'slug-climb', slug: 'the-gym', angle: 40, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('anonymous-climb'));
+    expect(angleAdjustableOf(container)).toBe('true');
+  });
+
+  // A tuple URL carries no board record, so there is nothing to read the flag
+  // off — it keeps the same default `createBoard` would have stored.
+  it('leaves a config-tuple URL adjustable', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(statusOf(container)).toBe('anonymous-climb'));
+    expect(angleAdjustableOf(container)).toBe('true');
+  });
+
+  // The anonymous branch has nothing to draw until the climb lands. Loosening
+  // this to the branch alone is not benign: `BoardRouteHandoff` only renders the
+  // view when it holds BOTH a climb and a config, so a still-loading anonymous
+  // climb would fall through to the redirector — and the existing
+  // "reports a missing climb as not-found" case stays green either way, because
+  // `climbIsGone` runs first and masks it.
+  it('sits on the spinner while an anonymous climb is still loading', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: undefined, isError: false, isSuccess: false };
+
+    const { container } = render(
+      createElement(Harness, {
+        target: { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget,
+      }),
+    );
+
+    await waitFor(() => expect(climbQueryVariables.current.length).toBeGreaterThan(0));
+    expect(statusOf(container)).toBe('resolving');
+    expect(climbOf(container)).toBe('');
   });
 
   // THE FLEET-SAFETY ORACLE. Every merge to main touching packages/mobile

--- a/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
+++ b/packages/mobile/src/lib/routing/__tests__/use-board-route-target.test.tsx
@@ -983,6 +983,26 @@ describe('useBoardRouteTarget signed-out on web', () => {
     expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
   });
 
+  // The switch is for an emergency, so it has to work on a session already in
+  // flight — not only on one that starts killed. Flipping it mid-render must
+  // hand the reader back to the login wall.
+  it('hands the reader to login when the kill switch flips mid-session', async () => {
+    gateState.relaxesRoutes = true;
+    authState.current = { isAuthenticated: false, isLoading: false };
+    climbQuery.current = { data: { uuid: CLIMB_UUID }, isError: false, isSuccess: true };
+    const target = { kind: 'climb', board: KILTER_BOARD, climbUuid: CLIMB_UUID } as BoardRouteTarget;
+
+    const { container, rerender } = render(createElement(Harness, { target, anonymousClimbEnabled: true }));
+    await waitFor(() => expect(statusOf(container)).toBe('anonymous-climb'));
+
+    rerender(createElement(Harness, { target, anonymousClimbEnabled: false }));
+
+    await waitFor(() => expect(statusOf(container)).toBe('auth-required'));
+    // And it must not have handed off on the way out — `/play` is still gated.
+    expect(openClimbInPlayDrawer).not.toHaveBeenCalled();
+    expect(setActiveBoard).not.toHaveBeenCalled();
+  });
+
   // A climb URL relaxes; a list URL does not. The list surface needs a board,
   // and minting one is `requireAuthenticated`.
   it('still hands a list URL to login', async () => {

--- a/packages/mobile/src/lib/routing/use-board-route-target.ts
+++ b/packages/mobile/src/lib/routing/use-board-route-target.ts
@@ -394,6 +394,50 @@ function useAdoptedBoard(
 }
 
 /**
+ * The board behind a `/b/{slug}` climb URL for a reader with no account.
+ *
+ * Separate from `useAdoptedBoard` rather than a mode inside it, because almost
+ * nothing it does applies: there is no owned-board list to walk, no board to
+ * mint, and no active board to write. What is left is one public read.
+ *
+ * Server only — deliberately no local-first pass. The device's stored active
+ * board and downloaded cards belong to whoever last signed in on this browser,
+ * and matching a slug against them would show an anonymous reader a board from
+ * somebody else's session. The offline healing `useAdoptedBoard` does is absent
+ * for the same reason: this path only exists on the web export.
+ *
+ * Privacy is the resolver's job and already done: `boardBySlug` returns `null`
+ * for a board a signed-out viewer may not see, indistinguishable from one that
+ * does not exist — so a private or gym-scoped board reaches the same not-found
+ * a typo does.
+ */
+function useAnonymousSlugBoard(slug: string | null): { board: UserBoard | null; error: boolean } {
+  const [resolved, setResolved] = useState<{ slug: string; board: UserBoard | null } | null>(null);
+
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+    void fetchBoardBySlug(slug)
+      .then((board) => {
+        if (!cancelled) setResolved({ slug, board });
+      })
+      .catch((slugError) => {
+        if (__DEV__) console.warn('[board-route] could not resolve anonymous board slug', slug, slugError);
+        if (!cancelled) setResolved({ slug, board: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+
+  // Same tagging rule as `useAdoptedBoard`: a result may only be read for the
+  // slug it was fetched for, so a second URL through the same mounted screen
+  // cannot render the previous board.
+  const settled = resolved && resolved.slug === slug ? resolved : null;
+  return { board: settled?.board ?? null, error: settled?.board === null };
+}
+
+/**
  * The status, in the order the checks have to run.
  *
  * `auth-required` comes before every resolution check: a signed-out visitor has
@@ -451,12 +495,23 @@ export function useBoardRouteTarget(
   // default has to be the feature. A flag that must resolve before the anonymous
   // branch turns on would show a login redirect as the first frame of the very
   // surface this exists to build.
-  const anonymousClimb = signedOutOnWeb && (options?.anonymousClimbEnabled ?? true) && target?.kind === 'climb';
+  const anonymousClimb =
+    signedOutOnWeb &&
+    (options?.anonymousClimbEnabled ?? true) &&
+    (target?.kind === 'climb' || target?.kind === 'slug-climb');
   const authRequired = signedOutOnWeb && !anonymousClimb;
   // Neither signed-out branch adopts. Adoption's first act is a CREATE_BOARD the
   // backend refuses without a session, and it is not a render input for either
   // one — so it is skipped rather than gated on the outcome.
-  const { board, error: boardError } = useAdoptedBoard(target, adoptsBoard && !signedOutOnWeb);
+  const { board: adoptedBoard, error: adoptedBoardError } = useAdoptedBoard(target, adoptsBoard && !signedOutOnWeb);
+  // A shared gym-board link is the same kind of arrival as a search result, so
+  // it must not be the one that still hits the login wall. It carries no config
+  // in the URL, so unlike the tuple form it does have to resolve — but by a
+  // public read, with nothing minted and nothing stored.
+  const anonymousSlug = anonymousClimb && target?.kind === 'slug-climb' ? target.slug : null;
+  const { board: anonymousBoard, error: anonymousBoardError } = useAnonymousSlugBoard(anonymousSlug);
+  const board = adoptedBoard ?? anonymousBoard;
+  const boardError = adoptedBoardError || anonymousBoardError;
 
   const wantsClimb = target?.kind === 'climb' || target?.kind === 'slug-climb';
   const climbUuid = wantsClimb ? target.climbUuid : undefined;
@@ -466,6 +521,13 @@ export function useBoardRouteTarget(
   // resolved board. One config feeds both the query and the drawer so the frames
   // the user sees can't drift from the ones we asked for.
   const configFromUrl = urlBoardConfig(target);
+  // A `/b/{slug}/{angle}/…` URL's angle wins over the board's stored one; a
+  // `/b/{slug}` URL carries none and the board's own angle is what the reader
+  // lands on. The ADOPTED board already arrives with that applied —
+  // `resolveBoardForSession` owns the rule for the signed-in path and the two
+  // branches must not encode it twice — so this covers only the anonymous slug
+  // read, which bypasses that resolver entirely.
+  const anonymousUrlAngle = anonymousBoard && target?.kind === 'slug-climb' ? target.angle : null;
   const configFromBoard = useMemo<BoardConfig | null>(
     () =>
       board
@@ -474,10 +536,10 @@ export function useBoardRouteTarget(
             layoutId: board.layoutId,
             sizeId: board.sizeId,
             setIds: board.setIds,
-            angle: board.angle,
+            angle: anonymousUrlAngle ?? board.angle,
           }
         : null,
-    [board],
+    [board, anonymousUrlAngle],
   );
   const boardConfig = configFromUrl ?? configFromBoard;
 
@@ -513,6 +575,11 @@ export function useBoardRouteTarget(
     // and `AuthProvider` re-reads `window.location.pathname` on every
     // navigation — so the drawer opening is exactly the moment the visitor gets
     // bounced back to the login wall this branch exists to remove.
+    //
+    // Ahead of the `!board` check below, not behind it. That check would happen
+    // to stop a TUPLE climb (which resolves no board at all), but a slug climb
+    // resolves one from the public read — so for `/b/{slug}/…` this line is the
+    // only thing between an anonymous reader and a hand-off to `/play`.
     if (anonymousClimb) return;
     // A deep link has to land on the adopted board — the Climbs tab behind the
     // drawer renders whatever the active board is.

--- a/packages/mobile/src/lib/routing/use-board-route-target.ts
+++ b/packages/mobile/src/lib/routing/use-board-route-target.ts
@@ -434,14 +434,20 @@ function useAnonymousSlugBoard(slug: string | null): { board: UserBoard | null; 
   // slug it was fetched for, so a second URL through the same mounted screen
   // cannot render the previous board.
   const settled = resolved && resolved.slug === slug ? resolved : null;
-  return { board: settled?.board ?? null, error: settled?.board === null };
+  // Spelled out rather than derived from `settled?.board === null`, which is
+  // only correct because an unsettled read is `undefined` and a resolved-empty
+  // one is `null` — a distinction the next refactor of this state would quietly
+  // lose. Pending is not an error; a settled null board is.
+  if (!settled) return { board: null, error: false };
+  return { board: settled.board, error: settled.board === null };
 }
 
 /**
  * The status, in the order the checks have to run.
  *
- * `auth-required` comes before every resolution check: a signed-out visitor has
- * no board to fail on, and nothing was asked of the server on their behalf.
+ * A URL that did not parse is a dead end whatever the session is, so it leads.
+ * `auth-required` then comes before every RESOLUTION check: a signed-out visitor
+ * has no board to fail on, and nothing was asked of the server on their behalf.
  */
 function resolveStatus({
   parsedUrl,

--- a/packages/mobile/src/lib/routing/use-board-route-target.ts
+++ b/packages/mobile/src/lib/routing/use-board-route-target.ts
@@ -414,12 +414,24 @@ function useAdoptedBoard(
  * somebody else's session. The offline healing `useAdoptedBoard` does is absent
  * for the same reason: this path only exists on the web export.
  *
- * Privacy is the resolver's job and already done: `boardBySlug` returns `null`
- * for a board a signed-out viewer may not see, indistinguishable from one that
- * does not exist — so a private or gym-scoped board reaches the same not-found
- * a typo does.
+ * `boardBySlug` returns `null` for a board a signed-out viewer may not see,
+ * indistinguishable from one that does not exist. That ambiguity is why
+ * `'unresolved'` is a state of its own rather than an error — see the call site
+ * for what the route does with it.
  */
-function useAnonymousSlugBoard(slug: string | null): { board: UserBoard | null; error: boolean } {
+type AnonymousSlugBoard =
+  /** The read is still in flight, or there is no slug to read. */
+  | { state: 'pending' }
+  | { state: 'resolved'; board: UserBoard }
+  /**
+   * The read came back with nothing — a private board, a gym board scoped to its
+   * members, a typo, or a failed request. Deliberately ONE state: the resolver
+   * masks all of them to the same `null` on purpose, so the route cannot tell
+   * them apart and must not pretend to.
+   */
+  | { state: 'unresolved' };
+
+function useAnonymousSlugBoard(slug: string | null): AnonymousSlugBoard {
   const [resolved, setResolved] = useState<{ slug: string; board: UserBoard | null } | null>(null);
 
   useEffect(() => {
@@ -442,12 +454,12 @@ function useAnonymousSlugBoard(slug: string | null): { board: UserBoard | null; 
   // slug it was fetched for, so a second URL through the same mounted screen
   // cannot render the previous board.
   const settled = resolved && resolved.slug === slug ? resolved : null;
-  // Spelled out rather than derived from `settled?.board === null`, which is
-  // only correct because an unsettled read is `undefined` and a resolved-empty
-  // one is `null` — a distinction the next refactor of this state would quietly
-  // lose. Pending is not an error; a settled null board is.
-  if (!settled) return { board: null, error: false };
-  return { board: settled.board, error: settled.board === null };
+  // A named state rather than a `board === null` reading: that one is correct
+  // only because an unsettled read is `undefined` and a resolved-empty one is
+  // `null`, a distinction the next refactor of this state would quietly lose —
+  // and losing it turns every in-flight read into a dead end.
+  if (!settled) return { state: 'pending' };
+  return settled.board ? { state: 'resolved', board: settled.board } : { state: 'unresolved' };
 }
 
 /**
@@ -509,23 +521,32 @@ export function useBoardRouteTarget(
   // default has to be the feature. A flag that must resolve before the anonymous
   // branch turns on would show a login redirect as the first frame of the very
   // surface this exists to build.
-  const anonymousClimb =
+  const anonymousClimbUrl =
     signedOutOnWeb &&
     (options?.anonymousClimbEnabled ?? true) &&
     (target?.kind === 'climb' || target?.kind === 'slug-climb');
-  const authRequired = signedOutOnWeb && !anonymousClimb;
-  // Neither signed-out branch adopts. Adoption's first act is a CREATE_BOARD the
-  // backend refuses without a session, and it is not a render input for either
-  // one — so it is skipped rather than gated on the outcome.
-  const { board: adoptedBoard, error: adoptedBoardError } = useAdoptedBoard(target, adoptsBoard && !signedOutOnWeb);
   // A shared gym-board link is the same kind of arrival as a search result, so
   // it must not be the one that still hits the login wall. It carries no config
   // in the URL, so unlike the tuple form it does have to resolve — but by a
   // public read, with nothing minted and nothing stored.
-  const anonymousSlug = anonymousClimb && target?.kind === 'slug-climb' ? target.slug : null;
-  const { board: anonymousBoard, error: anonymousBoardError } = useAnonymousSlugBoard(anonymousSlug);
+  const anonymousSlug = anonymousClimbUrl && target?.kind === 'slug-climb' ? target.slug : null;
+  const anonymousSlugBoard = useAnonymousSlugBoard(anonymousSlug);
+  // An unresolved slug asks for a sign-in; it is never a dead end. The resolver
+  // masks "you may not see this board" and "there is no such board" to the same
+  // null, so a not-found here would tell a gym member their own board does not
+  // exist — a REGRESSION on a URL that, before this branch existed, simply asked
+  // them to sign in and then showed them the climb. Sign-in is also the only
+  // move that resolves the ambiguity: signed in, the same URL either renders or
+  // reaches the route's own not-found. A typo'd slug costs one login form, which
+  // is what it cost yesterday.
+  const anonymousClimb = anonymousClimbUrl && anonymousSlugBoard.state !== 'unresolved';
+  const authRequired = signedOutOnWeb && !anonymousClimb;
+  // Neither signed-out branch adopts. Adoption's first act is a CREATE_BOARD the
+  // backend refuses without a session, and it is not a render input for either
+  // one — so it is skipped rather than gated on the outcome.
+  const { board: adoptedBoard, error: boardError } = useAdoptedBoard(target, adoptsBoard && !signedOutOnWeb);
+  const anonymousBoard = anonymousSlugBoard.state === 'resolved' ? anonymousSlugBoard.board : null;
   const board = adoptedBoard ?? anonymousBoard;
-  const boardError = adoptedBoardError || anonymousBoardError;
 
   const wantsClimb = target?.kind === 'climb' || target?.kind === 'slug-climb';
   const climbUuid = wantsClimb ? target.climbUuid : undefined;

--- a/packages/mobile/src/lib/routing/use-board-route-target.ts
+++ b/packages/mobile/src/lib/routing/use-board-route-target.ts
@@ -30,7 +30,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'expo-router';
 import { onlineManager } from '@tanstack/react-query';
 import { isNetworkError } from '@boardsesh/offline-sync/error-classification';
-import type { CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
+import type { Climb, CreateBoardInput, UserBoard } from '@boardsesh/shared-schema';
 import { toBoardPath, type BoardRouteTarget } from './board-route-target';
 // The platform switch is this constant, not `Platform.OS` — the hook then needs
 // no `react-native` import, whose RN 0.86 Flow entry the vitest node env cannot
@@ -60,10 +60,27 @@ import { openClimbInPlayDrawer } from '../open-climb-in-play-drawer';
  * in the same React batch a state update would land in, so the render carrying
  * it never commits. `onHandedOff` is how a caller hears about it instead.
  *
- * `auth-required` is reachable on web only: the browser export serves these
- * routes to signed-out visitors, and board adoption needs an account.
+ * `auth-required` and `anonymous-climb` are both reachable on web only: the
+ * browser export serves these routes to signed-out visitors. Which of the two a
+ * signed-out visitor gets is the whole point of this hook's gate — a climb URL
+ * renders read-only in place (`anonymous-climb`), everything else still hands
+ * the path to login (`auth-required`).
  */
-export type BoardRouteStatus = 'resolving' | 'not-found' | 'auth-required';
+export type BoardRouteStatus = 'resolving' | 'not-found' | 'auth-required' | 'anonymous-climb';
+
+/**
+ * What the entry route should draw, plus what it needs to draw it.
+ *
+ * `climb` and `boardConfig` are populated for `anonymous-climb` only. Every
+ * other status is a redirector state, and the redirector needs no data — the
+ * signed-in path never returns a climb here because it hands one to the play
+ * drawer imperatively and navigates away.
+ */
+export type BoardRouteResult = {
+  status: BoardRouteStatus;
+  climb: Climb | null;
+  boardConfig: BoardConfig | null;
+};
 
 /**
  * Where the target came from, which decides two things the caller can't:
@@ -377,26 +394,69 @@ function useAdoptedBoard(
 }
 
 /**
+ * The status, in the order the checks have to run.
+ *
+ * `auth-required` comes before every resolution check: a signed-out visitor has
+ * no board to fail on, and nothing was asked of the server on their behalf.
+ */
+function resolveStatus({
+  parsedUrl,
+  authRequired,
+  boardError,
+  climbIsGone,
+  anonymousClimbReady,
+}: {
+  parsedUrl: boolean;
+  authRequired: boolean;
+  boardError: boolean;
+  climbIsGone: boolean;
+  anonymousClimbReady: boolean;
+}): BoardRouteStatus {
+  if (!parsedUrl) return 'not-found';
+  if (authRequired) return 'auth-required';
+  if (boardError) return 'not-found';
+  if (climbIsGone) return 'not-found';
+  if (anonymousClimbReady) return 'anonymous-climb';
+  return 'resolving';
+}
+
+/**
  * Drive a canonical board URL to its destination. Returns the status the entry
  * route should render — these routes are redirectors, so all they ever show is
  * a spinner or a not-found.
  */
 export function useBoardRouteTarget(
   target: BoardRouteTarget | null,
-  options?: { mode?: BoardRouteMode; onHandedOff?: () => void },
-): BoardRouteStatus {
+  options?: { mode?: BoardRouteMode; onHandedOff?: () => void; anonymousClimbEnabled?: boolean },
+): BoardRouteResult {
   const mode = options?.mode ?? 'deep-link';
   const adoptsBoard = mode === 'deep-link';
   const router = useRouter();
   const { openPlayDrawer } = useDrawerHost();
   const { isAuthenticated, isLoading: authIsLoading } = useAuth();
-  // Only reachable on web: the native gate never serves these routes signed-out.
-  // Board adoption needs the account (the tuple form mints a UserBoard, which is
-  // `requireAuthenticated`), so the route hands the URL to login rather than
-  // resolving anything anonymously. An unsettled session waits — bouncing on
-  // `isLoading` would send a signed-in visitor to login on every cold open.
-  const authRequired = RELAXES_ANONYMOUS_ROUTES && adoptsBoard && !authIsLoading && !isAuthenticated;
-  const { board, error: boardError } = useAdoptedBoard(target, adoptsBoard && !authRequired);
+  // Only reachable on web: the native gate never serves these routes signed-out,
+  // because `RELAXES_ANONYMOUS_ROUTES` is a literal `false` in the native fork.
+  // That constant — never a `Platform.OS` check, which would put the web
+  // behaviour in the native bundle — is what holds the store fleet still across
+  // the OTA this ships in. An unsettled session waits: bouncing on `isLoading`
+  // would send a signed-in visitor to login on every cold open.
+  const signedOutOnWeb = RELAXES_ANONYMOUS_ROUTES && adoptsBoard && !authIsLoading && !isAuthenticated;
+  // A climb URL is renderable with no account at all. Every input is in the URL
+  // — the tuple carries the whole board config, board art is a local catalogue
+  // lookup, and the `climb` resolver takes no viewer — so the route draws it in
+  // place instead of handing the visitor to a login form. Everything else (the
+  // list surfaces) still needs a board, and minting one is `requireAuthenticated`.
+  //
+  // `anonymousClimbEnabled` defaults ON: it carries a KILL switch, and the
+  // default has to be the feature. A flag that must resolve before the anonymous
+  // branch turns on would show a login redirect as the first frame of the very
+  // surface this exists to build.
+  const anonymousClimb = signedOutOnWeb && (options?.anonymousClimbEnabled ?? true) && target?.kind === 'climb';
+  const authRequired = signedOutOnWeb && !anonymousClimb;
+  // Neither signed-out branch adopts. Adoption's first act is a CREATE_BOARD the
+  // backend refuses without a session, and it is not a render input for either
+  // one — so it is skipped rather than gated on the outcome.
+  const { board, error: boardError } = useAdoptedBoard(target, adoptsBoard && !signedOutOnWeb);
 
   const wantsClimb = target?.kind === 'climb' || target?.kind === 'slug-climb';
   const climbUuid = wantsClimb ? target.climbUuid : undefined;
@@ -448,6 +508,12 @@ export function useBoardRouteTarget(
   useEffect(() => {
     if (!target || !targetKey || handedOffRef.current === targetKey) return;
     if (authRequired) return;
+    // The anonymous climb renders where it stands. Handing off would navigate to
+    // `/(tabs)/climbs` and then `/play`, both outside the read-only allow-set,
+    // and `AuthProvider` re-reads `window.location.pathname` on every
+    // navigation — so the drawer opening is exactly the moment the visitor gets
+    // bounced back to the login wall this branch exists to remove.
+    if (anonymousClimb) return;
     // A deep link has to land on the adopted board — the Climbs tab behind the
     // drawer renders whatever the active board is.
     if (adoptsBoard && !board) return;
@@ -498,16 +564,38 @@ export function useBoardRouteTarget(
     }
     openDrawer();
     leave();
-  }, [adoptsBoard, authRequired, board, boardConfig, climb, openPlayDrawer, router, target, targetKey, wantsClimb]);
+  }, [
+    adoptsBoard,
+    anonymousClimb,
+    authRequired,
+    board,
+    boardConfig,
+    climb,
+    openPlayDrawer,
+    router,
+    target,
+    targetKey,
+    wantsClimb,
+  ]);
 
-  if (!target) return 'not-found';
-  // Before every resolution check: a signed-out visitor has no board to fail on,
-  // and nothing was asked of the server on their behalf.
-  if (authRequired) return 'auth-required';
-  if (boardError) return 'not-found';
-  // Only a settled query says the climb is gone: `isLoading` briefly reads false
-  // in the render where the query switches on, which would flash a not-found
-  // over a climb that is about to arrive.
-  if (wantsClimb && (climbQuery.isError || (climbQuery.isSuccess && !climb))) return 'not-found';
-  return 'resolving';
+  const status = resolveStatus({
+    parsedUrl: target !== null,
+    authRequired,
+    boardError,
+    // Only a settled query says the climb is gone: `isLoading` briefly reads
+    // false in the render where the query switches on, which would flash a
+    // not-found over a climb that is about to arrive.
+    climbIsGone: wantsClimb && (climbQuery.isError || (climbQuery.isSuccess && !climb)),
+    // The anonymous branch has nothing to draw until the climb lands, and
+    // nowhere else to be meanwhile — so it sits on the spinner.
+    anonymousClimbReady: anonymousClimb && climb != null && boardConfig != null,
+  });
+
+  return useMemo(
+    () =>
+      status === 'anonymous-climb'
+        ? { status, climb: climb ?? null, boardConfig }
+        : { status, climb: null, boardConfig: null },
+    [status, climb, boardConfig],
+  );
 }

--- a/packages/mobile/src/lib/routing/use-board-route-target.ts
+++ b/packages/mobile/src/lib/routing/use-board-route-target.ts
@@ -80,6 +80,14 @@ export type BoardRouteResult = {
   status: BoardRouteStatus;
   climb: Climb | null;
   boardConfig: BoardConfig | null;
+  /**
+   * Whether the board the climb is on can actually be tilted. Only a resolved
+   * board record carries the answer, so a `/b/{slug}` climb gets the gym's real
+   * setting and a config-tuple URL — which has no board record at all — keeps the
+   * same `true` the create path defaults to. Dropping it here is how an anonymous
+   * reader ends up with an angle pill for a wall bolted at one angle.
+   */
+  isAngleAdjustable: boolean;
 };
 
 /**
@@ -664,11 +672,15 @@ export function useBoardRouteTarget(
     anonymousClimbReady: anonymousClimb && climb != null && boardConfig != null,
   });
 
+  // Only the slug branch resolves a board anonymously; a tuple URL has none, and
+  // `true` is what `createBoard` would have stored for it anyway.
+  const isAngleAdjustable = board?.isAngleAdjustable ?? true;
+
   return useMemo(
     () =>
       status === 'anonymous-climb'
-        ? { status, climb: climb ?? null, boardConfig }
-        : { status, climb: null, boardConfig: null },
-    [status, climb, boardConfig],
+        ? { status, climb: climb ?? null, boardConfig, isAngleAdjustable }
+        : { status, climb: null, boardConfig: null, isAngleAdjustable: true },
+    [status, climb, boardConfig, isAngleAdjustable],
   );
 }

--- a/packages/mobile/src/providers/__tests__/feature-flags-provider.test.tsx
+++ b/packages/mobile/src/providers/__tests__/feature-flags-provider.test.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   FeatureFlagsProvider,
+  useAnonymousClimbViewEnabled,
   useBoardseshGradeEnabled,
   useFeatureFlag,
   useFeatureFlags,
@@ -151,6 +152,39 @@ describe('FeatureFlagsProvider', () => {
     );
     expect(result.current.snapshotBootstrap).toBe(true);
     expect(result.current.boardseshGrade).toBe(false);
+  });
+
+  // The kill switch's DIRECTION is the whole rollout-safety mechanism, and it is
+  // the one thing every other test mocks away (`BoardRouteRedirect.test.tsx`
+  // stubs this hook; the gate tests pass `anonymousClimbEnabled` in directly).
+  // Inverting the comparison here ships the feature dead for 100% of visitors and
+  // turns the emergency switch into an enable switch — so all three states are
+  // pinned, and the UNRESOLVED one is the assertion that distinguishes
+  // `!== true` from `=== false`.
+  it('the anonymous climb view is on while its kill flag is unresolved', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => <FeatureFlagsProvider>{children}</FeatureFlagsProvider>;
+    const { result } = renderHook(() => useAnonymousClimbViewEnabled(), { wrapper });
+    // PostHog resolves asynchronously, and never at all for a browser that blocks
+    // it. An OFF-until-resolved reading is a login-redirect flash as the first
+    // frame of the surface this exists to build, and a permanent login wall for
+    // the ad-blocker cohort.
+    expect(result.current).toBe(true);
+  });
+
+  it('stays on when the kill flag resolves false', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FeatureFlagsProvider flags={{ 'anonymous-climb-view-kill': false }}>{children}</FeatureFlagsProvider>
+    );
+    const { result } = renderHook(() => useAnonymousClimbViewEnabled(), { wrapper });
+    expect(result.current).toBe(true);
+  });
+
+  it('goes off only when the kill flag is actually flipped on', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <FeatureFlagsProvider flags={{ 'anonymous-climb-view-kill': true }}>{children}</FeatureFlagsProvider>
+    );
+    const { result } = renderHook(() => useAnonymousClimbViewEnabled(), { wrapper });
+    expect(result.current).toBe(false);
   });
 
   it('useFeatureFlagOverrides re-renders consumers when an override changes post-mount', () => {

--- a/packages/mobile/src/providers/feature-flags-provider.tsx
+++ b/packages/mobile/src/providers/feature-flags-provider.tsx
@@ -66,6 +66,12 @@ export const FEATURE_FLAG_DEFINITIONS = [
       'Show the data-science "Boardsesh grade" section in the play drawer (cross-board grade, confidence tier, send counts). Off hides the section.',
   },
   {
+    key: 'anonymous-climb-view-kill',
+    label: 'Disable the anonymous climb view',
+    description:
+      'Emergency kill switch: send signed-out visitors on app.boardsesh.com climb URLs back to the login wall instead of rendering the read-only climb. Web export only — native never serves those routes signed-out.',
+  },
+  {
     key: 'moonboard-wide-angles',
     label: 'MoonBoard wide angles',
     description:
@@ -167,6 +173,20 @@ export function useOfflineDownloadProgressEnabled(): boolean {
  */
 export function useOfflineNudgesEnabled(): boolean {
   return useFeatureFlag('offline-discovery-nudges') === true;
+}
+
+/**
+ * Kill switch for the signed-out read-only climb view on app.boardsesh.com.
+ *
+ * A KILL switch rather than a positive rollout flag, and the direction matters:
+ * PostHog flags resolve asynchronously, so a positive flag reads as OFF for the
+ * first frames of a cold open — which on this surface means an anonymous visitor
+ * watching a login redirect flash before the flag lands. Missing/undefined
+ * therefore reads as "not killed", i.e. the feature is on, and flipping the flag
+ * ON in PostHog restores the old login-wall behaviour.
+ */
+export function useAnonymousClimbViewEnabled(): boolean {
+  return useFeatureFlag('anonymous-climb-view-kill') !== true;
 }
 
 /**

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -124,10 +124,16 @@ export const SHARED_EVENTS = {
   //
   // Fired by the native fleet and app.boardsesh.com. Props: { kind: 'list' |
   // 'climb' | 'slug-list' | 'slug-climb' | 'unparsed', status: 'resolved' |
-  // 'not_found' | 'auth_required', source: 'deep-link' | 'in-app' }.
+  // 'not_found' | 'auth_required' | 'anonymous', source: 'deep-link' |
+  // 'in-app' }.
   // `not_found` is held back for a parsed URL that failed while the device was
   // offline — that one heals on reconnect and would otherwise double-count as a
   // failure and a success.
+  // `anonymous` is a signed-out reader who got the read-only climb view instead
+  // of the login wall — web export only, and a climb URL only. It is a status
+  // VALUE rather than a second event name precisely so the Clicked ÷ Handoff
+  // ratio keeps counting the whole hop; split anonymous from signed-in arrivals
+  // with a breakdown, not a new funnel.
   BoardRouteHandoff: 'Board Route Handoff',
   // Fired by www's SSR front doors when a reader taps "Climb this". Props:
   // { environment: 'production-web', surface: 'climb_front_door' |


### PR DESCRIPTION
## Summary

Part 2 of 2 for #4478 — **stacked on #4604, review and merge that first.** Marco ruled option B: make the read-only climb view genuinely anonymous.

Today a signed-out visitor who follows "Climb this" from a www climb page lands on a sign-in form — 209 characters of body copy, which is where the epic's SEO funnel currently ends. This is the PR that changes production behaviour.

### The issue's stated blocker was not one

Board adoption is not a render input. `parseClimbRoutePath` returns the numeric tuple, `urlBoardConfig()` already builds a `BoardConfig` from the URL alone and is already preferred over the board's, board art is a pure local catalogue lookup, and the `climb` resolver takes no ctx at all. So adoption is **skipped for both signed-out branches** rather than gated on its outcome — its first act is a `CREATE_BOARD` the backend refuses without a session, and it was never needed to draw anything.

### The real blocker, and the shape that avoids it

The hand-off does `router.replace('/(tabs)/climbs')` and then `openPlayDrawer` → `/play`. Both are outside the anonymous allow-set, and `AuthProvider` re-reads `window.location.pathname` on every navigation — so the visitor gets bounced back to the login wall the moment the drawer opens.

So the route **does not navigate**. `BoardRouteHandoff` renders `AnonymousClimbView` in place, on the canonical `/…/{angle}/view/{segment}` URL the visitor arrived at. That also keeps the address bar equal to the URL www linked, and the `?next=` builder correct for free. The anonymous surface is **not** widened to the player route.

`read-only-routes.test.ts` gains a named, corpus-independent assertion that `/play` and `/climbs/{uuid}` stay gated. Moving an entry between `GATED_PATHS` and `READ_ONLY_PATHS` leaves every corpus-driven suite green — they are all `it.each` over whichever array now holds it — so only a named literal goes red.

### Scope, and the four judgement calls inside it

Climb URLs only. Both trees: the config tuple (all ~128k sitemap URLs) and `/b/{slug}` (a shared gym-board link hitting the login wall while a search result does not is exactly the gradient this removes). List surfaces still gate — they need a board, and minting one is `requireAuthenticated` — so `/…/list` keeps its `?next=` login redirect (follow-up #4607).

1. **`/…/{angle}/play/{segment}` opens anonymously too, deliberately.** The two route files differ only in the surface they hand `buildBoardClimbTarget`, which drops it, so both produce the same `kind: 'climb'` target and the predicate cannot tell them apart. Left that way: `/play/…` is already in the read-only allow-set, older shares still emit it, and its readers would otherwise be the only arrivals left at the login form. Tested through the real builder. The app's own `/play` **modal** route stays gated.
2. **An unresolved `/b/{slug}` asks for a sign-in, never a dead end.** `boardBySlug` masks "you may not see this board" and "there is no such board" to the same `null`, so a not-found there would tell a gym member their own board does not exist — a regression on a URL that yesterday simply asked them to sign in and then showed them the climb. Sign-in is the only answer right in both cases, and the only one that resolves the ambiguity. A typo'd slug costs one login form, which is what it cost before. "Climb genuinely gone" (a settled climb query with nothing in it) is still a real not-found.
3. **Draft climbs render, and that is not new.** Checked rather than asserted: `fetchClimbFromDb` (`packages/web/app/lib/data/queries.ts`) selects by `(board_type, layout_id, uuid)` with no draft predicate, and `/[board_name]/…/view/[climb_uuid]/page.tsx` renders `ClimbFrontDoor` from it with no session — so a draft uuid already paints a full public page on **www**, the indexed surface. This PR adds a second surface for the same row on a `noindex` subdomain; it does not widen what is reachable, and it deliberately does not add an `is_draft` fall-through here, because "www shows you the climb, the app says it does not exist" is a worse answer than the one gap. Filed as #4608 to close at the resolver, where both surfaces read it.
4. **The drawer's queue is hidden, not local-only.** A queue a signed-out visitor cannot carry to a wall or a session is a dead affordance, and Similar Climbs — which stays — now swaps the drawer's preview instead of writing that queue (#4604).

The slug read is server-only on purpose: the device's stored board belongs to whoever last signed in on this browser.

### Rollout is a kill switch, not a percentage

There is no staged rollout to perform. This surface ships to **app.boardsesh.com via Cloudflare Pages**, not OTA, and the sanctioned publish wrapper drops `--rollout-percentage` anyway — merging *is* the publish, at 100%.

So the instrument is a flag: `anonymous-climb-view-kill`, **created and verified in PostHog** ([flag 832829](https://us.posthog.com/project/412845/feature_flags/832829)), active at 0% = feature on. It gates only the `AnonymousClimbView` branch. Flags resolve asynchronously, so an unresolved read has to mean *not killed* — a positive rollout flag would show an anonymous visitor a login-redirect flash as the first frame of the very surface this builds. `docs/feature-flags.md` gains that inversion as a documented pattern, because the file's standing rule ("unresolved leaves the control hidden") says the opposite.

**Recovery runbook, in the order to reach for it:**

| | Move | Reaches production in | Blast radius |
| --- | --- | --- | --- |
| 1 | Flip `anonymous-climb-view-kill` to 100% in PostHog | seconds, no deploy | exactly this branch; signed-out climb URLs go back to the login wall |
| 2 | Revert the merge commit → CI → `production-deploy.yml` rebuilds and `wrangler pages deploy`s the app subdomain | one green pipeline | the whole app subdomain moves to the reverted tree |
| 3 | Set the repo variable `APP_WEB_DEPLOY_HOLD` (any non-empty value) and roll back the Cloudflare Pages deployment | immediate | **freezes the entire subdomain** — every other app-web change is stranded until it is cleared, and the workflow surfaces the hold in the run summary so it cannot be forgotten quietly |

The native fleet needs none of these: the branch is unreachable there (below).

### Three fixes from the adversarial review

**The kill switch's direction had no oracle.** Every test that touches `useAnonymousClimbViewEnabled` mocked it away — `BoardRouteRedirect.test.tsx` stubs the hook, the gate tests pass `anonymousClimbEnabled` straight in — so flipping `!== true` to `=== false` left the whole mobile suite green while shipping the feature dead: the flag reads `undefined` until PostHog resolves, and forever for a browser that blocks it. Inverting it the other way turns the emergency switch into an enable switch. Three cases now pin all three states against a real `FeatureFlagsProvider`, and the *unresolved* one is the assertion that separates the two directions.

**`isAngleAdjustable` was resolved and then dropped.** A `/b/{slug}` climb resolves a real board record, the only place that flag exists, but `BoardRouteResult` carried only `{ status, climb, boardConfig }` — so an anonymous reader on a gym wall bolted at one angle still got an angle pill. It rides through now. A config tuple has no board record to read it off, so it keeps the `true` `createBoard` would have stored.

**A still-loading anonymous climb could have hit a dead end.** `resolveStatus` refuses to say `anonymous-climb` before the climb lands, but that guard had no test — and the fall-through was not benign: `BoardRouteHandoff` renders the view only when it holds both a climb and a config, and the redirector's only spinner branch was `resolving`, so a loosened guard would paint "Not found" plus a Back-to-home button on a URL one round trip from rendering. The guard has an oracle, and the redirector waits on that status instead of falling through.

### Telemetry

`Board Route Handoff` gains an `anonymous` status **value**, not a new event name, so `Climb Handoff Clicked` ÷ `Board Route Handoff` keeps counting the whole hop and anonymous-vs-signed-in becomes a breakdown.

(The issue's telemetry claim is stale, measured the day after #4418 merged. Over the last 7 days `Climb Handoff Clicked` fired ×10 and `Board Route Handoff` ×23 on native plus ×8 on web — both halves of the funnel are live.)

**Split out, not fixed here:** the app half of that funnel never sets the `environment: 'production-web'` its own contract documents — it registers the build environment (`production` / `preview`) on native and browser alike, so app.boardsesh.com is distinguishable only by a null `$app_version`. Unrelated to the auth boundary, so it went to **#4624** rather than into this diff.

### SEO

`app.boardsesh.com` serves `X-Robots-Tag: noindex` for `/*` (`deploy/app-subdomain/_headers`, verified on this branch), so an anonymously-rendered climb there competes with nothing on www. If that ever changes, the app climb view needs a `rel=canonical` back to the www climb page before it is indexed.

Closes #4478.

## Review gates

- **`ble-needs-fable-review`.** The stack suppresses the lightbulb and stops a similar-climb tap re-arming the BLE auto-sender; Web Bluetooth is live on the browser export. **Fable review required before merge**, on top of the standing Fable review every `packages/mobile` PR gets under epic #4358.
- **Needs Marco's explicit nod on epic #4358's standing rules** before merge (W-06 follow-up; publishes to the native fleet as an inert OTA).
- Not auto-mergeable.

### Production targets

**app.boardsesh.com** — where the behaviour change lands, via Cloudflare Pages. And **the native store fleet via auto-OTA**: this touches `packages/mobile/**` and `packages/shared/analytics`, so merging to `main` auto-publishes a production OTA that reaches every installed binary within hours. Not `www.boardsesh.com`.

**No native fingerprint inputs changed** — nothing under `app.config.ts`, `plugins/**`, `modules/**`, `locales/**`, `patches/**`, and no dependency edits — so `main` stays OTA-compatible with the store binaries, and the OTA check reports both platforms matching `main`.

**Native behaviour is unchanged, and that is the thing to scrutinise.** The whole anonymous branch sits behind `RELAXES_ANONYMOUS_ROUTES`, a literal `false` in the native fork — never a `Platform.OS` check, which would put the web behaviour in the native bundle with one boolean between the fleet and an anonymous route tree.

## Release Notes

- Find a climb on Google, tap through, and you see the climb — board, grade, community stats and beta — before anyone asks you to sign in.
- Sign in from there and you land straight back on the climb you came for.

## Test plan

- `vp run typecheck:mobile` — green.
- `vp run test:mobile` — green.
- `vp test run --project i18n catalog-completeness --reporter=agent` — 96 green (four-locale parity; `--project web` does not run this file).
- `vp run check:i18n`, `vp run check:i18n:orphans` — clean.
- `vp check` — 0 errors (324 pre-existing warnings), formatted.
- `vp run check:mobile-bundle`, `vp run check:mobile-web-bundle` — both OK.

**Every new oracle was mutation-tested** — mutation applied, test watched go red, reverted:

| Mutation | Caught by |
| --- | --- |
| **Drop `RELAXES_ANONYMOUS_ROUTES` from the anonymous condition** (the fleet mutation) | the native-invariance test |
| Adoption runs anonymously | 3 tests |
| Climb query re-muzzled for the anonymous branch | 2 tests |
| Kill switch ignored | the kill-switch test |
| Kill switch read once and cached (no mid-session flip) | the mid-session flip test |
| List URLs relax too | 6 tests |
| Slug climbs excluded again | 4 tests |
| An unresolved slug reported as not-found (private board reads as deleted) | 3 tests |
| Anonymous slug read falls back to the device's stored board | the stored-board test |
| URL angle ignored for the anonymous slug board | the angle test |
| A null `boardBySlug` reads as still resolving | 2 tests |
| Hand-off no longer skipped anonymously | the slug-climb test |
| A rejected `fetchBoardBySlug` left unsettled (permanent spinner) | the failed-lookup test |
| The view rendered on the status alone, with no climb in hand | the "waits rather than drawing" test |
| **Kill switch inverted any of four ways** (`=== false`, `=== true`, `!== false`, or ignored entirely) | `feature-flags-provider.test.tsx`, three new cases |
| A fixed-angle gym board's `isAngleAdjustable` dropped at the hook boundary | 1 hook test + 2 redirector tests |
| A config-tuple URL defaulted to no-tilt | the tuple test |
| `anonymousClimbReady` loosened to the branch alone | the still-loading test |
| `anonymous-climb` falling back to the not-found dead end | the redirector's spinner test |

The native-invariance oracle is phrased **positively** — `setActiveBoard` is still called with the resolved board and `openClimbInPlayDrawer` still fires once. The pre-existing `expect(status).not.toBe('auth-required')` stays **green** under exactly the mutation it appears to catch, because the anonymous branch is not `'auth-required'` either. That trap is why this one asserts what native still does, not what it doesn't.

### QA plan (browser, fresh incognito, `vp run dev:mobile:web`)

Not yet exercised end to end — the highest-value gate left on this stack, and the reason it stays draft until a human has driven it:

1. Signed-out tuple climb URL renders the climb, not the login form.
2. Signed-out `/b/{slug}/{angle}/view/{segment}` renders it too; a private/unknown slug shows the login form, not a not-found.
3. A locale-prefixed URL (`/es/kilter/…`) behaves the same and reads correctly in Spanish.
4. `/…/{angle}/play/{segment}` behaves identically to `/view/…`.
5. Write affordances absent: tick opens login, no queue button, no heart, no ellipsis, no lightbulb. Similar Climbs swaps the drawer without touching the queue.
6. Sign in from the bar → land back on the same climb.
7. A `/…/list` URL still redirects to `/auth/login?next=…` with a valid `next`.
8. A dead climb uuid shows not-found, not a spinner and not a login form.
9. How the pane-presentation drawer reads full-width in a browser — it has only ever been an iPad right column.

### Follow-ups filed

- #4606 — anonymous wall lighting (the LED path, hidden for v1 per Marco's ruling).
- #4607 — the anonymous list surfaces.
- #4608 — draft climbs fetchable by uuid with no viewer check.
- #4609 — five catalogued mobile feature flags that do not exist in PostHog.
- #4624 — the app half of the hand-off funnel never sets `environment: production-web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016552Be7ctNKKH8QM9rkryN

