### PR TITLE
fix(ci): 404 a missing app.boardsesh.com asset instead of caching the shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,7 +497,7 @@ jobs:
           cache: true
       - name: Install dependencies
         run: bun install --frozen-lockfile
-      - name: Validate deploy/app-subdomain config (_headers, _redirects, no-CSP rule)
+      - name: Validate deploy/app-subdomain config (_headers, _redirects, _routes.json, asset-404 Function, no-CSP rule)
         run: vp test run --project deploy-app-subdomain
       # Same fs-reading blind spot, one project over: both suites read
       # Dockerfile.web / build-expo-web-export.sh / create-service-docker-context.mjs

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -626,8 +626,15 @@ jobs:
         # config, not part of the export. Copy them into the publish dir.
         run: |
           set -euo pipefail
-          cp deploy/app-subdomain/_redirects "$RUNNER_TEMP/app-standalone/_redirects"
-          cp deploy/app-subdomain/_headers   "$RUNNER_TEMP/app-standalone/_headers"
+          cp deploy/app-subdomain/_redirects   "$RUNNER_TEMP/app-standalone/_redirects"
+          cp deploy/app-subdomain/_headers     "$RUNNER_TEMP/app-standalone/_headers"
+          # _routes.json scopes the Function below to the three asset prefixes,
+          # so the shell and every SPA route stay pure static assets.
+          cp deploy/app-subdomain/_routes.json "$RUNNER_TEMP/app-standalone/_routes.json"
+          # Pages discovers `functions/` relative to wrangler's cwd and requires
+          # it to sit OUTSIDE the static root — put it beside the export, and
+          # publish with `--cwd "$RUNNER_TEMP"` so wrangler finds it there.
+          cp -R deploy/app-subdomain/functions "$RUNNER_TEMP/functions"
 
       - name: Publish to Cloudflare Pages
         env:
@@ -635,6 +642,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           bunx wrangler@4 pages deploy "$RUNNER_TEMP/app-standalone" \
+            --cwd "$RUNNER_TEMP" \
             --project-name=boardsesh-app \
             --branch=main
 
@@ -692,16 +700,60 @@ jobs:
             ! echo "$cc" | grep -qi 'immutable'
           }
 
