### PR TITLE
fix(mobile): bring back climb thumbnails in the share-beta picker

### DIFF
--- a/packages/mobile/app/__tests__/share-beta.test.tsx
+++ b/packages/mobile/app/__tests__/share-beta.test.tsx
@@ -1,0 +1,353 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+import type { ShareBetaAscentSource, ShareBetaListItem } from '../../src/lib/share-beta-list';
+
+type MutationCallbacks = {
+  onSuccess: () => void;
+  onError: (error: unknown) => void;
+};
+
+const router = vi.hoisted(() => ({ back: vi.fn(), replace: vi.fn() }));
+const showToast = vi.hoisted(() => vi.fn());
+const notificationAsync = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const fetchNextPage = vi.hoisted(() => vi.fn());
+const mutate = vi.hoisted(() => vi.fn());
+const track = vi.hoisted(() => vi.fn());
+const flashListState = vi.hoisted(() => ({
+  props: null as null | { data: unknown[]; getItemType: (item: never) => string },
+}));
+
+const state = vi.hoisted(() => ({
+  link: 'https://instagram.com/reel/abc',
+  authenticated: true,
+  profileId: 'user-1' as string | undefined,
+  caption: 'Purple People Eater on the garage wall' as string | null,
+  ascents: [] as AscentFeedItem[],
+  suggestions: [] as AscentFeedItem[],
+  feedPending: false,
+  hasNextPage: false,
+  fetchingNextPage: false,
+  attachPending: false,
+}));
+
+function makeAscent(uuid: string, climbUuid = `climb-${uuid}`): AscentFeedItem {
+  return {
+    uuid,
+    climbUuid,
+    climbName: `Climb ${uuid}`,
+    setterUsername: null,
+    boardType: 'kilter',
+    boardId: null,
+    boardDisplayName: null,
+    layoutId: 8,
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 2,
+    quality: null,
+    difficulty: 20,
+    difficultyName: 'V4',
+    consensusDifficulty: 20,
+    consensusDifficultyName: 'V4',
+    boardseshDifficulty: null,
+    boardseshConfidence: null,
+    qualityAverage: null,
+    isBenchmark: false,
+    isNoMatch: false,
+    comment: '',
+    climbedAt: '2026-07-31T12:00:00.000Z',
+    frames: 'p1r1',
+  };
+}
+
+vi.mock('react-native', () => ({
+  View: ({ children }: { children?: ReactNode }) => createElement('div', null, children),
+  TextInput: ({
+    value,
+    onChangeText,
+    placeholder,
+  }: {
+    value: string;
+    onChangeText: (text: string) => void;
+    placeholder?: string;
+  }) =>
+    createElement('input', {
+      value,
+      placeholder,
+      onChange: (event: { target: { value: string } }) => onChangeText(event.target.value),
+    }),
+  Pressable: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { type: 'button', onClick: onPress, 'aria-label': accessibilityLabel }, children),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ link: state.link }),
+  useRouter: () => router,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const labels: Record<string, string> = {
+        'mobile.betaVideos.attachSuccess': 'Beta attached',
+        'mobile.betaVideos.attachError': 'Could not attach',
+        'mobile.betaVideos.shareNoAscents': 'No ascents',
+        'mobile.betaVideos.shareNoResults': 'No matches',
+        'mobile.betaVideos.shareSuggestedTitle': 'Matched from the caption',
+        'mobile.betaVideos.shareOtherAscents': 'Your other ascents',
+      };
+      return labels[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, bottom: 10 }) }));
+
+vi.mock('@shopify/flash-list', () => ({
+  FlashList: (props: {
+    data: ShareBetaListItem[];
+    renderItem: (input: { item: ShareBetaListItem }) => ReactNode;
+    keyExtractor: (item: ShareBetaListItem) => string;
+    getItemType: (item: ShareBetaListItem) => string;
+    ListFooterComponent?: ReactNode;
+    ListEmptyComponent?: ReactNode;
+  }) => {
+    flashListState.props = props as unknown as typeof flashListState.props;
+    return createElement(
+      'div',
+      { 'data-testid': 'flash-list' },
+      props.data.length === 0
+        ? props.ListEmptyComponent
+        : props.data.map((item) =>
+            createElement(
+              'div',
+              { key: props.keyExtractor(item), 'data-item-type': props.getItemType(item) },
+              props.renderItem({ item }),
+            ),
+          ),
+      props.ListFooterComponent,
+    );
+  },
+}));
+
+vi.mock('expo-image', () => ({ Image: () => createElement('div', { 'data-testid': 'image' }) }));
+
+vi.mock('expo-haptics', () => ({
+  notificationAsync,
+  NotificationFeedbackType: { Success: 'success', Error: 'error' },
+}));
+
+vi.mock('../../src/providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      background: '#fff',
+      secondaryBackground: '#eee',
+      label: '#000',
+      secondaryLabel: '#666',
+      tertiaryLabel: '#999',
+      separator: '#ccc',
+    },
+    brandColors: { primary: '#6D28D9', error: '#c00' },
+  }),
+}));
+
+vi.mock('../../src/providers/auth-provider', () => ({
+  useAuth: () => ({ isAuthenticated: state.authenticated }),
+}));
+
+vi.mock('../../src/providers/toast-provider', () => ({ useToast: () => ({ showToast }) }));
+
+vi.mock('../../src/lib/graphql/hooks', () => ({
+  useProfile: () => ({ data: state.profileId ? { id: state.profileId } : undefined }),
+  useUserAscentsFeed: () => ({
+    data: { pages: [{ userAscentsFeed: { items: state.ascents, hasMore: state.hasNextPage } }] },
+    isPending: state.feedPending,
+    hasNextPage: state.hasNextPage,
+    isFetchingNextPage: state.fetchingNextPage,
+    fetchNextPage,
+  }),
+  useAscentCaptionMatches: () => ({ data: state.suggestions }),
+  useAttachBetaLink: () => ({ isPending: state.attachPending, mutate }),
+  useBetaLinkPreview: () => ({ data: { caption: state.caption, thumbnail: null }, isLoading: false }),
+}));
+
+vi.mock('../../src/lib/graphql/extract-error-message', () => ({
+  extractGraphqlMessage: (error: unknown) => (error instanceof Error ? error.message : null),
+}));
+
+vi.mock('../../src/lib/analytics', () => ({ track }));
+
+vi.mock('../../src/theme/tokens', () => ({
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16, 5: 20, 6: 24, 8: 32 },
+  borderRadius: { sm: 4, md: 8 },
+}));
+
+vi.mock('../../src/theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#888' } }));
+
+vi.mock('../../src/components/Text', () => ({
+  Text: ({ children, accessibilityRole }: { children?: ReactNode; accessibilityRole?: string }) =>
+    createElement(accessibilityRole === 'header' ? 'h2' : 'span', null, children),
+}));
+
+vi.mock('../../src/components/Button', () => ({
+  Button: ({ title, onPress }: { title: string; onPress: () => void }) =>
+    createElement('button', { type: 'button', onClick: onPress }, title),
+}));
+
+vi.mock('../../src/components/Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+
+vi.mock('../../src/components/ActivityIndicator', () => ({
+  ActivityIndicator: () => createElement('div', { 'data-testid': 'spinner' }),
+}));
+
+// Stand-in for the real row — this file is about the list, not the art.
+vi.mock('../../src/components/share-beta/ShareBetaAscentRow', () => ({
+  ShareBetaAscentRow: ({
+    ascent,
+    source,
+    onActivate,
+  }: {
+    ascent: AscentFeedItem;
+    source: ShareBetaAscentSource;
+    onActivate: (ascent: AscentFeedItem, source: ShareBetaAscentSource) => void;
+  }) =>
+    createElement(
+      'button',
+      { type: 'button', 'aria-label': `attach-${ascent.uuid}`, onClick: () => onActivate(ascent, source) },
+      ascent.climbName,
+    ),
+}));
+
+import ShareBetaScreen from '../share-beta';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.link = 'https://instagram.com/reel/abc';
+  state.authenticated = true;
+  state.profileId = 'user-1';
+  state.caption = 'Purple People Eater on the garage wall';
+  state.ascents = [];
+  state.suggestions = [];
+  state.feedPending = false;
+  state.hasNextPage = false;
+  state.fetchingNextPage = false;
+  state.attachPending = false;
+  flashListState.props = null;
+  fetchNextPage.mockResolvedValue({});
+});
+
+describe('ShareBetaScreen — one virtualized list', () => {
+  it('puts the caption suggestions inside the FlashList data, not a header block', () => {
+    state.suggestions = [makeAscent('suggested', 'shared-climb')];
+    state.ascents = [makeAscent('other', 'other-climb')];
+
+    const { getByText, getByRole, container } = render(<ShareBetaScreen />);
+
+    expect(getByText('Matched from the caption')).toBeTruthy();
+    expect(getByText('Your other ascents')).toBeTruthy();
+    expect(getByRole('button', { name: 'attach-suggested' })).toBeTruthy();
+    expect(getByRole('button', { name: 'attach-other' })).toBeTruthy();
+    // Every row (headers included) came out of `data`, so nothing is mounted
+    // outside the recycler.
+    expect(flashListState.props?.data).toHaveLength(4);
+    expect(container.querySelectorAll('[data-item-type="section"]')).toHaveLength(2);
+    expect(container.querySelectorAll('[data-testid="flash-list"]')).toHaveLength(1);
+  });
+
+  it('does not list a suggested climb twice', () => {
+    state.suggestions = [makeAscent('suggested', 'shared-climb')];
+    state.ascents = [makeAscent('duplicate-recent', 'shared-climb'), makeAscent('other', 'other-climb')];
+
+    const { getByRole, queryByRole } = render(<ShareBetaScreen />);
+
+    expect(getByRole('button', { name: 'attach-suggested' })).toBeTruthy();
+    expect(getByRole('button', { name: 'attach-other' })).toBeTruthy();
+    expect(queryByRole('button', { name: 'attach-duplicate-recent' })).toBeNull();
+  });
+
+  it('shows the empty state when there is nothing to pick', () => {
+    const { getByText } = render(<ShareBetaScreen />);
+
+    expect(getByText('No ascents')).toBeTruthy();
+  });
+});
+
+describe('ShareBetaScreen — attaching', () => {
+  it('attaches the tapped ascent', () => {
+    state.ascents = [makeAscent('tick-1')];
+
+    const { getByRole } = render(<ShareBetaScreen />);
+    fireEvent.click(getByRole('button', { name: 'attach-tick-1' }));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate.mock.calls[0][0]).toEqual({
+      boardType: 'kilter',
+      climbUuid: 'climb-tick-1',
+      link: 'https://instagram.com/reel/abc',
+      angle: 40,
+      tickUuid: 'tick-1',
+    });
+  });
+
+  it('reports the attach with the section it came from', () => {
+    state.suggestions = [makeAscent('suggested', 'shared-climb')];
+    state.ascents = [makeAscent('other', 'other-climb')];
+
+    const { getByRole } = render(<ShareBetaScreen />);
+    fireEvent.click(getByRole('button', { name: 'attach-suggested' }));
+    const callbacks = mutate.mock.calls[0][1] as MutationCallbacks;
+    callbacks.onSuccess();
+
+    expect(track).toHaveBeenCalledWith('Beta Attached', {
+      source: 'suggested',
+      boardType: 'kilter',
+      viaSearch: false,
+      hasCaption: true,
+    });
+    expect(showToast).toHaveBeenCalledWith('Beta attached', 'success');
+    expect(router.back).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a browsed attach separately, and notes when there was no caption', () => {
+    state.caption = null;
+    state.ascents = [makeAscent('tick-1')];
+
+    const { getByRole } = render(<ShareBetaScreen />);
+    fireEvent.click(getByRole('button', { name: 'attach-tick-1' }));
+    (mutate.mock.calls[0][1] as MutationCallbacks).onSuccess();
+
+    expect(track).toHaveBeenCalledWith('Beta Attached', {
+      source: 'other',
+      boardType: 'kilter',
+      viaSearch: false,
+      hasCaption: false,
+    });
+  });
+
+  it('does not report an attach that failed', () => {
+    state.ascents = [makeAscent('tick-1')];
+
+    const { getByRole, getByText } = render(<ShareBetaScreen />);
+    fireEvent.click(getByRole('button', { name: 'attach-tick-1' }));
+    act(() => {
+      (mutate.mock.calls[0][1] as MutationCallbacks).onError(new Error('Already attached to Purple People Eater'));
+    });
+
+    expect(track).not.toHaveBeenCalled();
+    expect(getByText('Already attached to Purple People Eater')).toBeTruthy();
+    expect(router.back).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile/app/share-beta.tsx
+++ b/packages/mobile/app/share-beta.tsx
@@ -7,11 +7,12 @@ import { FlashList } from '@shopify/flash-list';
 import { Image } from 'expo-image';
 import * as Haptics from 'expo-haptics';
 import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+import { SHARED_EVENTS } from '@boardsesh/analytics';
 import { Text } from '../src/components/Text';
 import { Button } from '../src/components/Button';
 import { Icon } from '../src/components/Icon';
 import { ActivityIndicator } from '../src/components/ActivityIndicator';
-import { LogbookRow } from '../src/components/you/LogbookRow';
+import { ShareBetaAscentRow } from '../src/components/share-beta/ShareBetaAscentRow';
 import { useTheme } from '../src/providers/theme-provider';
 import { useAuth } from '../src/providers/auth-provider';
 import { useToast } from '../src/providers/toast-provider';
@@ -23,6 +24,14 @@ import {
   useBetaLinkPreview,
 } from '../src/lib/graphql/hooks';
 import { extractGraphqlMessage } from '../src/lib/graphql/extract-error-message';
+import { track } from '../src/lib/analytics';
+import {
+  buildShareBetaListItems,
+  shareBetaListItemType,
+  shareBetaListKey,
+  type ShareBetaAscentSource,
+  type ShareBetaListItem,
+} from '../src/lib/share-beta-list';
 import { spacing, borderRadius } from '../src/theme/tokens';
 import { iosSystemColors } from '../src/theme/ios-colors';
 
@@ -106,14 +115,27 @@ export default function ShareBetaScreen() {
     if (feed.hasNextPage && !feed.isFetchingNextPage) void feed.fetchNextPage();
   }, [feed]);
 
+  // Boolean, not the caption text — the event must never carry post content.
+  const hasCaption = caption != null;
+
   const handleAttach = useCallback(
-    (ascent: AscentFeedItem) => {
+    (ascent: AscentFeedItem, source: ShareBetaAscentSource) => {
       if (!link || attach.isPending) return;
       setAttachError(null);
       attach.mutate(
         { boardType: ascent.boardType, climbUuid: ascent.climbUuid, link, angle: ascent.angle, tickUuid: ascent.uuid },
         {
           onSuccess: () => {
+            // The picker had no product analytics at all, so "does anyone use
+            // this, and does the caption match actually pick the climb?" was
+            // only answerable by guessing. `source` splits caption-matched
+            // picks from browsed ones.
+            track(SHARED_EVENTS.BetaAttached, {
+              source,
+              boardType: ascent.boardType,
+              viaSearch: isSearching,
+              hasCaption,
+            });
             void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
             // Toast is fine on success — router.back() dismisses the modal first,
             // so it lands on the screen underneath where the toast is visible.
@@ -132,22 +154,37 @@ export default function ShareBetaScreen() {
         },
       );
     },
-    [attach, link, router, showToast, t],
+    [attach, hasCaption, isSearching, link, router, showToast, t],
   );
 
   const renderItem = useCallback(
-    ({ item }: { item: AscentFeedItem }) => <LogbookRow ascent={item} onActivate={handleAttach} />,
-    [handleAttach],
+    ({ item }: { item: ShareBetaListItem }) => {
+      if (item.kind === 'section') {
+        const suggested = item.source === 'suggested';
+        return (
+          <Text
+            variant="footnote"
+            color={suggested ? brandColors.primary : systemColors.tertiaryLabel}
+            style={styles.sectionLabel}
+            accessibilityRole="header"
+          >
+            {suggested ? t('mobile.betaVideos.shareSuggestedTitle') : t('mobile.betaVideos.shareOtherAscents')}
+          </Text>
+        );
+      }
+      return <ShareBetaAscentRow ascent={item.ascent} source={item.source} onActivate={handleAttach} />;
+    },
+    [brandColors.primary, handleAttach, systemColors.tertiaryLabel, t],
   );
 
-  // Drop suggested climbs from the browse list so a recent + matched climb isn't
-  // listed twice (once under "Suggested", once below).
-  const suggestedClimbUuids = useMemo(() => new Set(suggestions.map((ascent) => ascent.climbUuid)), [suggestions]);
-  const listData = useMemo(
-    () => (suggestedClimbUuids.size > 0 ? items.filter((ascent) => !suggestedClimbUuids.has(ascent.climbUuid)) : items),
-    [items, suggestedClimbUuids],
+  // One flat, fully virtualized list: section headers + suggested rows + the
+  // browse rows, with a suggested climb dropped from the browse section so a
+  // recent + matched climb isn't listed twice.
+  const listItems = useMemo(
+    () => buildShareBetaListItems({ ascents: items, suggestions, isSearching }),
+    [isSearching, items, suggestions],
   );
-  const showSuggestions = suggestions.length > 0;
+  const listContentStyle = useMemo(() => ({ paddingBottom: insets.bottom + spacing[6] }), [insets.bottom]);
 
   const containerStyle = [styles.container, { backgroundColor: systemColors.background, paddingTop: insets.top }];
 
@@ -245,30 +282,14 @@ export default function ShareBetaScreen() {
           </View>
         ) : (
           <FlashList
-            data={listData}
+            data={listItems}
             renderItem={renderItem}
-            keyExtractor={(item) => item.uuid}
+            keyExtractor={shareBetaListKey}
+            getItemType={shareBetaListItemType}
             keyboardShouldPersistTaps="handled"
             onEndReached={handleEndReached}
             onEndReachedThreshold={0.5}
-            contentContainerStyle={{ paddingBottom: insets.bottom + spacing[6] }}
-            ListHeaderComponent={
-              showSuggestions ? (
-                <View style={styles.suggestedSection}>
-                  <Text variant="footnote" color={brandColors.primary} style={styles.sectionLabel}>
-                    {t('mobile.betaVideos.shareSuggestedTitle')}
-                  </Text>
-                  {suggestions.map((ascent) => (
-                    <LogbookRow key={ascent.uuid} ascent={ascent} onActivate={handleAttach} />
-                  ))}
-                  {listData.length > 0 && (
-                    <Text variant="footnote" color={systemColors.tertiaryLabel} style={styles.sectionLabel}>
-                      {t('mobile.betaVideos.shareOtherAscents')}
-                    </Text>
-                  )}
-                </View>
-              ) : null
-            }
+            contentContainerStyle={listContentStyle}
             ListFooterComponent={
               feed.isFetchingNextPage ? (
                 <View style={styles.footer}>
@@ -277,14 +298,12 @@ export default function ShareBetaScreen() {
               ) : null
             }
             ListEmptyComponent={
-              showSuggestions ? null : (
-                <View style={styles.empty}>
-                  <Icon name="tick.outline" size={44} color={systemColors.tertiaryLabel} />
-                  <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyText}>
-                    {isSearching ? t('mobile.betaVideos.shareNoResults') : t('mobile.betaVideos.shareNoAscents')}
-                  </Text>
-                </View>
-              )
+              <View style={styles.empty}>
+                <Icon name="tick.outline" size={44} color={systemColors.tertiaryLabel} />
+                <Text variant="subheadline" color={systemColors.secondaryLabel} style={styles.emptyText}>
+                  {isSearching ? t('mobile.betaVideos.shareNoResults') : t('mobile.betaVideos.shareNoAscents')}
+                </Text>
+              </View>
             }
           />
         )}
@@ -320,7 +339,6 @@ const styles = StyleSheet.create({
   thumb: { width: 44, height: 44, borderRadius: borderRadius.sm },
   thumbFallback: { alignItems: 'center', justifyContent: 'center' },
   linkText: { flex: 1, gap: 2 },
-  suggestedSection: { gap: spacing[1] },
   sectionLabel: {
     paddingHorizontal: spacing[4],
     paddingTop: spacing[3],

--- a/packages/mobile/app/share-beta.tsx
+++ b/packages/mobile/app/share-beta.tsx
@@ -285,6 +285,9 @@ export default function ShareBetaScreen() {
             data={listItems}
             renderItem={renderItem}
             keyExtractor={shareBetaListKey}
+            // Separate recycler pools for the section headers and the ascent
+            // rows. No `estimatedItemSize` — FlashList v2 self-measures and
+            // removed the prop; mixed row heights are its normal case.
             getItemType={shareBetaListItemType}
             keyboardShouldPersistTaps="handled"
             onEndReached={handleEndReached}

--- a/packages/mobile/src/components/share-beta/ShareBetaAscentRow.tsx
+++ b/packages/mobile/src/components/share-beta/ShareBetaAscentRow.tsx
@@ -1,0 +1,298 @@
+import { memo, useCallback, useRef } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+import { getGradeColor, DEFAULT_GRADE_COLOR } from '@boardsesh/board-constants/grade-colors';
+import { deriveLogbookGradeDisplay, displayedAttemptCount, logbookAttemptsKind } from '@boardsesh/logbook';
+import { formatTickRelativeTime, getLayoutDisplayName } from '@boardsesh/profile-stats';
+import { ClimbListThumbnail } from '../ClimbListThumbnail';
+import { ClimbAttributeIcons } from '../ClimbAttributeIcons';
+import { Icon } from '../Icon';
+import { type IconName } from '../icon-map';
+import { PressableSurface } from '../PressableSurface';
+import { Text } from '../Text';
+import { useBoardseshGradesActive } from '../../hooks/use-display-grade';
+import { useGradeFormat } from '../../hooks/use-grade-format';
+import { GRADE_BY_ID, clampDifficultyId, resolveCrowdDifficultyId } from '../../lib/boardsesh-grade-display';
+import { renderBoardToPlaylistConfig } from '../../lib/playlists/board-details-for-playlist';
+import { hapticSelection } from '../../lib/haptics';
+import type { ShareBetaAscentSource } from '../../lib/share-beta-list';
+import { iosSystemColors } from '../../theme/ios-colors';
+import { borderRadius, spacing } from '../../theme/tokens';
+import { useTheme } from '../../providers/theme-provider';
+
+/**
+ * Portrait board-art cell for the picker — narrower than the 76×96 climbs-list
+ * cell so a recognition list still fits several ascents on screen, same 0.79
+ * aspect so the portrait board fills it instead of letterboxing.
+ *
+ * KEEP THE WIDTH ≤ 80. ClimbListThumbnail renders at
+ * `Math.max(400, width * 5)`, and that number is part of the render cache key
+ * (`..._w400_...`). At any width up to 80 this resolves to exactly 400 — the
+ * same key the climbs list and the play view already wrote — so a climb the
+ * climber has seen anywhere in the app paints straight from the disk PNG cache
+ * with zero render work. Bumping this to 84 would silently double the cache.
+ */
+const THUMBNAIL_SIZE = { width: 60, height: 76 } as const;
+
+/** Small result glyph — the picker's thumbnail owns the leading slot, so status rides the meta line. */
+const STATUS_ICON: Record<AscentFeedItem['status'], IconName> = {
+  flash: 'flash',
+  send: 'tick.outline',
+  attempt: 'circle',
+};
+
+type ShareBetaAscentRowProps = {
+  ascent: AscentFeedItem;
+  source: ShareBetaAscentSource;
+  onActivate: (ascent: AscentFeedItem, source: ShareBetaAscentSource) => void;
+};
+
+/**
+ * Picker row for the share-beta screen: board art first, then just enough of the
+ * log entry to tell two similar sends apart. Deliberately NOT `LogbookRow` —
+ * #3350 dropped the thumbnail from the diary row on purpose (the logbook and the
+ * climbs catalog rhymed and climbers lost track of which list they were on), and
+ * this row exists so the picker can have the art back without putting it back
+ * there. It is a selector, so it carries no swipe, long-press, or edit/delete
+ * accessibility actions.
+ */
+export const ShareBetaAscentRow = memo(function ShareBetaAscentRow({
+  ascent,
+  source,
+  onActivate,
+}: ShareBetaAscentRowProps) {
+  const { t } = useTranslation(['session', 'you']);
+  const { systemColors, brandColors } = useTheme();
+  const { formatGrade, formatGradeByDifficultyId } = useGradeFormat();
+  const boardseshActive = useBoardseshGradesActive();
+
+  // Grade column mirrors LogbookRow: the climber's own grade wins; the crowd
+  // grade (Boardsesh grade when that toggle is on and trusted) fills in when
+  // they never graded it, marked with the `people` glyph.
+  const crowdDifficulty = resolveCrowdDifficultyId(ascent, boardseshActive);
+  const { gradeIsConsensus } = deriveLogbookGradeDisplay(ascent.difficulty, crowdDifficulty);
+  const rawGradeLabel = ascent.difficultyName ?? ascent.consensusDifficultyName;
+  const displayedDifficulty = ascent.difficulty ?? crowdDifficulty;
+  const gradeLabel =
+    formatGradeByDifficultyId(displayedDifficulty) ?? formatGrade(rawGradeLabel) ?? rawGradeLabel ?? null;
+  const gradeColorName =
+    gradeIsConsensus && crowdDifficulty != null
+      ? (GRADE_BY_ID.get(clampDifficultyId(crowdDifficulty))?.difficulty_name ?? rawGradeLabel)
+      : rawGradeLabel;
+  const gradeColor = gradeColorName ? (getGradeColor(gradeColorName) ?? DEFAULT_GRADE_COLOR) : DEFAULT_GRADE_COLOR;
+
+  // Result line reuses the logbook's own wording so the picker and the diary
+  // agree — no new visible strings, no new translations to drift.
+  const attemptsKind = logbookAttemptsKind(ascent.status);
+  const tries = displayedAttemptCount(ascent.attemptCount);
+  const resultLabel =
+    attemptsKind === 'flash'
+      ? t('you:mobile.logbook.status.flash')
+      : attemptsKind === 'send'
+        ? t('you:mobile.logbook.tries', { count: tries })
+        : `${t('you:mobile.logbook.row.project')} · ${t('you:mobile.logbook.tries', { count: tries })}`;
+  const statusColor =
+    ascent.status === 'flash'
+      ? brandColors.warning
+      : ascent.status === 'send'
+        ? brandColors.success
+        : iosSystemColors.systemGray;
+
+  const wallLabel = ascent.boardDisplayName ?? getLayoutDisplayName(ascent.boardType, ascent.layoutId);
+  const wallAngleLabel = `${wallLabel} ${ascent.angle}°`;
+  const relativeTime = formatTickRelativeTime(ascent.climbedAt);
+  const hasBetaVideo = ascent.hasBetaVideo === true;
+
+  // Draw the climb on the board it was actually logged on. `renderBoard` is what
+  // the backend resolved for this tick; falling straight to the layout default
+  // (getBoardConfigForPlaylist) would draw every ascent of a climber with a
+  // 10x12 home wall on a 12x14 — the bug fixed in #4221. Memoised by board key,
+  // so this stays O(1) per row.
+  const boardConfig = ascent.frames
+    ? renderBoardToPlaylistConfig(ascent.boardType, ascent.layoutId, ascent.renderBoard)
+    : null;
+
+  // One a11y element per row: the thumbnail subtree is hidden below, so VoiceOver
+  // reads this composed sentence and nothing else.
+  const accessibilityDetails = [
+    ascent.climbName,
+    ascent.isMirror ? t('you:mobile.logbook.row.a11yMirrored') : null,
+    gradeLabel
+      ? gradeIsConsensus
+        ? t('you:mobile.logbook.row.a11yCommunityGrade', { grade: gradeLabel })
+        : gradeLabel
+      : null,
+    resultLabel,
+    hasBetaVideo ? t('you:mobile.logbook.row.a11yHasBetaVideo') : null,
+    wallAngleLabel,
+    relativeTime,
+  ]
+    .filter((part): part is string => !!part)
+    .join(', ');
+  const accessibilityLabel = t('session:mobile.betaVideos.shareAscentLabel', { details: accessibilityDetails });
+
+  // FlashList recycles this component onto another ascent. Read the ascent, the
+  // section and the host callback from refs so one dep-free press handler can
+  // never attach the beta to whichever tick used to occupy this cell.
+  const ascentRef = useRef(ascent);
+  ascentRef.current = ascent;
+  const sourceRef = useRef(source);
+  sourceRef.current = source;
+  const onActivateRef = useRef(onActivate);
+  onActivateRef.current = onActivate;
+  const handlePress = useCallback(() => {
+    hapticSelection();
+    onActivateRef.current(ascentRef.current, sourceRef.current);
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <PressableSurface
+        onPress={handlePress}
+        feedback="opacity"
+        opacityTo={0.7}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        style={[styles.row, { backgroundColor: systemColors.secondaryBackground }]}
+      >
+        <View
+          accessible={false}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          style={styles.thumbnailSlot}
+        >
+          {boardConfig && ascent.frames ? (
+            <ClimbListThumbnail
+              frames={ascent.frames}
+              boardName={boardConfig.boardName}
+              layoutId={boardConfig.layoutId}
+              sizeId={boardConfig.sizeId}
+              setIds={boardConfig.setIds.join(',')}
+              // CSS flip only — one cached PNG serves both orientations.
+              mirrored={ascent.isMirror}
+              size={THUMBNAIL_SIZE}
+            />
+          ) : (
+            // Frameless ticks (MoonBoard pulls) have nothing to draw.
+            <View style={[styles.thumbnailFallback, { backgroundColor: systemColors.fill }]}>
+              <Icon name="lightbulb" size={20} color={systemColors.tertiaryLabel} />
+            </View>
+          )}
+        </View>
+
+        <View style={styles.details}>
+          <View style={styles.nameRow}>
+            <Text variant="body" numberOfLines={2} style={styles.climbName}>
+              {ascent.climbName}
+            </Text>
+            <ClimbAttributeIcons
+              benchmarkDifficulty={
+                ascent.isBenchmark ? (ascent.consensusDifficultyName ?? ascent.difficultyName ?? '1') : null
+              }
+              isNoMatch={ascent.isNoMatch}
+            />
+            {ascent.isMirror ? (
+              <View style={styles.mirrorIcon}>
+                <Icon name="mirror" size={12} color={systemColors.secondaryLabel} />
+              </View>
+            ) : null}
+          </View>
+          <View style={styles.resultRow}>
+            <Icon name={STATUS_ICON[ascent.status]} size={13} color={statusColor} />
+            <Text variant="footnote" color={systemColors.secondaryLabel} numberOfLines={1} style={styles.resultText}>
+              {resultLabel}
+            </Text>
+          </View>
+          <Text variant="caption1" color={systemColors.tertiaryLabel} numberOfLines={1}>
+            {`${wallAngleLabel} · ${relativeTime}`}
+          </Text>
+        </View>
+
+        {gradeLabel || hasBetaVideo ? (
+          <View style={styles.gradeColumn}>
+            {hasBetaVideo ? <Icon name="video.fill" size={13} color={brandColors.primary} /> : null}
+            {gradeIsConsensus ? <Icon name="people" size={13} color={systemColors.secondaryLabel} /> : null}
+            {gradeLabel ? (
+              <Text variant="title3" numberOfLines={1} style={[styles.grade, { color: gradeColor }]}>
+                {gradeLabel}
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
+      </PressableSurface>
+      <View style={[styles.separator, { backgroundColor: systemColors.separator }]} />
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    overflow: 'hidden',
+  },
+  row: {
+    width: '100%',
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: spacing[3],
+    paddingHorizontal: spacing[4],
+    paddingVertical: spacing[2],
+  },
+  thumbnailSlot: {
+    width: THUMBNAIL_SIZE.width,
+    height: THUMBNAIL_SIZE.height,
+    flexShrink: 0,
+  },
+  thumbnailFallback: {
+    width: THUMBNAIL_SIZE.width,
+    height: THUMBNAIL_SIZE.height,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  details: {
+    flex: 1,
+    minWidth: 0,
+    justifyContent: 'center',
+    gap: 2,
+  },
+  nameRow: {
+    minWidth: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  climbName: {
+    flexShrink: 1,
+    fontWeight: '600',
+  },
+  mirrorIcon: {
+    marginLeft: 4,
+    flexShrink: 0,
+  },
+  resultRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    columnGap: 4,
+    minWidth: 0,
+  },
+  resultText: {
+    flexShrink: 1,
+  },
+  gradeColumn: {
+    flexShrink: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    marginLeft: spacing[1],
+    maxWidth: 110,
+  },
+  grade: {
+    fontWeight: '700',
+    textAlign: 'right',
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    // Inset to the text column: row padding + thumbnail + column gap.
+    marginLeft: spacing[4] + THUMBNAIL_SIZE.width + spacing[3],
+  },
+});

--- a/packages/mobile/src/components/share-beta/__tests__/share-beta-ascent-row.test.tsx
+++ b/packages/mobile/src/components/share-beta/__tests__/share-beta-ascent-row.test.tsx
@@ -1,0 +1,350 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+
+const hapticSelection = vi.hoisted(() => vi.fn());
+const renderState = vi.hoisted(() => ({ boardseshActive: true }));
+// The LAYOUT DEFAULT — deliberately a different sizeId from every ascent's own
+// renderBoard, so a row that silently fell back to it is impossible to miss.
+const getDefaultRenderBoard = vi.hoisted(() => vi.fn());
+
+vi.mock('react-native', () => ({
+  View: ({
+    children,
+    accessible,
+    accessibilityElementsHidden,
+    importantForAccessibility,
+  }: {
+    children?: ReactNode;
+    accessible?: boolean;
+    accessibilityElementsHidden?: boolean;
+    importantForAccessibility?: string;
+  }) =>
+    createElement(
+      'div',
+      {
+        'data-accessible': String(accessible),
+        'data-elements-hidden': String(accessibilityElementsHidden),
+        'data-important-for-accessibility': importantForAccessibility,
+      },
+      children,
+    ),
+  StyleSheet: { create: (styles: Record<string, unknown>) => styles, hairlineWidth: 1 },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number; grade?: string; details?: string }) => {
+      const labels: Record<string, string> = {
+        'you:mobile.logbook.status.flash': 'Flash',
+        'you:mobile.logbook.row.project': 'Project',
+        'you:mobile.logbook.row.a11yMirrored': 'mirrored',
+        'you:mobile.logbook.row.a11yHasBetaVideo': 'has beta video',
+      };
+      if (key === 'you:mobile.logbook.tries') return `${options?.count ?? 0} tries`;
+      if (key === 'you:mobile.logbook.row.a11yCommunityGrade') return `community grade ${options?.grade ?? ''}`;
+      if (key === 'session:mobile.betaVideos.shareAscentLabel') return `Attach your beta to ${options?.details ?? ''}`;
+      return labels[key] ?? key;
+    },
+  }),
+}));
+
+// The real board-config resolver is NOT mocked below — the point of this file is
+// that the row goes through renderBoardToPlaylistConfig — so stub the shared
+// board metadata it reads instead.
+vi.mock('@boardsesh/board-config', () => ({
+  getDefaultRenderBoard,
+  toBoardName: (boardType: string) => (boardType === 'kilter' || boardType === 'tension' ? boardType : null),
+}));
+
+vi.mock('@boardsesh/board-constants/grade-colors', () => ({
+  getGradeColor: (label: string) => `color:${label}`,
+  DEFAULT_GRADE_COLOR: 'color:default',
+}));
+
+vi.mock('@boardsesh/profile-stats', () => ({
+  formatTickRelativeTime: () => '2 hours ago',
+  getLayoutDisplayName: (boardType: string, layoutId: number | null) => `${boardType} layout ${String(layoutId)}`,
+}));
+
+vi.mock('../../../hooks/use-display-grade', () => ({
+  useBoardseshGradesActive: () => renderState.boardseshActive,
+}));
+
+vi.mock('../../../hooks/use-grade-format', () => ({
+  useGradeFormat: () => ({
+    formatGrade: (grade: string | null | undefined) => grade ?? null,
+    formatGradeByDifficultyId: (difficulty: number | null | undefined) =>
+      difficulty == null ? null : `V${difficulty}`,
+  }),
+}));
+
+vi.mock('../../../lib/boardsesh-grade-display', () => ({
+  resolveCrowdDifficultyId: (
+    ascent: {
+      boardseshDifficulty: number | null;
+      boardseshConfidence: string | null;
+      consensusDifficulty: number | null;
+    },
+    boardseshActive: boolean,
+  ) =>
+    boardseshActive && ascent.boardseshDifficulty != null && ascent.boardseshConfidence !== 'setter_only'
+      ? ascent.boardseshDifficulty
+      : ascent.consensusDifficulty,
+  GRADE_BY_ID: new Map([
+    [21, { difficulty_name: 'V21-name' }],
+    [25, { difficulty_name: 'V25-name' }],
+  ]),
+  clampDifficultyId: (difficulty: number) => Math.round(difficulty),
+}));
+
+vi.mock('../../../lib/haptics', () => ({ hapticSelection }));
+
+vi.mock('../../../providers/theme-provider', () => ({
+  useTheme: () => ({
+    systemColors: {
+      secondaryBackground: '#fff',
+      secondaryLabel: '#666',
+      tertiaryLabel: '#999',
+      separator: '#ccc',
+      fill: '#eee',
+    },
+    brandColors: { primary: '#6D28D9', success: '#34C759', warning: '#FF9F0A' },
+  }),
+}));
+
+vi.mock('../../../theme/ios-colors', () => ({ iosSystemColors: { systemGray: '#8E8E93' } }));
+vi.mock('../../../theme/tokens', () => ({
+  borderRadius: { md: 8 },
+  spacing: { 1: 4, 2: 8, 3: 12, 4: 16 },
+}));
+
+vi.mock('../../ClimbListThumbnail', () => ({
+  ClimbListThumbnail: (props: {
+    frames: string;
+    boardName: string;
+    layoutId: number;
+    sizeId: number;
+    setIds: string;
+    mirrored?: boolean;
+    size: { width: number; height: number };
+  }) =>
+    createElement('div', {
+      'data-testid': 'climb-thumbnail',
+      'data-frames': props.frames,
+      'data-board-name': props.boardName,
+      'data-layout-id': String(props.layoutId),
+      'data-size-id': String(props.sizeId),
+      'data-set-ids': props.setIds,
+      'data-mirrored': String(props.mirrored),
+      'data-width': String(props.size.width),
+      'data-height': String(props.size.height),
+    }),
+}));
+
+vi.mock('../../ClimbAttributeIcons', () => ({ ClimbAttributeIcons: () => null }));
+vi.mock('../../Icon', () => ({
+  Icon: ({ name }: { name: string }) => createElement('i', { 'data-icon': name }),
+}));
+
+vi.mock('../../PressableSurface', () => ({
+  PressableSurface: ({
+    children,
+    onPress,
+    accessibilityLabel,
+  }: {
+    children?: ReactNode;
+    onPress?: () => void;
+    accessibilityLabel?: string;
+  }) => createElement('button', { type: 'button', onClick: onPress, 'aria-label': accessibilityLabel }, children),
+}));
+
+vi.mock('../../Text', () => ({
+  Text: ({ children, variant }: { children?: ReactNode; variant?: string }) =>
+    createElement('span', { 'data-variant': variant }, children),
+}));
+
+import { ShareBetaAscentRow } from '../ShareBetaAscentRow';
+
+function makeAscent(overrides: Partial<AscentFeedItem> = {}): AscentFeedItem {
+  return {
+    uuid: 'tick-1',
+    climbUuid: 'climb-1',
+    climbName: 'Purple People Eater',
+    setterUsername: null,
+    boardType: 'kilter',
+    boardId: null,
+    boardDisplayName: 'Garage Board',
+    layoutId: 8,
+    renderBoard: { layoutId: 8, sizeId: 17, setIds: [20, 21] },
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 3,
+    quality: null,
+    difficulty: 21,
+    difficultyName: 'V5',
+    consensusDifficulty: 20,
+    consensusDifficultyName: 'V4',
+    boardseshDifficulty: 25,
+    boardseshConfidence: 'confirmed',
+    qualityAverage: null,
+    isBenchmark: false,
+    isNoMatch: false,
+    comment: '',
+    climbedAt: '2026-07-31T12:00:00.000Z',
+    frames: 'p1r1',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  renderState.boardseshActive = true;
+  getDefaultRenderBoard.mockReturnValue({ layoutId: 8, sizeId: 99, setIds: [1, 2, 3] });
+});
+
+describe('ShareBetaAscentRow — board art', () => {
+  it('draws the climb on the board the ascent was logged on, not the layout default', () => {
+    const { getByTestId } = render(
+      <ShareBetaAscentRow ascent={makeAscent({ isMirror: true })} source="other" onActivate={vi.fn()} />,
+    );
+    const thumbnail = getByTestId('climb-thumbnail');
+
+    expect(thumbnail.getAttribute('data-frames')).toBe('p1r1');
+    expect(thumbnail.getAttribute('data-board-name')).toBe('kilter');
+    expect(thumbnail.getAttribute('data-layout-id')).toBe('8');
+    // The regression guard for #4221: 17 is the climber's own wall, 99 the
+    // layout default the fallback would have handed back.
+    expect(thumbnail.getAttribute('data-size-id')).toBe('17');
+    expect(thumbnail.getAttribute('data-set-ids')).toBe('20,21');
+    // Mirror is a CSS flip on the same cached PNG.
+    expect(thumbnail.getAttribute('data-mirrored')).toBe('true');
+  });
+
+  it('falls back to the layout default when the tick carries no renderBoard', () => {
+    const { getByTestId } = render(
+      <ShareBetaAscentRow
+        ascent={makeAscent({ boardType: 'tension', renderBoard: null })}
+        source="other"
+        onActivate={vi.fn()}
+      />,
+    );
+
+    expect(getByTestId('climb-thumbnail').getAttribute('data-size-id')).toBe('99');
+  });
+
+  it('keeps the cell portrait and within the shared ≤80px render-cache width', () => {
+    const { getByTestId } = render(<ShareBetaAscentRow ascent={makeAscent()} source="other" onActivate={vi.fn()} />);
+    const thumbnail = getByTestId('climb-thumbnail');
+    const width = Number(thumbnail.getAttribute('data-width'));
+    const height = Number(thumbnail.getAttribute('data-height'));
+
+    expect(height).toBeGreaterThan(width);
+    // Above 80 the renderWidth leaves `_w400_` and the picker stops sharing the
+    // climbs list's cached PNG.
+    expect(width).toBeLessThanOrEqual(80);
+  });
+
+  it('shows the neutral tile for a frameless tick', () => {
+    const { container, queryByTestId } = render(
+      <ShareBetaAscentRow ascent={makeAscent({ frames: null })} source="other" onActivate={vi.fn()} />,
+    );
+
+    expect(queryByTestId('climb-thumbnail')).toBeNull();
+    expect(container.querySelector('[data-icon="lightbulb"]')).toBeTruthy();
+  });
+
+  it('shows the neutral tile when no board config resolves', () => {
+    getDefaultRenderBoard.mockReturnValue(null);
+    const { container, queryByTestId } = render(
+      <ShareBetaAscentRow
+        ascent={makeAscent({ boardType: 'moonboard', renderBoard: null })}
+        source="other"
+        onActivate={vi.fn()}
+      />,
+    );
+
+    expect(queryByTestId('climb-thumbnail')).toBeNull();
+    expect(container.querySelector('[data-icon="lightbulb"]')).toBeTruthy();
+  });
+});
+
+describe('ShareBetaAscentRow — grade column', () => {
+  it('shows the climber own grade with no community marker', () => {
+    const { getByText, container } = render(
+      <ShareBetaAscentRow ascent={makeAscent()} source="other" onActivate={vi.fn()} />,
+    );
+
+    expect(getByText('V21')).toBeTruthy();
+    expect(container.querySelector('[data-icon="people"]')).toBeNull();
+  });
+
+  it('marks the crowd grade when the climber never graded it', () => {
+    const { getByText, container } = render(
+      <ShareBetaAscentRow
+        ascent={makeAscent({ difficulty: null, difficultyName: null })}
+        source="other"
+        onActivate={vi.fn()}
+      />,
+    );
+
+    expect(getByText('V25')).toBeTruthy();
+    expect(container.querySelector('[data-icon="people"]')).toBeTruthy();
+  });
+
+  it('keeps the beta-video marker the logbook row shows', () => {
+    const { container } = render(
+      <ShareBetaAscentRow ascent={makeAscent({ hasBetaVideo: true })} source="other" onActivate={vi.fn()} />,
+    );
+
+    expect(container.querySelector('[data-icon="video.fill"]')).toBeTruthy();
+  });
+});
+
+describe('ShareBetaAscentRow — accessibility and press', () => {
+  it('exposes one descriptive button and hides the board art from assistive tech', () => {
+    const { getByRole, container } = render(
+      <ShareBetaAscentRow ascent={makeAscent({ isMirror: true })} source="suggested" onActivate={vi.fn()} />,
+    );
+
+    expect(
+      getByRole('button', {
+        name: 'Attach your beta to Purple People Eater, mirrored, V21, 3 tries, Garage Board 40°, 2 hours ago',
+      }),
+    ).toBeTruthy();
+    const decorativeWrapper = container.querySelector('[data-important-for-accessibility="no-hide-descendants"]');
+    expect(decorativeWrapper?.getAttribute('data-accessible')).toBe('false');
+    expect(decorativeWrapper?.getAttribute('data-elements-hidden')).toBe('true');
+  });
+
+  it('reads the current ascent and section when FlashList recycles the row', () => {
+    const onActivate = vi.fn();
+    const first = makeAscent({ uuid: 'tick-1', climbName: 'First climb' });
+    const second = makeAscent({ uuid: 'tick-2', climbName: 'Second climb' });
+    const { getByRole, rerender } = render(
+      <ShareBetaAscentRow ascent={first} source="suggested" onActivate={onActivate} />,
+    );
+
+    rerender(<ShareBetaAscentRow ascent={second} source="other" onActivate={onActivate} />);
+    fireEvent.click(getByRole('button'));
+
+    expect(hapticSelection).toHaveBeenCalledTimes(1);
+    expect(onActivate).toHaveBeenCalledWith(second, 'other');
+  });
+
+  it('is memoized — identical props do not re-run the row body', () => {
+    // A layoutId no other test touches, so the board-config module cache can't
+    // hide a second call.
+    const ascent = makeAscent({ boardType: 'tension', layoutId: 4242, renderBoard: null });
+    const onActivate = vi.fn();
+    const { rerender } = render(<ShareBetaAscentRow ascent={ascent} source="other" onActivate={onActivate} />);
+    expect(getDefaultRenderBoard).toHaveBeenCalledTimes(1);
+
+    rerender(<ShareBetaAscentRow ascent={ascent} source="other" onActivate={onActivate} />);
+
+    expect(getDefaultRenderBoard).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/mobile/src/components/you/LogbookRow.tsx
+++ b/packages/mobile/src/components/you/LogbookRow.tsx
@@ -39,11 +39,10 @@ import { hapticSelection, hapticMedium, hapticLight, hapticSuccess } from '../..
 
 type LogbookRowProps = {
   ascent: AscentFeedItem;
-  /** Tap → the row's primary action (logbook: activate + open play drawer;
-   *  beta-share: attach the video to this climb). */
+  /** Tap → the row's primary action (logbook: activate + open play drawer). */
   onActivate: (ascent: AscentFeedItem) => void;
-  /** Long press → open the climb actions sheet. Omit to disable long-press
-   *  (e.g. the beta-share picker, where the row is a plain selector). */
+  /** Long press → open the climb actions sheet. Omit to disable long-press on a
+   *  host that wants the row to be a plain selector. */
   onOpenActions?: (ascent: AscentFeedItem) => void;
   /** Swipe left-to-right → edit the logbook entry. Owner-only; when omitted the
    *  left swipe action is disabled (you can't edit another climber's ticks). */
@@ -61,8 +60,8 @@ type LogbookRowProps = {
    * Whether the meta line carries the BOARD name. The logbook tab passes false
    * when a divider or subdivider above already names the board; the angle
    * stays on the row either way (it varies per climb on adjustable boards and
-   * disambiguates repeat ascents). Defaults to true so flat views and the
-   * share-beta picker never lose the wall.
+   * disambiguates repeat ascents). Defaults to true so flat views never lose
+   * the wall.
    */
   showBoardInMeta?: boolean;
   /**
@@ -75,8 +74,7 @@ type LogbookRowProps = {
    * Device font scale, passed by the host so a 50-row list holds ONE dimension
    * subscription (the tab's) instead of one per row — useWindowDimensions in a
    * memo'd row re-renders every visible row on any dimension event (keyboard,
-   * rotation, split-screen). Defaults to 1 for hosts that don't scale (the
-   * share-beta picker).
+   * rotation, split-screen). Defaults to 1 for hosts that don't scale.
    */
   fontScale?: number;
 };
@@ -365,7 +363,7 @@ export const LogbookRow = memo(function LogbookRow({
   );
 
   // Long-press wins over tap; a quick tap fires once the long-press fails. With
-  // no long-press handler (beta-share picker) the row is tap-only.
+  // no long-press handler the row is tap-only.
   const tapGesture = useMemo(
     () => (onOpenActions ? Gesture.Exclusive(longPressGesture, singleTapGesture) : singleTapGesture),
     [onOpenActions, longPressGesture, singleTapGesture],

--- a/packages/mobile/src/lib/__tests__/share-beta-list.test.ts
+++ b/packages/mobile/src/lib/__tests__/share-beta-list.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+import {
+  buildShareBetaListItems,
+  shareBetaListItemType,
+  shareBetaListKey,
+  type ShareBetaListItem,
+} from '../share-beta-list';
+
+function makeAscent(uuid: string, climbUuid: string): AscentFeedItem {
+  return {
+    uuid,
+    climbUuid,
+    climbName: `Climb ${climbUuid}`,
+    setterUsername: null,
+    boardType: 'kilter',
+    boardId: null,
+    boardDisplayName: null,
+    layoutId: 8,
+    angle: 40,
+    isMirror: false,
+    status: 'send',
+    attemptCount: 1,
+    quality: null,
+    difficulty: 21,
+    difficultyName: 'V5',
+    consensusDifficulty: null,
+    consensusDifficultyName: null,
+    boardseshDifficulty: null,
+    boardseshConfidence: null,
+    qualityAverage: null,
+    isBenchmark: false,
+    isNoMatch: false,
+    comment: '',
+    climbedAt: '2026-07-31T12:00:00.000Z',
+    frames: 'p1r1',
+  };
+}
+
+function ascentKeys(items: ShareBetaListItem[]): string[] {
+  return items.filter((item) => item.kind === 'ascent').map((item) => item.key);
+}
+
+describe('buildShareBetaListItems', () => {
+  it('returns a flat ascent list with no headers when nothing matched the caption', () => {
+    const items = buildShareBetaListItems({
+      ascents: [makeAscent('tick-1', 'climb-1'), makeAscent('tick-2', 'climb-2')],
+      suggestions: [],
+      isSearching: false,
+    });
+
+    expect(items.map((item) => item.kind)).toEqual(['ascent', 'ascent']);
+    expect(ascentKeys(items)).toEqual(['other:tick-1', 'other:tick-2']);
+  });
+
+  it('puts every suggestion inside the list data rather than a header block', () => {
+    const items = buildShareBetaListItems({
+      ascents: [makeAscent('tick-2', 'climb-2')],
+      suggestions: [makeAscent('tick-1', 'climb-1')],
+      isSearching: false,
+    });
+
+    expect(items.map((item) => item.key)).toEqual([
+      'section:suggested',
+      'suggested:tick-1',
+      'section:other',
+      'other:tick-2',
+    ]);
+  });
+
+  it('drops every tick of a suggested climb from the browse section', () => {
+    const items = buildShareBetaListItems({
+      // Two ticks of climb-1 — the matched one plus a repeat further down the feed.
+      ascents: [makeAscent('tick-9', 'climb-1'), makeAscent('tick-2', 'climb-2')],
+      suggestions: [makeAscent('tick-1', 'climb-1')],
+      isSearching: false,
+    });
+
+    expect(ascentKeys(items)).toEqual(['suggested:tick-1', 'other:tick-2']);
+  });
+
+  it('omits the "other" header when every ascent was suggested', () => {
+    const items = buildShareBetaListItems({
+      ascents: [makeAscent('tick-9', 'climb-1')],
+      suggestions: [makeAscent('tick-1', 'climb-1')],
+      isSearching: false,
+    });
+
+    expect(items.map((item) => item.key)).toEqual(['section:suggested', 'suggested:tick-1']);
+  });
+
+  it('suppresses the suggestions while a search is committed', () => {
+    const items = buildShareBetaListItems({
+      ascents: [makeAscent('tick-2', 'climb-2')],
+      suggestions: [makeAscent('tick-1', 'climb-1')],
+      isSearching: true,
+    });
+
+    expect(items.map((item) => item.key)).toEqual(['other:tick-2']);
+  });
+
+  it('de-duplicates repeated uuids so FlashList never sees a duplicate key', () => {
+    const items = buildShareBetaListItems({
+      ascents: [makeAscent('tick-1', 'climb-1'), makeAscent('tick-1', 'climb-1')],
+      suggestions: [],
+      isSearching: false,
+    });
+
+    expect(ascentKeys(items)).toEqual(['other:tick-1']);
+  });
+
+  it('gives headers and rows distinct keys and recycler types', () => {
+    const items = buildShareBetaListItems({
+      ascents: [makeAscent('tick-2', 'climb-2')],
+      suggestions: [makeAscent('tick-1', 'climb-1')],
+      isSearching: false,
+    });
+
+    expect(new Set(items.map(shareBetaListKey)).size).toBe(items.length);
+    expect(items.map(shareBetaListItemType)).toEqual(['section', 'ascent', 'section', 'ascent']);
+  });
+});

--- a/packages/mobile/src/lib/share-beta-list.ts
+++ b/packages/mobile/src/lib/share-beta-list.ts
@@ -1,0 +1,104 @@
+import type { AscentFeedItem } from '@boardsesh/graphql/operations';
+
+/** Which section of the picker a row came from — carried into the attach analytics. */
+export type ShareBetaAscentSource = 'suggested' | 'other';
+
+export type ShareBetaListItem =
+  | {
+      kind: 'section';
+      key: 'section:suggested' | 'section:other';
+      source: ShareBetaAscentSource;
+    }
+  | {
+      kind: 'ascent';
+      key: string;
+      source: ShareBetaAscentSource;
+      ascent: AscentFeedItem;
+    };
+
+type BuildShareBetaListItemsInput = {
+  ascents: AscentFeedItem[];
+  suggestions: AscentFeedItem[];
+  isSearching: boolean;
+};
+
+function uniqueAscentsByUuid(ascents: AscentFeedItem[]): AscentFeedItem[] {
+  const seenUuids = new Set<string>();
+  const uniqueAscents: AscentFeedItem[] = [];
+  for (const ascent of ascents) {
+    if (seenUuids.has(ascent.uuid)) continue;
+    seenUuids.add(ascent.uuid);
+    uniqueAscents.push(ascent);
+  }
+  return uniqueAscents;
+}
+
+/**
+ * Flatten the caption matches and the paginated ascents feed into one
+ * heterogeneous list, so every row — suggestion included — lives inside
+ * FlashList and gets virtualized. The suggestions used to render inside
+ * `ListHeaderComponent`, which is mounted for the whole life of the screen and
+ * never recycled; that was harmless with text-only rows and wasteful now that
+ * each row decodes board art.
+ *
+ * A caption match owns its climb: every other tick of the same climb drops out
+ * of the "other" section, which is the de-duplication the screen did inline
+ * before.
+ */
+export function buildShareBetaListItems({
+  ascents,
+  suggestions,
+  isSearching,
+}: BuildShareBetaListItemsInput): ShareBetaListItem[] {
+  const uniqueAscents = uniqueAscentsByUuid(ascents);
+  const uniqueSuggestions = isSearching ? [] : uniqueAscentsByUuid(suggestions);
+
+  if (uniqueSuggestions.length === 0) {
+    return uniqueAscents.map((ascent) => ({
+      kind: 'ascent',
+      key: `other:${ascent.uuid}`,
+      source: 'other',
+      ascent,
+    }));
+  }
+
+  const suggestedClimbUuids = new Set(uniqueSuggestions.map((ascent) => ascent.climbUuid));
+  const otherAscents = uniqueAscents.filter((ascent) => !suggestedClimbUuids.has(ascent.climbUuid));
+  const listItems: ShareBetaListItem[] = [
+    { kind: 'section', key: 'section:suggested', source: 'suggested' },
+    ...uniqueSuggestions.map(
+      (ascent): ShareBetaListItem => ({
+        kind: 'ascent',
+        key: `suggested:${ascent.uuid}`,
+        source: 'suggested',
+        ascent,
+      }),
+    ),
+  ];
+
+  if (otherAscents.length > 0) {
+    listItems.push(
+      { kind: 'section', key: 'section:other', source: 'other' },
+      ...otherAscents.map(
+        (ascent): ShareBetaListItem => ({
+          kind: 'ascent',
+          key: `other:${ascent.uuid}`,
+          source: 'other',
+          ascent,
+        }),
+      ),
+    );
+  }
+
+  return listItems;
+}
+
+/** Hoisted so FlashList never sees a fresh closure on re-render. */
+export function shareBetaListKey(item: ShareBetaListItem): string {
+  return item.key;
+}
+
+/** Separate recycler pools for section headers and ascent rows. */
+export function shareBetaListItemType(item: ShareBetaListItem): ShareBetaListItem['kind'] {
+  return item.kind;
+}

--- a/packages/shared/analytics/src/events.ts
+++ b/packages/shared/analytics/src/events.ts
@@ -278,6 +278,15 @@ export const SHARED_EVENTS = {
   // both platforms land in one funnel.
   BetaCaptionCopied: 'Beta Caption Copied',
   BetaInstagramOpened: 'Beta Instagram Opened',
+  // The inbound half of that flow: a reel shared INTO the app got pinned to an
+  // ascent from the share-beta picker. That screen shipped with no analytics at
+  // all, so nothing could say whether the caption auto-match actually picks the
+  // climb or whether people scroll for it — which is exactly the question that
+  // had to be guessed at when #3357 asked how much the picker's board art is
+  // worth. Props: { source: 'suggested' | 'other', boardType, viaSearch,
+  // hasCaption }. `hasCaption` is a boolean on purpose — the caption is the
+  // user's post content and never leaves the device.
+  BetaAttached: 'Beta Attached',
   // Onboarding tour (first-run walkthrough). Web fires the same names from its
   // step-based guided tour; the mobile welcome carousel reuses them so both
   // platforms land in one PostHog funnel.

--- a/packages/shared/i18n/locales/de/session.json
+++ b/packages/shared/i18n/locales/de/session.json
@@ -242,6 +242,7 @@
       "shareReadingCaption": "Bildunterschrift wird gelesen…",
       "shareSuggestedTitle": "Aus der Bildunterschrift erkannt",
       "shareOtherAscents": "Deine anderen Begehungen",
+      "shareAscentLabel": "Häng deine Beta an {{details}} an",
       "shareTitle": "Teile deine Beta",
       "step1Title": "Bildunterschrift kopieren",
       "step2Title": "Als Reel posten",

--- a/packages/shared/i18n/locales/en-US/session.json
+++ b/packages/shared/i18n/locales/en-US/session.json
@@ -242,6 +242,7 @@
       "shareReadingCaption": "Reading the caption…",
       "shareSuggestedTitle": "Matched from the caption",
       "shareOtherAscents": "Your other ascents",
+      "shareAscentLabel": "Attach your beta to {{details}}",
       "shareTitle": "Share your beta",
       "step1Title": "Copy your caption",
       "step2Title": "Post it as a reel",

--- a/packages/shared/i18n/locales/es/session.json
+++ b/packages/shared/i18n/locales/es/session.json
@@ -242,6 +242,7 @@
       "shareReadingCaption": "Leyendo la descripción…",
       "shareSuggestedTitle": "Encontrado en la descripción",
       "shareOtherAscents": "Tus otros ascensos",
+      "shareAscentLabel": "Adjunta tu beta a {{details}}",
       "shareTitle": "Comparte tu beta",
       "step1Title": "Copia tu descripción",
       "step2Title": "Publícalo como reel",

--- a/packages/shared/i18n/locales/fr/session.json
+++ b/packages/shared/i18n/locales/fr/session.json
@@ -242,6 +242,7 @@
       "shareReadingCaption": "Lecture de la description...",
       "shareSuggestedTitle": "Trouve dans la description",
       "shareOtherAscents": "Tes autres ascensions",
+      "shareAscentLabel": "Joins ta beta à {{details}}",
       "shareTitle": "Partage ton beta",
       "step1Title": "Copie ta légende",
       "step2Title": "Publie-le en reel",


### PR DESCRIPTION
## Summary

The share-beta picker — the screen you land on after sharing an Instagram/TikTok reel into
Boardsesh — reuses `LogbookRow` verbatim to let you pick which of your ascents the reel belongs to.
When #3350 redesigned the logbook row it stopped wrapping `ClimbListItemContent`, and that took the
board thumbnail out of every consumer of the row, the picker included. #3350's own body lists this
as known fallout.

**This is not a revert of #3350.** Dropping the art from the logbook row was deliberate and it
stays dropped: the logbook and the climbs catalog "rhymed" and people lost track of which list they
were on, and the thumbnail was the priciest cell in an infinite-scroll diary. None of that argues
for the picker. A diary is a list of things you already know you did; the picker is a recognition
surface where two similarly-named ticks on the same wall at the same angle differ only in the art.

So the picker gets its own row instead of borrowing the diary's:

- **`ShareBetaAscentRow`** (new) — leading portrait board thumbnail, climb name with the
  benchmark/no-match/mirror glyphs, a result line, wall + angle + relative time, and the trailing
  grade column with the community marker. It keeps the beta-video camera marker the logbook row
  shows. No swipe, no long-press, no edit/delete: this row is a selector.
- **`LogbookRow` is untouched behaviourally** — only its prop docs, which named the share-beta
  picker as a consumer in four places. `LogbookTab` is now its sole caller.
- **The suggestions are virtualized.** They used to render as `suggestions.map(...)` inside
  `ListHeaderComponent`, which is mounted for the life of the screen and never recycled. Harmless
  with text-only rows, wasteful now that each one decodes board art. Section headers and rows are
  now items in the FlashList `data` with `getItemType` giving them separate recycler pools. The
  list shaping (dedupe, headers, suppress-while-searching) moved to a pure
  `src/lib/share-beta-list.ts` with its own tests.

### Cell size: 60×76

Portrait, not square, and **width ≤ 80 on purpose**. `ClimbListThumbnail` renders at
`Math.max(400, width * 5)` and that number is baked into the render cache key (`..._w400_...`), so
at any width up to 80 the picker reuses the exact PNG the climbs list and play view already wrote
to disk — a climb you've seen anywhere in the app paints with zero render work. Bumping the cell to
84 would silently double the cache; there's a comment on the constant saying so.

60×76 rather than the climbs list's 76×96 because a picker wants scanability over art. **This is
the one thing a device eyeball should decide** — see the screenshots note below.

### Beyond the issue's ask: a `Beta Attached` event

The picker shipped with zero product analytics. Answering "is the missing art actually costing
anyone anything?" meant reading `$screen` counts and guessing, which is a bad way to answer a
product question. This PR adds one `SHARED_EVENTS` entry and one `track()` call on a successful
attach, with `{ source: 'suggested' | 'other', boardType, viaSearch, hasCaption }`. `source` splits
caption-matched picks from browsed ones, so the next version of this question is answerable instead
of guessed. `hasCaption` is a boolean deliberately — the caption is the user's post content and
never leaves the device.

Flagging it explicitly because it is not what #3357 asked for.

### The prior-art branch

`origin/fix/3357-share-beta-thumbnails` (head `9d471914c`, 2026-08-02, 9 files / +1220 lines) is an
earlier attempt at this issue. No PR was ever opened for it. **It is not being merged as-is** and
this PR is a fresh branch, not a rebase of it. Its structure was a good starting point and the list
module here is close to its shape, but it has four problems:

1. It resolves the board with `getBoardConfigForPlaylist(boardType, layoutId)` — the layout default.
   Commit `0d01fa56e` (2026-08-10, *after* that branch) added `renderBoardToPlaylistConfig` for
   exactly this reason: the layout-default path draws a climber with a 10×12 Kilter home wall on a
   12×14 for every one of their ascents (#4221). This PR uses the new helper, with a test that an
   ascent carrying `renderBoard` renders *that* sizeId and not the layout default.
2. Its cell is `48 × 48`, square. `ClimbListThumbnail` uses `contentFit="contain"`, and board images
   run 1080×1170 to 1080×2498 — a 1080×2498 Kilter original in a 48×48 box renders 21 px wide. A
   21-px board is not a recognition cue.
3. It adds the new i18n key to `en-US`, `es` and `fr` only. `de` exists on main now and
   `catalog-completeness.test.ts` enforces per-namespace parity across all four — it would land red.
4. It bundles three unrelated changes with the fix: new `isSearching` debounce semantics, a
   rewrite of `handleAttach` onto refs with a double-tap latch, and an end-reached latch. Defensible
   on their own, none of them this issue.

**Disposition: delete `fix/3357-share-beta-thumbnails` once this merges.** It has no PR, it predates
both `renderBoard` and the `de` locale, and everything worth keeping from it is in this branch.

### Screenshots

**None captured — this needs a device eyeball. @marcodejongh**

I could not produce a real before/after of this screen from here, and I'm not going to paste
something I didn't take:

- The iOS simulator path (`vp run mobile:screenshots` / `mobile:ios-shots`) is macOS-only.
- The Android emulator path needs the picker populated with real logged ascents. The picker only
  renders for a signed-in account with ticks, so it needs `--backend local` against a seeded dev
  server — and `vp run dev` here dies during the migration sync against the shared dev Postgres
  (`0194_location_sync_unfreeze_audit` → `type "location_sync_entity_type" already exists`, a
  parallel session's DB state, unrelated to this change). The prod test account needs a password I
  don't have, and the `test`/`test` pair only exists on the local backend.

The cheap way to judge it: this PR is JS-only and OTA-safe, and the `pr-4620` preview channel has
published (iOS + Android). On a store/TestFlight build, What's New → "Try a preview" → this PR,
then share any Instagram/TikTok reel into Boardsesh. Or deep-link straight in:

    com.boardsesh.app://share-beta?link=https%3A%2F%2Fwww.instagram.com%2Freel%2FC0000000000%2F

**What to look at:** whether 60×76 is the right cell, or whether it wants the climbs list's 76×96
(bigger art, fewer rows per screen). Those are the only two real options — anything wider than 80px
leaves the shared `_w400_` render cache. Swapping is a one-line change to `THUMBNAIL_SIZE` in
`ShareBetaAscentRow.tsx`; say the word and I'll push it.

The rest of the device pass, once you're in there:

1. Art paints for both the "Matched from the caption" rows and the "Your other ascents" rows.
2. A climber whose registered wall is smaller than the layout default sees THEIR board size (the
   #4221 guard — unit-tested, but worth one real look).
3. A frameless MoonBoard tick shows the neutral lightbulb tile, not a blank cell.
4. VoiceOver/TalkBack reads one element per row and never announces the thumbnail.
5. Fast-scroll the browse list: no recycled row shows the previous ascent's art, and a tap right
   after a fast scroll attaches to the climb actually under your finger.
6. Dark mode and the Material variant.
7. You → Logbook still has NO thumbnail. That removal was deliberate in #3350 and must stay.

## Release Notes

- Sharing a reel into Boardsesh shows the wall for every climb again, so you can spot the right send
  instead of reading down a list of names.

## Test plan

- `vp test run --project mobile share-beta --reporter=agent` — 25 tests across the new row, the pure
  list module and the screen. Covers the `renderBoard` regression guard (#4221), the ≤80 px
  cache-key contract, the frameless-tick fallback tile, mirror pass-through, one-a11y-element-per-row
  with the thumbnail hidden from assistive tech, FlashList recycle safety (a recycled row attaches to
  the new ascent, not the one that used to be in the cell), the suggestions living in `data` rather
  than `ListHeaderComponent`, the no-duplicate-climb rule, and the analytics props.
- `vp test run --project i18n --reporter=agent` — 101 pass; catalog parity across en-US/es/fr/de.
- `vp run check:i18n` — OK.
- `vp run typecheck:mobile` — clean.
- `vp run check:mobile-bundle` — OK.
- `vp run test:mobile` — 6,573 tests across 687 files, all green.

JS-only under `packages/mobile/{app,src}`, `packages/shared/analytics` and `packages/shared/i18n`, so
this is OTA-safe and `ota-check` should report no native change.

Closes #3357
