### PR TITLE
fix(web): bound the embed and kiosk SSR fetches

### DIFF
--- a/packages/web/app/components/kiosk/__tests__/board-slot-data.test.ts
+++ b/packages/web/app/components/kiosk/__tests__/board-slot-data.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+
+// `fetchInitialClimbs` is the SSR seed for "what's lit on the wall right now".
+// It is `cache: 'no-store'`, so every kiosk and every board embed render pays
+// it for real — which makes it the backend read with the least excuse to be
+// unbounded. It already degrades to `[]` (the slot paints the bare board and
+// the live subscription fills it in a moment later); these pin that a stalled
+// backend reaches that degraded path instead of holding the render open.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/app/lib/graphql/client', () => ({
+  getGraphQLHttpUrl: () => 'http://backend.test/graphql',
+}));
+vi.mock('@/app/lib/board-utils', () => ({
+  getBoardDetailsForBoard: () => ({ board_name: 'kilter' }),
+}));
+vi.mock('../../board-renderer/util', () => ({
+  buildBoardRenderUrl: () => 'http://render.test/board.png',
+  toFlatFrames: () => '',
+}));
+
+import { SSR_BACKEND_FETCH_TIMEOUT_MS } from '@/app/lib/ssr-fetch-deadline';
+import { buildBoardSlotData, type BoardSlotSource } from '../board-slot-data';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const board: BoardSlotSource = {
+  boardId: 42,
+  boardUuid: '11111111-1111-4111-8111-111111111111',
+  boardType: 'kilter',
+  layoutId: 1,
+  sizeId: 10,
+  setIds: '1,20',
+};
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('buildBoardSlotData — the recent-climbs seed is deadlined', () => {
+  it('passes the AbortSignal built from SSR_BACKEND_FETCH_TIMEOUT_MS to fetch', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { boardRecentClimbs: [] } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await buildBoardSlotData(board);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(SSR_BACKEND_FETCH_TIMEOUT_MS);
+    const [, requestInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(requestInit.signal).toBe(timeoutSpy.mock.results[0].value);
+    expect(requestInit.cache).toBe('no-store');
+  });
+
+  it('degrades to an empty seed when the deadline fires', async () => {
+    mockFetch.mockRejectedValueOnce(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+
+    const slotData = await buildBoardSlotData(board);
+
+    expect(slotData?.initialClimb).toBeNull();
+    expect(slotData?.bareBoardImageUrl).toBe('http://render.test/board.png');
+  });
+});

--- a/packages/web/app/components/kiosk/__tests__/kiosk-fetch-deadline.test.ts
+++ b/packages/web/app/components/kiosk/__tests__/kiosk-fetch-deadline.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+
+// A gym TV is the surface with the least chance of a human hitting reload, so
+// `fetchGymKiosk` hanging on a stalled backend is the worst version of this
+// bug: an indefinitely blank screen on a wall. The fetch already maps every
+// failure to 'error' (→ KioskRetryScreen, which self-heals); these pin that a
+// stall reaches that path within the SSR deadline.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+vi.mock('server-only', () => ({}));
+vi.mock('@/app/lib/graphql/client', () => ({
+  getGraphQLHttpUrl: () => 'http://backend.test/graphql',
+}));
+
+import { SSR_BACKEND_FETCH_TIMEOUT_MS } from '@/app/lib/ssr-fetch-deadline';
+import { fetchGymKiosk } from '../kiosk-page-renderer';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+// `fetchGymKiosk` is React `cache()`-wrapped, so every test needs a fresh slug.
+let slugCounter = 0;
+function nextGymSlug(): string {
+  slugCounter += 1;
+  return `gym-${slugCounter}`;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchGymKiosk — the kiosk config read is deadlined', () => {
+  it('passes the AbortSignal built from SSR_BACKEND_FETCH_TIMEOUT_MS to fetch', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { gymKiosk: null } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await fetchGymKiosk(nextGymSlug(), null);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(SSR_BACKEND_FETCH_TIMEOUT_MS);
+    const [, requestInit] = mockFetch.mock.calls[0] as [string, RequestInit & { next?: unknown }];
+    expect(requestInit.signal).toBe(timeoutSpy.mock.results[0].value);
+    expect(requestInit.next).toEqual({ revalidate: 60 });
+  });
+
+  it('maps a fired deadline to error, so the TV shows the retry screen', async () => {
+    mockFetch.mockRejectedValueOnce(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+
+    expect(await fetchGymKiosk(nextGymSlug(), null)).toEqual({ status: 'error' });
+  });
+
+  it('still distinguishes a genuine missing kiosk from a stall', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { gymKiosk: null } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    expect(await fetchGymKiosk(nextGymSlug(), null)).toEqual({ status: 'ok', kiosk: null });
+  });
+});