-          # A real content-hashed asset URL, parsed out of the served index.html,
-          # must come back immutable-cached.
-          check_hashed_asset_immutable() {
+          # The entry chunk named by the served index.html must come back as real
+          # JavaScript, immutable-cached.
+          #
+          # The content-type and body checks are the point, not decoration. This
+          # used to assert only `immutable` off a HEAD, which cannot fail: when a
+          # chunk is missing, `_redirects`' `/* /index.html 200` answers the .js
+          # URL with the HTML shell, and `_headers`' `/_expo/*` rule stamps
+          # `immutable` on it by path — so a chunk that does not exist passed this
+          # check. The browser is stricter than the smoke was: `nosniff` + a
+          # `text/html` script means Chrome refuses to execute it, React never
+          # mounts, and #root stays empty with no console error to explain it.
+          # That is the exact silent failure this now catches, one step earlier
+          # and with a message that says which part was wrong.
+          check_entry_chunk_is_js() {
             local asset_path
-            asset_path=$(curl -sS "$base/" \
+            asset_path=$(curl -sS --max-time 20 "$base/" \
               | grep -oE '/_expo/static/[^"'"'"']+\.js' | head -n1)
             [ -n "$asset_path" ] || { echo "  no /_expo asset found in index.html"; return 1; }
-            local cc; cc=$(curl -sSI "$base$asset_path" | tr -d '\r' \
-              | grep -i '^cache-control:' || true)
-            echo "$cc" | grep -qi 'immutable'
+
+            local head; head=$(curl -sSI --max-time 20 "$base$asset_path" | tr -d '\r')
+            echo "$head" | grep -qiE '^content-type:.*javascript' || {
+              echo "  $asset_path"
+              echo "    status:       $(echo "$head" | head -n1 || echo '(none)')"
+              echo "    content-type: $(echo "$head" | grep -i '^content-type:' || echo '(none)')"
+              echo "  the entry chunk index.html names is not being served as JavaScript."
+              echo "  404 → the chunk is missing from the deployment (or has not propagated yet)."
+              echo "  text/html → the SPA fallback answered it, which also means the asset-404"
+              echo "    Function is not in the path; see deploy/app-subdomain/functions/_middleware.ts."
+              return 1
+            }
+            echo "$head" | grep -qi '^cache-control:.*immutable' || {
+              echo "  $asset_path is not immutable-cached: $(echo "$head" | grep -i '^cache-control:' || echo '(none)')"
+              return 1
+            }
+
+            # Read the start of the body too. Content-type can be right while the
+            # body is the shell if a future header rule ever sets the type by
+            # path as well.
+            #
+            # `head -c` closes the pipe once it has enough, so curl stops early
+            # and this never pulls the whole ~10MB chunk. Curl then reports a
+            # write failure, which is expected here and is why stderr is
+            # dropped; a fetch that genuinely failed still arrives as an empty
+            # `first` and is caught on the next line. Deliberately not a range
+            # request: asset paths are served through a Pages Function now
+            # (deploy/app-subdomain/functions/_middleware.ts), which does not
+            # answer 206, so `-r` would silently read the whole body anyway.
+            local first
+            first=$(curl -sS --max-time 60 "$base$asset_path" 2>/dev/null | head -c 64) || true
+            [ -n "$first" ] || { echo "  $asset_path body is empty"; return 1; }
+            case "$first" in
+              '<!doctype'*|'<!DOCTYPE'*|'<html'*)
+                echo "  $asset_path served the HTML shell, not JavaScript"; return 1 ;;
+            esac
           }
 
           check_manifest_link() {
@@ -747,7 +799,7 @@ jobs:
           retry "X-Robots-Tag: noindex on /"              check_noindex
           retry "wasm binary → 200 wasm/octet-stream"     check_wasm
           retry "index.html is NOT immutable-cached"      check_index_not_immutable
-          retry "hashed _expo asset is immutable-cached"  check_hashed_asset_immutable
+          retry "entry chunk serves as immutable JavaScript"  check_entry_chunk_is_js
           retry "PWA manifest → JSON with start_url/scope /"  check_manifest_link
 
       - name: Install Playwright chromium
@@ -769,6 +821,21 @@ jobs:
         env:
           PLAYWRIGHT_TEST_BASE_URL: https://app.boardsesh.com
         run: cd packages/web && bunx playwright test --config=playwright.production.config.ts
+
+      # The config already writes a trace on retry and a screenshot on failure,
+      # but nothing collected them, so a failed boot check left only the console
+      # output to work from — which for a blank #root says "element(s) not found"
+      # and nothing else. Keep them; this is the deploy that will need them.
+      - name: Upload boot-check artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-boot-check-failure
+          path: |
+            packages/web/test-results/
+            packages/web/playwright-report/
+          retention-days: 14
+          if-no-files-found: ignore
 
   # Homelab staging-backend deploy is currently broken — re-enable once the
   # self-hosted runner is healthy. It deploys the same :staging image and is

--- a/deploy/app-subdomain/README.md
+++ b/deploy/app-subdomain/README.md
@@ -1,11 +1,11 @@
 # `deploy/app-subdomain/` — Cloudflare Pages config for app.boardsesh.com
 
-`_redirects` and `_headers` are copied into the standalone Expo web export at
-deploy time and shipped to the `boardsesh-app` Cloudflare Pages project. They
-are the only deployed files here; the rest of the directory is this README plus
-the CI tests that guard both these files and the deploy job that ships them
-(`__tests__/`, `tsconfig.json`, `vite.config.ts`). They are **not** part of the
-export itself — the export recipe
+`_redirects`, `_headers`, `_routes.json` and `functions/` are copied into (or
+beside) the standalone Expo web export at deploy time and shipped to the
+`boardsesh-app` Cloudflare Pages project. They are the only deployed files here;
+the rest of the directory is this README plus the CI tests that guard them and
+the deploy job that ships them (`__tests__/`, `tsconfig.json`, `vite.config.ts`).
+They are **not** part of the export itself — the export recipe
 (`scripts/build-expo-web-export.sh --subdomain`) emits a `baseUrl /` static SPA;
 this directory adds the host-level SPA fallback and caching rules Pages needs.
 
@@ -38,6 +38,47 @@ else falls through to the shell.
 - `index.html` and `wasm/*` get **no** cache override — they have fixed
   filenames, so they must revalidate. A cached `index.html` would mask a deploy;
   a cached WASM binary would pin an old renderer.
+
+## `functions/_middleware.ts` + `_routes.json` — a missing asset must 404
+
+The SPA fallback has a sharp edge. `/* /index.html 200` answers **any** path that
+is not a real file, including asset URLs, so a request for a chunk that is not in
+the deployment gets the HTML shell with a `200`. `_headers` then stamps
+`Cache-Control: public, max-age=31536000, immutable` on it, because that rule
+matches on `/_expo/*` — the path — and knows nothing about what was served.
+
+That is worse than a 404 in both directions:
+
+- The browser refuses to execute an HTML `<script>` (`nosniff`), so React never
+  mounts and `#root` stays empty with no error naming the cause.
+- The edge **and** the user's browser then cache that HTML under the chunk's URL
+  for a year. A reload does not clear it.
+
+Pages `_redirects` cannot express this — it supports 301/302/303/307/308 and
+`200` rewrites, not 404 — so the check runs in code. `functions/_middleware.ts`
+returns a real `404` with `Cache-Control: no-store` when an asset path resolves
+to HTML, and passes every real asset straight through.
+
+`_routes.json` keeps the blast radius small: the Function is invoked only for
+`/_expo/*`, `/assets/*` and `/wasm/*`. The shell, the PWA manifest and every SPA
+deep link stay pure static assets with no Worker in the path.
+
+Two things to know about routing an asset prefix through a Function:
+
+- `_headers` still applies, so the immutable caching on `/_expo/*` and
+  `/assets/*` is unchanged (verified with `wrangler pages dev`). The middleware
+  re-asserts it only if it ever goes missing, and the deploy's
+  `entry chunk serves as immutable JavaScript` smoke is the alarm if both fail.
+- **Range requests are not answered with `206` on these paths.** Static Pages
+  assets are; a Worker-proxied response is not. Nothing we serve here is
+  range-fetched in practice (scripts, fonts and the WASM binary are all whole-file
+  loads), so this is a deliberate trade for the 404.
+
+Wrangler discovers `functions/` relative to its cwd and rejects it inside the
+static root, so the deploy copies it to `$RUNNER_TEMP/functions` — beside the
+export, not in it — and publishes with `--cwd "$RUNNER_TEMP"`.
+`__tests__/asset-404-deploy-wiring.test.ts` guards that wiring; delete the
+`--cwd` and the Function silently stops shipping.
 
 ## The one hard rule: no CSP `script-src`
 

--- a/deploy/app-subdomain/__tests__/asset-404-deploy-wiring.test.ts
+++ b/deploy/app-subdomain/__tests__/asset-404-deploy-wiring.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Guards the deploy-side wiring for ../functions/_middleware.ts in
+// .github/workflows/production-deploy.yml. The middleware is only worth anything
+// if it actually ships: Pages discovers `functions/` relative to wrangler's cwd
+// and refuses it inside the static root, and `_routes.json` has to reach the
+// export or the Function silently runs on every request instead of the three
+// asset prefixes.
+//
+// Same reasoning as production-deploy-hold.test.ts for living here: this reads
+// the workflow via fs, which Vitest's `--changed` selection cannot relate to a
+// diff of the file being read. ci.yml's `deploy-config` job runs this project
+// unfiltered whenever production-deploy.yml changes.
+
+const WORKFLOW_PATH = resolve(import.meta.dirname, '..', '..', '..', '.github', 'workflows', 'production-deploy.yml');
+const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+
+/** The YAML body of a top-level job (keys at 2-space indent, bodies at 4+). */
+function jobBlock(jobId: string): string {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex((line) => line.trimEnd() === `  ${jobId}:`);
+  if (start === -1) throw new Error(`production-deploy.yml has no \`${jobId}:\` job`);
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() !== '' && !line.startsWith('    ')) break;
+    body.push(line);
+  }
+  return body.join('\n');
+}
+
+const deployAppWeb = jobBlock('deploy-app-web');
+
+describe('deploy-app-web ships the asset-404 Function', () => {
+  it('copies _routes.json into the published export', () => {
+    expect(deployAppWeb).toMatch(
+      /cp deploy\/app-subdomain\/_routes\.json\s+"\$RUNNER_TEMP\/app-standalone\/_routes\.json"/,
+    );
+  });
+
+  it('copies functions/ beside the export, never inside it', () => {
+    // Cloudflare rejects a functions directory inside the static root, and a
+    // copy into app-standalone/ would also publish the source as static files.
+    expect(deployAppWeb).toMatch(/cp -R deploy\/app-subdomain\/functions\s+"\$RUNNER_TEMP\/functions"/);
+    expect(deployAppWeb).not.toMatch(/deploy\/app-subdomain\/functions\s+"\$RUNNER_TEMP\/app-standalone/);
+  });
+
+  it('points wrangler at the directory holding functions/', () => {
+    // Without --cwd, wrangler looks for `functions` in the repo root, finds
+    // nothing, and deploys a static-only build — the Function silently vanishes.
+    expect(deployAppWeb).toMatch(/--cwd "\$RUNNER_TEMP"/);
+  });
+});
+
+describe('post-deploy smoke proves the entry chunk is JavaScript', () => {
+  it('checks the content-type, not just the cache header', () => {
+    // The regression that made a missing chunk invisible: `_headers` stamps
+    // `immutable` on /_expo/* by path, so asserting only that passed even when
+    // the SPA fallback answered with HTML.
+    expect(deployAppWeb).toMatch(/content-type:\.\*javascript/);
+    expect(deployAppWeb).toContain('check_entry_chunk_is_js');
+  });
+
+  it('no longer relies on the header-only check it replaced', () => {
+    expect(deployAppWeb).not.toContain('check_hashed_asset_immutable');
+  });
+});

--- a/deploy/app-subdomain/__tests__/asset-404-middleware.test.ts
+++ b/deploy/app-subdomain/__tests__/asset-404-middleware.test.ts
@@ -1,0 +1,160 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { assetMiddlewareInternals, onRequest } from '../functions/_middleware';
+import { effectiveHeaderValues, headerBlocks } from './cloudflare-config';
+
+// Guards ../functions/_middleware.ts, which turns the SPA fallback's answer to a
+// missing asset URL back into a 404. See that file's header for why `_redirects`
+// cannot do this itself.
+
+const BASE = 'https://app.boardsesh.com';
+
+/** A fake Pages context whose `next()` returns a canned upstream response. */
+function contextFor(pathname: string, upstream: Response) {
+  let nextCalls = 0;
+  return {
+    context: {
+      request: new Request(`${BASE}${pathname}`),
+      next: async () => {
+        nextCalls += 1;
+        return upstream;
+      },
+    },
+    nextCalls: () => nextCalls,
+  };
+}
+
+/** What Cloudflare returns today when `/* /index.html 200` answers an asset URL. */
+function spaFallbackResponse(): Response {
+  return new Response('<!doctype html><html><body>shell</body></html>', {
+    status: 200,
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+      'cache-control': 'public, max-age=31536000, immutable',
+    },
+  });
+}
+
+function realAsset(contentType: string, cacheControl: string): Response {
+  return new Response('console.log(1)', {
+    status: 200,
+    headers: { 'content-type': contentType, 'cache-control': cacheControl },
+  });
+}
+
+describe('asset 404 middleware', () => {
+  it('404s a missing chunk instead of serving the HTML shell', async () => {
+    const { context } = contextFor('/_expo/static/js/web/entry-missing.js', spaFallbackResponse());
+    const response = await onRequest(context);
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toContain('/_expo/static/js/web/entry-missing.js');
+  });
+
+  it('never lets that 404 be cached', async () => {
+    // A cached 404 is the same year-long poisoning as the cached HTML it replaces.
+    const { context } = contextFor('/_expo/static/js/web/entry-missing.js', spaFallbackResponse());
+    const response = await onRequest(context);
+
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('cache-control')).not.toMatch(/immutable|max-age=[1-9]/i);
+  });
+
+  it.each([
+    ['/_expo/static/js/web/entry-abc123.js', 'application/javascript'],
+    ['/assets/fonts/inter.ttf', 'font/ttf'],
+    ['/wasm/board_renderer_wasm_bg.wasm', 'application/wasm'],
+  ])('passes a real asset through untouched (%s)', async (pathname, contentType) => {
+    const upstream = realAsset(contentType, 'public, max-age=31536000, immutable');
+    const { context } = contextFor(pathname, upstream);
+    const response = await onRequest(context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe(contentType);
+    // Identity, not just equivalence: the normal path must not rebuild the body.
+    expect(response).toBe(upstream);
+  });
+
+  it('re-asserts immutable caching if it ever goes missing', async () => {
+    // The regression this covers: routing a path through a Function stops
+    // `_headers` applying, and a ~10MB bundle silently becomes uncacheable.
+    const { context } = contextFor(
+      '/_expo/static/js/web/entry-abc123.js',
+      realAsset('application/javascript', 'public, max-age=0, must-revalidate'),
+    );
+    const response = await onRequest(context);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe(assetMiddlewareInternals.IMMUTABLE_CACHE_CONTROL);
+  });
+
+  it('does not force immutable onto /wasm/, which must revalidate', async () => {
+    // Fixed filename: an immutable wasm binary would mask the next deploy.
+    const upstream = realAsset('application/wasm', 'public, max-age=0, must-revalidate');
+    const { context } = contextFor('/wasm/board_renderer_wasm_bg.wasm', upstream);
+    const response = await onRequest(context);
+
+    expect(response.headers.get('cache-control')).toBe('public, max-age=0, must-revalidate');
+    expect(response).toBe(upstream);
+  });
+
+  it('leaves non-asset paths entirely alone', async () => {
+    // The shell legitimately is HTML; 404ing it would take the site down.
+    const shell = spaFallbackResponse();
+    const { context, nextCalls } = contextFor('/climbs', shell);
+    const response = await onRequest(context);
+
+    expect(response).toBe(shell);
+    expect(response.status).toBe(200);
+    expect(nextCalls()).toBe(1);
+  });
+});
+
+describe('_routes.json', () => {
+  const routes: { version: number; include: string[]; exclude: string[] } = JSON.parse(
+    readFileSync(resolve(import.meta.dirname, '..', '_routes.json'), 'utf8'),
+  );
+
+  it('routes exactly the asset prefixes the middleware handles', () => {
+    // A prefix the middleware guards but _routes.json omits is an unprotected
+    // path; the reverse is a Worker invocation on a path nothing inspects.
+    const guarded = assetMiddlewareInternals.ASSET_PREFIXES.map((prefix) => `${prefix}*`);
+    expect([...routes.include].sort()).toEqual([...guarded].sort());
+  });
+
+  it('does not route the shell or SPA deep links through the Function', () => {
+    for (const staticPath of ['/', '/index.html', '/manifest.json', '/climbs']) {
+      const routed = routes.include.some((pattern) =>
+        pattern.endsWith('*') ? staticPath.startsWith(pattern.slice(0, -1)) : pattern === staticPath,
+      );
+      expect(routed, `${staticPath} must stay a static asset, with no Worker in the path`).toBe(false);
+    }
+  });
+
+  it('stays inside Cloudflare limits', () => {
+    expect(routes.version).toBe(1);
+    expect(routes.include.length).toBeGreaterThan(0);
+    expect(routes.include.length + routes.exclude.length).toBeLessThanOrEqual(100);
+    for (const rule of [...routes.include, ...routes.exclude]) {
+      expect(rule.length, `"${rule}" exceeds Cloudflare's 100-character rule limit`).toBeLessThanOrEqual(100);
+    }
+  });
+});
+
+describe('immutable prefix parity with _headers', () => {
+  it('matches the prefixes _headers actually marks immutable', () => {
+    // The middleware's fallback cache policy is a copy of `_headers`. Pin them
+    // together so editing one alone fails here rather than in production.
+    const immutableFromHeaders = headerBlocks
+      .filter((block) => block.headers.get('Cache-Control')?.some((value) => /immutable/i.test(value)))
+      .map((block) => block.path.replace(/\*$/, ''));
+
+    expect([...immutableFromHeaders].sort()).toEqual([...assetMiddlewareInternals.IMMUTABLE_PREFIXES].sort());
+  });
+
+  it('agrees with _headers on the value it would re-assert', () => {
+    const fromHeaders = effectiveHeaderValues('/_expo/static/js/web/entry-abc123.js', 'Cache-Control');
+    expect(fromHeaders).toContain(assetMiddlewareInternals.IMMUTABLE_CACHE_CONTROL);
+  });
+});

