### PR TITLE
fix(shared): correct the Kilter 12x14 size description spelling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,11 +105,11 @@ We'll always create a PR, never asks if a PR should be created, open as a draft.
   /mobile/          # React Native (Expo) mobile application
   /backend/         # WebSocket backend for party mode (graphql-ws)
   /shared-schema/   # Shared GraphQL schema and TypeScript types
+  /board-constants/ # Generated Aurora board catalogue (sizes, layouts, sets, holds), grade colours, difficulty bands
   /shared/
     /play-view/     # Play-drawer logic (queue nav, tick utils, grade display)
     /queue/         # Queue state machine (reducer, types, event utils)
     /board-config/  # Board metadata, hold maps, angle tables
-    /board-constants/ # Grade colours, difficulty bands
     /board-react/   # Renderer-agnostic BoardProvider + logbook/tick hooks (useSaveTick/useUpdateTick/useDeleteTick)
     /offline-sync/  # Offline sync engine: mutation outbox + drainer, pull client, SQLite DDL (platform I/O injected)
     /profile-stats/ # Pure climbing-stats aggregation for the You page / profile (chart builders, deriveProfileViewModel)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,11 +34,11 @@ We'll always create a PR, never asks if a PR should be created, open as a draft.
   /mobile/          # React Native (Expo) mobile application
   /backend/         # WebSocket backend for party mode (graphql-ws)
   /shared-schema/   # Shared GraphQL schema and TypeScript types
+  /board-constants/ # Generated Aurora board catalogue (sizes, layouts, sets, holds), grade colours, difficulty bands
   /shared/
     /play-view/     # Play-drawer logic (queue nav, tick utils, grade display)
     /queue/         # Queue state machine (reducer, types, event utils)
     /board-config/  # Board metadata, hold maps, angle tables
-    /board-constants/ # Grade colours, difficulty bands
     /board-react/   # Renderer-agnostic BoardProvider + logbook/tick hooks (useSaveTick/useUpdateTick/useDeleteTick)
     /offline-sync/  # Offline sync engine: mutation outbox + drainer, pull client, SQLite DDL (platform I/O injected)
     /profile-stats/ # Pure climbing-stats aggregation for the You page / profile (chart builders, deriveProfileViewModel)

--- a/packages/board-constants/scripts/generate-board-constants.ts
+++ b/packages/board-constants/scripts/generate-board-constants.ts
@@ -10,6 +10,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { fileURLToPath } from 'url';
 import { config } from 'dotenv';
