### PR TITLE
test(mobile): expect the corrected Commercial size description

### DIFF
--- a/packages/mobile/src/components/board-discovery/__tests__/board-detail-fields.test.ts
+++ b/packages/mobile/src/components/board-discovery/__tests__/board-detail-fields.test.ts
@@ -77,7 +77,7 @@ describe('getBoardDetailFields size fallback', () => {
   const kilterBoard = { ...base, boardType: 'kilter', layoutId: 1, sizeId: 7 } as unknown as UserBoard;
 
   it('resolves the size from the bundled tables when the server sends null', () => {
-    expect(getBoardDetailFields(kilterBoard).sizeText).toBe('12 x 14 · Commerical');
+    expect(getBoardDetailFields(kilterBoard).sizeText).toBe('12 x 14 · Commercial');
   });
 
   it('still prefers the server values when it does send them', () => {


### PR DESCRIPTION
## Summary

Main CI is red on exactly one test: `board-detail-fields.test.ts` pins Aurora's `'12 x 14 · Commerical'` misspelling for the server-sends-null size fallback, but board-constants now ships a `normalizeSizeDescription` override that corrects the typo in the bundled tables. Two green PRs crossed; together they red `test-default (2, 3)` on every push to main and every PR. One-line expectation update.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- [x] `vp test run src/components/board-discovery/__tests__/board-detail-fields.test.ts` — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZuN2chYjMnXoNhzrCwSyF