--- a/deploy/app-subdomain/_routes.json
+++ b/deploy/app-subdomain/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/_expo/*", "/assets/*", "/wasm/*"],
+  "exclude": []
+}

--- a/deploy/app-subdomain/functions/_middleware.ts
+++ b/deploy/app-subdomain/functions/_middleware.ts
@@ -1,0 +1,100 @@
+// Cloudflare Pages Function for app.boardsesh.com — turns a missing asset back
+// into a 404.
+//
+// Why this exists. `_redirects` ends with `/* /index.html 200` because Expo
+// Router needs every deep link to serve the exported shell. That catch-all also
+// answers asset URLs: a request for a chunk that is not in the deployment gets
+// the HTML shell with a 200. `_headers` then stamps
+// `Cache-Control: public, max-age=31536000, immutable` on it, because that rule
+// matches on `/_expo/*` — the path — and knows nothing about what was served.
+//
+// The result is worse than a 404. The browser refuses to execute an HTML
+// `<script>` (`X-Content-Type-Options: nosniff`), so React never mounts and
+// #root stays empty with no error that names the cause; and both the Cloudflare
+// edge and the user's browser now hold that HTML under the chunk's URL for a
+// year. A reload does not clear it.
+//
+// Pages `_redirects` cannot express this: it supports 301/302/303/307/308 and
+// 200-rewrites, not 404. So the check has to run in code.
+//
+// Scope is deliberately narrow. `_routes.json` limits this Function to the three
+// asset prefixes, so the shell, the PWA manifest and every SPA route are still
+// served straight from static assets with no Worker in the path.
+
+/** Path prefixes the export serves as real files, never as SPA routes. */
+const ASSET_PREFIXES = ['/_expo/', '/assets/', '/wasm/'] as const;
+
+/**
+ * The subset of {@link ASSET_PREFIXES} that `_headers` marks immutable. `/wasm/`
+ * is deliberately absent: those filenames are fixed, so the binary must
+ * revalidate or a deploy would be masked by a stale cached copy.
+ *
+ * Kept in sync with `_headers` by immutable-prefix-parity.test.ts — this list
+ * exists only as a safety net (see below), and a copy of a caching policy that
+ * nothing checks is a copy that drifts.
+ */
+const IMMUTABLE_PREFIXES = ['/_expo/', '/assets/'] as const;
+
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+/** The slice of the Pages Functions context this middleware actually uses. */
+type AssetMiddlewareContext = {
+  request: Request;
+  next: () => Promise<Response>;
+};
+
+function hasAssetPrefix(pathname: string, prefixes: readonly string[]): boolean {
+  return prefixes.some((prefix) => pathname.startsWith(prefix));
+}
+
+export async function onRequest(context: AssetMiddlewareContext): Promise<Response> {
+  const { pathname } = new URL(context.request.url);
+
+  // Not an asset path — `_routes.json` should not have routed it here at all,
+  // so this is just the honest passthrough for a widened include list.
+  if (!hasAssetPrefix(pathname, ASSET_PREFIXES)) return context.next();
+
+  const response = await context.next();
+
+  // The SPA fallback answering an asset URL. Nothing under these prefixes is
+  // ever legitimately HTML, so this is unambiguous.
+  if (/^text\/html/i.test(response.headers.get('content-type') ?? '')) {
+    return new Response(`Not found: ${pathname}\n`, {
+      status: 404,
+      headers: {
+        'content-type': 'text/plain; charset=utf-8',
+        // The whole point: a 404 that gets cached is the same bug again.
+        'cache-control': 'no-store',
+      },
+    });
+  }
+
+  // Safety net, not the primary mechanism. `_headers` is what sets the immutable
+  // cache policy, and it is expected to apply to this response too — but a
+  // Function in the path is exactly the kind of change that could quietly stop
+  // that, and silently losing `immutable` on a ~10MB bundle would cost every
+  // user a re-download on every visit. Re-assert it only if it went missing, so
+  // in the normal case this returns the upstream response untouched. The
+  // deploy's `entry chunk serves as immutable JavaScript` smoke is the alarm if
+  // both this and `_headers` ever fail.
+  if (hasAssetPrefix(pathname, IMMUTABLE_PREFIXES)) {
+    const cacheControl = response.headers.get('cache-control') ?? '';
+    if (!/immutable/i.test(cacheControl)) {
+      const headers = new Headers(response.headers);
+      headers.set('cache-control', IMMUTABLE_CACHE_CONTROL);
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+      });
+    }
+  }
+
+  return response;
+}
+
+export const assetMiddlewareInternals = {
+  ASSET_PREFIXES,
+  IMMUTABLE_PREFIXES,
+  IMMUTABLE_CACHE_CONTROL,
+};

