### PR TITLE
fix(web): cache the playlists sitemap shard

### DIFF
--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -139,6 +139,79 @@ That lock serialises the _write_. Two instances can still _compute_ concurrently
 `superseded` check means the later finisher writes nothing instead of clobbering a
 newer answer.
 
+## The playlists cache
+
+`playlists` is a fixed shard, so the index asks it for the whole item list — one
+indexed query for every public playlist holding at least one climb. Uncached, that
+ran live on every `force-dynamic` index request. Measured across 12 distinct origin
+computations of the production index on 2026-08-19, `playlists` was named in
+`X-Sitemap-Degraded` in 4 of them, dropping 10,752 locale-expanded URLs each time
+(#4524). The shard route itself measured 1.3–4.3 s per CDN miss.
+
+It gets the boards treatment, not the climbs treatment, and the difference is a size
+question. The rows are the whole answer and they are small: 2,688 rows of
+`{ uuid, updatedAtIso }` is ~200 KB of JSON, ~840 KB at the hard `MAX_ITEMS_PER_SHARD`
+cap, against Vercel's 2 MB Data Cache entry ceiling. The climb item list is >10 MB,
+which is the only reason it needed a Postgres-backed summary store instead. So
+playlists caches the answer, which fixes the index _and_ `/sitemaps/playlists.xml`;
+a summary would have fixed only the index.
+
+Two layers, in `playlist-query.ts`:
+
+- **Next Data Cache** (`unstable_cache`, 1 hour, tag `sitemap-playlists`) — shared
+  across instances, so a cold lambda does not re-run the query.
+- **In-process TTL + single-flight** (1 hour) — `unstable_cache` does not dedupe
+  concurrent misses, and a crawl burst is the index plus the shard route arriving
+  together. Nothing is stored on rejection, so a failure is never memoised.
+
+### Dates do not survive the Data Cache
+
+`unstable_cache` JSON-serialises. A cached `Date` comes back a **string**, and
+`renderLastMod` calls `lastModified.toISOString()` on it — a TypeError that 503s
+`/sitemaps/playlists.xml` and degrades the index harder than no cache at all. So the
+cache stores `updatedAtIso` and the wrapper rehydrates with `new Date(...)`, once per
+TTL. A naive `unstable_cache` wrapper makes this bug worse; do not "simplify" that
+pair away. The climbs summary has the same pattern for the same reason.
+
+The round trip is lossless without a `to_char`: `playlists.updated_at` is a
+`timestamp` holding UTC and comes back through drizzle's timestamp decoder
+(`new Date(value + '+0000')`). `climb-query.ts` needs `to_char` only because its raw
+`sql` fragment bypasses that decoder.
+
+### Why the warm lives in `after()`
+
+`/sitemap.xml` calls `after(warmPlaylistSitemapCache)`. That is not belt-and-braces —
+without it the fix only heals probabilistically.
+
+On a first-population miss, `unstable_cache` registers its cache write in
+`workStore.pendingRevalidates` only **after** the callback resolves, while the route
+module snapshots `Object.values(workStore.pendingRevalidates)` into `pendingWaitUntil`
+at response time. An index that abandoned the query at the 3 s deadline has already
+returned, so its eventual write goes into an array nobody is holding and a freezing
+Vercel instance can drop it — and the next request misses again. Running the same
+fetch inside `after()` puts it under `withExecuteRevalidates`, whose `finally` diffs
+the store and awaits writes that appeared while the callbacks ran. The abandoned
+query is covered too, because the warm shares its in-flight promise.
+
+The warm returns without touching Postgres when the in-process cache is fresh, and a
+persistently failing query is held off by a 60 s per-instance floor rather than
+re-running on every crawl hit.
+
+### The statement timeout
+
+The query runs inside an explicit transaction with `SET LOCAL statement_timeout = '15s'`.
+`withDeadline` stops _waiting_ at 3 s but does not cancel, so before this an abandoned
+query kept a connection out of a pool of ten for as long as it liked.
+
+Fifteen seconds bounds a pathological plan; it is deliberately not tuned to the
+index's deadline, because `/sitemaps/playlists.xml` legitimately takes up to ~4 s and
+a deadline-tight timeout would break a working URL. A 57014 surfaces as a throw, which
+the index already degrades on and the shard route already 503s on.
+
+`SET LOCAL` in a transaction is the only form available: the `DB_STATEMENT_TIMEOUT_MS`
+startup parameter is deliberately off because PgBouncer transaction pooling rejects it
+and fails every connection (`packages/db/src/client/postgres.ts`, `docs/db-connectivity.md`).
+
 ## What is still slow
 
 `/sitemaps/climbs/N.xml` — the shard route, not the index. It still builds the full
@@ -147,8 +220,11 @@ instance takes ~51 s. The store fixes the index only. The fix for the route is a
 `sitemap_climb_urls` table holding the rendered paths, which is additive on the
 scaffolding above.
 
-`playlists` has no cache and no store at all: `fetchPlaylistSitemapRows` hits Postgres
-on every `force-dynamic` index request, and it is the shard degrading most often now.
+Fixed shards have **no byte budget**. `shardRouteHandler` checks `MAX_URLS_PER_SHARD`
+on the fixed path but never `MAX_SHARD_BYTES` — that guard exists only on the paged
+path. `/sitemaps/playlists.xml` already renders 2,326,713 bytes for 2,688 items
+(~866 B/item), so it crosses Vercel's 4.5 MB response ceiling at roughly 5,200 items
+while `MAX_ITEMS_PER_SHARD` lets it reach 11,250. Tracked separately.
 
 ## Operational gotchas
 

--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -98,7 +98,7 @@ path falls back to the live scan it replaced, and the next refresh repopulates i
    Worth being precise about what this buys, because it is easy to over- or
    under-sell. It is not required — the `after()` hook fires on the first
    `/sitemap.xml` request and closes the window for every request after it. What the
-   curl does is close it *now* rather than one crawl later, and it is the only one of
+   curl does is close it _now_ rather than one crawl later, and it is the only one of
    the three that reports back: a 409 tells you the refresh was refused and why,
    where the self-heal only writes that to the log. So: reach for it on a deploy that
    empties the store, and any time you want an answer rather than a hope.

--- a/packages/web/app/lib/seo/sitemap/__tests__/playlist-entries.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/playlist-entries.test.ts
@@ -7,6 +7,9 @@ vi.mock('server-only', () => ({}));
 // A drizzle instance with no client behind it: building and rendering a query
 // never touches the connection, and the test must not need a database.
 vi.mock('@/app/lib/db/db', () => ({ dbzRead: drizzle({} as never) }));
+// Module scope calls `unstable_cache` on import; the caching behaviour itself is
+// playlist-query.test.ts's subject, not this file's.
+vi.mock('next/cache', () => ({ unstable_cache: (fn: unknown) => fn }));
 
 const { buildPlaylistSitemapQuery } = await import('../playlist-query');
 
@@ -31,7 +34,10 @@ describe('the playlists query', () => {
   // Renders the SQL drizzle actually produces rather than grepping the source
   // for the predicate we hope is there: a restated predicate is a tautology, and
   // a substring grep false-reds on a harmless refactor.
-  const { sql, params } = buildPlaylistSitemapQuery().toSQL();
+  // The handle is a parameter now, so the query can run inside the transaction
+  // its `SET LOCAL statement_timeout` needs. Rendering it off a client-less
+  // drizzle instance is unchanged.
+  const { sql, params } = buildPlaylistSitemapQuery(drizzle({} as never)).toSQL();
   const normalised = sql.toLowerCase().replace(/\s+/g, ' ');
 
   it('filters to public playlists', () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/playlist-query.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/playlist-query.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { playlistRowsToItems } from '../playlist-entries';
+import { expandAllLocales, latestLastModified } from '../entries';
+import { MAX_ITEMS_PER_SHARD, renderUrlset } from '../sitemap-xml';
+
+vi.mock('server-only', () => ({}));
+
+/**
+ * Stands in for the whole read path, so every assertion below is about what
+ * reached the pool rather than about what the mock was asked for.
+ */
+const reads = vi.hoisted(() => ({
+  count: 0,
+  inFlight: 0,
+  maxInFlight: 0,
+  /** Statements run before the select, in order — the statement-timeout oracle. */
+  statements: [] as string[],
+  /** Set to a rejected/pending promise to stall or fail the query. */
+  gate: null as null | Promise<void>,
+  rows: [] as { uuid: string; updatedAt: Date }[],
+}));
+
+vi.mock('@/app/lib/db/db', () => {
+  const runSelect = async () => {
+    reads.count += 1;
+    reads.inFlight += 1;
+    reads.maxInFlight = Math.max(reads.maxInFlight, reads.inFlight);
+    try {
+      // A real await point, so concurrent callers would actually overlap here
+      // and show up in maxInFlight.
+      await Promise.resolve();
+      if (reads.gate) await reads.gate;
+      return reads.rows;
+    } finally {
+      reads.inFlight -= 1;
+    }
+  };
+
+  // Only the chain `buildPlaylistSitemapQuery` actually walks. Building the real
+  // SQL is playlist-entries.test.ts's job (it renders `.toSQL()` off a real
+  // drizzle handle); here the query is a stand-in for "one trip to Postgres".
+  const builder: Record<string, unknown> = {};
+  builder.select = () => builder;
+  builder.from = () => builder;
+  builder.where = () => builder;
+  builder.orderBy = () => builder;
+  builder.limit = () => runSelect();
+  builder.execute = async (statement: { queryChunks?: { value?: string[] }[] }) => {
+    reads.statements.push(
+      (statement.queryChunks ?? []).map((chunk) => (chunk.value ?? []).join('')).join(''),
+    );
+  };
+
+  return {
+    dbzRead: {
+      ...builder,
+      transaction: async (callback: (tx: unknown) => Promise<unknown>) => callback(builder),
+    },
+  };
+});
+
+/**
+ * The Data Cache as a JSON ROUND TRIP, deliberately not a pass-through.
+ *
+ * This is the oracle for the rehydration: `unstable_cache` serialises in
+ * production, so a `Date` that goes in comes back a string and `renderLastMod`
+ * TypeErrors on it. Delete the ISO/`new Date` pair in playlist-query.ts and the
+ * first two tests below go red — a pass-through mock would let that ship.
+ */
+vi.mock('next/cache', () => ({
+  unstable_cache:
+    (fn: () => Promise<unknown>) =>
+    async (): Promise<unknown> =>
+      JSON.parse(JSON.stringify(await fn())),
+}));
+
+const { fetchPlaylistSitemapRows, resetPlaylistSitemapCacheForTests, warmPlaylistSitemapCache } =
+  await import('../playlist-query');
+
+const SOURCE_ROWS = [
+  { uuid: 'abc-123', updatedAt: new Date('2026-04-30T10:00:00.123Z') },
+  { uuid: 'def-456', updatedAt: new Date('2026-01-02T00:00:00.000Z') },
+];
+
+afterEach(() => {
+  resetPlaylistSitemapCacheForTests();
+  reads.count = 0;
+  reads.inFlight = 0;
+  reads.maxInFlight = 0;
+  reads.statements = [];
+  reads.gate = null;
+  reads.rows = [];
+  vi.restoreAllMocks();
+});
+
+describe('fetchPlaylistSitemapRows', () => {
+  it('hands back real Date instances through the Data Cache round trip', async () => {
+    reads.rows = SOURCE_ROWS;
+
+    const rows = await fetchPlaylistSitemapRows();
+
+    expect(rows[0].updatedAt).toBeInstanceOf(Date);
+    // To the millisecond: the ISO round trip must not shift a timezone or round.
+    expect(rows[0].updatedAt.getTime()).toBe(SOURCE_ROWS[0].updatedAt.getTime());
+    expect(rows[1].updatedAt.toISOString()).toBe('2026-01-02T00:00:00.000Z');
+  });
+
+  it('renders through the real urlset without throwing', async () => {
+    // The end-to-end proof, and the reason a cache here is not a one-liner:
+    // `renderLastMod` calls `lastModified.toISOString()`, so a string timestamp
+    // 503s /sitemaps/playlists.xml instead of merely serving a stale answer.
+    reads.rows = SOURCE_ROWS;
+
+    const items = playlistRowsToItems(await fetchPlaylistSitemapRows());
+    const xml = renderUrlset(expandAllLocales(items));
+
+    expect(xml).toContain('<loc>https://www.boardsesh.com/playlists/abc-123</loc>');
+    expect(xml).toContain('<lastmod>2026-04-30T10:00:00.123Z</lastmod>');
+    expect(latestLastModified(items)?.toISOString()).toBe('2026-04-30T10:00:00.123Z');
+  });
+
+  it('queries once and serves the second caller from the TTL cache', async () => {
+    reads.rows = SOURCE_ROWS;
+
+    const first = await fetchPlaylistSitemapRows();
+    const second = await fetchPlaylistSitemapRows();
+
+    expect(reads.count).toBe(1);
+    // Same array identity: rehydration happens once per TTL, not per request.
+    expect(second).toBe(first);
+  });
+
+  it('collapses concurrent cold callers into one query', async () => {
+    // A crawl burst is /sitemap.xml and /sitemaps/playlists.xml arriving
+    // together; `unstable_cache` does not deduplicate concurrent misses.
+    reads.rows = SOURCE_ROWS;
+    let release = () => {};
+    reads.gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const inFlight = Promise.all([
+      fetchPlaylistSitemapRows(),
+      fetchPlaylistSitemapRows(),
+      fetchPlaylistSitemapRows(),
+    ]);
+    release();
+    const [first, second, third] = await inFlight;
+
+    expect(reads.count).toBe(1);
+    expect(reads.maxInFlight).toBe(1);
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+  });
+
+  it('does not memoise a failed query', async () => {
+    reads.rows = SOURCE_ROWS;
+    reads.gate = Promise.reject(new Error('pool exhausted'));
+
+    await expect(fetchPlaylistSitemapRows()).rejects.toThrow('pool exhausted');
+
+    reads.gate = null;
+    await expect(fetchPlaylistSitemapRows()).resolves.toHaveLength(2);
+    expect(reads.count).toBe(2);
+  });
+
+  it('warns rather than truncating silently when the shard fills its item budget', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    reads.rows = Array.from({ length: MAX_ITEMS_PER_SHARD }, (_row, index) => ({
+      uuid: `playlist-${index}`,
+      updatedAt: new Date('2026-04-30T10:00:00.000Z'),
+    }));
+
+    await fetchPlaylistSitemapRows();
+
+    expect(warn.mock.calls.some(([message]) => String(message).includes('item budget'))).toBe(true);
+  });
+
+  it('bounds the query with a statement timeout before it selects anything', async () => {
+    // `withDeadline` stops waiting at 3 s but does not cancel, so an abandoned
+    // query would otherwise hold a connection out of a pool of ten indefinitely.
+    reads.rows = SOURCE_ROWS;
+
+    await fetchPlaylistSitemapRows();
+
+    expect(reads.statements).toEqual(["SET LOCAL statement_timeout = '15s'"]);
+    expect(reads.count).toBe(1);
+  });
+});
+
+describe('warmPlaylistSitemapCache', () => {
+  it('populates the cache so the next request costs nothing', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    reads.rows = SOURCE_ROWS;
+
+    await warmPlaylistSitemapCache();
+    await fetchPlaylistSitemapRows();
+
+    expect(reads.count).toBe(1);
+  });
+
+  it('no-ops on a fresh cache', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    reads.rows = SOURCE_ROWS;
+    await fetchPlaylistSitemapRows();
+
+    await warmPlaylistSitemapCache();
+
+    expect(reads.count).toBe(1);
+  });
+
+  it('resolves rather than throwing when the query fails', async () => {
+    // It runs inside `after()`; a rejection there is a logged task error on a
+    // response that has already flushed.
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    reads.gate = Promise.reject(new Error('pool exhausted'));
+
+    await expect(warmPlaylistSitemapCache()).resolves.toBeUndefined();
+    expect(error.mock.calls.some(([message]) => String(message).includes('warming the playlists'))).toBe(true);
+  });
+
+  it('holds a failing query off behind the retry floor instead of re-running per crawl hit', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    reads.gate = Promise.reject(new Error('pool exhausted'));
+
+    await warmPlaylistSitemapCache();
+    await warmPlaylistSitemapCache();
+    await warmPlaylistSitemapCache();
+
+    expect(reads.count).toBe(1);
+  });
+});

