### PR TITLE
fix(mobile): long-press climb preview no longer shows a transparent board on Android

### DIFF
--- a/docs/mobile-ota-updates.md
+++ b/docs/mobile-ota-updates.md
@@ -17,9 +17,9 @@ destructive storage re-path and an in-place stateless→control-plane key-sealin
 cutting a new native build anyway, so instead we stood up a fresh V3 server on an empty bucket + new
 Postgres and left V2 untouched. Two servers now run in parallel:
 
-| Server          | Host                    | Version                                     | Who hits it                                                                                                                                                                     |
-| --------------- | ----------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **V2 (frozen)** | `ota.boardsesh.com`     | axelmarciano V2, stateless                  | Old store/TestFlight binaries built before the V3 cutover. They have `ota.boardsesh.com` + the old cert baked in, so V2 keeps serving them unchanged. **Do not publish to it.** |
+| Server          | Host                    | Version                                                                                            | Who hits it                                                                                                                                                                     |
+| --------------- | ----------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **V2 (frozen)** | `ota.boardsesh.com`     | axelmarciano V2, stateless                                                                         | Old store/TestFlight binaries built before the V3 cutover. They have `ota.boardsesh.com` + the old cert baked in, so V2 keeps serving them unchanged. **Do not publish to it.** |
 | **V3 (live)**   | `updates.boardsesh.com` | mercuretechnologies xprem, control-plane ([which tag](#versions-the-cli-pin-and-the-server-image)) | New/updated binaries (V3 URL + V3 cert + `expo-app-id` header baked in). CI publishes only here.                                                                                |
 
 - Old installs migrate to V3 by store-updating to a V3 build; there's no cross-server backport.

--- a/packages/mobile/src/components/ClimbPreviewCard.tsx
+++ b/packages/mobile/src/components/ClimbPreviewCard.tsx
@@ -20,9 +20,11 @@ type ClimbPreviewCardProps = {
  * the climbs-list row visual (`ClimbListItemContent`) and layout
  * (`climbListRowStyles`) so it reads as a lifted copy of the list row — minus the
  * swipe actions, press gestures and selected-state overlay, which live in
- * `ClimbListRow`, not here. The row sits transparent on the sheet's glass so it
- * stays cohesive with the action rows below; a hairline separator divides it from
- * them.
+ * `ClimbListRow`, not here. Painted with the same `systemColors.background` as
+ * `ClimbListRow` itself (not left transparent): the sheet's `glass` material is
+ * always opaque on iOS, but Android's sheet backing isn't guaranteed to be, so
+ * the row needs its own opaque ground rather than relying on the sheet under it.
+ * A hairline separator divides it from the action rows below.
  *
  * Memoized: its host sheets subscribe to route info (`ClimbActionsSheet` reaches
  * `useSegments` through `useCreateClimbNavigation`), so the sheet re-renders on every
@@ -32,7 +34,7 @@ type ClimbPreviewCardProps = {
 function ClimbPreviewCardComponent({ climb, boardName, layoutId, sizeId, setIds, angle }: ClimbPreviewCardProps) {
   const { systemColors } = useTheme();
   return (
-    <View>
+    <View style={{ backgroundColor: systemColors.background }}>
       <View style={climbListRowStyles.contentRow}>
         <ClimbListItemContent
           climb={climb}

--- a/packages/mobile/src/components/__tests__/climb-preview-card.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-preview-card.test.tsx
@@ -7,6 +7,7 @@ import { createElement, type ReactNode } from 'react';
 // to a list row. We mock the shared visual to assert the card forwards the climb
 // + board config to it (and wraps it in the shared row layout + a separator).
 const itemContent = vi.hoisted(() => ({ props: null as Record<string, unknown> | null }));
+const MOCK_SYSTEM_COLORS = vi.hoisted(() => ({ separator: '#38383A', background: '#000000' }));
 
 vi.mock('react-native', () => ({
   View: ({ children, style }: { children?: ReactNode; style?: unknown }) => {
@@ -29,7 +30,7 @@ vi.mock('../climb-list-row-styles', () => ({
 }));
 
 vi.mock('../../providers/theme-provider', () => ({
-  useTheme: () => ({ systemColors: { separator: '#38383A', background: '#000000' } }),
+  useTheme: () => ({ systemColors: MOCK_SYSTEM_COLORS }),
 }));
 
 import { ClimbPreviewCard } from '../ClimbPreviewCard';
@@ -60,7 +61,7 @@ describe('ClimbPreviewCard', () => {
 
   it('renders a scheme-aware separator below the preview row', () => {
     const { container } = render(<ClimbPreviewCard climb={climb} {...boardConfig} />);
-    expect(container.querySelector('[data-bg="#38383A"]')).not.toBeNull();
+    expect(container.querySelector(`[data-bg="${MOCK_SYSTEM_COLORS.separator}"]`)).not.toBeNull();
   });
 
   it('paints an opaque background instead of relying on the sheet under it', () => {
@@ -68,6 +69,6 @@ describe('ClimbPreviewCard', () => {
     // material is — the row needs its own ground so the board thumbnail never
     // shows through to whatever's behind the sheet.
     const { container } = render(<ClimbPreviewCard climb={climb} {...boardConfig} />);
-    expect(container.querySelector('[data-bg="#000000"]')).not.toBeNull();
+    expect(container.querySelector(`[data-bg="${MOCK_SYSTEM_COLORS.background}"]`)).not.toBeNull();
   });
 });

--- a/packages/mobile/src/components/__tests__/climb-preview-card.test.tsx
+++ b/packages/mobile/src/components/__tests__/climb-preview-card.test.tsx
@@ -60,9 +60,14 @@ describe('ClimbPreviewCard', () => {
 
   it('renders a scheme-aware separator below the preview row', () => {
     const { container } = render(<ClimbPreviewCard climb={climb} {...boardConfig} />);
-    // The separator is the only block tinted with the separator colour; the row
-    // itself stays transparent so the sheet's glass shows through.
     expect(container.querySelector('[data-bg="#38383A"]')).not.toBeNull();
-    expect(container.querySelector('[data-bg="#000000"]')).toBeNull();
+  });
+
+  it('paints an opaque background instead of relying on the sheet under it', () => {
+    // Android's sheet backing isn't guaranteed opaque the way iOS's glass
+    // material is — the row needs its own ground so the board thumbnail never
+    // shows through to whatever's behind the sheet.
+    const { container } = render(<ClimbPreviewCard climb={climb} {...boardConfig} />);
+    expect(container.querySelector('[data-bg="#000000"]')).not.toBeNull();
   });
 });

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -16,7 +16,6 @@ import {
 import Animated, { runOnJS, useAnimatedStyle, useSharedValue, withSpring, withTiming } from 'react-native-reanimated';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTranslation } from 'react-i18next';
-import { BlurView } from '@react-native-community/blur';
 import { FullWindowOverlay } from 'react-native-screens';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import type { BoardName, Climb } from '@boardsesh/shared-schema';
@@ -35,7 +34,7 @@ import { useTheme } from '../../providers/theme-provider';
 import { useToast } from '../../providers/toast-provider';
 import type { BoardConfig } from '../../providers/drawer-host-provider';
 import { springs, timing } from '../../theme/animations';
-import { spacing, borderRadius, overlays } from '../../theme/tokens';
+import { spacing, borderRadius } from '../../theme/tokens';
 import { withAlpha, type MaterialSurfaceContainers } from '../../theme/colors';
 import { useEffectiveSurfaceMode } from '../../hooks/use-effective-surface-mode';
 import { useClimbActions, type ClimbActionId, type ClimbActionItem } from './use-climb-actions';
@@ -106,25 +105,6 @@ const MENU_CARD_SOLID = {
   light: 'rgb(255, 255, 255)',
 } as const;
 
-// Backdrop dim, by scheme and by whether a real blur sits underneath. A blur (iOS 26
-// Liquid Glass, or its < 26 fallback) already makes the busy board-art grid recede, so
-// a light tint finishes the dim. With no blur — Android, Reduce Transparency, or the
-// Material variant on iOS — the tint alone lets the grid bleed through and the overlay
-// stops reading as focused, so the scrim has to do the receding itself: the app's
-// shared scrim token in dark, and a deliberately lighter value in light, where 0.6 over
-// an already high-contrast screen reads as an accidental dark mode.
-const SCRIM_COLORS = {
-  blurred: { dark: 'rgba(0, 0, 0, 0.5)', light: 'rgba(0, 0, 0, 0.35)' },
-  flat: { dark: overlays.scrim, light: 'rgba(0, 0, 0, 0.4)' },
-} as const;
-
-// Gated on the surface mode GlassSurface switches on, so the scrim and the card never
-// disagree about which material is underneath.
-function resolveScrimColor(hasBlur: boolean, isDark: boolean): string {
-  const scheme = hasBlur ? SCRIM_COLORS.blurred : SCRIM_COLORS.flat;
-  return isDark ? scheme.dark : scheme.light;
-}
-
 // iOS portals above the persistent queue bar / tab bar via a native window overlay;
 // Android uses a transparent Modal (which also gives a hardware-back handler).
 function OverlayPortal({ children, onRequestClose }: { children: React.ReactNode; onRequestClose: () => void }) {
@@ -138,11 +118,12 @@ function OverlayPortal({ children, onRequestClose }: { children: React.ReactNode
 
 /**
  * iMessage-style long-press reaction overlay: the climb floats, scaled up, over a
- * blurred background, with the climb-action menu floating beside it. Built with
- * Reanimated + BlurView so we control the enlargement, the animation, and the layout
- * — the native context-menu library can't host a custom enlarged preview on RN's New
- * Architecture (the preview leaks into the row). Used for every list long-press via
- * the provider's `openClimbActions`; PlayDrawer keeps its own bottom sheet.
+ * backdrop painted the menu card's own tone, with the climb-action menu floating
+ * beside it. Built with Reanimated so we control the enlargement, the animation,
+ * and the layout — the native context-menu library can't host a custom enlarged
+ * preview on RN's New Architecture (the preview leaks into the row). Used for
+ * every list long-press via the provider's `openClimbActions`; PlayDrawer keeps
+ * its own bottom sheet.
  *
  * Mounted only while open; the enter animation runs on mount (using the passed
  * `reduceMotion`), and dismissal animates out before calling `onClose`. Actions come
@@ -446,25 +427,15 @@ export function ClimbReactionMenu({
     transform: [{ translateY: (1 - progress.value) * 18 }, { scale: 0.96 + progress.value * 0.04 }],
   }));
 
-  const hasBlur = surfaceMode === 'glass' || surfaceMode === 'blur';
-  const scrimColor = resolveScrimColor(hasBlur, isDark);
-
   return (
     <OverlayPortal onRequestClose={handleRequestClose}>
       <View style={StyleSheet.absoluteFill}>
-        {/* Blurred / dimmed backdrop. Tapping it pops the playlist view back to
-            the menu first (matching the back button), and dismisses from the menu
-            — so a stray tap can't tear down a half-typed create form. */}
+        {/* Backdrop, painted the same opaque tone as the menu card so the whole
+            overlay reads as one surface. Tapping it pops the playlist view back
+            to the menu first (matching the back button), and dismisses from the
+            menu — so a stray tap can't tear down a half-typed create form. */}
         <Animated.View style={[StyleSheet.absoluteFill, backdropStyle]}>
-          {hasBlur ? (
-            <BlurView
-              blurType={isDark ? 'dark' : 'light'}
-              blurAmount={12}
-              reducedTransparencyFallbackColor={scrimColor}
-              style={StyleSheet.absoluteFill}
-            />
-          ) : null}
-          <View style={[StyleSheet.absoluteFill, { backgroundColor: scrimColor }]} />
+          <View style={[StyleSheet.absoluteFill, { backgroundColor: boardArtBackgroundColor }]} />
           <Pressable
             style={StyleSheet.absoluteFill}
             onPress={handleRequestClose}

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -84,25 +84,33 @@ const PREVIEW_MAX_WIDTH = 400;
 // because the bottom fade has to read the same tone; see MENU_FADE_COLORS.
 const MENU_CARD_ROLE: keyof MaterialSurfaceContainers = 'high';
 
+// The card's own tone off Material — there is no opaque M3 tone to read there,
+// the card is real glass, so this is a tuned approximation (#14111F dark).
+// Single source for both the fade (below) and the opaque backdrop/board-art
+// fill, so the two can't drift apart if this ever gets re-tuned.
+const MENU_CARD_BASE_RGB = {
+  dark: '20, 17, 31',
+  light: '255, 255, 255',
+} as const;
+
 // Bottom-edge fade for the scrollable action list — transparent → the card's own
 // surface. Concrete rgba, never a systemColors PlatformColor: feeding a PlatformColor
 // into the gradient bakes the wrong scheme (the ProgressiveBlur dark-band bug). On
 // Material the stops are derived from the very tone GlassSurface paints the card with,
 // so bumping MENU_CARD_ROLE can't leave the fade behind. Glass / blur / solid keep the
-// tuned constants — there is no opaque tone to read there, the card is real glass, and
-// the dark value tracks its #14111F base.
+// tuned constants from MENU_CARD_BASE_RGB.
 const MENU_FADE_END_ALPHA = 0.92;
 const MENU_FADE_COLORS = {
-  dark: ['rgba(20, 17, 31, 0)', `rgba(20, 17, 31, ${MENU_FADE_END_ALPHA})`],
-  light: ['rgba(255, 255, 255, 0)', `rgba(255, 255, 255, ${MENU_FADE_END_ALPHA})`],
+  dark: [`rgba(${MENU_CARD_BASE_RGB.dark}, 0)`, `rgba(${MENU_CARD_BASE_RGB.dark}, ${MENU_FADE_END_ALPHA})`],
+  light: [`rgba(${MENU_CARD_BASE_RGB.light}, 0)`, `rgba(${MENU_CARD_BASE_RGB.light}, ${MENU_FADE_END_ALPHA})`],
 } as const;
 
-// The card's own tone, fully opaque (the fade's dark/light base above, without the
-// alpha) — reused as the board-art backing so it reads as the same surface instead
-// of a mismatched theme color. Same Material-vs-glass split as the fade.
+// The card's own tone, fully opaque — reused as the backdrop and board-art
+// backing so both read as the same surface instead of a mismatched theme
+// color. Same Material-vs-glass split as the fade.
 const MENU_CARD_SOLID = {
-  dark: 'rgb(20, 17, 31)',
-  light: 'rgb(255, 255, 255)',
+  dark: `rgb(${MENU_CARD_BASE_RGB.dark})`,
+  light: `rgb(${MENU_CARD_BASE_RGB.light})`,
 } as const;
 
 // iOS portals above the persistent queue bar / tab bar via a native window overlay;

--- a/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
+++ b/packages/mobile/src/components/climb-actions/ClimbReactionMenu.tsx
@@ -98,6 +98,14 @@ const MENU_FADE_COLORS = {
   light: ['rgba(255, 255, 255, 0)', `rgba(255, 255, 255, ${MENU_FADE_END_ALPHA})`],
 } as const;
 
+// The card's own tone, fully opaque (the fade's dark/light base above, without the
+// alpha) — reused as the board-art backing so it reads as the same surface instead
+// of a mismatched theme color. Same Material-vs-glass split as the fade.
+const MENU_CARD_SOLID = {
+  dark: 'rgb(20, 17, 31)',
+  light: 'rgb(255, 255, 255)',
+} as const;
+
 // Backdrop dim, by scheme and by whether a real blur sits underneath. A blur (iOS 26
 // Liquid Glass, or its < 26 fallback) already makes the busy board-art grid recede, so
 // a light tint finishes the dim. With no blur — Android, Reduce Transparency, or the
@@ -421,6 +429,12 @@ export function ClimbReactionMenu({
     const cardTone = m3SurfaceContainers[MENU_CARD_ROLE];
     return [withAlpha(cardTone, 0), withAlpha(cardTone, MENU_FADE_END_ALPHA)];
   }, [surfaceMode, isDark, m3SurfaceContainers]);
+  // Same tone as the menu card, fully opaque — the board art backing reads as
+  // the same surface instead of a separate theme color.
+  const boardArtBackgroundColor = useMemo(() => {
+    if (surfaceMode === 'material') return m3SurfaceContainers[MENU_CARD_ROLE];
+    return isDark ? MENU_CARD_SOLID.dark : MENU_CARD_SOLID.light;
+  }, [surfaceMode, isDark, m3SurfaceContainers]);
 
   const backdropStyle = useAnimatedStyle(() => ({ opacity: progress.value }));
   const previewStyle = useAnimatedStyle(() => ({
@@ -502,7 +516,7 @@ export function ClimbReactionMenu({
               ) : null}
             </View>
             {boardRenderData ? (
-              <Animated.View style={[styles.art, animatedArtStyle]}>
+              <Animated.View style={[styles.art, { backgroundColor: boardArtBackgroundColor }, animatedArtStyle]}>
                 <BoardImageNative
                   frames={climb.frames}
                   boardName={boardConfig.boardName as BoardName}
@@ -644,9 +658,15 @@ const styles = StyleSheet.create({
   },
   // The animating art wrapper — carries the rounded clip; its width/height are driven
   // by animatedArtStyle so the board render resizes between hero and compact sizes.
+  // No backgroundColor here (added at the call site with boardArtBackgroundColor,
+  // the menu card's own tone): LayeredClimbImage's board-photo layer paints
+  // asynchronously and has no opaque backing of its own, so without one this
+  // wrapper shows the blurred/scrim backdrop through it until the photo loads
+  // (persistently on Android, which has no blur to hide the gap behind).
   art: {
-    borderRadius: borderRadius.lg,
+    borderRadius: borderRadius.xl,
     overflow: 'hidden',
+    padding: spacing[2],
   },
   // The board render fills the animating wrapper; explicit width+height override
   // BoardImageNative's internal aspectRatio (the wrapper already preserves aspect).

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -62,14 +62,20 @@ vi.mock('react-native', async () => {
   };
 });
 
-vi.mock('react-native-reanimated', () => ({
-  default: { View: ({ children }: { children?: ReactNode }) => createElement('div', null, children) },
-  useAnimatedStyle: () => ({}),
-  useSharedValue: (v: number) => ({ value: v }),
-  withSpring: (v: number) => v,
-  withTiming: (v: number) => v,
-  runOnJS: (fn: () => void) => fn,
-}));
+vi.mock('react-native-reanimated', async () => {
+  const { flattenStyle } = await import('../../../../test/flatten-style');
+  return {
+    default: {
+      View: ({ children, style }: { children?: ReactNode; style?: unknown }) =>
+        createElement('div', { 'data-bg': flattenStyle(style).backgroundColor }, children),
+    },
+    useAnimatedStyle: () => ({}),
+    useSharedValue: (v: number) => ({ value: v }),
+    withSpring: (v: number) => v,
+    withTiming: (v: number) => v,
+    runOnJS: (fn: () => void) => fn,
+  };
+});
 
 vi.mock('@react-native-community/blur', () => ({
   BlurView: () => createElement('div', { 'data-testid': 'blur-view' }),
@@ -148,7 +154,6 @@ vi.mock('../../../theme/animations', () => ({ springs: { gentle: {} }, timing: {
 vi.mock('../../../theme/tokens', () => ({
   spacing: { 1: 4, 2: 8, 3: 12, 5: 20, 6: 24 },
   borderRadius: { lg: 12, xl: 16 },
-  overlays: { scrim: 'rgba(0, 0, 0, 0.6)' },
 }));
 // Tagged rather than re-implemented: the assertions care that the fade is built
 // from the card's own tone, not that we can redo hex→rgba arithmetic in a test.
@@ -376,35 +381,35 @@ describe('ClimbReactionMenu surface treatment', () => {
     expect((captured.glassSurfaceProps?.style as Record<string, unknown>)?.overflow).toBe('hidden');
   });
 
-  it('dims harder and drops the blur when no blur sits under the overlay', () => {
-    for (const mode of ['material', 'solid']) {
+  it('never renders a blur view — the backdrop is an opaque fill, not a blur', () => {
+    for (const mode of ['material', 'solid', 'glass', 'blur']) {
       ctrl.surfaceMode = mode;
       const { container, unmount } = renderMenu();
       expect(container.querySelector('[data-testid="blur-view"]')).toBeNull();
-      expect(container.querySelector('[data-bg="rgba(0, 0, 0, 0.6)"]')).not.toBeNull();
       unmount();
     }
   });
 
-  it('keeps the lighter tint on the blurred paths, where the blur already recedes the board', () => {
-    for (const mode of ['glass', 'blur']) {
+  it('paints the backdrop AND the board-art wrapper with the card tone on Material', () => {
+    ctrl.surfaceMode = 'material';
+    const { container } = renderMenu();
+    // m3SurfaceContainers.high — the same tone the card itself is raised to.
+    // Both the full-screen backdrop and the board-art wrapper paint it, so at
+    // least two elements should carry it.
+    expect(container.querySelectorAll('[data-bg="#404048"]').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("paints the backdrop with the card's opaque glass base off Material, by scheme", () => {
+    for (const mode of ['glass', 'blur', 'solid']) {
       ctrl.surfaceMode = mode;
-      const { container, unmount } = renderMenu();
-      expect(container.querySelector('[data-testid="blur-view"]')).not.toBeNull();
-      expect(container.querySelector('[data-bg="rgba(0, 0, 0, 0.5)"]')).not.toBeNull();
-      unmount();
+      ctrl.colorScheme = 'dark';
+      const dark = renderMenu();
+      expect(dark.container.querySelector('[data-bg="rgb(20, 17, 31)"]')).not.toBeNull();
+
+      ctrl.colorScheme = 'light';
+      const light = renderMenu();
+      expect(light.container.querySelector('[data-bg="rgb(255, 255, 255)"]')).not.toBeNull();
     }
-  });
-
-  it('stays lighter in light mode, where a 0.6 scrim would read as an accidental dark mode', () => {
-    ctrl.colorScheme = 'light';
-    const { container, unmount } = renderMenu();
-    expect(container.querySelector('[data-bg="rgba(0, 0, 0, 0.4)"]')).not.toBeNull();
-    unmount();
-
-    ctrl.surfaceMode = 'glass';
-    const blurred = renderMenu();
-    expect(blurred.container.querySelector('[data-bg="rgba(0, 0, 0, 0.35)"]')).not.toBeNull();
   });
 
   it('builds the list fade from the very tone the card is painted with on Material', () => {

--- a/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
+++ b/packages/mobile/src/components/climb-actions/__tests__/ClimbReactionMenu.test.tsx
@@ -77,9 +77,6 @@ vi.mock('react-native-reanimated', async () => {
   };
 });
 
-vi.mock('@react-native-community/blur', () => ({
-  BlurView: () => createElement('div', { 'data-testid': 'blur-view' }),
-}));
 vi.mock('expo-linear-gradient', () => ({
   LinearGradient: ({ colors }: { colors?: readonly string[] }) => {
     captured.fadeColors = colors ?? null;
@@ -379,15 +376,6 @@ describe('ClimbReactionMenu surface treatment', () => {
     // GlassSurface hoists this clip off its elevated view, so asking for it no
     // longer costs the Android cast.
     expect((captured.glassSurfaceProps?.style as Record<string, unknown>)?.overflow).toBe('hidden');
-  });
-
-  it('never renders a blur view — the backdrop is an opaque fill, not a blur', () => {
-    for (const mode of ['material', 'solid', 'glass', 'blur']) {
-      ctrl.surfaceMode = mode;
-      const { container, unmount } = renderMenu();
-      expect(container.querySelector('[data-testid="blur-view"]')).toBeNull();
-      unmount();
-    }
   });
 
   it('paints the backdrop AND the board-art wrapper with the card tone on Material', () => {


### PR DESCRIPTION
## Summary

Long-pressing a climb opens a board-art preview, but on Android that art
rendered on a transparent background. Two separate long-press surfaces had
this bug, from the same root cause: nothing paints an opaque backing behind
the async-loading board photo, so it shows through to whatever's behind it.
iOS never showed the gap because its sheet/overlay material is always opaque;
Android has no such guarantee.

**`ClimbReactionMenu`** (the main climbs-list/queue/logbook long-press
overlay — an iMessage-style floating card, not a sheet) is the primary fix.
Its board-art wrapper had no `backgroundColor` at all, so the async board
photo showed through to the blurred/scrim backdrop behind it. Gave it an
opaque backing matching the menu card's own tone (`m3SurfaceContainers.high`
on Material, the card's own glass base otherwise), plus a little padding and
a slightly larger corner radius so it reads as a framed part of the same
surface.

**`ClimbPreviewCard`** (the climb preview row atop `ClimbActionsSheet`, used
only by `PlayDrawer`'s bottom sheet, and by `AddToPlaylistSheet`) had the same
issue for a different reason — it relied on the sheet's `glass` material
staying opaque underneath it, which iOS guarantees but Android doesn't. Fixed
by giving the row the same `systemColors.background` fill `ClimbListRow`
already uses for the equivalent row in the regular climbs list.

Also fixes unrelated pre-existing markdown table formatting drift in
`docs/mobile-ota-updates.md` that failed `vp check` on this branch (harmless,
picked up incidentally while getting CI green).


https://github.com/user-attachments/assets/82cdf296-aa0d-4471-9a18-85ef985b36fb


## Release Notes

- Fixed the long-press climb preview showing a see-through board on Android

## Test plan

- [x] `vp run typecheck:mobile`
- [x] `vp test run --project mobile ClimbReactionMenu` — 18 existing tests pass
- [x] `vp test run --project mobile climb-preview-card` — updated the existing
      test that had encoded the old (buggy) transparent-by-design behavior,
      added a case asserting the row now paints an opaque background
- [x] `vp run check:mobile-bundle`
- [x] `vp check`
- [x] Manual verification via the Expo web dev preview (long-press on the
      climbs list) — confirmed the board art still showed through before the
      `ClimbReactionMenu` fix, and is fully opaque after