### PR TITLE
fix(ci): fire deploy-app-web for the Pages Function and _routes.json

### DIFF
--- a/scripts/production-deploy-changes.mjs
+++ b/scripts/production-deploy-changes.mjs
@@ -89,8 +89,14 @@ function isAppAffecting(filePath) {
     // app.boardsesh.com serves, so it has to redeploy the subdomain — and run
     // the post-deploy manifest smoke that would catch a bad patch.
     filePath === 'scripts/lib/patch-expo-web-pwa-manifest.mjs' ||
+    // Everything deploy-app-web ships to the Pages project. Listed file by file
+    // rather than as a `deploy/app-subdomain/` prefix because the rest of that
+    // directory — README, tsconfig, vite config, __tests__ — is not deployed,
+    // and a README edit should not redeploy the subdomain.
     filePath === 'deploy/app-subdomain/_headers' ||
-    filePath === 'deploy/app-subdomain/_redirects'
+    filePath === 'deploy/app-subdomain/_redirects' ||
+    filePath === 'deploy/app-subdomain/_routes.json' ||
+    filePath.startsWith('deploy/app-subdomain/functions/')
   );
 }
 

--- a/scripts/production-deploy-changes.test.mjs
+++ b/scripts/production-deploy-changes.test.mjs
@@ -120,6 +120,39 @@ void test('treats every input of the app.boardsesh.com export as app-affecting',
   }
 });
 
+void test('treats every deployed Cloudflare Pages config file as app-affecting', () => {
+  // Same failure mode as the patcher above, one directory over. These four are
+  // the only files deploy-app-web copies into (or beside) the export, and each
+  // decides what app.boardsesh.com serves: the SPA fallback, the cache/security
+  // headers, which paths reach the Function, and the Function itself. A change
+  // to any of them that does not fire deploy-app-web merges green and ships
+  // nothing — the asset-404 Function in particular would sit in the repo
+  // looking deployed while a missing chunk kept serving the HTML shell.
+  for (const filePath of [
+    'deploy/app-subdomain/_headers',
+    'deploy/app-subdomain/_redirects',
+    'deploy/app-subdomain/_routes.json',
+    'deploy/app-subdomain/functions/_middleware.ts',
+  ]) {
+    assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: false, app: true });
+  }
+});
+
+void test('leaves the non-deployed files in deploy/app-subdomain out of the app deploy', () => {
+  // The README, the tsconfig that only exists for type-aware lint, the vitest
+  // project and its suites are never uploaded to Pages. Redeploying production
+  // for a docs edit is pure noise, and treating the whole directory as
+  // app-affecting is the easy mistake that causes it.
+  for (const filePath of [
+    'deploy/app-subdomain/README.md',
+    'deploy/app-subdomain/tsconfig.json',
+    'deploy/app-subdomain/vite.config.ts',
+    'deploy/app-subdomain/__tests__/asset-404-middleware.test.ts',
+  ]) {
+    assert.equal(classifyChangedFiles([filePath]).app, false, `${filePath} must not trigger deploy-app-web`);
+  }
+});
+
 void test('keeps every backend build and runtime control path backend-affecting', () => {
   for (const filePath of ['Dockerfile.backend', 'railway.toml', 'bun.lock', 'package.json']) {
     assert.deepEqual(classifyChangedFiles([filePath]), { web: true, backend: true, app: false });


### PR DESCRIPTION
## Summary

Follow-up to #4647, which added two files to the app.boardsesh.com Pages deployment: `_routes.json` and `functions/_middleware.ts`.

`isAppAffecting` in `scripts/production-deploy-changes.mjs` lists that config **by exact filename** — only `_headers` and `_redirects` — so neither new file counted as app-affecting:

```
deploy/app-subdomain/_routes.json              -> app: false   ← before
deploy/app-subdomain/functions/_middleware.ts  -> app: false   ← before
```

A PR touching only those would merge green, skip `deploy-app-web`, and ship nothing — leaving the asset-404 Function sitting in the repo looking deployed while a missing chunk kept serving the HTML shell. That is precisely the failure #4647 exists to prevent, and it would have been invisible until a user hit a white screen.

It is also the same failure mode the sibling `patch-expo-web-pwa-manifest.mjs` entry already guards, in the words of the test that guards it: *"would otherwise merge green, deploy nothing, and leave the author believing it shipped"* (W-24 / #4438).

After:

```
deploy/app-subdomain/_routes.json              -> { web: true, backend: false, app: true }
deploy/app-subdomain/functions/_middleware.ts  -> { web: true, backend: false, app: true }
deploy/app-subdomain/README.md                 -> { web: false, backend: false, app: false }
```

Still enumerated file by file rather than a `deploy/app-subdomain/` prefix: the README, `tsconfig.json`, `vite.config.ts` and `__tests__/` in that directory are never uploaded to Pages, and a docs edit should not redeploy production. Both halves are now pinned by tests, so widening it to a prefix later fails loudly rather than quietly adding deploys.

Not urgent for the currently-deploying merge — that run classified `app: true` from the accumulated `packages/mobile/` changes since the last successful deploy, so the Function does ship. This closes the gap for every edit after it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `bunx tsx --test scripts/production-deploy-changes.test.mjs` — 17 passed, 0 failed (2 new tests).
- New coverage both ways: the four deployed files must classify `app: true`; the four non-deployed files in the same directory must classify `app: false`.
- `vp check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016m8ikSwPbeK2CWiLJZcfE3