+import { normalizeSizeDescription } from '../src/size-description-overrides';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -171,7 +172,10 @@ function querySizes(boardName: GeneratedBoardName): ProductSize[] {
   return parseRows(result, ([id, name, description, edgeLeft, edgeRight, edgeBottom, edgeTop, productId]) => ({
     id: parseInt(id, 10),
     name: name.trim(),
-    description: description.trim(),
+    // Aurora ships one misspelled description ('Commerical'); correct it on the
+    // way in so the constants — and the board URLs built from them — read
+    // properly. See ../src/size-description-overrides.ts and issue #4554.
+    description: normalizeSizeDescription(description.trim()),
     edgeLeft: parseInt(edgeLeft, 10),
     edgeRight: parseInt(edgeRight, 10),
     edgeBottom: parseInt(edgeBottom, 10),

--- a/packages/board-constants/src/__tests__/size-description-overrides.test.ts
+++ b/packages/board-constants/src/__tests__/size-description-overrides.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { AURORA_PRODUCT_SIZES } from '../generated/product-sizes-data';
+import { normalizeSizeDescription } from '../size-description-overrides';
+
+describe('normalizeSizeDescription', () => {
+  it("corrects Aurora's 'Commerical' typo", () => {
+    expect(normalizeSizeDescription('Commerical')).toBe('Commercial');
+  });
+
+  it('passes an uncorrected description through unchanged', () => {
+    expect(normalizeSizeDescription('Home')).toBe('Home');
+    expect(normalizeSizeDescription('')).toBe('');
+  });
+});
+
+describe('generated Aurora product-size descriptions', () => {
+  it("spells the Kilter 12 x 14 size 'Commercial'", () => {
+    // Also the board URL segment: `generateSizeSlug` folds the description into
+    // the size slug, so this string is `12x14-commercial` in every board link.
+    expect(AURORA_PRODUCT_SIZES.kilter[7].description).toBe('Commercial');
+  });
+
+  // The point of the layering: the correction lives in the generator, and the
+  // generated file is committed. This fixed point is what ties the two together
+  // — a regeneration that somehow bypassed the map would reintroduce the typo
+  // silently, and this fails CI instead.
+  it('is a fixed point of the correction map', () => {
+    for (const [boardName, sizesById] of Object.entries(AURORA_PRODUCT_SIZES)) {
+      for (const size of Object.values(sizesById)) {
+        expect(
+          normalizeSizeDescription(size.description),
+          `${boardName} size ${size.id} ("${size.name}") has an uncorrected description`,
+        ).toBe(size.description);
+      }
+    }
+  });
+});

--- a/packages/board-constants/src/generated/product-sizes-data.ts
+++ b/packages/board-constants/src/generated/product-sizes-data.ts
@@ -26,7 +26,7 @@ export const AURORA_PRODUCT_SIZES: Record<BoardName, Record<number, ProductSizeD
     7: {
       id: 7,
       name: '12 x 14',
-      description: 'Commerical',
+      description: 'Commercial',
       edgeLeft: 0,
       edgeRight: 144,
       edgeBottom: 0,

--- a/packages/board-constants/src/size-description-overrides.ts
+++ b/packages/board-constants/src/size-description-overrides.ts
@@ -1,0 +1,32 @@
+/**
+ * Spelling corrections applied to Aurora's product-size descriptions.
+ *
+ * Aurora's own catalogue carries the typo — `board_product_sizes` (board_type
+ * 'kilter', id 7, "12 x 14") stores `description = 'Commerical'`, and their app
+ * shows it that way too. So this is a deliberate divergence from upstream, not a
+ * bug in the generator, which copies the column faithfully.
+ *
+ * The correction is applied where the data is WRITTEN — the board-constants
+ * generator — not where it is read. Fixing it in the database instead would not
+ * hold: `upsertProductSizes` in `@boardsesh/aurora-sync` re-writes `description`
+ * from Aurora on every catalog sync, so a migration would be reverted the next
+ * time the catalogue syncs.
+ *
+ * Keys match the WHOLE trimmed description, not a word-level regex, so the map
+ * stays narrow and auditable. As of 2026-08 this is the only misspelling in the
+ * upstream catalogue: all 43 `board_product_sizes` rows, 16 `board_layouts`
+ * names and 44 `board_sets` names were checked.
+ *
+ * See issue #4554.
+ */
+export const SIZE_DESCRIPTION_CORRECTIONS: Readonly<Record<string, string>> = {
+  Commerical: 'Commercial',
+};
+
+/**
+ * The description to store for a size, with any known upstream typo corrected.
+ * Unknown descriptions pass through untouched.
+ */
+export function normalizeSizeDescription(description: string): string {
+  return SIZE_DESCRIPTION_CORRECTIONS[description] ?? description;
+}

--- a/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
+++ b/packages/mobile/src/hooks/__tests__/use-share-climb.test.ts
@@ -47,7 +47,7 @@ const baseArgs = {
 };
 
 const expectedReadableShareUrl =
-  'https://www.boardsesh.com/kilter/original/12x14-commerical/screw_bolt/40/view/test-climb-climb-uuid-123';
+  'https://www.boardsesh.com/kilter/original/12x14-commercial/screw_bolt/40/view/test-climb-climb-uuid-123';
 
 const climbWithFrames = {
   uuid: 'climb-uuid-123',

--- a/packages/shared/play-view/src/__tests__/readable-url-utils.test.ts
+++ b/packages/shared/play-view/src/__tests__/readable-url-utils.test.ts
@@ -473,7 +473,7 @@ describe('legacy MoonBoard URL forms', () => {
   });
 });
 
-describe('permanently pinned qualified size slugs', () => {
+describe('permanently pinned size slugs', () => {
   const pinnedEntries = Object.entries(PERMANENT_SIZE_SLUG_ALIASES).flatMap(([boardName, aliasesBySizeId]) =>
     Object.entries(aliasesBySizeId ?? {}).flatMap(([sizeId, aliases]) =>
       aliases.map((alias) => ({ boardName: boardName as BoardName, sizeId: Number(sizeId), alias })),
@@ -481,7 +481,10 @@ describe('permanently pinned qualified size slugs', () => {
   );
 
   it('has exactly the forms we have shipped', () => {
+    // Integer-like keys enumerate ascending, so size 7 comes first however the
+    // source object is written.
     expect(pinnedEntries).toEqual([
+      { boardName: 'kilter', sizeId: 7, alias: '12x14-commerical' },
       { boardName: 'kilter', sizeId: 10, alias: '12x12-square' },
       { boardName: 'kilter', sizeId: 27, alias: '12x12-square-without-kickboard' },
     ]);
@@ -538,5 +541,44 @@ describe('permanently pinned qualified size slugs', () => {
         }
       }
     }
+  });
+});
+
+describe("the Kilter 12 x 14 'Commerical' spelling correction (#4554)", () => {
+  // Correcting Aurora's typo in the size description moved the generated URL
+  // segment from `12x14-commerical` to `12x14-commercial`. PostHog counted 629
+  // pageviews from 325 people on the old form in the 180 days to 2026-08-16 —
+  // /list, /view, /playlists, and the /es and /fr variants — and the Expo app's
+  // deep-link router resolves purely from board-constants with no database
+  // fallback. These cases are the proof those links still land.
+  it('mints the corrected slug for new links', () => {
+    expect(resolveSizeSlug('kilter', 1, 7)).toBe('12x14-commercial');
+    expect(generateSizeSlug('12 x 14', 'Commercial')).toBe('12x14-commercial');
+  });
+
+  it('still routes a climb link minted with the old spelling', () => {
+    expect(parseClimbRoutePath(`/kilter/original/12x14-commerical/screw_bolt/40/view/${CLIMB_UUID}`)).toEqual({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 7,
+      setIds: '1,20',
+      angle: 40,
+      climbUuid: CLIMB_UUID,
+      surface: 'view',
+    });
+  });
+
+  it('still routes a climb-list link minted with the old spelling', () => {
+    expect(parseBoardListPath('/kilter/original/12x14-commerical/screw_bolt/40/list')).toEqual({
+      boardName: 'kilter',
+      layoutId: 1,
+      sizeId: 7,
+      setIds: '1,20',
+      angle: 40,
+    });
+  });
+
+  it('routes the corrected slug to the same board', () => {
+    expect(parseBoardListPath('/kilter/original/12x14-commercial/screw_bolt/40/list')?.sizeId).toBe(7);
   });
 });

--- a/packages/shared/play-view/src/__tests__/url-utils.test.ts
+++ b/packages/shared/play-view/src/__tests__/url-utils.test.ts
@@ -39,7 +39,7 @@ describe('buildReadableClimbViewPath', () => {
         angle: 40,
         climbUuid: 'abc123',
       }),
-    ).toBe('/kilter/original/12x14-commerical/screw_bolt/40/view/abc123');
+    ).toBe('/kilter/original/12x14-commercial/screw_bolt/40/view/abc123');
   });
 
   it('falls back to numeric path with a climb slug when static board data cannot resolve', () => {

--- a/packages/shared/play-view/src/readable-url-utils.ts
+++ b/packages/shared/play-view/src/readable-url-utils.ts
@@ -159,16 +159,18 @@ export function resolveSizeSlug(boardName: BoardName, layoutId: number, sizeId: 
 }
 
 /**
- * Qualified size slugs that must keep resolving forever, keyed by board and then
- * by size id.
+ * Size slugs that must keep resolving forever, keyed by board and then by size
+ * id.
  *
- * The qualifier {@link sizeSlugsForLayout} appends is derived from the upstream
- * size *name*, and upstream renames sizes — the July 2026 sync audit caught
- * several. A rename re-mints the qualifier, so the slug generated after it and
- * the slug already sitting in every shared link, chat message and search index
- * are different strings. Nothing about a link in the wild changes when Aurora
- * edits a row, so pinning is the only thing that keeps it working: a qualified
- * form is recorded here by *id* the moment it ships, and resolves from then on
+ * A size slug is built from upstream text: the dimensions and description feed
+ * {@link generateSizeSlug}, and the qualifier {@link sizeSlugsForLayout} appends
+ * comes from the size *name*. That text moves — upstream renames sizes (the July
+ * 2026 sync audit caught several), and we ourselves correct upstream typos in
+ * the description (#4554). Either way the slug generated afterwards and the slug
+ * already sitting in every shared link, chat message and search index are
+ * different strings. Nothing about a link in the wild changes when the text
+ * moves, so pinning is the only thing that keeps it working: a shipped form is
+ * recorded here by *id* the moment it changes, and resolves from then on
  * whatever the size ends up being called.
  *
  * Consulted only after the generated slugs, so an alias can never shadow a live
@@ -176,6 +178,17 @@ export function resolveSizeSlug(boardName: BoardName, layoutId: number, sizeId: 
  */
 export const PERMANENT_SIZE_SLUG_ALIASES: Partial<Record<BoardName, Readonly<Record<number, readonly string[]>>>> = {
   kilter: {
+    // Kilter layout 1 size 7, "12 x 14": Aurora describes it "Commerical", and
+    // that misspelling was folded straight into the size slug, so every link
+    // minted before #4554 carries `12x14-commerical`. The description is now
+    // corrected at the generator, so the generated slug is `12x14-commercial`
+    // and the old form only keeps resolving from here. PostHog counted 629
+    // pageviews from 325 people on `12x14-commerical` URLs in the 180 days to
+    // 2026-08-16, across /list, /view, /playlists and the /es and /fr variants —
+    // delete this entry and all of those links 404. Unlike the pins below this
+    // is a BARE slug rather than a qualified one, which needs nothing special:
+    // generated slugs are still matched first, so it cannot shadow a live one.
+    7: ['12x14-commerical'],
     // Kilter layout 1 size 10, "12 x 12 with kickboard": owns the bare
     // `12x12-square` slug by being first on the layout. Pinned so an upstream
     // RENAME of the size (generated slug changes, bare form stops matching)
@@ -208,8 +221,8 @@ export function resolvePermanentSizeSlugAlias(boardName: BoardName, sizeSlug: st
 
 /**
  * Inverse of {@link resolveSizeSlug}. Accepts a qualified slug, the bare legacy
- * one (which keeps resolving to the first match), and any qualified form pinned
- * in {@link PERMANENT_SIZE_SLUG_ALIASES}. Exported so the web app's
+ * one (which keeps resolving to the first match), and any form pinned in
+ * {@link PERMANENT_SIZE_SLUG_ALIASES}. Exported so the web app's
  * `getSizeBySlug` resolves the qualified form identically — a link has to mean
  * the same board on both hosts.
  */


### PR DESCRIPTION
## Summary

**Read this first: this changes a live URL segment, and the pin that keeps the old one working ships in the same commit.**

The Kilter Original 12 x 14's board URL segment goes from `12x14-commerical` to `12x14-commercial`. That segment is not cosmetic — `generateSizeSlug` folds the size *description* into it, so correcting the spelling re-mints every board URL for that size. PostHog counted **629 pageviews from 325 people** on the old form in the 180 days to 2026-08-16, across `/list`, `/view`, `/playlists` and the `/es` and `/fr` variants. The Expo app's deep-link router resolves board segments purely from `@boardsesh/board-constants` with no database fallback, so an unpinned rename would drop those links on the floor.

So the old slug is pinned in `PERMANENT_SIZE_SLUG_ALIASES` (`kilter` → size 7 → `12x14-commerical`) in this same PR, with the traffic numbers in the comment so nobody prunes it later. That table is consulted *after* the generated slugs, so a pin can never shadow a live slug, and it still only resolves on a layout that actually carries size 7. This is the first *bare* (unqualified) slug in that table; it needs no special handling.

Only then, the actual typo. Aurora's own catalogue carries it: `board_product_sizes` (board_type `kilter`, id 7, "12 x 14") stores `description = 'Commerical'` verbatim, and their app shows it that way too.

### Why the fix is at the generator, and not in the database

`upsertProductSizes` in `@boardsesh/aurora-sync` re-writes `description` from Aurora on every catalog sync (`onConflictDoUpdate`), so a migration correcting the row would be reverted the next time the catalogue syncs. The durable layer is where we *write* our own copy of the data — the board-constants generator. New `packages/board-constants/src/size-description-overrides.ts` holds a one-entry, whole-string correction map (`Commerical` → `Commercial`); `querySizes()` applies it.

I deliberately did **not** normalise the description in `upsertProductSizes` too. Our DB mirror stays faithful to upstream: the copy there feeds only a URL fallback that never fires for kilter 1/7 and a `UserBoard.sizeDescription` field the backend hardcodes to `null`, so diverging it buys nothing user-visible — and it happens to leave web's `findSizeBySlug` DB leg as a second, independent resolver for the old slug. Please don't "finish the job" later.

I also checked the rest of the upstream catalogue against the dev DB: all 43 `board_product_sizes` rows, 16 `board_layouts` names and 44 `board_sets` names. `Commerical` is the only misspelling, which is why the map is a one-entry lookup rather than a word-level regex.

### About the hand-edited generated file

`packages/board-constants/src/generated/product-sizes-data.ts` says DO NOT EDIT, and this PR edits one line of it. That is deliberate, and it is safe only because of the two things shipping beside it:

1. The **generator is changed in the same PR** to emit exactly this value, so the next real regeneration produces the same string.
2. A **fixed-point test** pins the two together: for every size in `AURORA_PRODUCT_SIZES`, `normalizeSizeDescription(size.description) === size.description`. A regeneration that somehow bypassed the correction map reintroduces the typo *and fails CI* rather than doing it silently.

I did not run the generator. A full regeneration rewrites the `Generated at:` timestamp, all six hole-placement `.cjs` shards and the loader against whatever the local dev-DB image happens to hold — a large, unreviewable diff for a one-word fix.

### Not adding a 301

Old URLs keep serving 200 with a `rel=canonical` pointing at the corrected slug. That is exactly how every other alias spelling is already treated (the bare-dimension `12x12` form, the `kilter-original` layout prefix), and the numeric-only redirect in the board layout deliberately doesn't fire for readable URLs. Consistency beats a marginally cleaner SEO signal; happy to raise redirect consolidation separately if the SEO owner wants it.

Drive-by: `CLAUDE.md` / `AGENTS.md` listed `board-constants` under `packages/shared/`. It lives at `packages/board-constants/`. Fixed while I was in there.

Closes #4554

## Release Notes

- The Kilter 12 x 14 now reads "Commercial" instead of "Commerical" in the board picker and in board links.
- Links you shared before the fix still open the same board.

## Test plan

- `vp test run --project board-constants --reporter=agent` — 10 files / 125 tests green, including the new `size-description-overrides` suite (the correction, the pass-through, the pinned `AURORA_PRODUCT_SIZES.kilter[7].description`, and the fixed-point guard).
- `vp test run --project play-view --reporter=agent` — 11 files / 247 tests green (240 before; 7 new). The pinned-alias list now asserts three entries, and a new `#4554` block proves `parseClimbRoutePath` and `parseBoardListPath` still resolve `/kilter/original/12x14-commerical/...` to size 7 while `resolveSizeSlug('kilter', 1, 7)` mints `12x14-commercial`.
- `vp test run --project web --reporter=agent packages/web/app/lib/__tests__/slug-utils-catalogue-round-trip.test.ts packages/web/app/lib/__tests__/url-utils.test.ts` — 254 tests green. The catalogue round-trip walks every `PERMANENT_SIZE_SLUG_ALIASES` entry through the real async `getSizeBySlug` with a **throwing** db stub, so it proves the old slug resolves off the static tables via the new pin, not via the database.
- `vp run test:mobile` — 684 files / 6548 tests green, including the updated share-URL expectation.
- `vp run typecheck`, `vp check`.
- No native-fingerprint inputs touched (`packages/board-constants`, `packages/shared/play-view`, `packages/mobile/src` only), so this rides OTA. No BLE code, so no Fable review needed.