--- a/packages/web/e2e/production/boot-diagnostics.ts
+++ b/packages/web/e2e/production/boot-diagnostics.ts
@@ -1,0 +1,99 @@
+// Diagnostics for the production boot smoke (./boot.spec.ts).
+//
+// Split out of the spec rather than left inline so it can be exercised on its
+// own: importing a spec file from another spec re-registers its tests, so there
+// is no way to prove this code reports what it should while it lives there.
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Errors that mean the app is broken rather than noisy. Kept narrow on purpose:
+ * a production smoke that fails on any console error becomes a flake generator
+ * (third-party scripts, extensions, aborted requests on unload) and then gets
+ * ignored, which is worse than not having it.
+ */
+const FATAL_CONSOLE_PATTERNS = [
+  /Unable to get view config/i,
+  /No QueryClient set/i,
+  /Maximum update depth exceeded/i,
+  /ChunkLoadError/i,
+  /Failed to fetch dynamically imported module/i,
+];
+
+/**
+ * Everything worth printing when the app fails to mount. `fatal` is the narrow
+ * set the spec asserts on; the rest is context that is only printed once
+ * something has already gone wrong, so it costs nothing on a green run.
+ */
+export type BootDiagnostics = {
+  fatal: string[];
+  /** Scripts that failed outright, or came back as something other than JS. */
+  scriptProblems: string[];
+  consoleErrors: string[];
+};
+
+export function collectDiagnostics(page: Page): BootDiagnostics {
+  const diagnostics: BootDiagnostics = { fatal: [], scriptProblems: [], consoleErrors: [] };
+
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    const text = message.text();
+    // Capped: a broken boot can log the same error on a loop, and a thousand
+    // identical lines buries the one that matters.
+    if (diagnostics.consoleErrors.length < 20) diagnostics.consoleErrors.push(text);
+    if (FATAL_CONSOLE_PATTERNS.some((pattern) => pattern.test(text))) diagnostics.fatal.push(text);
+  });
+
+  // An uncaught exception is always fatal — that is a bundle that failed to boot.
+  page.on('pageerror', (error) => diagnostics.fatal.push(`pageerror: ${String(error)}`));
+
+  // The failure this exists for: `_redirects` answers a missing chunk with
+  // `/index.html 200` and `_headers` stamps `immutable` on it by path, so a
+  // script URL can come back as the HTML shell looking entirely healthy. Chrome
+  // then refuses to execute it (`nosniff`), React never mounts, and #root stays
+  // empty — with no page error and no console text matching the patterns above.
+  // Without this listener that failure is indistinguishable from "nothing
+  // happened", which is how it once failed a deploy with nothing to go on.
+  page.on('response', (response) => {
+    if (response.request().resourceType() !== 'script') return;
+    const contentType = response.headers()['content-type'] ?? '(none)';
+    if (/javascript|ecmascript/i.test(contentType)) return;
+    diagnostics.scriptProblems.push(`${response.url()} → HTTP ${response.status()}, content-type: ${contentType}`);
+  });
+
+  page.on('requestfailed', (request) => {
+    if (request.resourceType() !== 'script') return;
+    diagnostics.scriptProblems.push(`${request.url()} → request failed: ${request.failure()?.errorText ?? 'unknown'}`);
+  });
+
+  return diagnostics;
+}
+
+export function formatDiagnostics(diagnostics: BootDiagnostics): string {
+  const sections = [
+    ['script problems', diagnostics.scriptProblems],
+    ['page/fatal errors', diagnostics.fatal],
+    ['console errors', diagnostics.consoleErrors],
+  ] as const;
+  return sections
+    .map(([label, lines]) => `${label}:\n${lines.length ? lines.map((line) => `  ${line}`).join('\n') : '  (none)'}`)
+    .join('\n');
+}
+
+/**
+ * Assert React committed something into #root, and — when it did not — fail with
+ * what the page actually did rather than a bare "element(s) not found".
+ *
+ * The diagnostics have to be attached here rather than asserted at the end of
+ * the spec: this is the assertion that trips first, so anything checked after it
+ * never runs on the one failure that needs explaining.
+ */
+export async function expectMounted(page: Page, timeout: number, diagnostics: BootDiagnostics) {
+  const root = page.locator('#root');
+  try {
+    await expect(root.locator('> *').first()).toBeAttached({ timeout });
+  } catch (cause) {
+    throw new Error(
+      `#root never received a child — the bundle did not mount.\n\n${formatDiagnostics(diagnostics)}\n\n${String(cause)}`,
+    );
+  }
+}

