### PR TITLE
fix(mobile): label every session-exit control with its verb

### DIFF
--- a/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
+++ b/packages/mobile/src/components/session-screen/RecordTopChrome.tsx
@@ -12,10 +12,15 @@ import { UserAvatarToolbarAction } from '../user-drawer/UserAvatarToolbarAction'
 import { useTheme } from '../../providers/theme-provider';
 import { selectByVariant } from '../../theme/variants';
 import { spacing } from '../../theme/tokens';
+import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 
 // Record's defining action is the Start/End footer button, so the chrome's
 // create island is gated off — its handler is never invoked.
 const noop = () => {};
+
+// M3 text-button height. The pill sits in a 56dp app-bar row, so 40dp leaves the
+// bar's own breathing room; `hitSlop` lifts the effective target back over 48dp.
+const MATERIAL_EXIT_HEIGHT = 40;
 
 type RecordTopChromeProps = {
   /** The session title — shown in the Material app bar; on glass the board pill +
@@ -57,10 +62,11 @@ type RecordTopChromeProps = {
  * and light islands come for free from `CollapsingTopChrome`.
  *
  * Material: an absolutely-positioned, `onHeightChange`-measured M3 small app bar
- * (mirroring `ClimbTopChrome`) — the session title via `Appbar.Content` and (only
- * while a session is live) a share `Appbar.Action`. The board is switched from the
- * in-body `BoardSummaryCard` (which carries the full name · size · angle), so the
- * app bar stays session-titled rather than duplicating a board switcher.
+ * (mirroring `ClimbTopChrome`) — the session title via `Appbar.Content`, and (only
+ * while a session is live) a share `Appbar.Action` plus a labelled M3 text button
+ * for the exit, the flat counterpart of the glass Stop pill. The board is switched
+ * from the in-body `BoardSummaryCard` (which carries the full name · size · angle),
+ * so the app bar stays session-titled rather than duplicating a board switcher.
  */
 export function RecordTopChrome({
   title,
@@ -73,7 +79,7 @@ export function RecordTopChrome({
 }: RecordTopChromeProps) {
   const { t } = useTranslation('session');
   const { t: tBoards } = useTranslation('boards');
-  const { brandColors, systemColors, variant } = useTheme();
+  const { brandColors, systemColors, variant, radii } = useTheme();
   const insets = useSafeAreaInsets();
 
   // Leaving is non-destructive, so it gets neither the red tint nor the stop
@@ -81,6 +87,10 @@ export function RecordTopChrome({
   // ships for the same action, so the two surfaces read identically.
   const isLeaveExit = exitVariant === 'leave';
   const exitLabel = isLeaveExit ? t('queueBar.ariaLabels.leaveSession') : t('mobile.session.inEndSession');
+  // The word printed on the control, deliberately shorter than the accessibility
+  // label. A bare flag glyph reads as "report this climb" to climbers who have
+  // never ended a session (#4281), so every exit control carries its verb.
+  const exitActionLabel = isLeaveExit ? t('mobile.session.inLeave') : t('mobile.session.inStop');
   const exitTint = isLeaveExit ? systemColors.label : brandColors.error;
   const exitIcon = isLeaveExit ? 'leave.session' : 'flag';
 
@@ -142,15 +152,35 @@ export function RecordTopChrome({
             />
           ) : null}
           {onEndSession ? (
-            <Appbar.Action
-              icon={iconMap[exitIcon].android}
-              // Cast matches the sibling Appbar props: Paper types `color` as a
-              // plain string, while the iOS-flavoured tokens are a dynamic-colour
-              // union.
-              color={exitTint as string}
+            // A labelled M3 text button rather than an `Appbar.Action`: Paper's
+            // action slot is a 48dp circle with room for a glyph and nothing
+            // else, and an icon-only exit is exactly what climbers misread
+            // (#4281). Rendered as a plain app-bar child, the way
+            // `BoardSwitcherButton` sits in the climbs chrome.
+            <PressableSurface
               onPress={onEndSession}
+              feedback="opacity"
+              // M3 state layer, tinted from the same role the label uses, so Stop
+              // ripples red and Leave ripples neutral. Cast matches the sibling
+              // Appbar props: the iOS-flavoured tokens are a dynamic-colour union,
+              // but the Material variant always resolves them to plain strings.
+              rippleColor={exitTint as string}
+              hitSlop={8}
+              accessibilityRole="button"
               accessibilityLabel={exitLabel}
-            />
+              style={[styles.materialExitAction, { borderRadius: radii.button }]}
+            >
+              <Icon name={exitIcon} size={20} color={exitTint} />
+              <Text
+                variant="subheadline"
+                color={exitTint}
+                numberOfLines={1}
+                maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+                style={styles.exitLabel}
+              >
+                {exitActionLabel}
+              </Text>
+            </PressableSurface>
           ) : null}
         </Appbar.Header>
       </View>
@@ -179,11 +209,19 @@ export function RecordTopChrome({
       hitSlop={4}
       accessibilityRole="button"
       accessibilityLabel={exitLabel}
-      style={styles.stopAction}
+      style={styles.glassExitAction}
     >
       <Icon name={exitIcon} size={20} color={exitTint} />
-      <Text variant="subheadline" color={exitTint} style={styles.stopLabel}>
-        {isLeaveExit ? t('mobile.session.inLeave') : t('mobile.session.inStop')}
+      <Text
+        variant="subheadline"
+        color={exitTint}
+        numberOfLines={1}
+        // The pill's height is pinned to the glass slot ladder, so the label has
+        // to stop growing before it clips.
+        maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+        style={styles.exitLabel}
+      >
+        {exitActionLabel}
       </Text>
     </PressableSurface>
   ) : undefined;
@@ -222,7 +260,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0,
   },
   // The labelled Stop pill fills the two trailing toolbar slots it reserves.
-  stopAction: {
+  glassExitAction: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
@@ -230,7 +268,20 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing[3],
     height: TOP_ACTION_SIZE,
   },
-  stopLabel: {
+  // M3 text-button metrics: 40dp tall, 12dp side padding, pill corners from the
+  // variant radii. `overflow: hidden` keeps the Android ripple inside those
+  // corners; the trailing margin lands the label near the bar's 16dp edge inset.
+  materialExitAction: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing[1],
+    paddingHorizontal: spacing[3],
+    height: MATERIAL_EXIT_HEIGHT,
+    marginRight: spacing[1],
+    overflow: 'hidden',
+  },
+  exitLabel: {
     fontWeight: '600',
   },
 });

--- a/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
+++ b/packages/mobile/src/components/session-screen/SessionScreenHeader.tsx
@@ -5,6 +5,7 @@ import { Text } from '../Text';
 import { Icon } from '../Icon';
 import { useTheme } from '../../providers/theme-provider';
 import { spacing } from '../../theme/tokens';
+import { CHROME_LABEL_MAX_FONT_SCALE } from '../../theme/typography';
 
 type SessionScreenHeaderProps = {
   /** Minimize handler (chevron-down). Absent in tab mode — switching tabs minimizes. */
@@ -12,8 +13,8 @@ type SessionScreenHeaderProps = {
   sessionActive: boolean;
   /** When set, a share button floats at the trailing edge to invite climbers. */
   onShare?: () => void;
-  /** When set (session live), an exit glyph docks beside share so the overlay's
-   *  control matches the tab chrome's trailing exit action. */
+  /** When set (session live), a labelled exit control (icon + "Stop" / "Leave")
+   *  docks beside share so the overlay matches the tab chrome's trailing exit. */
   onEndSession?: () => void;
   /**
    * What this device's exit actually does — `end` (destructive red stop) or
@@ -55,7 +56,15 @@ export function SessionScreenHeader({
   const { systemColors, brandColors } = useTheme();
 
   const title = sessionActive ? t('mobile.session.headerActive') : t('mobile.session.headerStart');
+  // Same split RecordTopChrome makes: leaving is non-destructive, so it gets
+  // neither the red tint nor the stop glyph, and the accessibility label stays
+  // the long-form string web's queue bar already ships.
   const isLeaveExit = exitVariant === 'leave';
+  const exitLabel = isLeaveExit ? t('queueBar.ariaLabels.leaveSession') : t('mobile.session.inEndSession');
+  // The word on the control. A bare flag glyph reads as "report this climb"
+  // (#4281), so the overlay strip names its exit the way the tab chrome does.
+  const exitActionLabel = isLeaveExit ? t('mobile.session.inLeave') : t('mobile.session.inStop');
+  const exitTint = isLeaveExit ? systemColors.label : brandColors.error;
 
   const row = (
     <View style={styles.row}>
@@ -86,7 +95,13 @@ export function SessionScreenHeader({
               style={styles.shareButton}
             >
               {inviteHint ? (
-                <Text variant="subheadline" color={systemColors.label} style={styles.shareLabel}>
+                <Text
+                  variant="subheadline"
+                  color={systemColors.label}
+                  numberOfLines={1}
+                  maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+                  style={styles.shareLabel}
+                >
                   {t('mobile.session.inviteAction')}
                 </Text>
               ) : null}
@@ -94,20 +109,28 @@ export function SessionScreenHeader({
             </Pressable>
           ) : null}
           {onEndSession ? (
+            // Icon + word, matching the Stop pill in RecordTopChrome — the two
+            // surfaces show the same control for the same action, so neither can
+            // be the one a climber has to guess at.
             <Pressable
               onPress={onEndSession}
               hitSlop={12}
               accessibilityRole="button"
-              accessibilityLabel={
-                isLeaveExit ? t('queueBar.ariaLabels.leaveSession') : t('mobile.session.inEndSession')
-              }
-              style={styles.iconButton}
+              accessibilityLabel={exitLabel}
+              style={styles.exitButton}
             >
-              <Icon
-                name={isLeaveExit ? 'leave.session' : 'flag'}
-                size={22}
-                color={isLeaveExit ? systemColors.label : brandColors.error}
-              />
+              <Icon name={isLeaveExit ? 'leave.session' : 'flag'} size={22} color={exitTint} />
+              <Text
+                variant="subheadline"
+                color={exitTint}
+                numberOfLines={1}
+                // The strip's controls are pinned to 40dp, so the label has to
+                // stop growing before it clips.
+                maxFontSizeMultiplier={CHROME_LABEL_MAX_FONT_SCALE}
+                style={styles.exitLabel}
+              >
+                {exitActionLabel}
+              </Text>
             </Pressable>
           ) : null}
         </View>
@@ -159,6 +182,20 @@ const styles = StyleSheet.create({
     paddingLeft: spacing[2],
   },
   shareLabel: {
+    fontWeight: '600',
+  },
+  // Matches shareButton's metrics so the two right-cluster controls sit on one
+  // baseline. 40dp tall + hitSlop 12 keeps the target well past 44pt.
+  exitButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: spacing[1],
+    minWidth: 40,
+    height: 40,
+    paddingLeft: spacing[2],
+  },
+  exitLabel: {
     fontWeight: '600',
   },
 });

--- a/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/record-top-chrome.test.tsx
@@ -47,6 +47,7 @@ vi.mock('../../../providers/theme-provider', () => ({
   useTheme: () => ({
     brandColors: { primary: '#6D28D9', error: '#C81E1E' },
     systemColors: { label: '#000', secondaryBackground: '#111', separator: '#333' },
+    radii: { button: 20 },
     variant: ctrl.variant,
   }),
 }));
@@ -118,6 +119,7 @@ vi.mock('../../PressableSurface', () => ({
   }) => createElement('button', { onClick: onPress, 'data-pressable': accessibilityLabel ?? '' }, children),
 }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 3: 12 } }));
+vi.mock('../../../theme/typography', () => ({ CHROME_LABEL_MAX_FONT_SCALE: 1.2 }));
 vi.mock('../../user-drawer/UserAvatarToolbarAction', () => ({
   UserAvatarToolbarAction: ({ variant }: { variant: 'glass' | 'material' }) => {
     if (variant === 'material') {
@@ -132,6 +134,10 @@ vi.mock('../../user-drawer/UserAvatarToolbarAction', () => ({
 }));
 
 import { RecordTopChrome } from '../RecordTopChrome';
+
+// The exit is a labelled pill in both variants, so it is found by its pressable
+// accessibility label rather than by a Paper app-bar action slot.
+const MATERIAL_STOP = '[data-pressable="mobile.session.inEndSession"]';
 
 function makeProps(over: Partial<Parameters<typeof RecordTopChrome>[0]> = {}) {
   return {
@@ -264,13 +270,33 @@ describe('RecordTopChrome', () => {
       expect(appbar.actions).not.toContain('mobile.session.editTitleAria');
     });
 
-    it('shows the End app-bar action only while a session is live (onEndSession set)', () => {
-      const { rerender } = render(<RecordTopChrome {...makeProps()} />);
-      expect(appbar.actions).not.toContain('mobile.session.inEndSession');
+    it('shows the End control only while a session is live (onEndSession set)', () => {
+      const { container, rerender } = render(<RecordTopChrome {...makeProps()} />);
+      expect(container.querySelector(MATERIAL_STOP)).toBeNull();
 
-      appbar.actions = [];
-      rerender(<RecordTopChrome {...makeProps({ onEndSession: vi.fn() })} />);
-      expect(appbar.actions).toContain('mobile.session.inEndSession');
+      const onEndSession = vi.fn();
+      rerender(<RecordTopChrome {...makeProps({ onEndSession })} />);
+      const stopButton = container.querySelector(MATERIAL_STOP) as HTMLButtonElement | null;
+      expect(stopButton).not.toBeNull();
+      stopButton!.click();
+      expect(onEndSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the exit as a labelled Stop pill, not a bare icon app-bar action', () => {
+      const { container } = render(<RecordTopChrome {...makeProps({ onEndSession: vi.fn() })} />);
+      // The exit left the Paper action row — it is a pressable pill now.
+      expect(appbar.actions).not.toContain('mobile.session.inEndSession');
+      const stopButton = container.querySelector(MATERIAL_STOP);
+      expect(stopButton?.textContent).toContain('mobile.session.inStop');
+      // Destructive tint on the leader's Stop, same as the glass pill.
+      expect(stopButton?.querySelector('[data-icon="flag"]')?.getAttribute('data-color')).toBe('#C81E1E');
+    });
+
+    it('renders the joiner exit as a neutral labelled Leave pill', () => {
+      const { container } = render(<RecordTopChrome {...makeProps({ onEndSession: vi.fn(), exitVariant: 'leave' })} />);
+      const leaveButton = container.querySelector('[data-pressable="queueBar.ariaLabels.leaveSession"]');
+      expect(leaveButton?.textContent).toContain('mobile.session.inLeave');
+      expect(leaveButton?.querySelector('[data-icon="leave.session"]')?.getAttribute('data-color')).toBe('#000');
     });
   });
 });

--- a/packages/mobile/src/components/session-screen/__tests__/session-screen-header.test.tsx
+++ b/packages/mobile/src/components/session-screen/__tests__/session-screen-header.test.tsx
@@ -35,11 +35,13 @@ vi.mock('../../../providers/theme-provider', () => ({
   }),
 }));
 vi.mock('../../../theme/tokens', () => ({ spacing: { 1: 4, 2: 8, 3: 12 } }));
+vi.mock('../../../theme/typography', () => ({ CHROME_LABEL_MAX_FONT_SCALE: 1.2 }));
 
 import { SessionScreenHeader } from '../SessionScreenHeader';
 
 const SHARE = '[data-label="mobile.session.invite"]';
 const END = '[data-label="mobile.session.inEndSession"]';
+const LEAVE = '[data-label="queueBar.ariaLabels.leaveSession"]';
 const MINIMIZE = '[data-label="mobile.session.minimize"]';
 
 describe('SessionScreenHeader', () => {
@@ -54,6 +56,22 @@ describe('SessionScreenHeader', () => {
     expect(end).not.toBeNull();
     end!.click();
     expect(onEndSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('labels the leader exit "Stop" beside a destructive flag glyph', () => {
+    const { container } = render(<SessionScreenHeader sessionActive onEndSession={vi.fn()} />);
+    const end = container.querySelector(END);
+    expect(end?.textContent).toContain('mobile.session.inStop');
+    expect(end?.querySelector('[data-icon="flag"]')?.getAttribute('data-color')).toBe('#C81E1E');
+    expect(end?.querySelector('[data-text-color]')?.getAttribute('data-text-color')).toBe('#C81E1E');
+  });
+
+  it('labels the joiner exit "Leave" in the neutral tint', () => {
+    const { container } = render(<SessionScreenHeader sessionActive onEndSession={vi.fn()} exitVariant="leave" />);
+    expect(container.querySelector(END)).toBeNull();
+    const leave = container.querySelector(LEAVE);
+    expect(leave?.textContent).toContain('mobile.session.inLeave');
+    expect(leave?.querySelector('[data-icon="leave.session"]')?.getAttribute('data-color')).toBe('#000');
   });
 
   it('renders no End control when onEndSession is absent (e.g. pre-session)', () => {


### PR DESCRIPTION
## Summary

Part of #4281 (the secondary complaint): the flag glyph that ends a session reads as "report this climb" to climbers who have never ended one. The Liquid Glass Record chrome already ships a labelled Stop pill; the Material app bar and the session-screen overlay strip were still bare icons.

- **Material `RecordTopChrome`**: the exit `Appbar.Action` (a 48dp icon circle that can't host a word) becomes an M3 text button — icon + "Stop" (error tint) / "Leave" (neutral), 40dp + hitSlop past 48dp, pill corners from `theme.radii`, ripple tinted from the same role as the label.
- **`SessionScreenHeader`** (both variants): icon + word matching the Record chrome, on the share button's 40dp metrics so the right cluster sits on one baseline.
- Chrome labels in both fixed-height rows now cap Dynamic Type at `CHROME_LABEL_MAX_FONT_SCALE` so they stop growing before clipping (including the existing Glass pill + invite label).

Presentation only — handlers, confirm dialogs, tints, and a11y labels unchanged. No new strings: `session:mobile.session.inStop`/`.inLeave` already ship in all four locales.

## Release Notes

- Ending a session is now a labelled button — "Stop" if you started it, "Leave" if you joined — instead of a bare flag icon.

## Test plan

- [x] `vp run typecheck:mobile`
- [x] `vp run test:mobile` — session-screen suite 17 files / 114 tests green; one pre-existing unrelated failure (`board-detail-fields.test.ts`, red on main, fixed in #4659)
- [x] `vp run check:mobile-bundle`
- [x] `vp check --fix`
- [x] New test assertions: Material Stop carries the word + error-tint flag; Material Leave carries the word + neutral glyph; header leader/joiner labels
- [ ] Emulator screenshots (Material leader/joiner, fr locale for the longest label) — to follow in a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZuN2chYjMnXoNhzrCwSyF