### PR TITLE
fix(web): keep middleware off static API routes and stop crawler locale-redirect loops

### DIFF
--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -6,7 +6,7 @@ import { PATHNAME_HEADER } from '@/app/lib/request-pathname-header';
 
 const { getClimbViewPageCacheTTL, getListPageCacheTTL, hasUserSpecificFilters } =
   await import('@/app/lib/list-page-cache');
-const { middleware } = await import('@/middleware');
+const { middleware, config } = await import('@/middleware');
 
 function sp(params: Record<string, string> = {}): URLSearchParams {
   return new URLSearchParams(params);
@@ -312,6 +312,73 @@ function makeRequest(url: string): NextRequest {
   return new NextRequest(new URL(url, 'http://localhost:3000'));
 }
 
+describe('middleware matcher config', () => {
+  it('pins the exact matcher entries', () => {
+    // Vercel bills/logs per invocation — this literal is the whole point of
+    // the fix, so a drift here (an accidental widening back to /api/:path*,
+    // or a narrowing that drops an auth path) must fail the suite outright.
+    expect(config.matcher).toEqual([
+      '/api/v1/:path*',
+      '/api/auth/:path*',
+      '/api/internal/ws-auth',
+      '/((?!api/|_next/static|_next/image|favicon.ico|monitoring|\\.well-known/|.*\\..*).*)',
+    ]);
+  });
+
+  // Coverage helper mirroring how Next compiles each matcher shape: entries
+  // 1-2 are `:path*` prefixes, entry 3 is an exact path, entry 4 is the full
+  // page-routes regex tested anchored end-to-end.
+  function isMatchedByConfig(pathname: string): boolean {
+    const [v1Prefix, authPrefix, wsAuthExact, pageRoutesRegex] = config.matcher;
+    if (pathname.startsWith(v1Prefix.replace(':path*', ''))) return true;
+    if (pathname.startsWith(authPrefix.replace(':path*', ''))) return true;
+    if (pathname === wsAuthExact) return true;
+    return new RegExp(`^${pageRoutesRegex}$`).test(pathname);
+  }
+
+  it.each([
+    '/api/internal/board-render',
+    '/api/og/setter',
+    '/api/internal/prewarm-heatmap/kilter',
+    '/api/internal/revalidate-climb',
+  ])('does not run middleware on %s (no CORS/locale/board-validation work needed there)', (pathname) => {
+    expect(isMatchedByConfig(pathname)).toBe(false);
+  });
+
+  it.each([
+    '/api/internal/ws-auth',
+    '/api/auth/session',
+    '/api/auth/callback/credentials',
+    '/api/v1/kilter/grades',
+    '/',
+    '/es/kilter/original/12x12-square/screw_bolt/40/view/x',
+    '/b/some-board/40/list',
+  ])('still runs middleware on %s', (pathname) => {
+    expect(isMatchedByConfig(pathname)).toBe(true);
+  });
+
+  it.each(['/_next/static/chunk.js', '/logo.png'])('does not run middleware on static asset %s', (pathname) => {
+    expect(isMatchedByConfig(pathname)).toBe(false);
+  });
+});
+
+describe('middleware /api/v1 board validation', () => {
+  it('404s an unsupported board name', () => {
+    const response = middleware(makeRequest('/api/v1/fakeboard/grades'));
+    expect(response.status).toBe(404);
+  });
+
+  it('passes through a supported board', () => {
+    const response = middleware(makeRequest('/api/v1/kilter/grades'));
+    expect(response.status).toBe(200);
+  });
+
+  it.each(['angles', 'grades'])('passes through the %s special segment without board validation', (segment) => {
+    const response = middleware(makeRequest(`/api/v1/${segment}`));
+    expect(response.status).toBe(200);
+  });
+});
+
 describe('middleware session redirect', () => {
   it('redirects when ?session= is present on a list page', () => {
     const response = middleware(makeRequest('/b/kilter-original-12x12/40/list?session=abc-123'));
@@ -582,6 +649,58 @@ describe('middleware cache headers on climb view pages', () => {
       expect(response.headers.has('CDN-Cache-Control')).toBe(false);
     },
   );
+});
+
+// A crawler that persists cookies (observed in production logs) acquires
+// boardsesh-locale by crawling one /de|/es|/fr page, then bounces every
+// subsequent unprefixed URL through a locale twin — ~15k of these 307s/day,
+// plus the render MISS on the twin it lands on. Bots must never be sent
+// through the sticky-locale redirect, and must never acquire the cookie.
+describe('middleware bot-gates the sticky locale redirect and cookie', () => {
+  const GOOGLEBOT_UA = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+  const CHROME_UA =
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36';
+
+  function makeRequestWithUserAgent(url: string, ua: string): NextRequest {
+    return new NextRequest(new URL(url, 'http://localhost:3000'), {
+      headers: { 'user-agent': ua },
+    });
+  }
+
+  it('does not 307 a bot carrying a stale non-default locale cookie — it gets a default-locale 200 for the requested URL', () => {
+    const request = makeRequestWithUserAgent('/some/page', GOOGLEBOT_UA);
+    request.cookies.set(LOCALE_COOKIE, 'de');
+
+    const response = middleware(request);
+
+    expect(response.status).not.toBe(307);
+    expect(response.headers.has('location')).toBe(false);
+    expect(response.headers.get(`x-middleware-request-${LOCALE_HEADER}`)).toBe(DEFAULT_LOCALE);
+  });
+
+  it('still 307s a human (non-bot UA) carrying the same stale locale cookie', () => {
+    const request = makeRequestWithUserAgent('/some/page', CHROME_UA);
+    request.cookies.set(LOCALE_COOKIE, 'de');
+
+    const response = middleware(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost:3000/de/some/page');
+  });
+
+  it('never sets the boardsesh-locale cookie for a bot visiting a locale-prefixed URL', () => {
+    const response = middleware(makeRequestWithUserAgent('/es/some/page', GOOGLEBOT_UA));
+
+    expect(response.headers.has('set-cookie')).toBe(false);
+  });
+
+  it('sets the boardsesh-locale cookie for a human (non-bot UA) visiting a locale-prefixed URL', () => {
+    const response = middleware(makeRequestWithUserAgent('/es/some/page', CHROME_UA));
+
+    const setCookie = response.headers.get('set-cookie');
+    expect(setCookie).toContain(LOCALE_COOKIE);
+    expect(setCookie).toContain('es');
+  });
 });
 
 describe('middleware forwards the routing pathname header', () => {

--- a/packages/web/app/b/[board_slug]/__tests__/page.test.ts
+++ b/packages/web/app/b/[board_slug]/__tests__/page.test.ts
@@ -11,22 +11,11 @@ class RedirectSignal extends Error {
     super(`redirect:${target}`);
   }
 }
-// permanentRedirect gets its own sentinel class so a test can assert WHICH
-// redirect function fired — a plain string check couldn't distinguish a 307
-// (redirect) from a 308 (permanentRedirect) hop to the same target.
-class PermanentRedirectSignal extends Error {
-  constructor(readonly target: string) {
-    super(`permanentRedirect:${target}`);
-  }
-}
 const notFound = vi.hoisted(() => vi.fn(() => undefined));
 vi.mock('next/navigation', () => ({
   notFound,
   redirect: (target: string) => {
     throw new RedirectSignal(target);
-  },
-  permanentRedirect: (target: string) => {
-    throw new PermanentRedirectSignal(target);
   },
 }));
 
@@ -35,34 +24,20 @@ vi.mock('@/app/lib/board-slug-utils', () => ({ resolveBoardBySlug }));
 
 const BoardSlugPage = (await import('../page')).default;
 
-type RedirectOutcome = { type: 'redirect' | 'permanentRedirect'; target: string };
-
-async function runBoardSlugPage(
+async function redirectTargetFor(
   boardSlug: string,
   searchParams: Record<string, string | string[] | undefined>,
-): Promise<RedirectOutcome> {
+): Promise<string> {
   try {
     await BoardSlugPage({
       params: Promise.resolve({ board_slug: boardSlug }),
       searchParams: Promise.resolve(searchParams),
     });
   } catch (error) {
-    if (error instanceof RedirectSignal) return { type: 'redirect', target: error.target };
-    if (error instanceof PermanentRedirectSignal) return { type: 'permanentRedirect', target: error.target };
+    if (error instanceof RedirectSignal) return error.target;
     throw error;
   }
   throw new Error('expected a redirect');
-}
-
-// QR-attributed hops still go through `redirect` (307) — kept for the
-// existing attribution tests below, which only care about the target.
-async function redirectTargetFor(
-  boardSlug: string,
-  searchParams: Record<string, string | string[] | undefined>,
-): Promise<string> {
-  const outcome = await runBoardSlugPage(boardSlug, searchParams);
-  expect(outcome.type).toBe('redirect');
-  return outcome.target;
 }
 
 beforeEach(() => {
@@ -81,18 +56,14 @@ describe('/b/[board_slug] redirect', () => {
     );
   });
 
-  it('permanently redirects to a clean URL with no trailing "?" when there were no params', async () => {
-    // No QR attribution to carry means this hop is a stable, deterministic
-    // redirect to the same list page every time — cacheable as a 308.
-    const outcome = await runBoardSlugPage('main-kilter', {});
-    expect(outcome.type).toBe('permanentRedirect');
-    expect(outcome.target).toBe('/b/main-kilter/40/list');
+  it('redirects to a clean URL with no trailing "?" when there were no params', () => {
+    return expect(redirectTargetFor('main-kilter', {})).resolves.toBe('/b/main-kilter/40/list');
   });
 
-  it('drops a crafted medium and still permanently redirects (no attribution to carry)', async () => {
-    const outcome = await runBoardSlugPage('main-kilter', { src: 'qr', medium: 'evil' });
-    expect(outcome.type).toBe('permanentRedirect');
-    expect(outcome.target).toBe('/b/main-kilter/40/list');
+  it('drops a crafted medium instead of echoing it into the redirect target', () => {
+    return expect(redirectTargetFor('main-kilter', { src: 'qr', medium: 'evil' })).resolves.toBe(
+      '/b/main-kilter/40/list',
+    );
   });
 
   it('drops every other param a crafted link carries', () => {
@@ -126,5 +97,16 @@ describe('/b/[board_slug] redirect', () => {
     });
 
     expect(notFound).toHaveBeenCalled();
+  });
+
+  it('stays a temporary (307) redirect even for the clean, no-attribution case', async () => {
+    // The target embeds `board.angle`, a live DB field a board editor can change
+    // via `updateBoard` (`isAngleAdjustable`). A permanent (308) redirect here
+    // would be cached by browsers indefinitely, pinning a visitor to a stale
+    // angle forever if the gym re-angled the board after they followed it — see
+    // the rationale comment on the page component. `next/navigation` isn't
+    // mocked with a `permanentRedirect` export at all, so this test also fails
+    // loudly (a missing-export error) if a future change reaches for it here.
+    await expect(redirectTargetFor('main-kilter', {})).resolves.toBe('/b/main-kilter/40/list');
   });
 });

--- a/packages/web/app/b/[board_slug]/__tests__/page.test.ts
+++ b/packages/web/app/b/[board_slug]/__tests__/page.test.ts
@@ -11,11 +11,22 @@ class RedirectSignal extends Error {
     super(`redirect:${target}`);
   }
 }
+// permanentRedirect gets its own sentinel class so a test can assert WHICH
+// redirect function fired — a plain string check couldn't distinguish a 307
+// (redirect) from a 308 (permanentRedirect) hop to the same target.
+class PermanentRedirectSignal extends Error {
+  constructor(readonly target: string) {
+    super(`permanentRedirect:${target}`);
+  }
+}
 const notFound = vi.hoisted(() => vi.fn(() => undefined));
 vi.mock('next/navigation', () => ({
   notFound,
   redirect: (target: string) => {
     throw new RedirectSignal(target);
+  },
+  permanentRedirect: (target: string) => {
+    throw new PermanentRedirectSignal(target);
   },
 }));
 
@@ -24,20 +35,34 @@ vi.mock('@/app/lib/board-slug-utils', () => ({ resolveBoardBySlug }));
 
 const BoardSlugPage = (await import('../page')).default;
 
-async function redirectTargetFor(
+type RedirectOutcome = { type: 'redirect' | 'permanentRedirect'; target: string };
+
+async function runBoardSlugPage(
   boardSlug: string,
   searchParams: Record<string, string | string[] | undefined>,
-): Promise<string> {
+): Promise<RedirectOutcome> {
   try {
     await BoardSlugPage({
       params: Promise.resolve({ board_slug: boardSlug }),
       searchParams: Promise.resolve(searchParams),
     });
   } catch (error) {
-    if (error instanceof RedirectSignal) return error.target;
+    if (error instanceof RedirectSignal) return { type: 'redirect', target: error.target };
+    if (error instanceof PermanentRedirectSignal) return { type: 'permanentRedirect', target: error.target };
     throw error;
   }
   throw new Error('expected a redirect');
+}
+
+// QR-attributed hops still go through `redirect` (307) — kept for the
+// existing attribution tests below, which only care about the target.
+async function redirectTargetFor(
+  boardSlug: string,
+  searchParams: Record<string, string | string[] | undefined>,
+): Promise<string> {
+  const outcome = await runBoardSlugPage(boardSlug, searchParams);
+  expect(outcome.type).toBe('redirect');
+  return outcome.target;
 }
 
 beforeEach(() => {
@@ -56,14 +81,18 @@ describe('/b/[board_slug] redirect', () => {
     );
   });
 
-  it('redirects to a clean URL with no trailing "?" when there were no params', () => {
-    return expect(redirectTargetFor('main-kilter', {})).resolves.toBe('/b/main-kilter/40/list');
+  it('permanently redirects to a clean URL with no trailing "?" when there were no params', async () => {
+    // No QR attribution to carry means this hop is a stable, deterministic
+    // redirect to the same list page every time — cacheable as a 308.
+    const outcome = await runBoardSlugPage('main-kilter', {});
+    expect(outcome.type).toBe('permanentRedirect');
+    expect(outcome.target).toBe('/b/main-kilter/40/list');
   });
 
-  it('drops a crafted medium instead of echoing it into the redirect target', () => {
-    return expect(redirectTargetFor('main-kilter', { src: 'qr', medium: 'evil' })).resolves.toBe(
-      '/b/main-kilter/40/list',
-    );
+  it('drops a crafted medium and still permanently redirects (no attribution to carry)', async () => {
+    const outcome = await runBoardSlugPage('main-kilter', { src: 'qr', medium: 'evil' });
+    expect(outcome.type).toBe('permanentRedirect');
+    expect(outcome.target).toBe('/b/main-kilter/40/list');
   });
 
   it('drops every other param a crafted link carries', () => {

--- a/packages/web/app/b/[board_slug]/page.tsx
+++ b/packages/web/app/b/[board_slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, permanentRedirect, redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import type { GymQrSearchParams } from '@boardsesh/analytics';
 import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import { gymQrAttributionQuery } from '@/app/lib/gym-attribution';
@@ -29,11 +29,16 @@ type BoardSlugPageProps = {
  * swallow the params. Board slugs are generated, so this is a guard rather than
  * a fix — but the printed URL and the redirect that carries it must agree.
  *
- * The clean case (no QR attribution query) is a stable, deterministic hop —
- * this URL always resolves to the same list page — so it's a 308
- * (permanent) redirect a crawler and browser can cache. A QR-attributed hop
- * carries a one-off tracking query that must be re-evaluated on every visit,
- * so it stays a 307.
+ * This redirect must stay a 307 (temporary), even for the clean, no-attribution
+ * case: the target embeds `board.angle`, a live DB field any board editor can
+ * change via the `updateBoard` mutation (see `isAngleAdjustable` in
+ * `packages/backend/src/graphql/resolvers/social/boards.ts`). A 308 is cached
+ * by browsers indefinitely — Server Components can't attach cache-control
+ * headers to `permanentRedirect` — so a visitor who followed a permanent
+ * redirect before a gym re-angled its board would be pinned to a stale
+ * `/b/{slug}/<old-angle>/list` forever. This hop is ~1 request/day in prod, so
+ * the crawl-cost win from caching it isn't worth that risk. (Considered and
+ * rejected in QA review on #4667.)
  */
 export default async function BoardSlugPage(props: BoardSlugPageProps) {
   const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
@@ -44,9 +49,5 @@ export default async function BoardSlugPage(props: BoardSlugPageProps) {
   }
 
   const listPath = `/b/${encodeURIComponent(board.slug)}/${board.angle}/list`;
-  const attribution = gymQrAttributionQuery(searchParams);
-  if (attribution === '') {
-    permanentRedirect(listPath);
-  }
-  redirect(`${listPath}${attribution}`);
+  redirect(`${listPath}${gymQrAttributionQuery(searchParams)}`);
 }

--- a/packages/web/app/b/[board_slug]/page.tsx
+++ b/packages/web/app/b/[board_slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from 'next/navigation';
+import { notFound, permanentRedirect, redirect } from 'next/navigation';
 import type { GymQrSearchParams } from '@boardsesh/analytics';
 import { resolveBoardBySlug } from '@/app/lib/board-slug-utils';
 import { gymQrAttributionQuery } from '@/app/lib/gym-attribution';
@@ -28,6 +28,12 @@ type BoardSlugPageProps = {
  * that a query rides behind the slug, a `#` in one would open a fragment and
  * swallow the params. Board slugs are generated, so this is a guard rather than
  * a fix — but the printed URL and the redirect that carries it must agree.
+ *
+ * The clean case (no QR attribution query) is a stable, deterministic hop —
+ * this URL always resolves to the same list page — so it's a 308
+ * (permanent) redirect a crawler and browser can cache. A QR-attributed hop
+ * carries a one-off tracking query that must be re-evaluated on every visit,
+ * so it stays a 307.
  */
 export default async function BoardSlugPage(props: BoardSlugPageProps) {
   const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
@@ -38,5 +44,9 @@ export default async function BoardSlugPage(props: BoardSlugPageProps) {
   }
 
   const listPath = `/b/${encodeURIComponent(board.slug)}/${board.angle}/list`;
-  redirect(`${listPath}${gymQrAttributionQuery(searchParams)}`);
+  const attribution = gymQrAttributionQuery(searchParams);
+  if (attribution === '') {
+    permanentRedirect(listPath);
+  }
+  redirect(`${listPath}${attribution}`);
 }

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -1,5 +1,5 @@
 // middleware.ts
-import { NextResponse, type NextRequest } from 'next/server';
+import { NextResponse, userAgent, type NextRequest } from 'next/server';
 import { SUPPORTED_BOARDS } from './app/lib/board-data';
 import { getClimbViewPageCacheTTL, getListPageCacheTTL } from './app/lib/list-page-cache';
 import { CLIMB_SESSION_COOKIE } from './app/lib/climb-session-cookie';
@@ -186,10 +186,18 @@ export function middleware(request: NextRequest) {
     ? { locale: DEFAULT_LOCALE, strippedPath: pathname, needsRewrite: false }
     : detectLocale(pathname);
 
+  const requestUserAgent = userAgent(request);
+
   // Cookie-driven sticky locale: when a page request arrives without a locale
   // prefix and the visitor previously chose a non-default locale, send them
   // to the prefixed URL so subsequent navigation stays in their language.
-  if (!isApi && locale === DEFAULT_LOCALE) {
+  //
+  // Bots are excluded: crawlers that persist cookies (observed in production
+  // logs) acquire the boardsesh-locale cookie by crawling a /de|/es|/fr page
+  // once, then bounce every subsequent unprefixed URL through a locale twin —
+  // ~15k of these 307s/day, plus the render MISS on the twin they land on.
+  // Bots get a default-locale 200 for the URL they actually requested instead.
+  if (!isApi && locale === DEFAULT_LOCALE && !requestUserAgent.isBot) {
     const cookieLocale = request.cookies.get(LOCALE_COOKIE)?.value;
     if (isSupportedLocale(cookieLocale) && cookieLocale !== DEFAULT_LOCALE) {
       const target = new URL(`/${cookieLocale}${pathname}`, request.url);
@@ -225,7 +233,9 @@ export function middleware(request: NextRequest) {
 
   // Sticky cookie: any visit on a non-default locale URL writes the cookie so
   // a shared /es/... link from a friend persists for the recipient too.
-  if (locale !== DEFAULT_LOCALE) {
+  // Bots never acquire it — see the sticky-locale redirect bot-gate above for
+  // why a cookie-persisting crawler must never be handed this cookie.
+  if (locale !== DEFAULT_LOCALE && !requestUserAgent.isBot) {
     response.cookies.set(LOCALE_COOKIE, locale, {
       path: '/',
       sameSite: 'lax',
@@ -260,10 +270,27 @@ export function middleware(request: NextRequest) {
   return response;
 }
 
+// Vercel bills and logs per middleware invocation. The previous catch-all
+// matcher (`/api/:path*`-shaped, via the page-routes negative-lookahead not
+// excluding /api/) ran this middleware on every /api/** request, including
+// ~50k+/day board-render image fetches that take nothing from it — the
+// function does no locale/session/CORS work for those paths and every
+// invocation was pure cost. Only three /api families actually need it:
+//   - /api/v1/:path* — board-name validation (404s an unsupported board).
+//   - /api/auth/:path* — all 9 CORS_AUTH_PATHS auth endpoints live here
+//     (see cross-subdomain-cors.ts) and need the credentialed-CORS handling.
+//   - /api/internal/ws-auth — the one /api/internal path in CORS_AUTH_PATHS;
+//     its OPTIONS preflight is answered by middleware itself, so it must stay
+//     matched even though the rest of /api/internal/** is now excluded.
+// Pre-verified safe: no route under packages/web/app/api reads the
+// locale/pathname headers middleware sets, and nothing excluded here accepts
+// a `?session=` query param that middleware needs to intercept.
 export const config = {
   matcher: [
     '/api/v1/:path*',
+    '/api/auth/:path*',
+    '/api/internal/ws-auth',
     // Match all page routes but skip static files, Next.js internals, and Vercel Flags Explorer
-    '/((?!_next/static|_next/image|favicon.ico|monitoring|\\.well-known/|.*\\..*).*)',
+    '/((?!api/|_next/static|_next/image|favicon.ico|monitoring|\\.well-known/|.*\\..*).*)',
   ],
 };


### PR DESCRIPTION
## Summary
- Narrow the middleware matcher (#4650) so Vercel only invokes edge middleware where it does real work: `/api/v1/:path*` (board validation), `/api/auth/:path*` + `/api/internal/ws-auth` (the 9 CORS_AUTH_PATHS auth endpoints), and page routes. The previous catch-all ran middleware on every `/api/**` request, including ~50k+/day board-render image fetches that take nothing from it — pinned at 218k edge-middleware invocations/day in prod logs.
- Bot-gate the sticky-locale 307 redirect and the `boardsesh-locale` cookie write with `next/server`'s `userAgent(request).isBot`. Cookie-persisting crawlers (Googlebot et al.) were crawling one `/de|/es|/fr` page, acquiring the sticky cookie, then bouncing every subsequent unprefixed URL through a locale twin and back — ~15k of these 307s/day plus the render MISS on the twin, pinned in prod logs.
- `/b/[board_slug]` keeps its existing 307 `redirect` for every case, unchanged from before this PR. A `permanentRedirect` (308) for the clean, no-attribution case was considered (that hop is deterministic) and rejected in QA review: the target embeds `board.angle`, a live DB field a board editor can change, and a cached 308 would pin a visitor to a stale angle after a re-angle — see the rationale comment on the page component.

## Test plan
- [x] `vp run typecheck` (full monorepo, incl. `@boardsesh/web` build + `tsc --noEmit`) — clean
- [x] `vp check` scoped to the changed files — 0 lint/format/type errors
- [x] `vp test run --project web` on the changed test files — 167/167 passing
- New tests pin the exact matcher literal and cover match/no-match cases for `/api/v1`, `/api/auth`, `/api/internal/ws-auth`, static assets, and page routes.
- New tests cover the bot-gate: a bot with a stale locale cookie gets a default-locale 200 (no redirect, no cookie); a human still gets the 307 and the cookie.
- New `/api/v1` board-validation tests (none existed before): unsupported board 404s, supported board and `angles`/`grades` special segments pass through.
- `/b/[board_slug]` tests: unchanged assertions (all cases still 307 `redirect`), plus a new test pinning the clean case to 307 so it can't be silently "optimised" back to a permanent redirect.

## Release Notes

- [x] No release note needed (internal / technical change)