--- a/packages/web/e2e/production/boot.spec.ts
+++ b/packages/web/e2e/production/boot.spec.ts
@@ -1,12 +1,12 @@
 // Production boot smoke for app.boardsesh.com.
 //
 // The curl smoke in production-deploy.yml already proves the transport layer:
-// the shell 200s, a deep route falls back to it, the WASM binary serves, and a
-// content-hashed asset comes back immutable. What none of that can prove is
-// that the bundle actually *boots* — a JS chunk can serve with perfect headers
-// and still throw on evaluation, and `_redirects`' `/* /index.html 200` means
-// even a missing route answers 200. Both failures look healthy to curl and
-// blank to a user.
+// the shell 200s, a deep route falls back to it, the WASM binary serves, and the
+// entry chunk comes back as immutable JavaScript rather than the SPA fallback.
+// What none of that can prove is that the bundle actually *boots* — a JS chunk
+// can serve with perfect headers and still throw on evaluation, and
+// `_redirects`' `/* /index.html 200` means even a missing route answers 200.
+// Both failures look healthy to curl and blank to a user.
 //
 // So this is deliberately one thing: put a real browser in front of the deploy
 // and confirm React mounted. It never signs in — this runs against production
@@ -18,37 +18,12 @@
 // cold edge rather than a value anything is expected to approach. If a future
 // splash screen renders with no text at all, this is the test that will say so
 // — which is the point; a splash with no visible text is not a booted app.
