### PR TITLE
fix(mobile): make the playlist Edit climbs menu row work

### DIFF
--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, Alert, Pressable } from 'react-native';
-import { useLocalSearchParams, useNavigation } from 'expo-router';
+import { useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import type { BottomSheet } from '@expo/ui/community/bottom-sheet';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -61,6 +61,7 @@ export default function PlaylistDetail() {
   const { playlist_uuid: playlistUuid } = useLocalSearchParams<DetailParams>();
   const { t } = useTranslation('playlists');
   const navigation = useNavigation();
+  const router = useRouter();
   const queryClient = useQueryClient();
   const { isAuthenticated } = useAuth();
   const { showToast } = useToast();
@@ -211,10 +212,8 @@ export default function PlaylistDetail() {
   const [editMode, setEditMode] = useState(false);
   const [editClimbs, setEditClimbs] = useState<Climb[]>([]);
   const editClimbsRef = useRef<Climb[]>([]);
-  const pendingEditClimbsRef = useRef(false);
-  // Always-current view of the loaded climbs so enterEditMode — which runs
-  // asynchronously after the actions sheet finishes dismissing — seeds from the
-  // latest data, not the snapshot captured when the menu opened.
+  // Always-current view of the loaded climbs so enterEditMode seeds from the
+  // latest data, not the snapshot captured when the actions menu opened.
   const allClimbsRef = useRef(allClimbs);
   allClimbsRef.current = allClimbs;
 
@@ -453,38 +452,60 @@ export default function PlaylistDetail() {
     ]);
   }, [playlist, deletePlaylist, queryClient, playlistUuid, showToast, t, navigation]);
 
-  // Cog (shown in edit mode) → open the edit-details sheet directly. No menu is
-  // involved, so no sheet-handoff dance is needed.
+  // Cog (shown in edit mode) → open the edit-details sheet directly.
   const openEditDetails = useCallback(() => {
     setEditError(null);
     setEditVisible(true);
   }, []);
 
-  // Collapsed overflow menu (owner): Pin toggles in place; Delete confirms; Edit
-  // enters the climbs edit mode once the menu sheet has dismissed (deferred via
-  // the pending ref so the sheet's exit animation doesn't fight the top-bar swap).
+  // Collapsed overflow menu (owner). Every row acts IMMEDIATELY and closes the
+  // sheet itself — never defer the work to `onClose`. Setting `visible` false
+  // goes through the sheet coordinator, which sets `selfDismissRef` and
+  // deliberately swallows `onClose` for a controlled close (see the
+  // 'a coordinator-driven dismiss does NOT fire onClose (selfDismissRef gate)'
+  // test in src/providers/__tests__/sheet-presentation-provider.test.tsx). A row
+  // that hands its work to `onClose` is a silent no-op — that was #3966.
   const menuTogglePin = useCallback(() => {
     setActionsVisible(false);
     void handleTogglePin();
   }, [handleTogglePin]);
 
   const menuEnterEdit = useCallback(() => {
-    pendingEditClimbsRef.current = true;
     setActionsVisible(false);
-  }, []);
+    enterEditMode();
+  }, [enterEditMode]);
+
+  // The coordinator serialises the dismiss-then-present handoff, so opening the
+  // edit-details sheet in the same tick is safe.
+  const menuEditDetails = useCallback(() => {
+    setActionsVisible(false);
+    openEditDetails();
+  }, [openEditDetails]);
+
+  // There is no add-from-here flow yet — adding runs through a climb's own
+  // action menu — so both the overflow row and the empty-state CTA just land the
+  // user on the Climbs tab instead of leaving them at a dead end (#3966).
+  const goToClimbs = useCallback(() => router.navigate('/(tabs)/climbs'), [router]);
+
+  const menuAddClimbs = useCallback(() => {
+    setActionsVisible(false);
+    goToClimbs();
+  }, [goToClimbs]);
 
   const openDelete = useCallback(() => {
     setActionsVisible(false);
     handleDelete();
   }, [handleDelete]);
 
-  const handleActionsClose = useCallback(() => {
-    setActionsVisible(false);
-    if (pendingEditClimbsRef.current) {
-      pendingEditClimbsRef.current = false;
-      enterEditMode();
-    }
-  }, [enterEditMode]);
+  const handleActionsClose = useCallback(() => setActionsVisible(false), []);
+
+  // Owners only, and only while the playlist matches the active board — when it
+  // does not, the switch-board banner owns that prompt.
+  const canAddClimbs = isOwner && !boardBanner;
+  const emptyAction = useMemo(
+    () => (canAddClimbs ? { label: t('detail.menu.addClimbs'), onPress: goToClimbs } : undefined),
+    [canAddClimbs, goToClimbs, t],
+  );
 
   // Floating controls over the hero. Owners get a pin · edit · delete glass
   // toolbar that collapses to a single overflow ⋯ on scroll (and always on
