### PR TITLE
ci(repo): lint the whole repo on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,11 +213,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 50
-      - name: Fetch base ref
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: git fetch --depth=50 origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
       - uses: oven-sh/setup-bun@v2
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -226,7 +221,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Install Expo web lint dependencies
-        # Unconditional: the push-to-main step below lints the WHOLE repo, so
+        # Unconditional: the lint step below lints the WHOLE repo, so
         # packages/mobile/src/web-shims/bottom-sheet.tsx is always in scope and
         # its `@gorhom/bottom-sheet` types only resolve through the isolated
         # web-runtime install (packages/mobile/tsconfig.json maps the path
@@ -294,34 +289,19 @@ jobs:
       # `vp check`, so this grep guard is the real backstop.
       - name: Check offline-sync adapter boundary
         run: vp run check:mobile-offline-sync-imports
-      - name: Lint changed files (PR)
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          # Match the staged-hook scope in root vite.config.ts: TS/JS files,
-          # excluding generated/, board-controller, and embedded firmware sources.
-          # xargs -r ensures no-op on empty input.
-          git diff --name-only --diff-filter=ACMR \
-            "origin/$BASE_REF...HEAD" \
-            -- '*.ts' '*.tsx' '*.js' '*.mjs' '*.cjs' \
-            | grep -vE '(/node_modules/|/generated/|^packages/board-controller/|^embedded/)' \
-            > changed-lintable.txt || true
-          if [ -s changed-lintable.txt ]; then
-            # Same stdout redirect as the full-repo step below, and for the same
-            # reason: vp panics on EAGAIN when it flushes a long warning list to the
-            # runner's non-blocking stdout, and xargs reports that crash as 123 with
-            # the diagnostics cut off mid-line. A PR touching one warning-heavy file
-            # is enough to hit it. Writing to a regular file never EAGAINs; vp's real
-            # exit code is preserved so lint errors still fail the job.
-            xargs -r vp check < changed-lintable.txt > vp-check.log 2>&1 && status=0 || status=$?
-            cat vp-check.log || true
-            exit $status
-          else
-            echo "No lintable files changed."
-          fi
-      - name: Lint full repo (main)
-        if: github.event_name != 'pull_request'
+      # PRs and main lint the SAME thing: the whole repo. This job used to lint
+      # only a PR's changed files and reserve the full-repo pass for push-to-main,
+      # which meant an error in a file no PR happened to touch could not be caught
+      # until it was already on main. 33 of them accumulated that way and broke
+      # every main run for days (issue #4488, fixed by #4521) while every PR that
+      # introduced them stayed green. Measured cost of closing that gap: ~26s per
+      # PR (step timings, job 96193441921), against a 109s job dominated by
+      # setup-vp. Scope is now identical on both sides by construction, so the
+      # only way to land a lint error is to be the PR that shows it.
+      #
+      # Effective config is the `lint` block in root vite.config.ts, NOT
+      # .oxlintrc.json — see issue #4548 and the comment on that block.
+      - name: Lint full repo
         # vp/Vite+ panics with "failed printing to stdout: Resource temporarily
         # unavailable (os error 11)" when it flushes the full-repo warning list to the
         # runner's non-blocking stdout. Write to a regular file (never EAGAIN), then

--- a/packages/backend/src/__tests__/board-merge-tombstone.test.ts
+++ b/packages/backend/src/__tests__/board-merge-tombstone.test.ts
@@ -9,6 +9,7 @@ import { boardPresenceMutations } from '../graphql/resolvers/board-presence/muta
 import { findChosenBoardForSerial } from '../graphql/resolvers/board-presence/shared';
 import { lockBoardSerialWrite } from '../graphql/resolvers/board-serial-write-lock';
 import { seedAuroraCatalogFixtures } from './helpers/board-catalog-fixture';