--- a/packages/web/app/components/kiosk/board-slot-data.ts
+++ b/packages/web/app/components/kiosk/board-slot-data.ts
@@ -8,6 +8,7 @@ import 'server-only';
 import { BOARD_RECENT_CLIMBS } from '@boardsesh/graphql/operations';
 import type { BoardPresenceClimb } from '@boardsesh/shared-schema';
 import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+import { SSR_BACKEND_FETCH_TIMEOUT_MS } from '@/app/lib/ssr-fetch-deadline';
 import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import type { BoardDetails } from '@/app/lib/types';
 import { buildBoardRenderUrl, toFlatFrames } from '../board-renderer/util';
@@ -51,13 +52,19 @@ function resolveBoardDetails(board: BoardSlotSource): BoardDetails | null {
 }
 
 /** Latest climbs for a board (newest first; index 0 = current). Anonymous,
- * uncached — this is the SSR seed for what's lit right now. */
+ * uncached — this is the SSR seed for what's lit right now.
+ *
+ * `cache: 'no-store'` means every kiosk/embed render pays this call for real,
+ * so it is the one with the least excuse to be unbounded. It already degrades
+ * to `[]` (the slot paints the bare board and the live subscription fills it in
+ * a moment later), which is a far better answer than a render that never ends. */
 async function fetchInitialClimbs(boardId: number): Promise<BoardPresenceClimb[]> {
   try {
     const response = await fetch(getGraphQLHttpUrl(), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query: BOARD_RECENT_CLIMBS, variables: { boardId } }),
+      signal: AbortSignal.timeout(SSR_BACKEND_FETCH_TIMEOUT_MS),
       cache: 'no-store',
     });
     if (!response.ok) return [];

--- a/packages/web/app/components/kiosk/embed/__tests__/embed-fetchers.server.test.ts
+++ b/packages/web/app/components/kiosk/embed/__tests__/embed-fetchers.server.test.ts
@@ -9,13 +9,14 @@
 // working embeds; one that flips ok/null into error would mask the security
 // gates behind the retry screen — both directions matter.
 
-import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
 vi.mock('server-only', () => ({}));
 vi.mock('@/app/lib/graphql/client', () => ({
   getGraphQLHttpUrl: () => 'http://backend.test/graphql',
 }));
 
+import { SSR_BACKEND_FETCH_TIMEOUT_MS } from '@/app/lib/ssr-fetch-deadline';
 import { fetchBoardForEmbed, fetchGymBoardsForEmbed, fetchGymForEmbed } from '../embed-fetchers';
 
 const mockFetch = vi.fn();