@@ -653,6 +674,7 @@ export default function PlaylistDetail() {
         fetchNextPage={query.fetchNextPage}
         onActivateClimb={playlistActivation.activate}
         emptyMessage={t('detail.empty')}
+        emptyAction={emptyAction}
         actions={renderActions}
         editMode={editMode}
         onReorderClimb={handleReorderClimb}
@@ -669,6 +691,8 @@ export default function PlaylistDetail() {
         visible={actionsVisible}
         isPinned={isPinned}
         onTogglePin={menuTogglePin}
+        onAddClimbs={canAddClimbs ? menuAddClimbs : undefined}
+        onEditDetails={menuEditDetails}
         onEdit={menuEnterEdit}
         onDelete={openDelete}
         onClose={handleActionsClose}

--- a/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
+++ b/packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx
@@ -503,7 +503,7 @@ export default function PlaylistDetail() {
   // does not, the switch-board banner owns that prompt.
   const canAddClimbs = isOwner && !boardBanner;
   const emptyAction = useMemo(
-    () => (canAddClimbs ? { label: t('detail.menu.addClimbs'), onPress: goToClimbs } : undefined),
+    () => (canAddClimbs ? { label: t('detail.menu.addClimbs'), icon: 'add' as const, onPress: goToClimbs } : undefined),
     [canAddClimbs, goToClimbs, t],
   );
 

--- a/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
+++ b/packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx
@@ -55,6 +55,9 @@ vi.mock('../../../../src/lib/graphql/hooks', () => ({
 const commentSheetProps = vi.hoisted(() => ({
   current: null as { entityType?: string; entityId: string | null; canComment?: boolean } | null,
 }));
+const detailViewProps = vi.hoisted(() => ({
+  current: null as { editMode: boolean; emptyAction: { label: string } | null } | null,
+}));
 const snapToIndex = vi.hoisted(() => vi.fn());
 vi.mock('../../../../src/components/you/CommentSheet', () => ({
   CommentSheet: (props: {
@@ -104,9 +107,11 @@ vi.mock('@boardsesh/playlists-react', () => ({
 }));
 
 vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+const routerNavigate = vi.hoisted(() => vi.fn());
 vi.mock('expo-router', () => ({
   useLocalSearchParams: () => ({ playlist_uuid: 'p-1' }),
   useNavigation: () => ({ goBack: vi.fn() }),
+  useRouter: () => ({ navigate: routerNavigate, push: vi.fn(), back: vi.fn() }),
 }));
 
 vi.mock('react-native', () => ({
@@ -169,17 +174,41 @@ vi.mock('../../../../src/components/GlassIconButton', () => ({
   GlassIconButton: () => createElement('div', { 'data-glass-button': 'true' }),
 }));
 // PlaylistDetailView surfaces the hero title so we can prove the error branch
-// renders *instead of* a fallback-titled hero.
+// renders *instead of* a fallback-titled hero, and `editMode` so the overflow
+// menu's regression tests can see the screen actually flip into edit mode.
 vi.mock('../../../../src/components/playlist', () => ({
   PlaylistDetailView: ({
     hero,
     headerSlot,
     actions,
+    editMode,
+    emptyAction,
   }: {
     hero: { name: string };
     headerSlot?: ReactNode;
     actions?: (collapsed: boolean) => ReactNode;
-  }) => createElement('div', { 'data-detail-view': 'true', 'data-hero-name': hero.name }, actions?.(false), headerSlot),
+    editMode?: boolean;
+    emptyAction?: { label: string; onPress: () => void };
+  }) => {
+    detailViewProps.current = { editMode: !!editMode, emptyAction: emptyAction ?? null };
+    return createElement(
+      'div',
+      {
+        'data-detail-view': 'true',
+        'data-hero-name': hero.name,
+        'data-edit-mode': String(!!editMode),
+      },
+      actions?.(false),
+      headerSlot,
+      emptyAction
+        ? createElement(
+            'button',
+            { 'data-empty-action': emptyAction.label, onClick: emptyAction.onPress },
+            emptyAction.label,
+          )
+        : null,
+    );
+  },
   PlaylistDiscussionRow: ({ commentCount, onPress }: { commentCount: number; onPress: () => void }) =>
     createElement(
       'button',
@@ -190,15 +219,19 @@ vi.mock('../../../../src/components/playlist', () => ({
   // Surface the edit submit so the cache-patch test can drive handleEditSubmit
   // without the real gorhom sheet.
   PlaylistFormSheet: ({
+    mode,
+    visible,
     submitError,
     onSubmit,
   }: {
+    mode?: string;
+    visible?: boolean;
     submitError?: string | null;
     onSubmit?: (values: unknown) => void;
   }) =>
     createElement(
       'div',
-      null,
+      { 'data-form-sheet': 'true', 'data-form-mode': mode ?? '', 'data-form-visible': String(!!visible) },
       submitError ? createElement('span', { 'data-edit-error': 'true' }, submitError) : null,
       createElement(
         'button',
@@ -210,7 +243,34 @@ vi.mock('../../../../src/components/playlist', () => ({
         'form-submit',
       ),
     ),
-  PlaylistActionsMenu: () => null,
+  // The overflow menu's rows are the regression surface for #3966: each callback
+  // gets its own button so a test can fire it WITHOUT ever calling `onClose`
+  // (which the real sheet coordinator suppresses on a controlled close).
+  PlaylistActionsMenu: ({
+    onTogglePin,
+    onAddClimbs,
+    onEditDetails,
+    onEdit,
+    onDelete,
+    onClose,
+  }: {
+    onTogglePin?: () => void;
+    onAddClimbs?: () => void;
+    onEditDetails?: () => void;
+    onEdit?: () => void;
+    onDelete?: () => void;
+    onClose?: () => void;
+  }) =>
+    createElement(
+      'div',
+      { 'data-actions-menu': 'true', 'data-has-add-climbs': String(!!onAddClimbs) },
+      createElement('button', { 'data-menu-pin': 'true', onClick: onTogglePin }),
+      onAddClimbs ? createElement('button', { 'data-menu-add': 'true', onClick: onAddClimbs }) : null,
+      createElement('button', { 'data-menu-edit-details': 'true', onClick: onEditDetails }),
+      createElement('button', { 'data-menu-edit-climbs': 'true', onClick: onEdit }),
+      createElement('button', { 'data-menu-delete': 'true', onClick: onDelete }),
+      createElement('button', { 'data-menu-close': 'true', onClick: onClose }),
+    ),
   PlaylistFollowButton: () => null,
   PlaylistEditDoneButton: () => null,
   // Surfaces onEdit so a test can enter the climbs edit mode without the real
@@ -245,6 +305,8 @@ beforeEach(() => {
   commentsMock.calls = [];
   commentsMock.totalCount = 0;
   commentSheetProps.current = null;
+  detailViewProps.current = null;
+  routerNavigate.mockClear();
   snapToIndex.mockClear();
   authMock.isAuthenticated = true;
 });
@@ -456,5 +518,87 @@ describe('PlaylistDetail discussion thread', () => {
     fireEvent.click(container.querySelector('[data-owner-edit="true"]') as HTMLButtonElement);
 
     await waitFor(() => expect(container.querySelector('[data-discussion-row="true"]')).toBeNull());
+  });
+});
+
+// #3966. Every overflow-menu row used to defer its work to the menu's `onClose`,
+// which the sheet coordinator deliberately suppresses on a controlled
+// `visible: true -> false` (see the 'a coordinator-driven dismiss does NOT fire
+// onClose (selfDismissRef gate)' test in sheet-presentation-provider.test.tsx).
+// These tests fire each row WITHOUT calling `onClose` — the exact sequence a
+// real tap produces — so a row that goes back to deferring fails here.
+describe('PlaylistDetail owner overflow menu', () => {
+  async function renderOwnerDetail(playlistOverrides: Record<string, unknown> = {}) {
+    requestMock.mockResolvedValue({ playlist: makePlaylist({ userRole: 'owner', ...playlistOverrides }) });
+    const rendered = renderDetail();
+    await waitFor(() => expect(rendered.container.querySelector('[data-actions-menu="true"]')).not.toBeNull());
+    return rendered;
+  }
+
+  it('enters the climbs edit mode from the menu without waiting on onClose', async () => {
+    const { container } = await renderOwnerDetail();
+    expect(container.querySelector('[data-detail-view="true"]')?.getAttribute('data-edit-mode')).toBe('false');
+
+    fireEvent.click(container.querySelector('[data-menu-edit-climbs="true"]') as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-detail-view="true"]')?.getAttribute('data-edit-mode')).toBe('true'),
+    );
+  });
+
+  it('does not enter edit mode when the menu is only swiped away', async () => {
+    const { container } = await renderOwnerDetail();
+
+    fireEvent.click(container.querySelector('[data-menu-close="true"]') as HTMLButtonElement);
+
+    await waitFor(() => expect(container.querySelector('[data-detail-view="true"]')).not.toBeNull());
+    expect(container.querySelector('[data-detail-view="true"]')?.getAttribute('data-edit-mode')).toBe('false');
+  });
+
+  it('opens the edit-details sheet from the menu (rename has its own row now)', async () => {
+    const { container } = await renderOwnerDetail();
+    expect(container.querySelector('[data-form-sheet="true"]')?.getAttribute('data-form-visible')).toBe('false');
+
+    fireEvent.click(container.querySelector('[data-menu-edit-details="true"]') as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-form-sheet="true"]')?.getAttribute('data-form-visible')).toBe('true'),
+    );
+    expect(container.querySelector('[data-form-sheet="true"]')?.getAttribute('data-form-mode')).toBe('edit');
+    // The rename sheet must NOT drag the screen into edit mode with it.
+    expect(container.querySelector('[data-detail-view="true"]')?.getAttribute('data-edit-mode')).toBe('false');
+  });
+
+  it('routes the add-climbs row and the empty-state CTA to the Climbs tab', async () => {
+    const { container } = await renderOwnerDetail();
+
+    fireEvent.click(container.querySelector('[data-menu-add="true"]') as HTMLButtonElement);
+    expect(routerNavigate).toHaveBeenCalledWith('/(tabs)/climbs');
+
+    routerNavigate.mockClear();
+    fireEvent.click(container.querySelector('[data-empty-action="detail.menu.addClimbs"]') as HTMLButtonElement);
+    expect(routerNavigate).toHaveBeenCalledWith('/(tabs)/climbs');
+  });
+
+  it('hides the add-climbs affordances when the playlist is on another board', async () => {
+    playlistMocks.renderBoardResult = {
+      renderBoard: { boardName: 'kilter', layoutId: 1, sizeId: 10, setIds: '1,20', angle: 40 },
+      banner: { title: 'title', subtitle: 'subtitle', cta: 'cta', onPress: vi.fn() },
+    };
+
+    const { container } = await renderOwnerDetail();
+
+    // The switch-board banner owns that prompt, so no competing add CTA.
+    expect(container.querySelector('[data-actions-menu="true"]')?.getAttribute('data-has-add-climbs')).toBe('false');
+    expect(detailViewProps.current?.emptyAction).toBeNull();
+  });
+
+  it('gives a non-owner no overflow menu at all', async () => {
+    requestMock.mockResolvedValue({ playlist: makePlaylist({ userRole: 'viewer', isPublic: true }) });
+
+    const { container } = renderDetail();
+
+    await waitFor(() => expect(container.querySelector('[data-detail-view="true"]')).not.toBeNull());
+    expect(detailViewProps.current?.emptyAction).toBeNull();
   });
 });

--- a/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistActionsMenu.tsx
@@ -12,6 +12,11 @@ type PlaylistActionsMenuProps = {
   visible: boolean;
   isPinned: boolean;
   onTogglePin: () => void;
+  /** Head to the Climbs tab to pick something to add. Omit to hide the row (the
+   *  playlist belongs to another board, or the viewer is not the owner). */
+  onAddClimbs?: () => void;
+  /** Open the edit-details sheet — name, description, colour, icon, visibility. */
+  onEditDetails: () => void;
   /** Enter the climbs edit mode (reorder + remove). */
   onEdit: () => void;
   onDelete: () => void;
@@ -20,22 +25,30 @@ type PlaylistActionsMenuProps = {
 
 /**
  * Owner overflow sheet — the collapsed form of the hero's pin · edit · delete
- * toolbar, shown once the hero scrolls away (and always on Material). The parent
- * wires Pin → toggle pin, Edit → enter the climbs reorder/remove mode, and
- * Delete → the confirm Alert.
+ * toolbar, shown once the hero scrolls away (and ALWAYS on Material, where it is
+ * the only owner affordance). Rows: pin · add climbs · edit details · reorder &
+ * remove climbs · delete.
+ *
+ * Every row's handler must do its work immediately. `onClose` only fires on a
+ * user pan-down or backdrop tap — the sheet coordinator suppresses it for a
+ * controlled `visible: true -> false` — so a handler that defers to `onClose`
+ * silently does nothing (#3966).
  */
 export function PlaylistActionsMenu({
   visible,
   isPinned,
   onTogglePin,
+  onAddClimbs,
+  onEditDetails,
   onEdit,
   onDelete,
   onClose,
 }: PlaylistActionsMenuProps) {
   const { t } = useTranslation('playlists');
   const { actionColors } = useTheme();
-  // 36% leaves room for the three rows on short screens (e.g. iPhone SE landscape).
-  const snapPoints = useMemo(() => ['36%'], []);
+  // Room for four rows, or five when the add-climbs row is shown, on short
+  // screens (e.g. iPhone SE landscape).
+  const snapPoints = useMemo(() => [onAddClimbs ? '56%' : '46%'], [onAddClimbs]);
   // Monochrome on Liquid Glass, semantic on Material — resolved once as a token.
   const { accent: accentActionIconColor, pin: pinActionIconColor } = actionColors;
 
@@ -52,6 +65,20 @@ export function PlaylistActionsMenu({
             />
           }
           onPress={onTogglePin}
+          showSeparator
+        />
+        {onAddClimbs ? (
+          <ListRow
+            title={t('detail.menu.addClimbs')}
+            leading={<Icon name="add" size={22} color={accentActionIconColor} />}
+            onPress={onAddClimbs}
+            showSeparator
+          />
+        ) : null}
+        <ListRow
+          title={t('detail.menu.editDetails')}
+          leading={<Icon name="settings" size={22} color={accentActionIconColor} />}
+          onPress={onEditDetails}
           showSeparator
         />
         <ListRow

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -84,6 +84,8 @@ export type PlaylistDetailEmptyState = {
 export type PlaylistDetailEmptyAction = {
   /** Already-translated button label. */
   label: string;
+  /** Leading icon on the button. */
+  icon?: IconName;
   onPress: () => void;
 };
 
@@ -410,7 +412,7 @@ export function PlaylistDetailView({
           title={emptyAction.label}
           onPress={emptyAction.onPress}
           size="medium"
-          icon="add"
+          icon={emptyAction.icon}
           style={styles.emptyActionButton}
         />
       ) : null}
@@ -725,7 +727,7 @@ function MaterialEmptyState({
           title={action.label}
           onPress={action.onPress}
           size="medium"
-          icon="add"
+          icon={action.icon}
           style={styles.emptyActionButton}
         />
       ) : null}

--- a/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
+++ b/packages/mobile/src/components/playlist/PlaylistDetailView.tsx
@@ -80,6 +80,13 @@ export type PlaylistDetailEmptyState = {
   supporting?: string;
 };
 
+/** Optional CTA button under the empty state, shown in both variants. */
+export type PlaylistDetailEmptyAction = {
+  /** Already-translated button label. */
+  label: string;
+  onPress: () => void;
+};
+
 export type PlaylistDetailHero = {
   name: string;
   climbCount: number;
@@ -121,6 +128,9 @@ export type PlaylistDetailViewProps = {
   /** Richer Material-branch empty state (e.g. the liked-climbs heart prompt).
    *  Glass branch ignores this and keeps `emptyMessage`. */
   emptyState?: PlaylistDetailEmptyState;
+  /** Optional CTA under the empty state (e.g. "Add climbs" on an owner's empty
+   *  playlist). Rendered in BOTH variants; omit for a message-only empty state. */
+  emptyAction?: PlaylistDetailEmptyAction;
   /** Floating top-right controls (follow / pin / more) over the hero, given the
    *  current collapse state so a control can swap to its compact icon form once
    *  the colour header bar takes over. The back FAB on the left is always
@@ -182,6 +192,7 @@ export function PlaylistDetailView({
   onActivateClimb,
   emptyMessage,
   emptyState,
+  emptyAction,
   actions,
   editMode = false,
   onReorderClimb,
@@ -384,6 +395,7 @@ export function PlaylistDetailView({
       icon={emptyState?.icon ?? 'playlist'}
       title={emptyState?.title ?? emptyMessage}
       supporting={emptyState?.supporting}
+      action={emptyAction}
       titleColor={systemColors.label}
       supportingColor={systemColors.secondaryLabel}
     />
@@ -393,6 +405,15 @@ export function PlaylistDetailView({
       <Text variant="subheadline" style={styles.emptyText}>
         {emptyMessage}
       </Text>
+      {emptyAction ? (
+        <Button
+          title={emptyAction.label}
+          onPress={emptyAction.onPress}
+          size="medium"
+          icon="add"
+          style={styles.emptyActionButton}
+        />
+      ) : null}
     </View>
   );
 
@@ -669,17 +690,20 @@ export function PlaylistDetailView({
   );
 }
 
-/** Centered Material empty state: tonal icon + headline + supporting copy. */
+/** Centered Material empty state: tonal icon + headline + supporting copy, plus
+ *  an optional CTA. */
 function MaterialEmptyState({
   icon,
   title,
   supporting,
+  action,
   titleColor,
   supportingColor,
 }: {
   icon: IconName;
   title: string;
   supporting?: string;
+  action?: PlaylistDetailEmptyAction;
   titleColor: ColorValue;
   supportingColor: ColorValue;
 }) {
@@ -695,6 +719,15 @@ function MaterialEmptyState({
         <Text variant="subheadline" color={supportingColor} style={styles.materialEmptySupporting}>
           {supporting}
         </Text>
+      ) : null}
+      {action ? (
+        <Button
+          title={action.label}
+          onPress={action.onPress}
+          size="medium"
+          icon="add"
+          style={styles.emptyActionButton}
+        />
       ) : null}
     </View>
   );
@@ -964,6 +997,9 @@ const styles = StyleSheet.create({
   },
   materialEmptySupporting: {
     textAlign: 'center',
+  },
+  emptyActionButton: {
+    marginTop: spacing[4],
   },
   banner: {
     marginHorizontal: spacing[4],

--- a/packages/mobile/src/components/playlist/__tests__/playlist-actions-menu.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-actions-menu.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { createElement, type ReactNode, type Ref } from 'react';
 
 const ctrl = vi.hoisted(() => ({ variant: 'liquidGlass' as 'liquidGlass' | 'material' }));
@@ -22,8 +22,8 @@ vi.mock('../../ModalSheet', async () => {
   };
 });
 vi.mock('../../ListRow', () => ({
-  ListRow: ({ title, leading }: { title: string; leading?: ReactNode }) =>
-    createElement('div', { 'data-row': title }, leading),
+  ListRow: ({ title, leading, onPress }: { title: string; leading?: ReactNode; onPress?: () => void }) =>
+    createElement('button', { 'data-row': title, onClick: onPress }, leading),
 }));
 vi.mock('../../Icon', () => ({
   Icon: ({ name, color }: { name: string; color?: unknown }) =>
@@ -49,19 +49,26 @@ vi.mock('../../../theme/tokens', () => ({ spacing: { 2: 8 } }));
 
 import { PlaylistActionsMenu } from '../PlaylistActionsMenu';
 
-const baseProps = {
-  visible: true,
+const handlers = {
   onTogglePin: vi.fn(),
+  onAddClimbs: vi.fn(),
+  onEditDetails: vi.fn(),
   onEdit: vi.fn(),
   onDelete: vi.fn(),
   onClose: vi.fn(),
 };
 
+const baseProps = { visible: true, ...handlers };
+
 beforeEach(() => {
   ctrl.variant = 'liquidGlass';
   modal.present.mockClear();
   modal.dismiss.mockClear();
+  for (const handler of Object.values(handlers)) handler.mockClear();
 });
+
+const rowTitles = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('[data-row]')).map((row) => row.getAttribute('data-row'));
 
 describe('PlaylistActionsMenu', () => {
   it('uses neutral pin/edit icons and destructive delete in Liquid Glass', () => {
@@ -81,5 +88,49 @@ describe('PlaylistActionsMenu', () => {
 
     rerender(<PlaylistActionsMenu {...baseProps} isPinned={false} />);
     expect(container.querySelector('[data-icon="pin"]')?.getAttribute('data-color')).toBe('#007AFF');
+  });
+
+  it('lays the owner rows out pin / add / details / climbs / delete', () => {
+    const { container } = render(<PlaylistActionsMenu {...baseProps} isPinned={false} />);
+
+    expect(rowTitles(container)).toEqual([
+      'library.pin.pin',
+      'detail.menu.addClimbs',
+      'detail.menu.editDetails',
+      'detail.menu.editClimbs',
+      'detail.menu.delete',
+    ]);
+  });
+
+  it('drops the add-climbs row (and its snap height) when the caller omits the handler', () => {
+    const { container } = render(<PlaylistActionsMenu {...baseProps} onAddClimbs={undefined} isPinned={false} />);
+
+    expect(rowTitles(container)).toEqual([
+      'library.pin.pin',
+      'detail.menu.editDetails',
+      'detail.menu.editClimbs',
+      'detail.menu.delete',
+    ]);
+  });
+
+  // #3966: these rows used to hand their work to the sheet's `onClose`, which
+  // the coordinator suppresses on a controlled close, so the taps did nothing.
+  // Each row must call its own handler, and none of them may touch `onClose`.
+  it('fires each row handler exactly once on press and never leans on onClose', () => {
+    const { container } = render(<PlaylistActionsMenu {...baseProps} isPinned={false} />);
+
+    const press = (title: string) => fireEvent.click(container.querySelector(`[data-row="${title}"]`) as HTMLElement);
+    press('library.pin.pin');
+    press('detail.menu.addClimbs');
+    press('detail.menu.editDetails');
+    press('detail.menu.editClimbs');
+    press('detail.menu.delete');
+
+    expect(handlers.onTogglePin).toHaveBeenCalledTimes(1);
+    expect(handlers.onAddClimbs).toHaveBeenCalledTimes(1);
+    expect(handlers.onEditDetails).toHaveBeenCalledTimes(1);
+    expect(handlers.onEdit).toHaveBeenCalledTimes(1);
+    expect(handlers.onDelete).toHaveBeenCalledTimes(1);
+    expect(handlers.onClose).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
+++ b/packages/mobile/src/components/playlist/__tests__/playlist-detail-view.test.tsx
@@ -445,6 +445,25 @@ describe('PlaylistDetailView', () => {
     expect(container.querySelector('[data-icon="playlist"]')).not.toBeNull();
   });
 
+  it('renders the empty-state CTA in both variants and fires it on press', () => {
+    const onPress = vi.fn();
+    const emptyAction = { label: 'Add climbs', onPress };
+
+    for (const variant of ['liquidGlass', 'material'] as const) {
+      ctrl.variant = variant;
+      const { getByText, unmount } = render(<PlaylistDetailView {...makeProps({ climbs: [], emptyAction })} />);
+      fireEvent.click(getByText('Add climbs'));
+      unmount();
+    }
+
+    expect(onPress).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves the empty state CTA-free when no emptyAction is given', () => {
+    const { container } = render(<PlaylistDetailView {...makeProps({ climbs: [] })} />);
+    expect(container.querySelector('[data-button="true"]')).toBeNull();
+  });
+
   it('shows a small footer spinner when isFetchingNextPage=true', () => {
     const { container } = render(<PlaylistDetailView {...makeProps({ isFetchingNextPage: true, climbs: [CLIMB] })} />);
     expect(container.querySelector('[data-spinner="small"]')).not.toBeNull();

--- a/packages/mobile/src/components/playlist/index.ts
+++ b/packages/mobile/src/components/playlist/index.ts
@@ -7,6 +7,7 @@ export {
   type PlaylistDetailViewProps,
   type PlaylistDetailHero,
   type PlaylistDetailEmptyState,
+  type PlaylistDetailEmptyAction,
 } from './PlaylistDetailView';
 export { PlaylistBackFab } from './PlaylistBackFab';
 export { PlaylistFormSheet, type PlaylistFormValues } from './PlaylistFormSheet';

--- a/packages/shared/i18n/locales/de/playlists.json
+++ b/packages/shared/i18n/locales/de/playlists.json
@@ -118,7 +118,9 @@
       "subtitle": "Für diesen Boulder fehlen die Board-Daten."
     },
     "menu": {
-      "editClimbs": "Boulder bearbeiten",
+      "addClimbs": "Boulder hinzufügen",
+      "editDetails": "Details bearbeiten",
+      "editClimbs": "Boulder umsortieren & entfernen",
       "delete": "Löschen"
     },
     "visibility": {

--- a/packages/shared/i18n/locales/en-US/playlists.json
+++ b/packages/shared/i18n/locales/en-US/playlists.json
@@ -118,7 +118,9 @@
       "subtitle": "Board data is missing for this climb."
     },
     "menu": {
-      "editClimbs": "Edit climbs",
+      "addClimbs": "Add climbs",
+      "editDetails": "Edit details",
+      "editClimbs": "Reorder & remove climbs",
       "delete": "Delete"
     },
     "visibility": {

--- a/packages/shared/i18n/locales/es/playlists.json
+++ b/packages/shared/i18n/locales/es/playlists.json
@@ -118,7 +118,9 @@
       "subtitle": "Faltan datos del plafón para este bloque."
     },
     "menu": {
-      "editClimbs": "Editar bloques",
+      "addClimbs": "Añadir bloques",
+      "editDetails": "Editar detalles",
+      "editClimbs": "Reordenar y quitar bloques",
       "delete": "Eliminar"
     },
     "visibility": {

--- a/packages/shared/i18n/locales/fr/playlists.json
+++ b/packages/shared/i18n/locales/fr/playlists.json
@@ -118,7 +118,9 @@
       "subtitle": "Les données de board manquent pour cette voie."
     },
     "menu": {
-      "editClimbs": "Modifier les blocs",
+      "addClimbs": "Ajouter des blocs",
+      "editDetails": "Modifier les détails",
+      "editClimbs": "Réorganiser et retirer des blocs",
       "delete": "Supprimer"
     },
     "visibility": {


### PR DESCRIPTION
## Summary

Closes #3966.

The reporter filed four complaints against Android 2.2.2. Three are still live on `main`; one was
fixed after the report landed.

**The primary bug is a regression, and it is the reason the other two look broken.** In
`packages/mobile/app/(tabs)/discover/[playlist_uuid].tsx`, the owner overflow menu's "Edit climbs"
row did not enter edit mode. `menuEnterEdit` only set `pendingEditClimbsRef.current = true` and
`setActionsVisible(false)`; the actual `enterEditMode()` call lived in `handleActionsClose`, which is
wired to `PlaylistActionsMenu` → `ModalSheet`'s `onClose`. But `onClose` fires **only** on a user
pan-down / backdrop tap. A controlled `visible: true -> false` goes through the sheet coordinator,
which sets `selfDismissRef` and deliberately swallows `onClose`
(`src/providers/sheet-presentation-provider.tsx`; the contract is already pinned by the
`a coordinator-driven dismiss does NOT fire onClose (selfDismissRef gate)` test). So the row closed
the sheet and did nothing. The stale `pendingEditClimbsRef = true` then dropped the screen into edit
mode the next time the user swiped that menu away, which reads as a second, unrelated glitch.

Regression origin: `8973ec8f1` (2026-07-02) swapped `ModalSheet`'s `onDismiss` (gesture **or**
programmatic) for `onClose` (user-initiated only). Its commit message states the semantic change, but
the one consumer that depended on the old behaviour — this deferred handoff, added 2026-06-10 in
`3e577cfef` — was not audited.

Why it reads as "can't rename / can't delete climbs", and why on Android: edit mode is the only route
to both. Removing a climb is the per-row control in edit mode; renaming is the cog beside the
playlist name, which `PlaylistDetailView` renders only when `editMode && onEditDetails`. On the
Material (Android) variant `PlaylistDetailView` always renders the collapsed form, so the overflow
menu is the only owner affordance and both actions were permanently unreachable. On iOS/Liquid Glass
the un-collapsed toolbar calls `enterEditMode` directly, so it only broke once the hero scrolled
away.

### The four complaints

| # | Reported | Status |
| --- | --- | --- |
| 1 | "Can't rename playlist" | **Fixed here** — rename gets its own "Edit details" row, and the edit-climbs route it used to hide behind now works. |
| 2 | "Can't delete climbs from playlist" | **Fixed here** — the per-row remove control lives in edit mode, which the menu now actually enters. |
| 3 | "Can't add from menu option only from climb" | **Partly fixed here** — an "Add climbs" row and an empty-state CTA now land on the Climbs tab instead of leaving a dead end. Adding still runs through a climb's own action menu; a real "adding to `<playlist>`" selection mode on the climbs list is a separate, larger change, filed as #4630. |
| 4 | "Can't play a playlist. Only the first climb gets added to the queue" | **Already fixed** by `b487e6cfc` + `bae27879c` (#3997 / #4010, issue #3891) — the MoonBoard `compatible_size_ids` / `required_set_ids` filters were dropping every row from the playlist-climbs join. Backend-side, so it reached the reporter without an app update. Nothing in this PR. |

### What changed

- Every overflow-menu row now acts immediately and closes the sheet itself. `pendingEditClimbsRef` is
  gone and `handleActionsClose` is back to just clearing `actionsVisible`. A comment on both the
  screen and the component points at the `selfDismissRef` contract test so nobody re-adds an
  onClose-deferred handoff.
- New "Edit details" row (cog) opens the rename / colour / icon / visibility sheet. The coordinator
  already serialises a dismiss-then-present handoff, so this needs no deferral either.
- New "Add climbs" row + empty-state CTA, both routing to the Climbs tab. Gated on
  `isOwner && !boardBanner` — when the playlist belongs to another board the existing switch-board
  banner owns that prompt.
- "Edit climbs" is relabelled "Reorder & remove climbs" now that details editing is its own row.
- `PlaylistDetailView` gains an optional `emptyAction`, rendered in **both** the Material and Liquid
  Glass empty states.
- Sheet snap points go `36%` → `46%` (four rows) / `56%` (five, with add-climbs).
- New keys `detail.menu.addClimbs` and `detail.menu.editDetails` plus the relabelled
  `detail.menu.editClimbs`, in all four locales per the `docs/i18n-*-glossary.md` files (es
  "bloques", fr "blocs", de "Boulder").

No native fingerprint inputs touched — everything is under `packages/mobile/src`,
`packages/mobile/app`, and `packages/shared/i18n/locales/**`. Ships over OTA.

## Release Notes

- Managing your own playlist works again on Android: the ⋯ menu's edit row now actually opens edit mode, so you can reorder and pull climbs out.
- Rename a playlist, change its colour or icon straight from the ⋯ menu — no more hunting for the cog.
- Empty playlist? There's a button that takes you to the climbs list instead of a dead end.

## Test plan

Automated:

- **Regression guard** in `packages/mobile/app/(tabs)/discover/__tests__/playlist-uuid.test.tsx` fires
  each menu row **without ever calling the sheet's `onClose`** — the exact sequence a real tap
  produces. Verified it FAILS on the old wiring (reverted the two callbacks locally: 1 failed /
  15 passed, `data-edit-mode` stuck at `"false"`) and passes on this branch.
- Same file: the rename row opens the form sheet at `mode: 'edit'` without dragging the screen into
  edit mode; a menu-only swipe-away does not enter edit mode; add-climbs and the empty CTA both call
  `router.navigate('/(tabs)/climbs')`; both add affordances disappear behind a board banner and for
  non-owners.
- `playlist-actions-menu.test.tsx`: row order pin / add / details / climbs / delete, the add row
  drops when the handler is omitted, and each row fires its own handler exactly once while `onClose`
  stays untouched.
- `playlist-detail-view.test.tsx`: the empty-state CTA renders and fires in both variants, and the
  empty state stays CTA-free without `emptyAction`.

Commands (all green):

- `vp run typecheck:mobile`
- `vp run test:mobile` — 684 files / 6559 tests passed
- `vp run check:mobile-bundle` — android bundle OK
- `vp run check:i18n` — 323 .tsx scanned, no hardcoded strings
- `vp test run --reporter=agent catalog-completeness` — 96 passed (four-locale key parity)
- `vp check`

**Device QA is owed and I could not capture it.** No Android device or working emulator in this
environment, and the flows in question are native sheet + Material Appbar behaviour that jsdom tests
cannot stand in for. @marcodejongh — please exercise on Android (Material variant), on a playlist you
own:

1. ⋯ → **Reorder & remove climbs** enters edit mode (drag handles + red remove controls appear, Done
   replaces the ⋯).
2. ⋯ → **Edit details** opens the rename sheet, and a rename persists.
3. ⋯ → **Add climbs** lands on the Climbs tab; an empty playlist shows the same CTA in its empty
   state.
4. Removing a climb decrements the hero count.
5. Open ⋯ and swipe the sheet **down** — the screen must NOT jump into edit mode.
6. Sanity-check the five-row sheet is not clipped at `56%` on a short screen.