+import { createBarrier, createValueBarrier, handleLater } from './helpers/concurrency';
 
 /**
  * Real-DB coverage for issue #3407's merge-tombstone following and the
@@ -155,40 +156,6 @@ async function serialPointerUuid(userId: string, serial: string): Promise<string
     `),
   );
   return rows[0]?.board_uuid ?? null;
-}
-
-function createBarrier(): { promise: Promise<void>; release: () => void } {
-  let release = (): void => undefined;
-  const promise = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  return { promise, release };
-}
-
-function createValueBarrier<Result>(): { promise: Promise<Result>; release: (result: Result) => void } {
-  let release = (_result: Result): void => undefined;
-  const promise = new Promise<Result>((resolve) => {
-    release = resolve;
-  });
-  return { promise, release };
-}
-
-/**
- * Attach an inert rejection handler to a promise this test asserts on later.
- *
- * These tests deliberately leave a promise in flight across several `await`s.
- * If it rejects during one of them, Node reaches its unhandled-rejection
- * checkpoint before the assertion further down can attach a handler — vitest
- * counts that under `Errors` and exits 1 with every test still passing
- * (issue #4488, main run 31880202330).
- *
- * The promise itself is untouched: still rejected, still assertable. The
- * `await expect(...).rejects.toThrow(...)` or bare `await` below still runs,
- * still sees the same rejection, and still fails on the wrong error — so this
- * cannot hide a defect. Its contract is pinned in deferred-rejection.test.ts.
- */
-function handleLater(promise: Promise<unknown>): void {
-  void promise.catch((): void => undefined);
 }
 
 async function waitForAdvisoryWaitBlockedBy(blockingPid: number): Promise<number> {

--- a/packages/backend/src/__tests__/board-merge-tombstone.test.ts
+++ b/packages/backend/src/__tests__/board-merge-tombstone.test.ts
@@ -173,6 +173,24 @@ function createValueBarrier<Result>(): { promise: Promise<Result>; release: (res
   return { promise, release };
 }
 
+/**
+ * Attach an inert rejection handler to a promise this test asserts on later.
+ *
+ * These tests deliberately leave a promise in flight across several `await`s.
+ * If it rejects during one of them, Node reaches its unhandled-rejection
+ * checkpoint before the assertion further down can attach a handler — vitest
+ * counts that under `Errors` and exits 1 with every test still passing
+ * (issue #4488, main run 31880202330).
+ *
+ * The promise itself is untouched: still rejected, still assertable. The
+ * `await expect(...).rejects.toThrow(...)` or bare `await` below still runs,
+ * still sees the same rejection, and still fails on the wrong error — so this
+ * cannot hide a defect. Its contract is pinned in deferred-rejection.test.ts.
+ */
+function handleLater(promise: Promise<unknown>): void {
+  void promise.catch((): void => undefined);
+}
+
 async function waitForAdvisoryWaitBlockedBy(blockingPid: number): Promise<number> {
   const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
@@ -516,6 +534,7 @@ describe('followBoard during a board merge', () => {
         },
         { isolationLevel: 'read committed' },
       );
+      handleLater(mergePromise);
       const mergePid = await mergeReady.promise;
 
       followPromise = socialBoardMutations.followBoard(
@@ -523,6 +542,7 @@ describe('followBoard during a board merge', () => {
         { input: { boardUuid: loserUuid } },
         authCtx(followerId),
       );
+      handleLater(followPromise);
       await waitForRowWaitBlockedBy(mergePid);
 
       releaseMerge.release();
@@ -593,6 +613,7 @@ describe('followBoard during a board merge', () => {
         userRowLocked.release(Number(session.pid));
         await releaseUserRow.promise;
       });
+      handleLater(userRowHolderPromise);
       const userRowHolderPid = await userRowLocked.promise;
 
       followPromise = socialBoardMutations.followBoard(
@@ -600,6 +621,7 @@ describe('followBoard during a board merge', () => {
         { input: { boardUuid: loserUuid } },
         authCtx(followerId),
       );
+      handleLater(followPromise);
       const followerPid = await waitForRowWaitBlockedBy(userRowHolderPid);
 
       // This is the follow-repoint portion of the real dedupe transaction. It
@@ -635,6 +657,7 @@ describe('followBoard during a board merge', () => {
         },
         { isolationLevel: 'read committed' },
       );
+      handleLater(mergePromise);
       const mergePid = await mergeStarted.promise;
       expect(await waitForRowWaitBlockedBy(followerPid)).toBe(mergePid);
 
@@ -749,9 +772,11 @@ describe('findChosenBoardForSerial pointer healing', () => {
       await insertSerialPointer(pointerOwner, serial, oldLoserUuid);
 
       mergePromise = tombstoneBoardUnderSerialLock(serial, loserUuid, canonicalUuid, mergeReady, releaseMerge.promise);
+      handleLater(mergePromise);
       const mergePid = await mergeReady.promise;
 
       healPromise = findChosenBoardForSerial(pointerOwner, serial);
+      handleLater(healPromise);
       await waitForAdvisoryWaitBlockedBy(mergePid);
 
       releaseMerge.release();
@@ -1345,6 +1370,7 @@ describe('serial pointer lock ordering', () => {
         }
         await releaseRowHolder.promise;
       });
+      handleLater(rowHolderPromise);
       const rowHolderPid = await rowHolderReady.promise;
 
       choosePromise = boardPresenceMutations.chooseBoardForSerial(
@@ -1352,6 +1378,7 @@ describe('serial pointer lock ordering', () => {
         { boardId: Number(chosenBoard.id), serial },
         authCtx(userId),
       );
+      handleLater(choosePromise);
       const choosingPid = await waitForRowWaitBlockedBy(rowHolderPid);
 
       // Before the fix, the FK check on user_board_serials.board_uuid waited
@@ -1424,6 +1451,7 @@ describe('serial pointer lock ordering', () => {
         }
         await releaseRowHolder.promise;
       });
+      handleLater(rowHolderPromise);
       const rowHolderPid = await rowHolderReady.promise;
 
       resolvePromise = boardPresenceMutations.resolveBoardForSerial(
@@ -1431,6 +1459,7 @@ describe('serial pointer lock ordering', () => {
         { serial, boardType: 'kilter', layoutId: 99, sizeId: 10, setIds: '1,2' },
         authCtx(userId),
       );
+      handleLater(resolvePromise);
       const resolvingPid = await waitForRowWaitBlockedBy(rowHolderPid);
 
       // Planning is serial-only and read-only. The write phase must wait on the
@@ -1522,9 +1551,11 @@ describe('serial pointer lock ordering', () => {
         }
         await releaseRowHolder.promise;
       });
+      handleLater(rowHolderPromise);
       const rowHolderPid = await rowHolderReady.promise;
 
       lookupPromise = findChosenBoardForSerial(userId, serial);
+      handleLater(lookupPromise);
       const healingPid = await waitForRowWaitBlockedBy(rowHolderPid);
 
       // The serial-first lookup is read-only. Its separate healer must be
@@ -1595,6 +1626,7 @@ describe('serial pointer lock ordering', () => {
         }
         await releaseRowHolder.promise;
       });
+      handleLater(rowHolderPromise);
       const rowHolderPid = await rowHolderReady.promise;
 
       recordPromise = socialBoardMutations.recordBoardSerial(
@@ -1611,6 +1643,7 @@ describe('serial pointer lock ordering', () => {
         },
         authCtx(userId),
       );
+      handleLater(recordPromise);
       const recordingPid = await waitForRowWaitBlockedBy(rowHolderPid);
 
       // Waiting on the board row while holding nothing else. The serial advisory
@@ -1662,6 +1695,7 @@ describe('serial choices during a board merge', () => {
       });
 
       mergePromise = tombstoneBoardUnderSerialLock(serial, loserUuid, canonicalUuid, mergeReady, releaseMerge.promise);
+      handleLater(mergePromise);
       const mergePid = await mergeReady.promise;
 
       resolvePromise = boardPresenceMutations.resolveBoardForSerial(
@@ -1669,6 +1703,7 @@ describe('serial choices during a board merge', () => {
         { serial, boardType: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,2' },
         authCtx(userId),
       );
+      handleLater(resolvePromise);
       await waitForAdvisoryWaitBlockedBy(mergePid);
 
       releaseMerge.release();
@@ -1715,6 +1750,7 @@ describe('serial choices during a board merge', () => {
       );
 
       mergePromise = tombstoneBoardUnderSerialLock(serial, loserUuid, canonicalUuid, mergeReady, releaseMerge.promise);
+      handleLater(mergePromise);
       const mergePid = await mergeReady.promise;
 
       choosePromise = boardPresenceMutations.chooseBoardForSerial(
@@ -1722,6 +1758,7 @@ describe('serial choices during a board merge', () => {
         { boardId: Number(loser.id), serial },
         authCtx(userId),
       );
+      handleLater(choosePromise);
       const choosingPid = await waitForRowWaitBlockedBy(mergePid);
       expect(await grantedAdvisoryLockCount(choosingPid)).toBe(0);
 

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -32,6 +32,7 @@ import { setCachedBoardPresenceStats } from '../graphql/resolvers/board-presence
 import { buildTickBoardLockQuery, tickMutations } from '../graphql/resolvers/ticks/mutations';
 import { seedAuroraCatalogFixtures } from './helpers/board-catalog-fixture';
 import { logger } from '../utils/logger';
+import { createBarrier, createValueBarrier, handleLater } from './helpers/concurrency';
 
 // Board presence is always-on (the BOARD_PRESENCE_ENABLED env gate and the
 // PostHog flag were removed when the feature went GA), so the suite needs no
@@ -90,40 +91,6 @@ beforeAll(async () => {
 afterAll(async () => {
   await cleanupBoardPresenceCatalogFixtures();
 });
-
-function createBarrier(): { promise: Promise<void>; release: () => void } {
-  let release = (): void => undefined;
-  const promise = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  return { promise, release };
-}
-
-function createValueBarrier<Result>(): { promise: Promise<Result>; release: (result: Result) => void } {
-  let release = (_result: Result): void => undefined;
-  const promise = new Promise<Result>((resolve) => {
-    release = resolve;
-  });
-  return { promise, release };
-}
-
-/**
- * Attach an inert rejection handler to a promise this test asserts on later.
- *
- * These tests deliberately leave a promise in flight across several `await`s.
- * If it rejects during one of them, Node reaches its unhandled-rejection
- * checkpoint before the assertion further down can attach a handler — vitest
- * counts that under `Errors` and exits 1 with every test still passing
- * (issue #4488, main run 31880202330).
- *
- * The promise itself is untouched: still rejected, still assertable. The
- * `await expect(...).rejects.toThrow(...)` or bare `await` below still runs,
- * still sees the same rejection, and still fails on the wrong error — so this
- * cannot hide a defect. Its contract is pinned in deferred-rejection.test.ts.
- */
-function handleLater(promise: Promise<unknown>): void {
-  void promise.catch((): void => undefined);
-}
 
 async function waitForSessionBlockedBy(blockingPid: number): Promise<void> {
   const deadline = Date.now() + 5_000;

--- a/packages/backend/src/__tests__/board-presence.test.ts
+++ b/packages/backend/src/__tests__/board-presence.test.ts
@@ -107,6 +107,24 @@ function createValueBarrier<Result>(): { promise: Promise<Result>; release: (res
   return { promise, release };
 }
 
+/**
+ * Attach an inert rejection handler to a promise this test asserts on later.
+ *
+ * These tests deliberately leave a promise in flight across several `await`s.
+ * If it rejects during one of them, Node reaches its unhandled-rejection
+ * checkpoint before the assertion further down can attach a handler — vitest
+ * counts that under `Errors` and exits 1 with every test still passing
+ * (issue #4488, main run 31880202330).
+ *
+ * The promise itself is untouched: still rejected, still assertable. The
+ * `await expect(...).rejects.toThrow(...)` or bare `await` below still runs,
+ * still sees the same rejection, and still fails on the wrong error — so this
+ * cannot hide a defect. Its contract is pinned in deferred-rejection.test.ts.
+ */
+function handleLater(promise: Promise<unknown>): void {
+  void promise.catch((): void => undefined);
+}
+
 async function waitForSessionBlockedBy(blockingPid: number): Promise<void> {
   const deadline = Date.now() + 5_000;
   while (Date.now() < deadline) {
@@ -1265,6 +1283,7 @@ describe('board-presence resolvers', () => {
       // Prime the iterator: kick off the first next() (this runs up to the
       // first `yield`, establishing the subscription) then report a climb.
       const nextPromise = iterator.next();
+      handleLater(nextPromise);
       // Give the eager subscribe a tick to settle.
       await new Promise((r) => setTimeout(r, 50));
 
@@ -1479,6 +1498,7 @@ describe('board-presence resolvers', () => {
           mergeReady.release(Number((session as { pid: number }).pid));
           await releaseMerge.promise;
         });
+        handleLater(mergePromise);
         const mergePid = await mergeReady.promise;
 
         savePromise = tickMutations.saveTick(
@@ -1486,6 +1506,7 @@ describe('board-presence resolvers', () => {
           { input: baseTickInput({ uuid: tickUuid, boardId: loserId }) },
           authCtx(),
         );
+        handleLater(savePromise);
         await waitForSessionBlockedBy(mergePid);
 
         releaseMerge.release();
@@ -1520,6 +1541,7 @@ describe('board-presence resolvers', () => {
           await releaseDelete.promise;
           await transaction.execute(sql`UPDATE user_boards SET deleted_at = now() WHERE id = ${boardId}`);
         });
+        handleLater(deletePromise);
         const deletePid = await deleteReady.promise;
 
         savePromise = tickMutations.saveTick(
@@ -1527,6 +1549,7 @@ describe('board-presence resolvers', () => {
           { input: baseTickInput({ uuid: tickUuid, boardId }) },
           authCtx(),
         );
+        handleLater(savePromise);
         await waitForSessionBlockedBy(deletePid);
 
         releaseDelete.release();

--- a/packages/backend/src/__tests__/deferred-rejection.test.ts
+++ b/packages/backend/src/__tests__/deferred-rejection.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The concurrency tests in board-merge-tombstone.test.ts and board-presence.test.ts
+ * start a promise, then `await` something else before asserting on it. When the
+ * started promise rejects during one of those intervening awaits, Node reaches its
+ * unhandled-rejection checkpoint with no handler attached: vitest reports it under
+ * `Errors` and the job exits 1 with every test passing (issue #4488, main run
+ * 31880202330 — `test-backend (2, 2)`, 1712 tests passed, 1 error).
+ *
+ * The fix in both files is an inert `.catch()` attached at creation time. This file
+ * pins the two properties that make it safe, with no database and no services:
+ *
+ *   1. the promise stays rejected, so the assertion further down still discriminates;
+ *   2. the rejection survives an intervening await without leaking.
+ *
+ * The complementary evidence is the mutation probe recorded in the PR: with the
+ * handler in place, changing the expected message in board-merge-tombstone.test.ts
+ * makes the test fail. An inert guard that swallowed the rejection could not do that.
+ */
+function handleLater(promise: Promise<unknown>): void {
+  void promise.catch((): void => undefined);
+}
+
+describe('handleLater', () => {
+  it('leaves the promise rejected, so a later assertion still discriminates', async () => {
+    const rejected = Promise.reject(new Error('Board not found'));
+    handleLater(rejected);
+
+    await expect(rejected).rejects.toThrow('Board not found');
+    // The same handler must NOT make a wrong expectation pass. This is the
+    // property that distinguishes it from swallowing the rejection.
+    await expect(expect(rejected).rejects.toThrow('a message it never throws')).rejects.toThrow();
+  });
+
+  it('does not leak when the rejection lands during an intervening await', async () => {
+    const leaks: string[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      leaks.push(reason instanceof Error ? reason.message : String(reason));
+    };
+    process.on('unhandledRejection', onUnhandled);
+
+    try {
+      // Same shape as the failing test: this rejects at ~10ms...
+      const followPromise = new Promise<never>((_resolve, reject) => {
+        setTimeout(() => reject(new Error('Board not found')), 10);
+      });
+      handleLater(followPromise);
+      // ...while the test is suspended awaiting something that settles at ~30ms.
+      const mergePromise = new Promise<void>((resolve) => setTimeout(resolve, 30));
+
+      await mergePromise;
+      await expect(followPromise).rejects.toThrow('Board not found');
+      // Give Node's unhandled-rejection checkpoint room to fire if it were going to.
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+      expect(leaks).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('resolves values through untouched', async () => {
+    const resolved = Promise.resolve('survivor');
+    handleLater(resolved);
+    await expect(resolved).resolves.toBe('survivor');
+  });
+});

--- a/packages/backend/src/__tests__/deferred-rejection.test.ts
+++ b/packages/backend/src/__tests__/deferred-rejection.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { handleLater } from './helpers/concurrency';
+
 /**
  * The concurrency tests in board-merge-tombstone.test.ts and board-presence.test.ts
  * start a promise, then `await` something else before asserting on it. When the
@@ -18,10 +20,6 @@ import { describe, expect, it } from 'vitest';
  * handler in place, changing the expected message in board-merge-tombstone.test.ts
  * makes the test fail. An inert guard that swallowed the rejection could not do that.
  */
-function handleLater(promise: Promise<unknown>): void {
-  void promise.catch((): void => undefined);
-}
-
 describe('handleLater', () => {
   it('leaves the promise rejected, so a later assertion still discriminates', async () => {
     const rejected = Promise.reject(new Error('Board not found'));

--- a/packages/backend/src/__tests__/deferred-rejection.test.ts
+++ b/packages/backend/src/__tests__/deferred-rejection.test.ts
@@ -41,20 +41,32 @@ describe('handleLater', () => {
     process.on('unhandledRejection', onUnhandled);
 
     try {
-      // Same shape as the failing test: this rejects at ~10ms...
+      // Same shape as the failing test, sequenced by macrotask rather than by
+      // wall clock — a de-flaking test that races its own setTimeout budget on a
+      // loaded runner would be self-defeating.
+      let rejectFollow: (error: Error) => void = () => undefined;
       const followPromise = new Promise<never>((_resolve, reject) => {
-        setTimeout(() => reject(new Error('Board not found')), 10);
+        rejectFollow = reject;
       });
       handleLater(followPromise);
-      // ...while the test is suspended awaiting something that settles at ~30ms.
-      const mergePromise = new Promise<void>((resolve) => setTimeout(resolve, 30));
 
+      // The follow rejects while the test is suspended on something else.
+      const mergePromise = new Promise<void>((resolve) => {
+        setImmediate(() => {
+          rejectFollow(new Error('Board not found'));
+          resolve();
+        });
+      });
       await mergePromise;
-      await expect(followPromise).rejects.toThrow('Board not found');
-      // Give Node's unhandled-rejection checkpoint room to fire if it were going to.
-      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+      // Node runs its unhandled-rejection checkpoint once the microtask queue
+      // drains at the end of a turn, so hopping two macrotasks is enough to give
+      // it every chance to fire. No time budget to blow.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
 
       expect(leaks).toEqual([]);
+      await expect(followPromise).rejects.toThrow('Board not found');
     } finally {
       process.off('unhandledRejection', onUnhandled);
     }

--- a/packages/backend/src/__tests__/helpers/concurrency.ts
+++ b/packages/backend/src/__tests__/helpers/concurrency.ts
@@ -1,0 +1,42 @@
+/**
+ * Primitives for the tests that drive two database transactions against each
+ * other on purpose — board merges racing a follow, a serial choice racing a
+ * tombstone. Shared by board-merge-tombstone.test.ts and board-presence.test.ts,
+ * and pinned by deferred-rejection.test.ts.
+ */
+
+/** A promise plus the handle that resolves it, so one side can gate the other. */
+export function createBarrier(): { promise: Promise<void>; release: () => void } {
+  let release = (): void => undefined;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+/** `createBarrier` that also carries a value across — usually a backend PID. */
+export function createValueBarrier<Result>(): { promise: Promise<Result>; release: (result: Result) => void } {
+  let release = (_result: Result): void => undefined;
+  const promise = new Promise<Result>((resolve) => {
+    release = resolve;
+  });
+  return { promise, release };
+}
+
+/**
+ * Attach an inert rejection handler to a promise the caller asserts on later.
+ *
+ * These tests deliberately leave a promise in flight across several `await`s.
+ * If it rejects during one of them, Node reaches its unhandled-rejection
+ * checkpoint before the assertion further down can attach a handler — vitest
+ * counts that under `Errors` and exits 1 with every test still passing
+ * (issue #4488, main run 31880202330).
+ *
+ * The promise itself is untouched: still rejected, still assertable. The
+ * `await expect(...).rejects.toThrow(...)` or bare `await` below still runs,
+ * still sees the same rejection, and still fails on the wrong error — so this
+ * cannot hide a defect. Its contract is pinned in deferred-rejection.test.ts.
+ */
+export function handleLater(promise: Promise<unknown>): void {
+  void promise.catch((): void => undefined);
+}

--- a/packages/mobile/src/hooks/use-offline-mutations.ts
+++ b/packages/mobile/src/hooks/use-offline-mutations.ts
@@ -298,8 +298,8 @@ export function useOfflineFollowUser(db: OfflineDatabase, graphqlFetch: GraphQLF
 
       reportSuppressedEnqueue('user_follows', 'create', enqueueOutcome);
 
-      queryClient.invalidateQueries({ queryKey: ['followers'] });
-      queryClient.invalidateQueries({ queryKey: ['following'] });
+      void queryClient.invalidateQueries({ queryKey: ['followers'] });
+      void queryClient.invalidateQueries({ queryKey: ['following'] });
 
       scheduleDrain(db, queryClient, graphqlFetch);
     },
@@ -329,8 +329,8 @@ export function useOfflineUnfollowUser(db: OfflineDatabase, graphqlFetch: GraphQ
 
       reportSuppressedEnqueue('user_follows', 'delete', enqueueOutcome);
 
-      queryClient.invalidateQueries({ queryKey: ['followers'] });
-      queryClient.invalidateQueries({ queryKey: ['following'] });
+      void queryClient.invalidateQueries({ queryKey: ['followers'] });
+      void queryClient.invalidateQueries({ queryKey: ['following'] });
 
       scheduleDrain(db, queryClient, graphqlFetch);
     },

--- a/packages/web/app/lib/i18n/client.tsx
+++ b/packages/web/app/lib/i18n/client.tsx
@@ -50,7 +50,7 @@ let clientInstance: i18n | undefined;
 
 function createConfiguredInstance(locale: Locale, resources: Record<string, Record<string, unknown>>): i18n {
   const instance = i18next.createInstance();
-  instance
+  void instance
     .use(resourcesToBackend((lng: string, ns: string) => loadCatalog(lng, ns)))
     .use(initReactI18next)
     .init({

--- a/scripts/__tests__/ci-lint-scope.test.ts
+++ b/scripts/__tests__/ci-lint-scope.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const WORKFLOW_PATH = '.github/workflows/ci.yml';
+const VITE_CONFIG_PATH = 'vite.config.ts';
+const OXLINTRC_PATH = '.oxlintrc.json';
+
+const workflowSource = readFileSync(WORKFLOW_PATH, 'utf8');
+
+/**
+ * Return one YAML mapping entry by exact key and indentation. Copied from
+ * ci-location-sync-workflow.test.ts on purpose: the repo declares no YAML
+ * parser, and a CI contract test is not worth the dependency churn.
+ */
+function mappingEntry(source: string, key: string, indentation: number): string {
+  const lines = source.split('\n');
+  const prefix = `${' '.repeat(indentation)}${key}:`;
+  const startIndex = lines.findIndex((line) => line.startsWith(prefix));
+  if (startIndex < 0) {
+    throw new Error(`missing ${key} mapping at indentation ${indentation}`);
+  }
+
+  let endIndex = lines.length;
+  for (let lineIndex = startIndex + 1; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    const lineIndentation = line.length - line.trimStart().length;
+    if (lineIndentation <= indentation) {
+      endIndex = lineIndex;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex, endIndex).join('\n');
+}
+
+/** Strip `#` comment lines so a rule's rationale can never satisfy an assertion. */
+function withoutComments(source: string): string {
+  return source
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('#'))
+    .join('\n');
+}
+
+/** Read a single-level string-array literal out of a TS source by property name. */
+function stringArrayLiteral(source: string, property: string): string[] {
+  const startIndex = source.indexOf(`${property}: [`);
+  if (startIndex < 0) throw new Error(`missing ${property} array`);
+  const openIndex = source.indexOf('[', startIndex);
+  const closeIndex = source.indexOf(']', openIndex);
+  if (closeIndex < 0) throw new Error(`unterminated ${property} array`);
+  return [...source.slice(openIndex + 1, closeIndex).matchAll(/'([^']*)'/g)].map((match) => match[1]);
+}
+
+describe('CI lint scope contract', () => {
+  const lintJob = mappingEntry(workflowSource, 'lint', 2);
+  const lintSteps = withoutComments(lintJob);
+
+  it('lints the whole repo exactly once, with no per-event branch', () => {
+    // The gap this pins shut: the job used to lint only a PR's changed files and
+    // reserve the full-repo pass for push-to-main, so an error in a file no PR
+    // touched could only ever be discovered after it landed. 33 of them did
+    // (issue #4488). PR and main scope must stay identical by construction.
+    expect(lintSteps.match(/vp check/g)).toHaveLength(1);
+    expect(lintSteps).toContain('- name: Lint full repo');
+    expect(lintSteps).not.toContain('Lint changed files');
+  });
+
+  it('runs no step of the lint job conditionally on the event type', () => {
+    expect(lintSteps).not.toContain('github.event_name');
+    expect(lintSteps).not.toContain('github.base_ref');
+  });
+
+  it('derives no file list from a diff', () => {
+    expect(lintSteps).not.toContain('git diff');
+    expect(lintSteps).not.toContain('changed-lintable');
+    expect(lintSteps).not.toContain('--changed');
+  });
+
+  it('keeps the stdout redirect that stops vp panicking on a long warning list', () => {
+    // vp/Vite+ panics with EAGAIN flushing the full-repo warning list to the
+    // runner's non-blocking stdout. Every PR now prints that list, so losing this
+    // redirect would turn a clean lint into a mystery exit code.
+    expect(lintSteps).toContain('vp check > vp-check.log 2>&1 && status=0 || status=$?');
+    expect(lintSteps).toContain('exit $status');
+  });
+
+  it('still runs when only the workflow itself changes', () => {
+    const changesJob = mappingEntry(workflowSource, 'changes', 2);
+    const rootCiFilter = mappingEntry(changesJob, 'rootCi', 12);
+    expect(rootCiFilter).toContain("- '.github/workflows/ci.yml'");
+    expect(lintJob).toContain("needs.changes.outputs.rootCi == 'true'");
+  });
+});
+
+describe('lint ignore scope', () => {
+  it('never ignores a path that .oxlintrc.json lints', () => {
+    // `vp check` reads the `lint` block in vite.config.ts, not .oxlintrc.json
+    // (issue #4548). The two are hand-duplicated, so this pins the direction that
+    // costs coverage: vp must not skip a path oxlint would have flagged.
+    const viteIgnores = stringArrayLiteral(readFileSync(VITE_CONFIG_PATH, 'utf8'), 'ignorePatterns');
+    const oxlintConfig = JSON.parse(readFileSync(OXLINTRC_PATH, 'utf8')) as { ignorePatterns: string[] };
+
+    expect(viteIgnores.length).toBeGreaterThan(0);
+    for (const pattern of viteIgnores) {
+      expect(oxlintConfig.ignorePatterns).toContain(pattern);
+    }
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,16 @@ export default defineConfig({
     ignore: ['design/**', '**/generated/**', '**/board-controller/**', 'CHANGELOG.md'],
   },
   lint: {
-    ignorePatterns: ['**/board-controller/**'],
+    // Keep this list in lock-step with `ignorePatterns` in .oxlintrc.json.
+    // `vp check` — the pre-commit hook and CI's only linter — reads THIS block,
+    // not .oxlintrc.json (see issue #4548), so the two drifted: main's full-repo
+    // pass was type-aware-linting embedded firmware scripts and design/ that
+    // .oxlintrc.json excludes and that no PR ever linted. board-controller is a
+    // vendored minified bundle; embedded/ is ESP firmware helper scripts;
+    // design/, **/generated/** and the drizzle SQL journal are generated or
+    // hand-off artefacts nobody edits to satisfy a linter. Matches the fmt
+    // ignore list above.
+    ignorePatterns: ['**/board-controller/**', 'embedded/**', 'design/**', '**/generated/**', 'packages/db/drizzle/**'],
     options: {
       typeAware: true,
       typeCheck: true,


### PR DESCRIPTION
## Summary

Closes #4488.

**First, the issue's headline is stale.** #4488 says `main` is 0-green in 30 runs from 33 lint errors. Those 33 errors were cleared by #4521 (`1ee16af3`, 2026-08-16). Since then `main` is **11 green of 13 completed `ci.yml` runs (~85%)**, and neither red is lint or the unhandled rejection. The 324 warnings the issue also mentions never failed CI and never could — `vp check` exits 0 on warnings; the exit-1 came only from the errors. This PR is not rescuing a broken `main`.

What is still open is the *reason* those 33 errors could accumulate invisibly, plus the one nondeterministic red that can still fire.

### 1. PR CI now lints the whole repo, same as `main`

**⚠️ @marcodejongh — this changes every contributor's PR experience, so it wants your explicit nod before merge.**

Today the `lint` job runs two different things: `Lint changed files (PR)` on a PR, `Lint full repo (main)` on a push. An error in a file no PR happened to touch therefore could not be caught until it was already on `main`. That is exactly how 33 of them accumulated while every PR that introduced them stayed green.

This deletes the diff-lint step and runs the same full-repo `vp check` on both sides.

- **Measured cost: ~26s per PR.** Step timings for the green `main` lint job 96193441921: `Lint full repo` 19:12:28 → 19:12:54. The whole lint job is 109s, 51s of which is `voidzero-dev/setup-vp`.
- **`main` is green by construction**, so the "an unrelated pre-existing error blocks your PR" risk is largely theoretical — but it is not zero. If someone lands an error on `main` through a path that skips the lint job's `if:` gate, the next PR to touch any JS file eats it and has to rebase.
- **Fallback if you'd rather not:** keep diff-lint on PRs and add a scheduled job that runs the full-repo pass, burns the delta down, and files what it cannot fix. Say the word and I'll swap to that; the rest of this PR is independent.

`scripts/__tests__/ci-lint-scope.test.ts` pins the job to exactly one `vp check` with no event-conditioned step and no diff-derived file list, so the two scopes cannot silently drift apart again. Verified discriminating: run against the pre-change `ci.yml`, all four assertions fail (2 `vp check` invocations, `Lint changed files` present, `github.event_name` present, `git diff` present).

### 2. Lint scope aligned with `.oxlintrc.json`

`vp check` reads the `lint` block in root `vite.config.ts`, **not** `.oxlintrc.json` — that is #4548, and it is a real trap: editing `.oxlintrc.json` to change severities or scope changes nothing in CI. The two had drifted, so `main`'s full-repo pass was type-aware-linting `embedded/` firmware scripts and `design/` that `.oxlintrc.json` excludes and that no PR ever linted — the same asymmetry as above, one level down.

`lint.ignorePatterns` now carries the same list, plus `**/generated/**` and `packages/db/drizzle/**` for lock-step hygiene (those two produce 0 diagnostics either way). A test asserts `vp` never ignores a path oxlint would lint, so the hand-duplication stops being a trust exercise.

### 3. The unhandled rejection

Appeared once, in `main` run 31880202330, `test-backend (2, 2)`: 1712 tests passed, `Errors 1`, exit 1. Not seen in the 13 runs since.

`board-merge-tombstone.test.ts` starts `followPromise` and attaches its first handler three `await`s later. If the follow's rejection (`Board not found`) is delivered in an earlier macrotask than the merge's COMMIT, Node reaches its unhandled-rejection checkpoint with no handler attached, vitest counts it under `Errors`, and the job exits 1 with every test green.

`handleLater()` attaches an inert `.catch()` at creation, at 24 sites across the two concurrency test files.

**Proven:**

- **The mechanism, deterministically, in-suite.** `packages/backend/src/__tests__/deferred-rejection.test.ts` reproduces the leak in the abstracted shape — a promise that rejects while the test is suspended on another — sequenced by macrotask rather than wall clock, so it does not race a timer budget under load. Drop the `handleLater()` call from it and it fails:

  ```
  AssertionError: expected [ 'Board not found' ] to deeply equal []
  ```

  With the call in place the leak list is empty and the rejection is still there to assert on.

- **That the fix cannot hide a defect.** Discriminating mutation probe: with `handleLater(followPromise)` in place, change the expectation at `board-merge-tombstone.test.ts:517` to a message the code never throws, and the test **fails** —

  ```
  AssertionError: expected [Function] to throw error including 'a message it never throws' but got 'Board not found'
  ```

  The inert catch did not consume the rejection. The assertion still receives it and still discriminates. Reverted after the probe.

- **The contract**, pinned in the same file (no DB, no services): the promise stays rejected, a wrong expectation still fails, and a resolved value passes through untouched.

**Inferred, not proven:** that this specific race is what fired in run 31880202330. There is no reproduction. The race needs a 2-core CI Postgres under a 128-file shard; the previous attempt recorded on #4488 established that neither the single file nor the full 256-file `--project backend` run reproduces it locally, with or without the fix. So the mutation probe is what carries the weight here: the change is provably not an inert guard, and it is provably not load-bearing on any assertion. Worst case it is a no-op.

### 4. Production floating promises

The five non-BLE ones now take the `void` operator the rule asks for (`use-offline-mutations.ts` ×4, `i18n/client.tsx` ×1). All were already deliberate fire-and-forget; behaviour is unchanged.

Deliberately **not** in this PR:

- `packages/mobile/src/lib/ble/use-board-scan.ts:48` — BLE, needs a Fable review per CLAUDE.md, and dragging one onto a CI-hygiene PR helps nobody.
- The ~166 test-file occurrences. They are `node:test`'s `test()` return value and vitest `act()` noise, they are warnings, they never failed CI, and a 166-file diff would bury everything above.

### Not in scope — filed separately

The other two `main` reds in the window are different bugs:

- #4614 — `session-persistence.test.ts:679` races a fixed 200ms real-timer sleep waiting on async Postgres I/O.
- #4615 — `test-location-sync-integration` dies in `db:migrate` with `PostgresError: could not open file "base/16384/17249": Interrupted system call`. Three occurrences, identical relfilenode; runner I/O, wants a retry not a code fix.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- **Full-repo `vp check` on this branch**: `Found 0 errors and 254 warnings in 4396 files`, exit 0. Down from `main`'s `0 errors and 324 warnings in 4414 files` — 65 fewer from the `embedded/` + `design/` scope alignment, 5 from the `void` operators. Zero diagnostics remain under `embedded/` or `design/`. This is the local evidence that turning full-repo lint on for PRs passes on this branch.
- `vp test run --project scripts scripts/__tests__/ci-lint-scope.test.ts` — 6 passed. Same assertions against the pre-change `ci.yml`: all four fail.
- `vp test run --project backend packages/backend/src/__tests__/deferred-rejection.test.ts` — 3 passed; the leak test fails when `handleLater()` is removed from it.
- `vp test run --project backend packages/backend/src/__tests__/board-merge-tombstone.test.ts packages/backend/src/__tests__/board-presence.test.ts` — 130 passed, no `Errors` line.
- `vp test run --project backend packages/backend/src/__tests__/board-merge-tombstone.test.ts -t "returns Board not found when the merge commits first"` — passes; fails as quoted above under the mutation probe.
- Backend tests here share fixed ports and worker DBs on `:5433` with ~10 sibling worktrees, so the whole-suite run is CI's to arbitrate.