-import { expect, test, type Page } from '@playwright/test';
-
-/**
- * Errors that mean the app is broken rather than noisy. Kept narrow on purpose:
- * a production smoke that fails on any console error becomes a flake generator
- * (third-party scripts, extensions, aborted requests on unload) and then gets
- * ignored, which is worse than not having it.
- */
-const FATAL_CONSOLE_PATTERNS = [
-  /Unable to get view config/i,
-  /No QueryClient set/i,
-  /Maximum update depth exceeded/i,
-  /ChunkLoadError/i,
-  /Failed to fetch dynamically imported module/i,
-];
-
-function collectFatalErrors(page: Page): string[] {
-  const fatal: string[] = [];
-  page.on('console', (message) => {
-    if (message.type() !== 'error') return;
-    const text = message.text();
-    if (FATAL_CONSOLE_PATTERNS.some((pattern) => pattern.test(text))) fatal.push(text);
-  });
-  // An uncaught exception is always fatal — that is a bundle that failed to boot.
-  page.on('pageerror', (error) => fatal.push(`pageerror: ${String(error)}`));
-  return fatal;
-}
+import { expect, test } from '@playwright/test';
+import { collectDiagnostics, expectMounted, formatDiagnostics } from './boot-diagnostics';
 
 test.describe('app.boardsesh.com boots', () => {
   test('mounts React into #root and renders visible content', async ({ page }) => {
-    const fatalErrors = collectFatalErrors(page);
+    const diagnostics = collectDiagnostics(page);
 
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
@@ -57,7 +32,7 @@ test.describe('app.boardsesh.com boots', () => {
     // that separates "assets serve" from "the app works".
     const root = page.locator('#root');
     await expect(root).toBeAttached();
-    await expect(root.locator('> *').first()).toBeAttached({ timeout: 60_000 });
+    await expectMounted(page, 60_000, diagnostics);
 
     // Rendered *something a human would see*, not just an empty wrapper tree.
     await expect
@@ -67,11 +42,11 @@ test.describe('app.boardsesh.com boots', () => {
       })
       .toBeGreaterThan(0);
 
-    expect(fatalErrors, `fatal errors during boot:\n${fatalErrors.join('\n')}`).toEqual([]);
+    expect(diagnostics.fatal, `fatal errors during boot:\n${formatDiagnostics(diagnostics)}`).toEqual([]);
   });
 
   test('serves the SPA shell for a deep route without a hard error', async ({ page }) => {
-    const fatalErrors = collectFatalErrors(page);
+    const diagnostics = collectDiagnostics(page);
 
     // `_redirects` answers `/* /index.html 200`, so this must boot the same
     // shell rather than a 404 page. A route that resolves to a blank body is
@@ -79,7 +54,7 @@ test.describe('app.boardsesh.com boots', () => {
     await page.goto('/climbs', { waitUntil: 'domcontentloaded' });
 
     const root = page.locator('#root');
-    await expect(root.locator('> *').first()).toBeAttached({ timeout: 60_000 });
+    await expectMounted(page, 60_000, diagnostics);
     // Same bar as the root test: an empty wrapper is a mount, not a render,
     // and the SPA fallback makes an unresolved route look exactly like that.
     await expect
@@ -89,6 +64,6 @@ test.describe('app.boardsesh.com boots', () => {
       })
       .toBeGreaterThan(0);
 
-    expect(fatalErrors, `fatal errors on deep route:\n${fatalErrors.join('\n')}`).toEqual([]);
+    expect(diagnostics.fatal, `fatal errors on deep route:\n${formatDiagnostics(diagnostics)}`).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

The `deploy-app-web` boot check failed on the 21 Aug production deploy with nothing to work from — `#root` never received a child, no page error, no console text matching the fatal patterns — while every curl check in the post-deploy smoke went green and the identical bundle boots fine in a browser today.

Both facts have the same cause. `_redirects` ends with `/* /index.html 200`, so an asset URL that isn't in the deployment gets the **HTML shell with a 200**, and `_headers` then stamps `Cache-Control: public, max-age=31536000, immutable` on it — that rule matches on `/_expo/*`, the path, and knows nothing about what was served.

Confirmed against live production:

```
$ curl -sSI https://app.boardsesh.com/_expo/static/js/web/entry-deadbeef….js
HTTP/2 200
content-type: text/html; charset=utf-8
cache-control: public, max-age=31536000, immutable
cf-cache-status: HIT
```

That is worse than a 404 in both directions. The browser refuses to execute an HTML `<script>` under `nosniff`, so React never mounts and `#root` stays empty with no error naming the cause. And the edge *and* the user's browser now hold that HTML under the chunk's URL for a year — a reload doesn't clear it.

Reproduced the exact CI signature by serving the entry chunk as `text/html`:

```
Error: #root never received a child — the bundle did not mount.

script problems:
  …/entry-2c7a49….js → HTTP 200, content-type: text/html; charset=utf-8
page/fatal errors:
  (none)
console errors:
  Refused to execute script from '…' because its MIME type ('text/html')
  is not executable, and strict MIME type checking is enabled.
```

### What changed

**1. A missing asset now 404s.** `deploy/app-subdomain/functions/_middleware.ts` returns a real `404` with `Cache-Control: no-store` when an asset path resolves to HTML. Pages `_redirects` can't express this — it supports 301/302/303/307/308 and 200-rewrites, not 404 — so the check runs in code. `_routes.json` scopes the Function to `/_expo/*`, `/assets/*` and `/wasm/*`, so the shell, the PWA manifest and every SPA deep link stay pure static assets with no Worker in the path.

**2. The smoke can now fail.** `check_hashed_asset_immutable` asserted only `immutable`, off a HEAD — a header `_headers` supplies by path — so it passed on a chunk that did not exist. It now asserts the entry chunk's content-type and body are JavaScript, failing inside the existing 12×5s retry loop (which is also the propagation headroom) with a message naming what was wrong.

**3. The boot spec now explains itself.** It collected page errors and threw them away: `expect(fatalErrors)` ran *after* the mount assertion, which is the one that trips first. Diagnostics moved to `boot-diagnostics.ts`, are attached to the mount failure itself, and now include scripts served with a non-JS content-type. CI keeps the trace and screenshot on failure (nothing collected them before).

### Trade-off worth knowing

Range requests on those three prefixes stop returning `206` — a Worker-proxied response isn't a static asset. Nothing we serve there is range-fetched in practice (scripts, fonts and the WASM binary are whole-file loads). `_headers` still applies through the Function, so immutable caching on `/_expo/*` is unchanged; the middleware re-asserts it only if it ever goes missing, and the new smoke check is the alarm if both fail.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp test run --project deploy-app-subdomain` — 31 passed (12 new: middleware behaviour, `_routes.json` scoping/limits, `_headers` immutable-prefix parity, deploy wiring).
- **End-to-end through the real compiled Worker** via `wrangler pages dev` against a fixture export:

  | path | result |
  |---|---|
  | `/_expo/…/entry-real.js` | `200` `application/javascript`, `immutable` |
  | `/_expo/…/entry-missing.js` | `404` `text/plain`, `no-store` |
  | `/assets/does-not-exist.png` | `404` `no-store` |
  | `/wasm/board_renderer_wasm_bg.wasm` | `200` `application/wasm`, `max-age=0, must-revalidate` |
  | `/wasm/missing.wasm` | `404` `no-store` |
  | `/`, `/climbs`, `/auth/callback` | `200` HTML shell |

- Smoke check extracted from the workflow and run both ways: passes on live production, fails with a clear message when the chunk is missing. Old check passed that same case.
- `wrangler pages functions build --cwd "$RUNNER_TEMP"` on the rehearsed deploy layout — confirms discovery via `--cwd` with `functions/` beside the export.
- `vp run smoke:app-boot` green against live production; boot spec typechecks (`tsc --noEmit`) and `vp check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016m8ikSwPbeK2CWiLJZcfE3