@@ -38,6 +39,48 @@ function nextUuid(): string {
 
 beforeEach(() => {
   mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// An unbounded SSR fetch is what turns a stalled backend into a blank iframe:
+// Node's fetch has no default timeout, so nothing else in this file's contract
+// gets a chance to run. These pin that the deadline is actually attached to the
+// request — not merely declared as a constant somewhere.
+describe('every embed fetch carries the SSR deadline', () => {
+  it('passes the AbortSignal built from SSR_BACKEND_FETCH_TIMEOUT_MS to fetch', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: { board: null } }));
+
+    await fetchBoardForEmbed(nextUuid());
+
+    expect(timeoutSpy).toHaveBeenCalledWith(SSR_BACKEND_FETCH_TIMEOUT_MS);
+    const [, requestInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(requestInit.signal).toBe(timeoutSpy.mock.results[0].value);
+    expect(requestInit.signal?.aborted).toBe(false);
+  });
+
+  it('holds the deadline for the gym and gym-boards queries too', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: { gym: null } }));
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: { gymBoards: [] } }));
+
+    await fetchGymForEmbed(nextUuid());
+    await fetchGymBoardsForEmbed(nextUuid());
+
+    expect(timeoutSpy.mock.calls).toEqual([[SSR_BACKEND_FETCH_TIMEOUT_MS], [SSR_BACKEND_FETCH_TIMEOUT_MS]]);
+    for (const [, requestInit] of mockFetch.mock.calls as [string, RequestInit][]) {
+      expect(requestInit.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it('maps a fired deadline to error, so the widget paints the retry screen', async () => {
+    mockFetch.mockRejectedValueOnce(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+
+    expect(await fetchBoardForEmbed(nextUuid())).toEqual({ status: 'error' });
+  });
 });
 
 describe('fetchBoardForEmbed — transient failures are errors, never ok/null', () => {

--- a/packages/web/app/components/kiosk/embed/embed-fetchers.ts
+++ b/packages/web/app/components/kiosk/embed/embed-fetchers.ts
@@ -15,6 +15,13 @@
 // board/gym config changes still land within minutes. Live climb data does NOT
 // ride these fetches (the board embed's presence hub and the leaderboard's
 // client refetch carry freshness).
+//
+// Deadline: an unbounded `await fetch` here is what turns a slow backend into a
+// blank iframe. Node's fetch has no default timeout, so a socket that is
+// accepted and then never answered holds the render open indefinitely. With the
+// signal the catch below maps the abort to 'error' and the widget paints its
+// retry screen in seconds. See SSR_BACKEND_FETCH_TIMEOUT_MS for the value and
+// for the one case Next will not let us bound.
 
 import 'server-only';
 import { cache } from 'react';
@@ -28,6 +35,7 @@ import {
 } from '@boardsesh/graphql/operations';
 import type { Gym, UserBoard } from '@boardsesh/shared-schema';
 import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+import { SSR_BACKEND_FETCH_TIMEOUT_MS } from '@/app/lib/ssr-fetch-deadline';
 
 const EMBED_REVALIDATE_SECONDS = 300;
 
@@ -49,6 +57,7 @@ async function fetchEmbedGraphQL<ResponseData, Entity>(
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(SSR_BACKEND_FETCH_TIMEOUT_MS),
       next: { revalidate: EMBED_REVALIDATE_SECONDS },
     });
     if (!response.ok) return { status: 'error' };

--- a/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
+++ b/packages/web/app/components/kiosk/kiosk-page-renderer.tsx
@@ -13,6 +13,7 @@ import type { Metadata } from 'next';
 import { GET_GYM_KIOSK } from '@boardsesh/graphql/operations';
 import type { GymKiosk, GymKioskBoard } from '@boardsesh/shared-schema';
 import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+import { SSR_BACKEND_FETCH_TIMEOUT_MS } from '@/app/lib/ssr-fetch-deadline';
 import { getPublicBackendHttpUrl } from '@/app/lib/backend-url';
 import { resolveGymLogoDisplayUrl } from '@/app/lib/gym-logo-display-url';
 import { getLocale } from '@/app/lib/i18n/get-locale';
@@ -47,6 +48,11 @@ export type GymKioskFetchResult = { status: 'ok'; kiosk: GymKiosk | null } | { s
 /**
  * Anonymous, request-deduped (React cache) kiosk fetch shared by the page body
  * and generateMetadata. Mirrors `resolveBoardBySlug`'s transport.
+ *
+ * The deadline matters more here than anywhere: nobody is watching a gym TV's
+ * tab to hit reload. An aborted fetch lands in the catch as 'error', which is
+ * already the retry screen — so a wedged backend costs the TV a few seconds and
+ * a self-healing reload instead of an indefinitely blank page.
  */
 export const fetchGymKiosk = cache(async (gymSlug: string, kioskSlug: string | null): Promise<GymKioskFetchResult> => {
   try {
@@ -54,6 +60,7 @@ export const fetchGymKiosk = cache(async (gymSlug: string, kioskSlug: string | n
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ query: GET_GYM_KIOSK, variables: { gymSlug, kioskSlug } }),
+      signal: AbortSignal.timeout(SSR_BACKEND_FETCH_TIMEOUT_MS),
       next: { revalidate: KIOSK_REVALIDATE_SECONDS },
     });
     if (!response.ok) return { status: 'error' };

--- a/packages/web/app/lib/__tests__/board-slug-utils.test.ts
+++ b/packages/web/app/lib/__tests__/board-slug-utils.test.ts
@@ -25,6 +25,7 @@ vi.mock('@/app/lib/graphql/client', () => ({
 vi.stubGlobal('fetch', fetchMock);
 
 import { resolveBoardBySlug, type ResolvedBoard } from '../board-slug-utils';
+import { SSR_BACKEND_FETCH_TIMEOUT_MS } from '../ssr-fetch-deadline';
 
 const publicBoard: ResolvedBoard = {
   uuid: '11111111-1111-4111-8111-111111111111',
@@ -142,6 +143,31 @@ describe('resolveBoardBySlug', () => {
     );
 
     await expect(resolveBoardBySlug(publicBoard.slug)).rejects.toThrow(/GraphQL errors/);
+  });
+
+  // "Every failure throws" only holds if failures happen. A backend that
+  // accepts the socket and never answers is otherwise not a failure at all —
+  // it is a `/b/{slug}` render that never finishes.
+  it('bounds both the anonymous and the authenticated read with the SSR deadline', async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+    getServerAuthTokenMock.mockResolvedValueOnce(undefined).mockResolvedValueOnce('signed-session-token');
+    fetchMock.mockResolvedValueOnce(graphQlResponse(publicBoard)).mockResolvedValueOnce(graphQlResponse(privateBoard));
+
+    await resolveBoardBySlug(publicBoard.slug);
+    await resolveBoardBySlug(privateBoard.slug);
+
+    expect(timeoutSpy.mock.calls).toEqual([[SSR_BACKEND_FETCH_TIMEOUT_MS], [SSR_BACKEND_FETCH_TIMEOUT_MS]]);
+    const [, anonymousRequest] = fetchMock.mock.calls[0];
+    const [, authenticatedRequest] = fetchMock.mock.calls[1];
+    expect(anonymousRequest?.signal).toBe(timeoutSpy.mock.results[0].value);
+    expect(authenticatedRequest?.signal).toBe(timeoutSpy.mock.results[1].value);
+    timeoutSpy.mockRestore();
+  });
+
+  it('throws instead of returning null when the deadline fires', async () => {
+    fetchMock.mockRejectedValueOnce(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+
+    await expect(resolveBoardBySlug(publicBoard.slug)).rejects.toThrow(/aborted/);
   });
 
   it('does not let an anonymous miss cross into a later authenticated request', async () => {

--- a/packages/web/app/lib/board-slug-utils.ts
+++ b/packages/web/app/lib/board-slug-utils.ts
@@ -3,6 +3,7 @@ import { cache } from 'react';
 import type { ParsedBoardRouteParameters, BoardName } from '@/app/lib/types';
 import { getServerAuthToken } from '@/app/lib/auth/server-auth';
 import { getGraphQLHttpUrl } from '@/app/lib/graphql/client';
+import { SSR_BACKEND_FETCH_TIMEOUT_MS } from '@/app/lib/ssr-fetch-deadline';
 
 export type ResolvedBoard = {
   uuid: string;
@@ -42,6 +43,11 @@ export type ResolvedBoard = {
  * Vercel's cacheable-status list — one blip pinned a cached 404 on an indexed
  * front door for the length of its `s-maxage` (24 h on lists). A 5xx is never
  * CDN-cached, and Google retries it and keeps the URL.
+ *
+ * "Every failure throws" only works if every failure eventually happens, which
+ * is what SSR_BACKEND_FETCH_TIMEOUT_MS buys: a backend that accepts the socket
+ * and never answers is otherwise not a failure at all, just a render that never
+ * finishes.
  */
 export const resolveBoardBySlug = cache(async (slug: string): Promise<ResolvedBoard | null> => {
   const url = getGraphQLHttpUrl();
@@ -77,10 +83,14 @@ export const resolveBoardBySlug = cache(async (slug: string): Promise<ResolvedBo
   // enter the shared data cache. Anonymous responses remain safely reusable.
   const cacheOptions = authToken ? { cache: 'no-store' as const } : { next: { revalidate: 300 } };
 
+  // An abort lands in the same bucket as a rejected fetch: it throws, so
+  // `/b/{slug}` answers 5xx (retried by crawlers, never CDN-cached) instead of
+  // holding the connection open for as long as the backend cares to stall.
   const response = await fetch(url, {
     method: 'POST',
     headers,
     body: JSON.stringify({ query, variables: { slug } }),
+    signal: AbortSignal.timeout(SSR_BACKEND_FETCH_TIMEOUT_MS),
     ...cacheOptions,
   });
 

--- a/packages/web/app/lib/ssr-fetch-deadline.ts
+++ b/packages/web/app/lib/ssr-fetch-deadline.ts
@@ -1,0 +1,28 @@
+import 'server-only';
+
+/**
+ * Wall-clock ceiling for a server-render fetch to the GraphQL backend.
+ *
+ * Without one, an SSR `await fetch(...)` inherits undici's default: no timeout
+ * at all. A backend that accepts the socket and then never answers holds the
+ * render open until the client, the proxy, or the platform gives up — which on
+ * an unattended surface (an iframe on a gym's website, a TV in a gym) means a
+ * blank frame for minutes instead of the retry screen the page already knows
+ * how to render.
+ *
+ * 3000 ms matches the deadline #4461 put on the home page's `popularBoardConfigs`
+ * / `recentBetaLinks` reads and on the front-door `createCachedGraphQLQuery`
+ * calls. One number across every SSR backend read beats a bespoke value per
+ * surface: these are all "render something within a page-load budget or degrade",
+ * and a caller that genuinely needs longer should say so at its own call site.
+ *
+ * What this does NOT cover: Next deliberately strips the signal when it
+ * revalidates a STALE cache entry (`patch-fetch.js`, "don't pass through signal
+ * when revalidating" → `signal: isStale ? undefined : signal`), and the render
+ * waits on that revalidate promise before the response closes
+ * (`app-render.js` puts it on `options.waitUntil`; `render-result.js`'s `pipeTo`
+ * awaits `this.waitUntil` before closing the stream). So a warm entry rolling
+ * over against a slow backend can still hold a response open past this deadline.
+ * The deadline bounds the COLD render; the stale-revalidate hole is upstream.
+ */
+export const SSR_BACKEND_FETCH_TIMEOUT_MS = 3000;

--- a/packages/web/e2e/aa-embed-headers.spec.ts
+++ b/packages/web/e2e/aa-embed-headers.spec.ts
@@ -4,9 +4,15 @@ import { test, expect, type APIResponse } from '@playwright/test';
 // alphabetically within a shard, and this file's raw APIRequestContext
 // requests hang for 60s+ if certain browser-driven specs run against the
 // same server first — first-in-shard they pass every time, and the whole
-// suite is green. Which test poisons the server for raw requests is
-// unsolved and tracked; do not rename this file below its neighbours
-// until that is fixed.
+// suite is green. Do not rename this file below its neighbours.
+//
+// Half of that is fixed: #4463 gave the embed/kiosk SSR backend fetches a 3 s
+// deadline, so a stalled backend now renders the retry screen instead of
+// hanging the request. The other half is not: why the backend stalls on those
+// queries only after browser specs have run is still unexplained, and #4463
+// stays open on it. Nothing about this file is a Playwright state leak — the
+// `request` fixture builds a fresh APIRequestContext per test, and the suite
+// installs no service worker, storageState, or route interception.
 
 // These are raw APIRequestContext gets against a server that is concurrently
 // SSR-ing front-door pages for the other worker's browser tests. On a 2-core

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -16,23 +16,25 @@ export default defineConfig({
   /* 1 retry in CI and locally — enough to absorb a single transient infra blip,
    * but not enough to bury a hard-broken test the way `retries: 3` did before. */
   retries: 1,
-  /* 1 in CI, deliberately. The suite already fans out as 8 shard jobs, each
-   * with its own server + database, so cross-shard parallelism carries the
-   * wall-clock. A second in-shard worker makes front-door page loads compete
-   * with the raw-request specs on a 2-core runner; the observed symptom was the
-   * embed header checks hanging >60s whenever they shared shard 7 with the
-   * rewritten tab-bar spec's front-door loads (#4448).
+  /* 1 in CI, deliberately, and staying that way. The suite already fans out as
+   * 8 shard jobs, each with its own server + database, so cross-shard
+   * parallelism carries the wall-clock and a second in-shard worker only adds
+   * contention on a 2-core runner.
    *
-   * Attribution corrected in #4461: this is NOT web DB-pool contention, as this
-   * comment used to claim. `/embed/**` issues zero web-side Postgres statements
-   * — it fetches the backend over HTTP (`embed-fetchers.ts`), so it cannot
-   * queue behind the web pool. The likelier mechanism is the event loop: a
-   * `/list` SSR render fires same-origin `/api/internal/board-render` warm
-   * requests, each a CPU-bound WASM render in the same runtime, and unrelated
-   * raw requests queue behind those. #4461 capped that fan-out; whether it is
-   * enough to restore 2 workers is #4463's call, not a change to make here.
-   * Which files share a shard reshuffles whenever specs are added or removed,
-   * so the flake jumps between unrelated files instead of staying put. */
+   * Two mechanisms this comment used to blame have been ruled out. It is not
+   * web DB-pool contention (#4461): `/embed/**` issues zero web-side Postgres
+   * statements, it fetches the backend over HTTP. It is not the web event loop
+   * being pegged by `/api/internal/board-render` WASM renders either: in run
+   * 31857179523's shard 7 the same server answered `/embed/gym/...` in 201 ms
+   * and `/` in 3.2 s while a `/embed/board/...` request started 1.3 s earlier
+   * sat stuck for 30 s. A blocked event loop cannot do that.
+   *
+   * What that shard actually showed was one un-deadlined SSR backend fetch
+   * hanging while the rest of the server stayed healthy. #4463 put a deadline
+   * on those fetches so a stall degrades in 3 s. What is still unexplained is
+   * why the backend stalled on that one query only after browser specs had run
+   * — until that is understood, 1 worker is the setting we can defend, and the
+   * `aa-embed-headers.spec.ts` ordering pin stays. */
   workers: process.env.CI ? 1 : undefined,
   /* Global per-test timeout — some tests (zoom, login flows) need more than Playwright's 30 s default */
   timeout: 60_000,


### PR DESCRIPTION
## Summary

Refs #4463.

Four SSR reads awaited the GraphQL backend with no deadline. Node's `fetch` has no default timeout, so a backend that accepts the socket and never answers holds the render open for as long as the platform allows. On `/embed/**` that is a blank iframe on a gym's website; on `/kiosk/**` it is a blank TV on a gym wall — the two surfaces where nobody is watching a tab to hit reload. Each fetcher already had a degraded path (the self-healing retry screen, an empty climb seed, a throw); a stall was simply never reaching it.

This adds `signal: AbortSignal.timeout(3000)` to:

| | file | degrades to |
|---|---|---|
| `fetchEmbedGraphQL` | `components/kiosk/embed/embed-fetchers.ts` | `{ status: 'error' }` → `EmbedRetryState` |
| `fetchGymKiosk` | `components/kiosk/kiosk-page-renderer.tsx` | `{ status: 'error' }` → `KioskRetryScreen` |
| `fetchInitialClimbs` | `components/kiosk/board-slot-data.ts` | `[]` → bare board, live subscription fills it in |
| `resolveBoardBySlug` | `lib/board-slug-utils.ts` | throws → 5xx (never CDN-cached, crawler-retried) |

`resolveBoardBySlug` is included because it is the identical shape on higher traffic: same anonymous POST, same `next: { revalidate: 300 }`, no signal, and it backs the `/b/{slug}` front doors. Its docstring already promised "every failure throws" — that only holds if failures actually happen, and a socket that is accepted and never answered is otherwise not a failure at all.

**3000 ms, not a bespoke value.** #4461 chose 3000 for the home page's `popularBoardConfigs` / `recentBetaLinks` and for the front-door `createCachedGraphQLQuery` calls. These are all "render something within a page-load budget or degrade", and an unattended screen is better served by a retry loop that turns over quickly than by one long wait. The number and the reasoning live in one place now (`app/lib/ssr-fetch-deadline.ts`) instead of being a literal per call site.

## What this does NOT explain

**The order dependence in #4463 is still unexplained, so this uses `Refs`, not `Closes`, and the issue stays open.** The `aa-` filename pin on `e2e/aa-embed-headers.spec.ts` stays too. What we know is that a backend stall reaches those specs; what we still cannot say is why the backend stalls on those queries only after browser-driven specs have run against the same server. Bounding the fetch changes a 60 s hang into a 3 s degrade — it does not tell you why the backend was slow.

### What the mechanism is not

The un-deadlined fetch by itself explains the CI trace, without any cross-request coupling. Two candidate amplifiers were checked and are wrong:

- **Not a process-global Next fetch-cache lock.** `IncrementalCache` is constructed fresh per request (`next-server.js`, whose own comment reads "incremental-cache is request specific"), and `locks` is an instance field on it (`this.locks = new Map()` in the constructor). A stalled fetch in request A cannot make request B wait. Only the cache **handler's** module-scope store is shared, and it only gets an entry once a fetch has settled — which is exactly why, in the failing shard, the gym embed's retry answered in 201 ms (its first fetch had finally settled and written an entry) while the board embed's retry was still cold and hung again.
- **Not the web event loop pegged by `/api/internal/board-render` WASM renders**, which is what `playwright.config.ts` used to claim. In run 31857179523 shard 7, at 02:02:42 the same server answered `/embed/gym/...` in 201 ms and `/` + `/kiosk/whatever` in 3221 ms while a `/embed/board/...` request started 1.3 s earlier sat stuck for 30 s. A blocked event loop cannot serve two requests fast and one not at all. (The 3221 ms is itself the home page's existing 3000 ms deadline firing — that page degrades because it *has* one.)

That comment in `playwright.config.ts` is corrected here, and `workers: 1` stays: this removes a hang, not the fact that a 2-core runner hosts Next + backend + Chromium.

### The gap this deadline cannot close

Next deliberately strips the signal when it revalidates a **stale** cache entry — `patch-fetch.js`, `// don't pass through signal when revalidating` → `signal: isStale ? undefined : signal` — and the render then waits on that revalidate promise before the response closes (`app-render.js` puts it on `options.waitUntil`; `render-result.js`'s `pipeTo` awaits `this.waitUntil` before closing the stream). So on any `next: { revalidate: N }` read, this bounds the **cold** render only. A warm entry rolling over against a stalled backend still holds the response open. That is written down next to the constant, and the release note says "cold render" for that reason.

### Coverage is partial

Deliberately. Still unbounded, listed in #4625: `session/[sessionId]/page.tsx`'s `fetchSessionDetail`, `executeAuthenticatedGraphQL` (which takes no signal parameter at all, so no caller *can* bound it), and five `createCachedGraphQLQuery` call sites that omit the `timeoutMs` the function already supports. #4626 covers the separate pile-up problem: `React.cache()` dedupes within one request, so K concurrent cold embed renders still make K backend calls.

### Cheap fixes a reviewer should reject

Raising `REQUEST_TIMEOUT_MS` in the spec, giving it its own Playwright project, `describe.configure({ mode: 'serial' })`, or swapping the raw requests for `page.goto` all make the CI symptom go away while leaving a real production hang on gym embeds and kiosk TVs.

## Release Notes

- Gym embeds and kiosk screens no longer sit blank when the backend is slow — a cold render gives up after 3 seconds and shows the retry screen, which reloads itself.

## Test plan

- `vp test run --project web --reporter=agent` — green. New assertions read the signal off the mocked `fetch` call rather than the source text: `AbortSignal.timeout` is spied, and each fetcher is checked to pass **that** signal object to `fetch` with `SSR_BACKEND_FETCH_TIMEOUT_MS`. Paired with the degradation direction: a `TimeoutError` rejection maps to `{ status: 'error' }` / `[]` / a throw, never to a hang or a false `ok`/`null`.
- The existing embed-fetchers suite pins the direction that matters most and stays green: a transport/HTTP/GraphQL error is `{ status: 'error' }` (retry screen) and only a *successful* null entity is `{ status: 'ok', entity: null }` (`notFound()`). A deadline must not turn a genuine not-found into a retry screen.
- `vp run typecheck:web`, `vp check` — green.
- Next 16.2.12's behaviour was read out of `packages/web/node_modules/next` rather than assumed: `signal` is not part of `generateCacheKey` (url + method + bodyType + headers + mode/redirect/credentials/referrer/integrity/cache + body), so adding one cannot split the Data Cache.