--- a/packages/web/app/lib/seo/sitemap/__tests__/playlist-query.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/playlist-query.test.ts
@@ -46,9 +46,7 @@ vi.mock('@/app/lib/db/db', () => {
   builder.orderBy = () => builder;
   builder.limit = () => runSelect();
   builder.execute = async (statement: { queryChunks?: { value?: string[] }[] }) => {
-    reads.statements.push(
-      (statement.queryChunks ?? []).map((chunk) => (chunk.value ?? []).join('')).join(''),
-    );
+    reads.statements.push((statement.queryChunks ?? []).map((chunk) => (chunk.value ?? []).join('')).join(''));
   };
 
   return {
@@ -68,10 +66,7 @@ vi.mock('@/app/lib/db/db', () => {
  * first two tests below go red — a pass-through mock would let that ship.
  */
 vi.mock('next/cache', () => ({
-  unstable_cache:
-    (fn: () => Promise<unknown>) =>
-    async (): Promise<unknown> =>
-      JSON.parse(JSON.stringify(await fn())),
+  unstable_cache: (fn: () => Promise<unknown>) => async (): Promise<unknown> => JSON.parse(JSON.stringify(await fn())),
 }));
 
 const { fetchPlaylistSitemapRows, resetPlaylistSitemapCacheForTests, warmPlaylistSitemapCache } =
@@ -139,11 +134,7 @@ describe('fetchPlaylistSitemapRows', () => {
       release = resolve;
     });
 
-    const inFlight = Promise.all([
-      fetchPlaylistSitemapRows(),
-      fetchPlaylistSitemapRows(),
-      fetchPlaylistSitemapRows(),
-    ]);
+    const inFlight = Promise.all([fetchPlaylistSitemapRows(), fetchPlaylistSitemapRows(), fetchPlaylistSitemapRows()]);
     release();
     const [first, second, third] = await inFlight;
 

--- a/packages/web/app/lib/seo/sitemap/__tests__/playlist-query.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/playlist-query.test.ts
@@ -181,7 +181,7 @@ describe('fetchPlaylistSitemapRows', () => {
 
 describe('warmPlaylistSitemapCache', () => {
   it('populates the cache so the next request costs nothing', async () => {
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
     reads.rows = SOURCE_ROWS;
 
     await warmPlaylistSitemapCache();
@@ -191,7 +191,7 @@ describe('warmPlaylistSitemapCache', () => {
   });
 
   it('no-ops on a fresh cache', async () => {
-    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
     reads.rows = SOURCE_ROWS;
     await fetchPlaylistSitemapRows();
 

--- a/packages/web/app/lib/seo/sitemap/playlist-query.ts
+++ b/packages/web/app/lib/seo/sitemap/playlist-query.ts
@@ -202,7 +202,9 @@ export async function warmPlaylistSitemapCache(): Promise<void> {
 
   try {
     const rows = await fetchPlaylistSitemapRows();
-    console.warn(`[sitemap] warmed the playlists rows cache: ${rows.length} playlists.`);
+    // `info`, not `warn`: this fires only on a cold cache past the floor, and a
+    // successful warm is the expected outcome rather than something to action.
+    console.info(`[sitemap] warmed the playlists rows cache: ${rows.length} playlists.`);
   } catch (err) {
     // Swallowed on purpose: this runs in `after()`, where a rejection is only a
     // logged task error, and the next crawl past the floor above retries it.

--- a/packages/web/app/lib/seo/sitemap/playlist-query.ts
+++ b/packages/web/app/lib/seo/sitemap/playlist-query.ts
@@ -1,23 +1,39 @@
 import 'server-only';
-import { and, desc, eq, exists } from 'drizzle-orm';
+import { unstable_cache } from 'next/cache';
+import { and, desc, eq, exists, sql } from 'drizzle-orm';
+import type { SerialPlanDb } from '@boardsesh/db/queries';
 import { dbzRead } from '@/app/lib/db/db';
 import { playlistClimbs, playlists } from '@/app/lib/db/schema';
 import type { PlaylistSitemapRow } from './playlist-entries';
 import { MAX_ITEMS_PER_SHARD } from './sitemap-xml';
 
+/** Next Data Cache window; matches the shard route's own `s-maxage=3600`. */
+const PLAYLIST_REVALIDATE_SECONDS = 3_600;
+/** In-process window, in front of the Data Cache (which does not dedupe misses). */
+const PLAYLIST_TTL_MS = 3_600_000;
+/** Per-instance floor between `after()` warm attempts, so a failing query cannot re-run on every crawl hit. */
+const WARM_RETRY_MS = 60_000;
+const PLAYLIST_CACHE_TAG = 'sitemap-playlists';
+
 /**
  * Split out from the fetch so a test can render this query's real SQL with
  * `.toSQL()` instead of grepping the source for the predicate it hopes is there.
+ *
+ * Takes the handle rather than closing over `dbzRead` — the shape
+ * `buildTier2ClimbQuery` already uses — so the caller can run it inside the
+ * transaction the statement timeout needs. Both the outer select and the
+ * correlated `exists(...)` use the same handle, so the subquery runs inside that
+ * transaction too rather than on a second pooled connection with no timeout.
  */
-export function buildPlaylistSitemapQuery() {
-  return dbzRead
+export function buildPlaylistSitemapQuery(db: SerialPlanDb) {
+  return db
     .select({ uuid: playlists.uuid, updatedAt: playlists.updatedAt })
     .from(playlists)
     .where(
       and(
         eq(playlists.isPublic, true),
         exists(
-          dbzRead
+          db
             .select({ playlistId: playlistClimbs.playlistId })
             .from(playlistClimbs)
             .where(eq(playlistClimbs.playlistId, playlists.id)),
@@ -29,19 +45,174 @@ export function buildPlaylistSitemapQuery() {
 }
 
 /**
+ * The query, bounded so an abandoned one cannot pin a pooled connection.
+ *
+ * `withDeadline` in the index stops WAITING at `SHARD_DEADLINE_MS`, but it does
+ * not cancel: the query keeps running against a pool of ten. Fifteen seconds is a
+ * pathological-plan bound, NOT an attempt to meet the 3 s deadline — the shard
+ * route `/sitemaps/playlists.xml` legitimately takes up to ~4 s in production, so
+ * a 3 s statement timeout would break a working URL. A 57014 surfaces as a throw,
+ * which the index already degrades on and the shard route already 503s on.
+ *
+ * `SET LOCAL` inside an explicit transaction is the only form available here.
+ * `DB_STATEMENT_TIMEOUT_MS` emits a `statement_timeout` STARTUP parameter, which
+ * PgBouncer transaction pooling rejects outright — packages/db/src/client/postgres.ts
+ * documents why it stays off. Same shape as
+ * `packages/db/scripts/repair-moonboard-8c-grades.ts`.
+ */
+async function fetchPlaylistRowsFromDb(): Promise<PlaylistSitemapRow[]> {
+  return dbzRead.transaction(async (transactionDb) => {
+    await transactionDb.execute(sql`SET LOCAL statement_timeout = '15s'`);
+    return buildPlaylistSitemapQuery(transactionDb);
+  });
+}
+
+/**
+ * What actually goes into the Data Cache: ISO strings, never `Date`s.
+ *
+ * Load-bearing, not stylistic. `unstable_cache` JSON-serialises, so a cached
+ * `Date` comes back a string, and `renderLastMod` (sitemap-xml.ts) calls
+ * `lastModified.toISOString()` on it — a TypeError that 503s
+ * `/sitemaps/playlists.xml` and degrades the index HARDER than the uncached
+ * version this replaces. A naive `unstable_cache` wrapper makes #4524 worse; this
+ * pair is what stops it. Same reasoning and same shape as `cachedTier2Summary` in
+ * climb-query.ts.
+ */
+type CachedPlaylistRow = { uuid: string; updatedAtIso: string };
+
+/**
+ * The rows behind the Next Data Cache.
+ *
+ * Caching the ROWS rather than a summary is what makes this different from the
+ * climbs shard, and it is a size question: 2,688 production rows of
+ * `{ uuid, updatedAtIso }` is ~200 KB of JSON, and even at the hard
+ * `MAX_ITEMS_PER_SHARD` cap it is ~840 KB — comfortably inside Vercel's 2 MB
+ * entry ceiling. The climb item list is >10 MB, which is the only reason #4523
+ * had to materialise a summary into Postgres instead. Caching the rows fixes both
+ * the index AND `/sitemaps/playlists.xml`, measured at 1.3–4.3 s per CDN miss.
+ *
+ * `row.updatedAt.toISOString()` round-trips exactly: `playlists.updated_at` is a
+ * `timestamp` holding UTC and comes back through drizzle's timestamp decoder
+ * (`new Date(value + '+0000')`), so no `to_char` is needed here — climb-query.ts
+ * only needs one because its raw `sql` fragment bypasses that decoder.
+ */
+const cachedPlaylistSitemapRows = unstable_cache(
+  async (): Promise<CachedPlaylistRow[]> => {
+    const rows = await fetchPlaylistRowsFromDb();
+
+    // When the result length equals the budget the shard is full and needs
+    // splitting into paged shards — we log rather than silently truncate the tail.
+    if (rows.length === MAX_ITEMS_PER_SHARD) {
+      console.warn(
+        `[sitemap] playlists shard hit its ${MAX_ITEMS_PER_SHARD}-item budget — split it into paged shards before the tail goes missing.`,
+      );
+    }
+
+    return rows.map((row) => ({ uuid: row.uuid, updatedAtIso: row.updatedAt.toISOString() }));
+  },
+  ['sitemap-playlist-rows'],
+  { revalidate: PLAYLIST_REVALIDATE_SECONDS, tags: [PLAYLIST_CACHE_TAG] },
+);
+
+let cachedRows: { builtAt: number; rows: PlaylistSitemapRow[] } | null = null;
+let rowsInFlight: Promise<PlaylistSitemapRow[]> | null = null;
+let lastWarmAt = 0;
+
+/**
  * Public playlists with at least one climb, newest first, hard-capped at the
- * per-shard item budget. When the result length equals the budget the shard is
- * full and needs splitting into `playlists-1.xml` / `playlists-2.xml` — we log
- * rather than silently truncate the tail.
+ * per-shard item budget — behind the Next Data Cache plus an in-process TTL and
+ * single-flight, the same two-layer shape `getAllBoardConfigsOrThrow` uses.
+ *
+ * Uncached, this ran live on every `force-dynamic` `/sitemap.xml` hit, racing the
+ * index's 3 s `SHARD_DEADLINE_MS` against a ten-connection pool it shares with
+ * the climbs builder. Re-measured on 2026-08-19 across 12 distinct origin
+ * computations of the production index: `playlists` was named in
+ * `x-sitemap-degraded` in 4 of them, dropping 10,752 locale-expanded URLs each
+ * time (#4524).
+ *
+ * The in-process layer is not redundant with the Data Cache. `unstable_cache`
+ * does not deduplicate concurrent misses, and a crawl burst is `/sitemap.xml`
+ * plus `/sitemaps/playlists.xml` arriving together. Sharing one in-flight promise
+ * turns that into one query. Nothing is stored on rejection, so a failure is
+ * never memoised.
+ *
+ * Rehydration happens once per TTL, inside the build, so the per-request path
+ * reuses the same `Date` objects instead of allocating 2,688 of them per hit.
+ *
+ * The name and signature are load-bearing: `shard-registry.ts` calls this, and
+ * three test files mock this exact symbol.
  */
 export async function fetchPlaylistSitemapRows(): Promise<PlaylistSitemapRow[]> {
-  const rows = await buildPlaylistSitemapQuery();
-
-  if (rows.length === MAX_ITEMS_PER_SHARD) {
-    console.warn(
-      `[sitemap] playlists shard hit its ${MAX_ITEMS_PER_SHARD}-item budget — split it into paged shards before the tail goes missing.`,
-    );
+  if (cachedRows && Date.now() - cachedRows.builtAt < PLAYLIST_TTL_MS) {
+    return cachedRows.rows;
+  }
+  if (rowsInFlight) {
+    return rowsInFlight;
   }
 
-  return rows;
+  const build = (async () => {
+    const rows = (await cachedPlaylistSitemapRows()).map(({ uuid, updatedAtIso }) => ({
+      uuid,
+      updatedAt: new Date(updatedAtIso),
+    }));
+    cachedRows = { builtAt: Date.now(), rows };
+    return rows;
+  })();
+  rowsInFlight = build;
+
+  try {
+    return await build;
+  } finally {
+    rowsInFlight = null;
+  }
+}
+
+/**
+ * Populate both cache layers after the response has flushed. Call it from
+ * `after()`; never await it in a handler.
+ *
+ * This is the half of the fix that makes degradation self-healing rather than
+ * probabilistic, and the mechanism is not obvious. On a first-population MISS,
+ * `unstable_cache` registers its write in `workStore.pendingRevalidates` only
+ * AFTER the callback resolves (next/dist/server/web/spec-extension/unstable-cache.js),
+ * while the route module snapshots `Object.values(workStore.pendingRevalidates)`
+ * into `pendingWaitUntil` at response time (route-modules/app-route/module.js). So
+ * an index that abandoned this query at 3 s has already returned, its eventual
+ * write is registered into an array nobody is holding, and a freezing Vercel
+ * instance can drop it — leaving the next request to miss again. Running the same
+ * fetch inside `after()` puts it under `withExecuteRevalidates`
+ * (server/after/after-context.js), whose `finally` diffs the store and awaits the
+ * writes that appeared while the callbacks ran. That covers the abandoned query
+ * too: this call shares its in-flight promise, so the write is registered before
+ * the diff.
+ *
+ * Cheap on the normal path — it returns without touching Postgres when the
+ * in-process cache is fresh, and a persistently failing query is held off by a
+ * per-instance retry floor instead of re-running on every crawl hit.
+ */
+export async function warmPlaylistSitemapCache(): Promise<void> {
+  const now = Date.now();
+  if (cachedRows && now - cachedRows.builtAt < PLAYLIST_TTL_MS) {
+    return;
+  }
+  if (now - lastWarmAt < WARM_RETRY_MS) {
+    return;
+  }
+  lastWarmAt = now;
+
+  try {
+    const rows = await fetchPlaylistSitemapRows();
+    console.warn(`[sitemap] warmed the playlists rows cache: ${rows.length} playlists.`);
+  } catch (err) {
+    // Swallowed on purpose: this runs in `after()`, where a rejection is only a
+    // logged task error, and the next crawl past the floor above retries it.
+    console.error('[sitemap] warming the playlists rows cache failed:', err instanceof Error ? err.message : err);
+  }
+}
+
+/** Test seam: drops the in-process TTL cache, any in-flight query, and the warm floor. */
+export function resetPlaylistSitemapCacheForTests(): void {
+  cachedRows = null;
+  rowsInFlight = null;
+  lastWarmAt = 0;
 }

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -407,12 +407,15 @@ export async function pagedShardRouteHandler(id: PagedShardId, rawPage: string):
  * PRECOMPUTED: one row of `sitemap_shard_refreshes`, written by a cron and an
  * `after()` self-heal, because caching an expensive question only moves when you
  * pay for it — a cold miss on sixteen sequential `DISTINCT ON` scans could never
- * meet 3 s at any cache temperature (#4523). `fetchPlaylistSitemapRows` remains
- * uncached and unprecomputed, and is the shard still degrading most often.
+ * meet 3 s at any cache temperature (#4523). `fetchPlaylistSitemapRows` is cached
+ * like boards rather than precomputed like climbs, because its answer is small
+ * enough to hold — ~200 KB of rows today, ~840 KB at the item cap, against
+ * Vercel's 2 MB Data Cache entry ceiling (#4524). All three data-backed builders
+ * are covered now; none of them is covered on a genuinely cold entry.
  *
  * None of that makes the deadline redundant. It makes it *reachable*: the first
- * boards miss after a cold start still pays full price, and an empty climbs store
- * falls back to the same scan that used to blow the budget.
+ * boards or playlists miss after a cold start still pays full price, and an empty
+ * climbs store falls back to the same scan that used to blow the budget.
  */
 export const SHARD_DEADLINE_MS = 3_000;
 
@@ -420,9 +423,14 @@ export const SHARD_DEADLINE_MS = 3_000;
  * Bounds `work` without cancelling it — a builder that ignores the deadline keeps
  * running (and, for boards, still hits its own `AbortController`); we simply stop
  * waiting. So this bounds *this request's* latency, not the load the abandoned
- * query keeps putting on the pool. Real cancellation needs an `AbortSignal`
- * threaded into `fetchPlaylistSitemapRows` (or a statement timeout on its query),
- * which is a follow-up, not something to claim here.
+ * query keeps putting on the pool.
+ *
+ * Still not cancellation, and the wording matters. The playlists query now runs
+ * under `SET LOCAL statement_timeout = '15s'` (#4524), which bounds a pathological
+ * plan rather than releasing the connection at 3 s — deliberately, since the
+ * `/sitemaps/playlists.xml` route legitimately takes up to ~4 s and a deadline-tight
+ * timeout would break a working URL. Real cancellation still needs an `AbortSignal`
+ * threaded through, which is a follow-up, not something to claim here.
  */
 async function withDeadline<T>(work: Promise<T>, ms: number, label: string): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;

--- a/packages/web/app/sitemap.xml/route.ts
+++ b/packages/web/app/sitemap.xml/route.ts
@@ -1,5 +1,6 @@
 import { after } from 'next/server';
 import { refreshClimbSummaryIfStale } from '@/app/lib/seo/sitemap/climb-store';
+import { warmPlaylistSitemapCache } from '@/app/lib/seo/sitemap/playlist-query';
 import { sitemapIndexRouteHandler } from '@/app/lib/seo/sitemap/shard-registry';
 
 /**
@@ -42,6 +43,15 @@ export async function GET(): Promise<Response> {
   // 16.2 supplies a real awaiter on self-hosted Node too, and the Vercel-only
   // import would not survive the move off Vercel.
   after(refreshClimbSummaryIfStale);
+
+  // Same slot, same reason, different shard. The playlists rows are cached rather
+  // than stored (#4524), and a first-population `unstable_cache` miss registers
+  // its write only after the callback resolves — so an index that abandoned the
+  // query at the 3 s deadline has already returned and the write is not covered
+  // by `pendingWaitUntil`. Re-running it here puts it under the after-context's
+  // `withExecuteRevalidates`, where the write is actually executed, which is what
+  // turns "heals on some later request" into "heals on this one".
+  after(warmPlaylistSitemapCache);
 
   return response;
 }

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -89,8 +89,20 @@ describe('www production smoke checks', () => {
       '<sitemapindex>' +
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
       '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
+      '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
       '</sitemapindex>';
     expect(check.assert(response({ contentType: 'application/xml', body: healthyIndex }))).toBeNull();
+
+    // #4524: `playlists` was excluded from the required list as "legitimately
+    // empty". It is not — production serves 2,688 public playlists holding a
+    // climb — so an index that quietly drops it is 10,752 URLs gone and now goes
+    // red exactly like boards does.
+    const withoutPlaylists =
+      '<sitemapindex>' +
+      '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
+      '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
+      '</sitemapindex>';
+    expect(check.assert(response({ contentType: 'application/xml', body: withoutPlaylists }))).toMatch(/playlists/);
 
     // The regression this check has to keep catching after #4476. The index now
     // degrades rather than 503ing, so a cold-start failure of the boards builder
@@ -145,8 +157,11 @@ describe('www production smoke checks', () => {
     });
     expect(check.assert(wrongShardDeclared)).toMatch(/boards/);
 
-    // Optional shards degrading is worth a warning but is not a missing mandatory.
-    const optionalOnly = response({
+    // A required-but-degradable shard the header names is a warning, and the
+    // annotation says which of the dropped shards was a required one — that is
+    // what separates "playlists missed the deadline again" from "climbs is
+    // deliberately not asserted here".
+    const declaredDegradable = response({
       contentType: 'application/xml',
       body:
         '<sitemapindex>' +
@@ -155,8 +170,24 @@ describe('www production smoke checks', () => {
         '</sitemapindex>',
       headers: { 'x-sitemap-degraded': 'playlists,climbs' },
     });
+    expect(check.assert(declaredDegradable)).toBeNull();
+    expect(check.degradation?.(declaredDegradable)).toMatch(/playlists, climbs/);
+    expect(check.degradation?.(declaredDegradable)).toMatch(/required playlists/);
+
+    // A shard this list does not require at all is worth a warning but is not a
+    // missing mandatory, so nothing is flagged as required.
+    const optionalOnly = response({
+      contentType: 'application/xml',
+      body:
+        '<sitemapindex>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
+        '</sitemapindex>',
+      headers: { 'x-sitemap-degraded': 'climbs' },
+    });
     expect(check.assert(optionalOnly)).toBeNull();
-    expect(check.degradation?.(optionalOnly)).toMatch(/playlists, climbs/);
+    expect(check.degradation?.(optionalOnly)).toMatch(/climbs/);
     expect(check.degradation?.(optionalOnly)).not.toMatch(/required/);
 
     // The header can never rescue a genuinely broken index: a non-200, a body
@@ -192,6 +223,7 @@ describe('www production smoke checks', () => {
         '<sitemapindex>' +
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
         '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
         '</sitemapindex>',
     });
     expect(check.degradation?.(healthy) ?? null).toBeNull();

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -152,8 +152,16 @@ const SITEMAP_DEGRADED_HEADER = 'x-sitemap-degraded';
 /**
  * Shards the index must always list.
  *
- * `gyms`, `setters` and `playlists` are legitimately empty, so a missing entry
- * there proves nothing.
+ * `gyms` and `setters` are legitimately empty, so a missing entry there proves
+ * nothing.
+ *
+ * `playlists` used to sit in that sentence too, and the justification was stale:
+ * production serves 2,688 public playlists holding at least one climb, so a
+ * missing entry there is 10,752 locale-expanded URLs gone, not an empty surface.
+ * That is exactly why this check never caught #4524. It is `degradable: true`
+ * because the shard's rows are cached rather than stored, so a cold Data Cache
+ * entry can still lose the 3 s deadline once and self-heal on the `after()` warm —
+ * a WARN. The shard vanishing without the header saying so is still a FAIL.
  *
  * `climbs` is excluded for a different reason, and the reason is now weaker than
  * it was. Its summary could not meet `SHARD_DEADLINE_MS` at any cache temperature,
@@ -181,6 +189,7 @@ const SITEMAP_DEGRADED_HEADER = 'x-sitemap-degraded';
 const REQUIRED_SITEMAP_SHARDS = [
   { id: 'static', loc: 'https://www.boardsesh.com/sitemaps/static.xml', degradable: false },
   { id: 'boards', loc: 'https://www.boardsesh.com/sitemaps/boards.xml', degradable: true },
+  { id: 'playlists', loc: 'https://www.boardsesh.com/sitemaps/playlists.xml', degradable: true },
 ] as const;
 
 type RequiredSitemapShard = (typeof REQUIRED_SITEMAP_SHARDS)[number];


### PR DESCRIPTION
## Summary

`fetchPlaylistSitemapRows` had no cache of any kind. `/sitemap.xml` is `force-dynamic`, so every CDN miss ran the live query — `SELECT uuid, updated_at FROM playlists WHERE is_public AND EXISTS(playlist_climbs …)` — inside the index's 3 s `SHARD_DEADLINE_MS`, against the same ten-connection pool the climbs builder is using on the same request. When it loses that race the index publishes without the `playlists` entry for 60 s, and 10,752 locale-expanded URLs vanish from the sitemap.

**The issue's headline is overstated and this PR corrects it.** #4524 says `playlists` was degraded in 100% of samples. Re-measured on 2026-08-19 across 12 distinct origin computations of `https://www.boardsesh.com/sitemap.xml` (cache-busted per request — the Data Cache key does not include the URL, so busting the CDN alone would not have re-run anything): `x-sitemap-degraded` named `playlists` in **4 of 12**, about a third, not all of them. Index responses sat at 3.05–5.37 s, pinned at the deadline by climbs. The bug is real — a third of origin computations dropping the whole playlists surface is worth fixing — but the issue's sample was thin and it says so itself.

Supporting cost measurement: `GET /sitemaps/playlists.xml`, cache-busted ×5, took 4.25 / 1.37 / 2.29 / 1.33 / 1.51 s and returns 2,326,713 bytes containing 2,688 `<url>` entries × 4 locales. Net of render and transfer the query alone is ~0.8–1 s warm and up to ~3.7 s cold — i.e. it straddles the 3 s deadline, which is exactly the intermittency above.

### The fix

Two cache layers in `playlist-query.ts`, the same shape `getAllBoardConfigsOrThrow` got for boards in #4522:

- **Next Data Cache** (`unstable_cache`, 1 hour, tag `sitemap-playlists`) — cross-instance, so a cold lambda does not re-run the query.
- **In-process TTL + single-flight** (1 hour) — `unstable_cache` does not deduplicate concurrent misses, and a crawl burst is the index plus `/sitemaps/playlists.xml` arriving together. Nothing is stored on rejection, so a failure is never memoised.

Caching the **rows** rather than a summary is what makes this different from #4523's climbs store, and it is a size question. The rows are the whole answer and they fit: ~200 KB of JSON today, ~840 KB at the hard `MAX_ITEMS_PER_SHARD` cap, against Vercel's 2 MB Data Cache entry ceiling. The climb item list is >10 MB, which is the only reason it needed a Postgres-backed summary instead. So this fixes the index **and** the shard route; a summary would have fixed only the index. No new table, no cron, no advisory lock.

### Two details that are load-bearing — please don't let review simplify them away

**1. The ISO rehydration.** A naive `unstable_cache` wrapper makes this bug *worse*, not better. The Data Cache JSON-serialises, so a cached `Date` comes back a **string**, and `renderLastMod` (`sitemap-xml.ts:69`) calls `lastModified.toISOString()` on it — a TypeError that 503s `/sitemaps/playlists.xml` and makes `buildIndexEntry` throw. So the cache stores `updatedAtIso` and the public wrapper rehydrates with `new Date(...)`, once per TTL. Exact prior art in the same directory: `cachedTier2Summary` in `climb-query.ts`. The reasoning is in a comment so nobody removes the pair later.

No `to_char` is needed: `playlists.updated_at` is a `timestamp` holding UTC and comes back through drizzle's timestamp decoder (`new Date(value + '+0000')`), so the `.toISOString()` round trip is exact to the millisecond. `climb-query.ts` needs `to_char` only because its raw `sql` fragment bypasses that decoder.

The test mocks the Data Cache as a **JSON round trip**, not a pass-through, so this stays honest — delete the ISO/`new Date` pair and two tests go red immediately.

**2. The `after()` warm is required, not belt-and-braces.** On a first-population MISS, `unstable_cache` registers its cache write in `workStore.pendingRevalidates` only *after* the callback resolves (`next/dist/server/web/spec-extension/unstable-cache.js`), while the route module snapshots `Object.values(workStore.pendingRevalidates)` into `pendingWaitUntil` at response time (`route-modules/app-route/module.js:224`). An index that abandoned the query at 3 s has already returned, so its eventual write lands in an array nobody is holding and a freezing Vercel instance can drop it — and the next request misses again. Running the same fetch inside `after()` puts it under `withExecuteRevalidates` (`server/after/after-context.js:107`), whose `finally` diffs the store and awaits writes that appeared while the callbacks ran; the abandoned query is covered too, because the warm shares its in-flight promise. This is the structural note #4522 raised, made concrete. Without it, the fix heals only probabilistically.

The warm returns without touching Postgres when the in-process cache is fresh, and a persistently failing query is held off by a 60 s per-instance floor rather than re-running on every crawl hit.

### Also here

- **`SET LOCAL statement_timeout = '15s'`** in an explicit transaction. `withDeadline` stops *waiting* at 3 s but does not cancel, so an abandoned query previously kept a connection out of a pool of ten for as long as it liked. Fifteen seconds bounds a pathological plan; it is deliberately not tuned to the deadline, because `/sitemaps/playlists.xml` legitimately takes ~4 s and a deadline-tight timeout would break a working URL. `SET LOCAL` in a transaction is the only form available — the `DB_STATEMENT_TIMEOUT_MS` startup parameter stays off because PgBouncer transaction pooling rejects it (`packages/db/src/client/postgres.ts`). **This step is cleanly separable**: it is confined to `fetchPlaylistRowsFromDb`, and a reviewer who wants the caching change isolated can ask for it to be dropped without touching anything else.
- **`scripts/production-smoke.ts`**: `playlists` is now in `REQUIRED_SITEMAP_SHARDS` as `degradable: true`. The old comment excluded it as "legitimately empty" — production serves 2,688 public playlists holding a climb, so that justification was stale, and it is why the post-deploy smoke never caught this.
- **Two stale comments in `shard-registry.ts`**: "`fetchPlaylistSitemapRows` remains uncached", and the `withDeadline` note that a statement timeout is a follow-up. Comment blocks only — no structural edits, to stay out of #4579's way.
- **`docs/sitemap.md`**: a playlists section covering both layers, the rehydration rule and the 503 it prevents, why the warm lives in `after()`, and the statement-timeout bound.

### Honest caveats

- **#4555 removes the sixteen climb scans from the index request path**, so some of the remaining playlists degradation will disappear on its own. This PR's own contribution has to be re-measured after *both* deploy, not attributed from the 4/12 baseline alone.
- **The very first `/sitemap.xml` after a Data Cache purge still degrades.** The `after()` hook is what heals it on that same request rather than one crawl later; it does not prevent the first miss.
- **No `playlists` row in `sitemap_shard_refreshes`.** That would need a summary concept added to `SitemapShard`/`buildIndexEntry` — shared infrastructure #4555 and #4579 are both already editing. Promoting it later is purely additive; re-measure first.
- #4583 (a longer deadline for paged summaries) is adjacent and would reduce the urgency here, but not the uncached query. Nothing in this PR depends on it.
- **`SHARD_DEADLINE_MS` is untouched.** The issue forbids raising it and the constant's own doc comment explains why.

### Stacking

**Based on `fix/4523-sitemap-climbs-shard` (#4555), not `main`** — that PR rewrites three of the files this one touches (`app/sitemap.xml/route.ts`, `docs/sitemap.md`, `scripts/production-smoke.ts`), so basing on main guaranteed three conflicts. The core change (`playlist-query.ts`) is untouched by #4555.

Review #4555 first; this diff is against it. **If #4555 merges first, retarget this to `main`**; if it is reworked or closed, this rebases onto main — the conflict surface is only those three files. This stays a draft until #4555 is ready.

Follow-up filed: #4618 — fixed sitemap shards have no byte budget (`shardRouteHandler` checks `MAX_URLS_PER_SHARD` but never `MAX_SHARD_BYTES` on the fixed path), and `/sitemaps/playlists.xml` already renders 2,326,713 bytes.

Closes #4524

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project web --reporter=agent packages/web/app/lib/seo/sitemap` — 13 files, 146 tests green. `climb-shards.test.ts`, `shard-registry.test.ts` and `shard-route-handler.test.ts` all mock `fetchPlaylistSitemapRows` by name and pass **unchanged**, which is the check that the exported signature did not drift.
- `vp test run --project web --reporter=agent` — full web suite.
- New `packages/web/app/lib/seo/sitemap/__tests__/playlist-query.test.ts`, 11 tests. Each oracle was mutation-tested — mutation applied, watched red, reverted, tree confirmed clean:
  - drop the ISO/`new Date` pair → "hands back real Date instances" and "renders through the real urlset" both red;
  - drop the single-flight → "collapses concurrent cold callers" red;
  - drop the `SET LOCAL statement_timeout` → "bounds the query with a statement timeout" red;
  - drop the warm retry floor → "holds a failing query off behind the retry floor" red.
- `playlist-entries.test.ts` updated only for the new `db` parameter; every existing `.toSQL()` assertion survives unchanged.
- `vp check` — no lint or format findings in any changed file. The 2 repo-wide `no-floating-promises` errors are in `packages/db/scripts/dedupe-beta-links-args.test.ts`, pre-existing on `main` (fb2d59220). `after(warmPlaylistSitemapCache)` passes a function reference, so it adds no new warning.
- `vp run typecheck`.
- **Local dev DB cannot measure this and no local timing is claimed**: the dev image has 40 playlists, 4 public, 0 `playlist_climbs`. Every number above is production HTTP.
- **Post-deploy, and the only check that actually proves it** (not run yet — needs the deploy): sample `GET /sitemap.xml?probe=<random>` at least 12 times with distinct busting params, confirm `x-vercel-cache: MISS` on each, and assert `x-sitemap-degraded` never names `playlists`. Baseline to beat: 4/12, measured 2026-08-19.
- **Post-deploy**: `/sitemaps/playlists.xml` must still 200 with ~2,688 `<url>` blocks and a real `<lastmod>` — not a 503, and not a missing or `Invalid Date` timestamp, which is the rehydration regression in production form. Confirm the `<lastmod>` values are unchanged to the millisecond before vs after: a timezone shift is the silent failure mode of the ISO round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016552Be7ctNKKH8QM9rkryN
