### PR TITLE
fix(backend): stop the home page's cold reads from eating the pool

### DIFF
--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -110,11 +110,13 @@ The home page's two backend reads — `popularBoardConfigs` and
 a heavy statement on a miss. The fall-through had no concurrency control, so N
 simultaneous visitors during a cold window meant N simultaneous copies, each
 holding one of the pool's ten connections. `popularBoardConfigs` costs 82 s on
-the dev-db image, so ten visitors emptied the pool for well over a minute, and
-after that every _other_ query in the process queued forever on the untimed
-acquire queue described above. `{ __typename }` kept answering in single-digit
-milliseconds through the same event loop, which is why it read as anything but
-saturation.
+the dev-db image; the one production observation on record is ~10 s cold, read
+through the sitemap's copy of the same statement
+(`packages/web/app/lib/server-popular-configs.ts`). Either number times ten
+visitors empties the pool, and after that every _other_ query in the process
+queued forever on the untimed acquire queue described in the next section.
+`{ __typename }` kept answering in single-digit milliseconds through the same
+event loop, which is why it read as anything but saturation.
 
 `packages/backend/src/utils/single-flight.ts` is the fix: concurrent callers of
 one key share one in-flight promise, so a cold window costs one statement and

--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -99,6 +99,39 @@ off) rather than reaching into postgres.js's backoff.
 The connect-retry tests pin their pools to `backoff: () => 0` so they measure this
 wrapper's loop rather than that ramp.
 
+## What actually exhausts a pool: one uncached read, run concurrently (#4463)
+
+The deadlines above bound how long a caller _waits_. Neither bounds how many
+connections one logical read can hold at once, and that is what took the
+backend down in #4463.
+
+The home page's two backend reads — `popularBoardConfigs` and
+`recentBetaLinks` — are Redis-cached with a long TTL and both fall through to
+a heavy statement on a miss. The fall-through had no concurrency control, so N
+simultaneous visitors during a cold window meant N simultaneous copies, each
+holding one of the pool's ten connections. `popularBoardConfigs` costs 82 s on
+the dev-db image, so ten visitors emptied the pool for well over a minute, and
+after that every _other_ query in the process queued forever on the untimed
+acquire queue described above. `{ __typename }` kept answering in single-digit
+milliseconds through the same event loop, which is why it read as anything but
+saturation.
+
+`packages/backend/src/utils/single-flight.ts` is the fix: concurrent callers of
+one key share one in-flight promise, so a cold window costs one statement and
+one connection instead of one per caller. It is deliberately not a cache — the
+promise is dropped the moment it settles. A process-local copy
+(`REDISLESS_FALLBACK_TTL_MS`) covers deployments with no Redis, where
+single-flight alone would still re-run the statement for the first caller after
+every completion.
+
+The distributed Redis lock those reads' warm-up jobs take is not a substitute:
+it only stops a second _node_ from refreshing, and it is not held on the
+resolver path at all.
+
+**When adding a cache-with-fallthrough on a read that costs more than a few
+hundred milliseconds, wrap the fall-through.** The Redis hit rate is not the
+safety property; the concurrency of the miss is.
+
 ## Front-door read deadlines and pool sizing (#4461)
 
 The connect retry above bounds a _failed_ connect. It does nothing about a

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -138,6 +138,7 @@ import {
   betaLinkQueries,
   warmRecentBetaLinksCache,
   invalidateRecentBetaLinksCache,
+  resetRecentBetaLinksFallbackForTests,
 } from '../graphql/resolvers/beta-videos/queries';
 
 type Row = {
@@ -338,6 +339,10 @@ describe('recentBetaLinks resolver', () => {
     // underlying CTE on every call. Individual tests opt-in to a connected
     // mock when they want to exercise cache hit/miss behaviour.
     redisConnectedMock.mockReturnValue(false);
+    // With no Redis the resolver keeps a process-local copy for 10 minutes
+    // (#4463), which would otherwise answer the next test from the previous
+    // test's fixture instead of hitting `executeMock`.
+    resetRecentBetaLinksFallbackForTests();
   });
 
   // The CTE-based resolver returns flat snake_case rows from `db.execute` and
@@ -593,6 +598,9 @@ describe('recentBetaLinks Redis cache', () => {
     redisSetMock.mockReset();
     redisDelMock.mockReset();
     redisConnectedMock.mockReturnValue(true);
+    // The Redis-less branch keeps a process-local copy for 10 minutes (#4463);
+    // clear it so the one test here that disconnects Redis still reaches the CTE.
+    resetRecentBetaLinksFallbackForTests();
   });
 
   it('returns cached rows without running the CTE on hit', async () => {

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -738,6 +738,21 @@ describe('recentBetaLinks Redis cache', () => {
 
     expect(redisDelMock).not.toHaveBeenCalled();
   });
+
+  it('invalidateRecentBetaLinksCache: drops the Redis-less copy so a new link shows up', async () => {
+    redisConnectedMock.mockReturnValue(false);
+    executeMock.mockReturnValue([cachedRow({ link: 'https://www.instagram.com/p/BEFORE/' })]);
+
+    await betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+    expect(executeMock).toHaveBeenCalledTimes(1);
+
+    // Without the drop, a dev/CI server serves the pre-save strip for up to
+    // REDISLESS_FALLBACK_TTL_MS (10 min) after a climber posts a beta link.
+    await invalidateRecentBetaLinksCache();
+
+    await betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+    expect(executeMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('betaLinkPreview resolver', () => {

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -739,6 +739,29 @@ describe('recentBetaLinks Redis cache', () => {
     expect(redisDelMock).not.toHaveBeenCalled();
   });
 
+  it('invalidateRecentBetaLinksCache: a read already in flight cannot restore the pre-write strip', async () => {
+    redisConnectedMock.mockReturnValue(false);
+    let releaseFirstRead!: (rows: unknown) => void;
+    executeMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        releaseFirstRead = resolve;
+      }),
+    );
+
+    const readStartedFirst = betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+    // The climber saves their link while that CTE is still running, so its rows
+    // are the pre-save strip.
+    await invalidateRecentBetaLinksCache();
+    releaseFirstRead([cachedRow({ link: 'https://www.instagram.com/p/BEFORE/' })]);
+    await readStartedFirst;
+
+    executeMock.mockReturnValueOnce([cachedRow({ link: 'https://www.instagram.com/p/AFTER/' })]);
+    const readStartedAfter = await betaLinkQueries.recentBetaLinks(undefined, { limit: 20 });
+
+    expect(executeMock).toHaveBeenCalledTimes(2);
+    expect(readStartedAfter[0]?.betaLink.link).toBe('https://www.instagram.com/p/AFTER/');
+  });
+
   it('invalidateRecentBetaLinksCache: drops the Redis-less copy so a new link shows up', async () => {
     redisConnectedMock.mockReturnValue(false);
     executeMock.mockReturnValue([cachedRow({ link: 'https://www.instagram.com/p/BEFORE/' })]);

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -602,6 +602,9 @@ describe('recentBetaLinks Redis cache', () => {
     // The Redis-less branch keeps a process-local copy for 10 minutes (#4463);
     // clear it so the one test here that disconnects Redis still reaches the CTE.
     dropRecentBetaLinksFallback();
+    // Same reason, one layer up: a case that leaves a flight pending would
+    // otherwise hand its promise to the next case instead of hitting the CTE.
+    resetSingleFlightForTests();
   });
 
   it('returns cached rows without running the CTE on hit', async () => {
@@ -666,7 +669,6 @@ describe('recentBetaLinks Redis cache', () => {
   // pool's ten connections until it finished — after which every other query
   // in the process queued behind them forever.
   it('runs one CTE for callers that arrive while the first is still running', async () => {
-    resetSingleFlightForTests();
     redisConnectedMock.mockReturnValue(false);
     let releaseCte!: (rows: unknown) => void;
     executeMock.mockReturnValue(

--- a/packages/backend/src/__tests__/beta-link-queries.test.ts
+++ b/packages/backend/src/__tests__/beta-link-queries.test.ts
@@ -138,8 +138,9 @@ import {
   betaLinkQueries,
   warmRecentBetaLinksCache,
   invalidateRecentBetaLinksCache,
-  resetRecentBetaLinksFallbackForTests,
+  dropRecentBetaLinksFallback,
 } from '../graphql/resolvers/beta-videos/queries';
+import { resetSingleFlightForTests } from '../utils/single-flight';
 
 type Row = {
   boardType: string;
@@ -342,7 +343,7 @@ describe('recentBetaLinks resolver', () => {
     // With no Redis the resolver keeps a process-local copy for 10 minutes
     // (#4463), which would otherwise answer the next test from the previous
     // test's fixture instead of hitting `executeMock`.
-    resetRecentBetaLinksFallbackForTests();
+    dropRecentBetaLinksFallback();
   });
 
   // The CTE-based resolver returns flat snake_case rows from `db.execute` and
@@ -600,7 +601,7 @@ describe('recentBetaLinks Redis cache', () => {
     redisConnectedMock.mockReturnValue(true);
     // The Redis-less branch keeps a process-local copy for 10 minutes (#4463);
     // clear it so the one test here that disconnects Redis still reaches the CTE.
-    resetRecentBetaLinksFallbackForTests();
+    dropRecentBetaLinksFallback();
   });
 
   it('returns cached rows without running the CTE on hit', async () => {
@@ -657,6 +658,38 @@ describe('recentBetaLinks Redis cache', () => {
     expect(executeMock).toHaveBeenCalledTimes(1);
     expect(redisGetMock).not.toHaveBeenCalled();
     expect(redisSetMock).not.toHaveBeenCalled();
+  });
+
+  // The other half of the home page's cold read (#4463). Same hazard as
+  // popularBoardConfigs: with no concurrency control, N simultaneous visitors
+  // during a cold window meant N copies of the CTE, each holding one of the
+  // pool's ten connections until it finished — after which every other query
+  // in the process queued behind them forever.
+  it('runs one CTE for callers that arrive while the first is still running', async () => {
+    resetSingleFlightForTests();
+    redisConnectedMock.mockReturnValue(false);
+    let releaseCte!: (rows: unknown) => void;
+    executeMock.mockReturnValue(
+      new Promise((resolve) => {
+        releaseCte = resolve;
+      }),
+    );
+
+    const concurrent = [
+      betaLinkQueries.recentBetaLinks(undefined, { limit: 20 }),
+      betaLinkQueries.recentBetaLinks(undefined, { limit: 20 }),
+      betaLinkQueries.recentBetaLinks(undefined, { limit: 20 }),
+      betaLinkQueries.recentBetaLinks(undefined, { limit: 20 }),
+    ];
+    expect(executeMock).toHaveBeenCalledTimes(1);
+
+    releaseCte([cachedRow({ link: 'https://www.instagram.com/p/HERD/' })]);
+    const results = await Promise.all(concurrent);
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    for (const result of results) {
+      expect(result).toHaveLength(1);
+    }
   });
 
   it('still serves a result when the Redis read throws', async () => {

--- a/packages/backend/src/__tests__/popular-configs-stampede.test.ts
+++ b/packages/backend/src/__tests__/popular-configs-stampede.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
+import type { ConnectionContext } from '@boardsesh/shared-schema';
+
+/**
+ * #4463: `popularBoardConfigs` is the home page's resolver and the heaviest
+ * read in the app — 82 s on the dev database when cold. It is Redis-cached,
+ * but the fall-through had no concurrency control, so N simultaneous visitors
+ * during a cold window meant N simultaneous copies, each pinning one of the
+ * pool's ten connections. Once the pool was gone every other query in the
+ * process queued behind it forever (postgres.js's acquire queue is unbounded
+ * and untimed), which is what made `/embed/**` renders hang for 60 s+ in the
+ * e2e suite — the CI backend runs with no REDIS_URL, so every render was a
+ * cold window.
+ *
+ * These pin the two properties that make that impossible: one in-flight
+ * statement per process, and a process-local copy when there is no Redis to
+ * hold one.
+ */
+
+const { executeMock, redisConnectedMock, redisGetMock, redisSetMock } = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  redisConnectedMock: vi.fn(() => false),
+  redisGetMock: vi.fn(),
+  redisSetMock: vi.fn(),
+}));
+
+vi.mock('../db/client', () => ({
+  db: {
+    execute: executeMock,
+  },
+}));
+
+vi.mock('../redis/client', () => ({
+  redisClientManager: {
+    isRedisConnected: redisConnectedMock,
+    getClients: () => ({ publisher: { get: redisGetMock, set: redisSetMock, del: vi.fn() } }),
+  },
+}));
+
+import { socialBoardQueries, resetPopularConfigsFallbackForTests } from '../graphql/resolvers/social/boards';
+import { resetSingleFlightForTests } from '../utils/single-flight';
+
+const CONFIG_ROW = {
+  board_type: 'kilter',
+  layout_id: 1,
+  layout_name: 'Kilter Board Original',
+  size_id: 10,
+  size_name: '12x12 With Kickboard',
+  size_description: '12 x 12',
+  set_ids: [1, 2],
+  set_names: ['Bolt Ons', 'Screw Ons'],
+  climb_count: 4200,
+  total_ascents: 99000,
+  board_count: 12,
+};
+
+function deferredRows() {
+  let resolve!: (rows: unknown) => void;
+  const promise = new Promise<unknown>((resolveFn) => {
+    resolve = resolveFn;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  executeMock.mockReset();
+  redisConnectedMock.mockReset();
+  redisConnectedMock.mockReturnValue(false);
+  redisGetMock.mockReset();
+  redisSetMock.mockReset();
+  resetPopularConfigsFallbackForTests();
+  resetSingleFlightForTests();
+});
+
+// The resolver ignores its ctx (popularBoardConfigs is anonymous), but the
+// signature demands one.
+const anonCtx = { connectionId: 'conn-anon', isAuthenticated: false } as ConnectionContext;
+
+const askForConfigs = () => socialBoardQueries.popularBoardConfigs(undefined, { input: { limit: 20 } }, anonCtx);
+
+describe('popularBoardConfigs does not stampede the connection pool', () => {
+  it('runs one statement for callers that arrive while the first is still running', async () => {
+    const inFlight = deferredRows();
+    executeMock.mockReturnValue(inFlight.promise);
+
+    const concurrent = [askForConfigs(), askForConfigs(), askForConfigs(), askForConfigs(), askForConfigs()];
+    // Five concurrent home-page renders, one pool connection.
+    expect(executeMock).toHaveBeenCalledTimes(1);
+
+    inFlight.resolve([CONFIG_ROW]);
+    const results = await Promise.all(concurrent);
+
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    for (const result of results) {
+      expect(result.totalCount).toBe(1);
+      expect(result.configs[0]?.boardType).toBe('kilter');
+    }
+  });
+
+  it('answers a later caller from the process-local copy when there is no Redis', async () => {
+    executeMock.mockResolvedValue([CONFIG_ROW]);
+
+    await askForConfigs();
+    await askForConfigs();
+
+    // Without the fallback, single-flight alone would re-run the 82 s
+    // statement for the first caller after every completion.
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(redisGetMock).not.toHaveBeenCalled();
+    expect(redisSetMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the Redis path exactly as it was — no process-local copy is consulted', async () => {
+    redisConnectedMock.mockReturnValue(true);
+    redisGetMock.mockResolvedValue(null);
+    executeMock.mockResolvedValue([CONFIG_ROW]);
+
+    await askForConfigs();
+    await askForConfigs();
+
+    // Every call still asks Redis first and still writes back, so the
+    // deliberate cache DELETE `warmPopularConfigsCache` does on each deploy
+    // is still what decides freshness in production.
+    expect(redisGetMock).toHaveBeenCalledTimes(2);
+    expect(redisSetMock).toHaveBeenCalledTimes(2);
+    expect(executeMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/backend/src/__tests__/popular-configs-stampede.test.ts
+++ b/packages/backend/src/__tests__/popular-configs-stampede.test.ts
@@ -133,6 +133,24 @@ describe('popularBoardConfigs does not stampede the connection pool', () => {
     expect(executeMock).toHaveBeenCalledTimes(2);
   });
 
+  it('does not let a flight that started before a drop repopulate the copy behind it', async () => {
+    const inFlight = deferredRows();
+    executeMock.mockReturnValueOnce(inFlight.promise);
+
+    const readStartedFirst = askForConfigs();
+    // The deploy warm-up (or a test) drops the copy while that 82 s statement
+    // is still running. Its rows are pre-deploy; caching them afterwards would
+    // undo the drop for the next 10 minutes.
+    dropPopularConfigsFallback();
+    inFlight.resolve([CONFIG_ROW]);
+    await readStartedFirst;
+
+    executeMock.mockResolvedValueOnce([CONFIG_ROW]);
+    await askForConfigs();
+
+    expect(executeMock).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps the Redis path exactly as it was — no process-local copy is consulted', async () => {
     redisConnectedMock.mockReturnValue(true);
     redisGetMock.mockResolvedValue(null);

--- a/packages/backend/src/__tests__/popular-configs-stampede.test.ts
+++ b/packages/backend/src/__tests__/popular-configs-stampede.test.ts
@@ -37,7 +37,11 @@ vi.mock('../redis/client', () => ({
   },
 }));
 
-import { socialBoardQueries, dropPopularConfigsFallback } from '../graphql/resolvers/social/boards';
+import {
+  socialBoardQueries,
+  dropPopularConfigsFallback,
+  warmPopularConfigsCache,
+} from '../graphql/resolvers/social/boards';
 import { resetSingleFlightForTests } from '../utils/single-flight';
 
 const CONFIG_ROW = {
@@ -108,6 +112,25 @@ describe('popularBoardConfigs does not stampede the connection pool', () => {
     expect(executeMock).toHaveBeenCalledTimes(1);
     expect(redisGetMock).not.toHaveBeenCalled();
     expect(redisSetMock).not.toHaveBeenCalled();
+  });
+
+  it('re-runs the statement on the deploy warm-up instead of answering it from the last run', async () => {
+    executeMock.mockResolvedValue([CONFIG_ROW]);
+
+    await askForConfigs();
+    expect(executeMock).toHaveBeenCalledTimes(1);
+
+    // `warmPopularConfigsCache` exists to re-run the query on every deploy
+    // because the Aurora sync may have moved the data under it. With Redis it
+    // does that by DELETing the cache key; with no Redis it must drop the
+    // process-local copy, or the warm-up is answered from the previous run's
+    // fixture and quietly does nothing.
+    await warmPopularConfigsCache();
+    expect(executeMock).toHaveBeenCalledTimes(2);
+
+    // The warm-up re-seeded the copy, so the next visitor is still cheap.
+    await askForConfigs();
+    expect(executeMock).toHaveBeenCalledTimes(2);
   });
 
   it('keeps the Redis path exactly as it was — no process-local copy is consulted', async () => {

--- a/packages/backend/src/__tests__/popular-configs-stampede.test.ts
+++ b/packages/backend/src/__tests__/popular-configs-stampede.test.ts
@@ -37,7 +37,7 @@ vi.mock('../redis/client', () => ({
   },
 }));
 
-import { socialBoardQueries, resetPopularConfigsFallbackForTests } from '../graphql/resolvers/social/boards';
+import { socialBoardQueries, dropPopularConfigsFallback } from '../graphql/resolvers/social/boards';
 import { resetSingleFlightForTests } from '../utils/single-flight';
 
 const CONFIG_ROW = {
@@ -68,7 +68,7 @@ beforeEach(() => {
   redisConnectedMock.mockReturnValue(false);
   redisGetMock.mockReset();
   redisSetMock.mockReset();
-  resetPopularConfigsFallbackForTests();
+  dropPopularConfigsFallback();
   resetSingleFlightForTests();
 });
 

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -19,7 +19,7 @@ import {
 } from '../../../lib/beta-link-thumbnails';
 import { redisClientManager } from '../../../redis/client';
 import { logger } from '../../../utils/logger';
-import { singleFlight } from '../../../utils/single-flight';
+import { REDISLESS_FALLBACK_TTL_MS, singleFlight } from '../../../utils/single-flight';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { applyRateLimit, requireAuthenticated } from '../shared/helpers';
 
@@ -358,11 +358,14 @@ const RECENT_BETA_LINKS_FLIGHT_KEY = 'recent-beta-links';
  * Redis-less fallback, mirroring `getPopularConfigs`. Never read or written
  * when a shared cache is available, so production behaviour is unchanged.
  */
-const LOCAL_FALLBACK_TTL_MS = 10 * 60 * 1000;
 let localFallbackRows: { rows: CachedRecentBetaLinkRow[]; expiresAt: number } | null = null;
 
-/** Test-only: drop the Redis-less fallback so one test cannot leak into the next. */
-export function resetRecentBetaLinksFallbackForTests(): void {
+/**
+ * The Redis-less twin of deleting RECENT_BETA_LINKS_REDIS_KEY. Called by
+ * `invalidateRecentBetaLinksCache`, and by tests so one case cannot answer the
+ * next from the previous one's fixture.
+ */
+export function dropRecentBetaLinksFallback(): void {
   localFallbackRows = null;
 }
 
@@ -400,7 +403,7 @@ async function getCachedRecentBetaLinks(): Promise<CachedRecentBetaLinkRow[]> {
         logger.error('[RecentBetaLinks] Redis write failed:', err);
       }
     } else {
-      localFallbackRows = { rows, expiresAt: Date.now() + LOCAL_FALLBACK_TTL_MS };
+      localFallbackRows = { rows, expiresAt: Date.now() + REDISLESS_FALLBACK_TTL_MS };
     }
     return rows;
   });
@@ -454,8 +457,8 @@ export async function warmRecentBetaLinksCache(): Promise<void> {
  */
 export async function invalidateRecentBetaLinksCache(): Promise<void> {
   // Drop the Redis-less copy too, or a dev/CI server would serve the pre-save
-  // strip for up to LOCAL_FALLBACK_TTL_MS after a new link lands.
-  localFallbackRows = null;
+  // strip for up to REDISLESS_FALLBACK_TTL_MS after a new link lands.
+  dropRecentBetaLinksFallback();
   if (!redisClientManager.isRedisConnected()) return;
   try {
     const { publisher } = redisClientManager.getClients();

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../lib/beta-link-thumbnails';
 import { redisClientManager } from '../../../redis/client';
 import { logger } from '../../../utils/logger';
+import { singleFlight } from '../../../utils/single-flight';
 import type { ConnectionContext } from '@boardsesh/shared-schema';
 import { applyRateLimit, requireAuthenticated } from '../shared/helpers';
 
@@ -351,6 +352,20 @@ async function runRecentBetaLinksQuery(): Promise<CachedRecentBetaLinkRow[]> {
  * and writes the result back. On Redis unavailable, runs the CTE inline
  * (same fall-through pattern as `getPopularConfigs` in social/boards.ts).
  */
+const RECENT_BETA_LINKS_FLIGHT_KEY = 'recent-beta-links';
+
+/**
+ * Redis-less fallback, mirroring `getPopularConfigs`. Never read or written
+ * when a shared cache is available, so production behaviour is unchanged.
+ */
+const LOCAL_FALLBACK_TTL_MS = 10 * 60 * 1000;
+let localFallbackRows: { rows: CachedRecentBetaLinkRow[]; expiresAt: number } | null = null;
+
+/** Test-only: drop the Redis-less fallback so one test cannot leak into the next. */
+export function resetRecentBetaLinksFallbackForTests(): void {
+  localFallbackRows = null;
+}
+
 async function getCachedRecentBetaLinks(): Promise<CachedRecentBetaLinkRow[]> {
   if (redisClientManager.isRedisConnected()) {
     try {
@@ -362,19 +377,33 @@ async function getCachedRecentBetaLinks(): Promise<CachedRecentBetaLinkRow[]> {
     } catch (err) {
       logger.error('[RecentBetaLinks] Redis read failed:', err);
     }
+  } else if (localFallbackRows && localFallbackRows.expiresAt > Date.now()) {
+    return localFallbackRows.rows;
   }
 
-  const rows = await runRecentBetaLinksQuery();
+  // Same pool-exhaustion hazard as popularBoardConfigs (#4463): the other half
+  // of the home page's cold read. One in-flight copy per process, joined by
+  // every concurrent caller.
+  return singleFlight(RECENT_BETA_LINKS_FLIGHT_KEY, async () => {
+    const rows = await runRecentBetaLinksQuery();
 
-  if (redisClientManager.isRedisConnected()) {
-    try {
-      const { publisher } = redisClientManager.getClients();
-      await publisher.set(RECENT_BETA_LINKS_REDIS_KEY, JSON.stringify(rows), 'EX', RECENT_BETA_LINKS_REDIS_TTL_SECONDS);
-    } catch (err) {
-      logger.error('[RecentBetaLinks] Redis write failed:', err);
+    if (redisClientManager.isRedisConnected()) {
+      try {
+        const { publisher } = redisClientManager.getClients();
+        await publisher.set(
+          RECENT_BETA_LINKS_REDIS_KEY,
+          JSON.stringify(rows),
+          'EX',
+          RECENT_BETA_LINKS_REDIS_TTL_SECONDS,
+        );
+      } catch (err) {
+        logger.error('[RecentBetaLinks] Redis write failed:', err);
+      }
+    } else {
+      localFallbackRows = { rows, expiresAt: Date.now() + LOCAL_FALLBACK_TTL_MS };
     }
-  }
-  return rows;
+    return rows;
+  });
 }
 
 /**
@@ -424,6 +453,9 @@ export async function warmRecentBetaLinksCache(): Promise<void> {
  * never blocks the calling mutation.
  */
 export async function invalidateRecentBetaLinksCache(): Promise<void> {
+  // Drop the Redis-less copy too, or a dev/CI server would serve the pre-save
+  // strip for up to LOCAL_FALLBACK_TTL_MS after a new link lands.
+  localFallbackRows = null;
   if (!redisClientManager.isRedisConnected()) return;
   try {
     const { publisher } = redisClientManager.getClients();

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -352,6 +352,13 @@ async function runRecentBetaLinksQuery(): Promise<CachedRecentBetaLinkRow[]> {
  * and writes the result back. On Redis unavailable, runs the CTE inline
  * (same fall-through pattern as `getPopularConfigs` in social/boards.ts).
  */
+/**
+ * One key for every caller, deliberately: the CTE below fetches a fixed
+ * RECENT_BETA_LINKS_CACHE_SIZE rows regardless of the caller's `limit`, which
+ * the resolver then slices. So two concurrent callers asking for different
+ * limits are asking for the same statement — the same reason the Redis key
+ * isn't parameterised either.
+ */
 const RECENT_BETA_LINKS_FLIGHT_KEY = 'recent-beta-links';
 
 /**
@@ -430,6 +437,11 @@ export async function warmRecentBetaLinksCache(): Promise<void> {
   // No Redis means there's no cache to warm — running the CTE here would
   // just discard the result. Skip the work and the log so dev/test logs
   // stay honest.
+  //
+  // This is why there is no `dropRecentBetaLinksFallback()` here to mirror
+  // `warmPopularConfigsCache`'s drop: that one keeps going without Redis (it
+  // seeds the process-local copy), this one stops before it could read or
+  // write anything.
   if (!redisClientManager.isRedisConnected()) return;
 
   try {

--- a/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
+++ b/packages/backend/src/graphql/resolvers/beta-videos/queries.ts
@@ -361,12 +361,22 @@ const RECENT_BETA_LINKS_FLIGHT_KEY = 'recent-beta-links';
 let localFallbackRows: { rows: CachedRecentBetaLinkRow[]; expiresAt: number } | null = null;
 
 /**
+ * Bumped on every invalidation. A CTE that was already running when a climber
+ * posted a link holds a pre-write snapshot, and without this it would repopulate
+ * the fallback *after* the drop and hide the new link for the full 10 minutes.
+ * A flight captures the counter before it starts and declines to cache its
+ * result if the number moved underneath it.
+ */
+let fallbackGeneration = 0;
+
+/**
  * The Redis-less twin of deleting RECENT_BETA_LINKS_REDIS_KEY. Called by
  * `invalidateRecentBetaLinksCache`, and by tests so one case cannot answer the
  * next from the previous one's fixture.
  */
 export function dropRecentBetaLinksFallback(): void {
   localFallbackRows = null;
+  fallbackGeneration += 1;
 }
 
 async function getCachedRecentBetaLinks(): Promise<CachedRecentBetaLinkRow[]> {
@@ -388,6 +398,7 @@ async function getCachedRecentBetaLinks(): Promise<CachedRecentBetaLinkRow[]> {
   // of the home page's cold read. One in-flight copy per process, joined by
   // every concurrent caller.
   return singleFlight(RECENT_BETA_LINKS_FLIGHT_KEY, async () => {
+    const generationAtStart = fallbackGeneration;
     const rows = await runRecentBetaLinksQuery();
 
     if (redisClientManager.isRedisConnected()) {
@@ -402,7 +413,7 @@ async function getCachedRecentBetaLinks(): Promise<CachedRecentBetaLinkRow[]> {
       } catch (err) {
         logger.error('[RecentBetaLinks] Redis write failed:', err);
       }
-    } else {
+    } else if (fallbackGeneration === generationAtStart) {
       localFallbackRows = { rows, expiresAt: Date.now() + REDISLESS_FALLBACK_TTL_MS };
     }
     return rows;

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -37,6 +37,7 @@ import { publishBoardQueuePreviewTombstoneForBoard } from '../../../services/boa
 import { logger } from '../../../utils/logger';
 import { redisClientManager } from '../../../redis/client';
 import { isUniqueViolation } from '../../../utils/postgres-errors';
+import { singleFlight } from '../../../utils/single-flight';
 import { lockAndAssertBoardSerialAvailable } from '../board-serial-write-lock';
 
 // ============================================
@@ -740,6 +741,37 @@ const REDIS_CACHE_TTL_SECONDS = 365 * 24 * 60 * 60; // 1 year
 const REDIS_LOCK_KEY = 'boardsesh:popular-board-configs:lock';
 const REDIS_LOCK_TTL_SECONDS = 120; // 2 min lock to prevent duplicate queries across nodes
 
+/**
+ * Key for the in-process single-flight. The statement below is the heaviest
+ * read in the app — one LATERAL with a nested NOT EXISTS per listed config,
+ * 51 of them today — and it is the resolver behind the home page, so a cold
+ * cache used to mean one copy per concurrent visitor, each holding a pool
+ * connection until it finished. See utils/single-flight.ts for what that did
+ * to every other query in the process.
+ */
+const POPULAR_CONFIGS_FLIGHT_KEY = 'popular-board-configs';
+
+/**
+ * Last-resort cache for deployments with no Redis (local dev, the e2e CI
+ * stack). With a shared cache there is nothing to fall back to and this is
+ * never read or written, so production behaviour — including the deliberate
+ * cache DELETE in `warmPopularConfigsCache` on every deploy — is unchanged.
+ * Without one, single-flight alone would still re-run the statement for the
+ * first caller after each completion, forever.
+ */
+const LOCAL_FALLBACK_TTL_MS = 10 * 60 * 1000;
+let localFallbackConfigs: { configs: CachedPopularConfig[]; expiresAt: number } | null = null;
+
+/** The Redis-less twin of deleting REDIS_CACHE_KEY: force the next read to re-query. */
+function dropPopularConfigsFallback(): void {
+  localFallbackConfigs = null;
+}
+
+/** Test-only: drop the Redis-less fallback so one test cannot leak into the next. */
+export function resetPopularConfigsFallbackForTests(): void {
+  dropPopularConfigsFallback();
+}
+
 async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
   // Try Redis cache first
   if (redisClientManager.isRedisConnected()) {
@@ -752,12 +784,25 @@ async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
     } catch (err) {
       logger.error('[PopularConfigs] Redis read failed:', err);
     }
+  } else if (localFallbackConfigs && localFallbackConfigs.expiresAt > Date.now()) {
+    return localFallbackConfigs.configs;
   }
 
+  return singleFlight(POPULAR_CONFIGS_FLIGHT_KEY, runPopularConfigsQuery);
+}
+
+async function runPopularConfigsQuery(): Promise<CachedPopularConfig[]> {
   // Query all per-size configs with climb counts filtered by size edges AND set membership.
   // A climb counts for a config only if ALL its holds belong to placements in that config's sets.
   // board_climb_holds.hold_id = board_placements.id (placement ID).
-  // ~31 configs, ~750ms worst case per LATERAL, cached in Redis for 1 year (refreshed on deploy).
+  //
+  // Cached in Redis for 1 year (deliberately re-run on deploy). Cost, measured
+  // 2026-08-22 against the dev-db image (51 listed configs, 648k board_climbs,
+  // idle 10-core box): 82 s for one execution. The header on this block used to
+  // read "~31 configs, ~750ms worst case per LATERAL" — that is long stale, and
+  // the gap is why an uncached window mattered so much (#4463). Making this
+  // statement cheap is its own piece of work; what is fixed here is that a cold
+  // window can no longer run more than one copy of it at a time.
   const result = await db.execute(sql`
     SELECT
       configs.board_type,
@@ -862,6 +907,8 @@ async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
     } catch (err) {
       logger.error('[PopularConfigs] Redis write failed:', err);
     }
+  } else {
+    localFallbackConfigs = { configs, expiresAt: Date.now() + LOCAL_FALLBACK_TTL_MS };
   }
   return configs;
 }
@@ -873,6 +920,11 @@ async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
  * other nodes skip — they'll read from Redis when the resolver executes.
  */
 export async function warmPopularConfigsCache(): Promise<void> {
+  // Mirrors the cache DELETE below for a deployment with no Redis: the warm-up
+  // exists to re-run the query on deploy, so it must not be answered by the
+  // copy the previous run left behind.
+  dropPopularConfigsFallback();
+
   if (redisClientManager.isRedisConnected()) {
     try {
       const { publisher } = redisClientManager.getClients();

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -37,7 +37,7 @@ import { publishBoardQueuePreviewTombstoneForBoard } from '../../../services/boa
 import { logger } from '../../../utils/logger';
 import { redisClientManager } from '../../../redis/client';
 import { isUniqueViolation } from '../../../utils/postgres-errors';
-import { singleFlight } from '../../../utils/single-flight';
+import { REDISLESS_FALLBACK_TTL_MS, singleFlight } from '../../../utils/single-flight';
 import { lockAndAssertBoardSerialAvailable } from '../board-serial-write-lock';
 
 // ============================================
@@ -759,17 +759,15 @@ const POPULAR_CONFIGS_FLIGHT_KEY = 'popular-board-configs';
  * Without one, single-flight alone would still re-run the statement for the
  * first caller after each completion, forever.
  */
-const LOCAL_FALLBACK_TTL_MS = 10 * 60 * 1000;
 let localFallbackConfigs: { configs: CachedPopularConfig[]; expiresAt: number } | null = null;
 
-/** The Redis-less twin of deleting REDIS_CACHE_KEY: force the next read to re-query. */
-function dropPopularConfigsFallback(): void {
+/**
+ * The Redis-less twin of deleting REDIS_CACHE_KEY: force the next read to
+ * re-query. Called by the deploy warm-up, and by tests so one case cannot
+ * answer the next from the previous one's fixture.
+ */
+export function dropPopularConfigsFallback(): void {
   localFallbackConfigs = null;
-}
-
-/** Test-only: drop the Redis-less fallback so one test cannot leak into the next. */
-export function resetPopularConfigsFallbackForTests(): void {
-  dropPopularConfigsFallback();
 }
 
 async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
@@ -908,7 +906,7 @@ async function runPopularConfigsQuery(): Promise<CachedPopularConfig[]> {
       logger.error('[PopularConfigs] Redis write failed:', err);
     }
   } else {
-    localFallbackConfigs = { configs, expiresAt: Date.now() + LOCAL_FALLBACK_TTL_MS };
+    localFallbackConfigs = { configs, expiresAt: Date.now() + REDISLESS_FALLBACK_TTL_MS };
   }
   return configs;
 }

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -798,9 +798,17 @@ async function runPopularConfigsQuery(): Promise<CachedPopularConfig[]> {
   // 2026-08-22 against the dev-db image (51 listed configs, 648k board_climbs,
   // idle 10-core box): 82 s for one execution. The header on this block used to
   // read "~31 configs, ~750ms worst case per LATERAL" — that is long stale, and
-  // the gap is why an uncached window mattered so much (#4463). Making this
-  // statement cheap is its own piece of work; what is fixed here is that a cold
-  // window can no longer run more than one copy of it at a time.
+  // the gap is why an uncached window mattered so much (#4463).
+  //
+  // Production is faster than the dev image but not fast: the only production
+  // observation on record is ~10 s cold, measured through the sitemap's copy of
+  // this same read (`packages/web/app/lib/server-popular-configs.ts`, which
+  // wraps it in an in-process TTL + single-flight for exactly this reason —
+  // prior art for what happens below). Ten seconds × one connection per
+  // concurrent visitor is still a pool.
+  //
+  // Making this statement cheap is its own piece of work; what is fixed here is
+  // that a cold window can no longer run more than one copy of it at a time.
   const result = await db.execute(sql`
     SELECT
       configs.board_type,

--- a/packages/backend/src/graphql/resolvers/social/boards.ts
+++ b/packages/backend/src/graphql/resolvers/social/boards.ts
@@ -762,12 +762,23 @@ const POPULAR_CONFIGS_FLIGHT_KEY = 'popular-board-configs';
 let localFallbackConfigs: { configs: CachedPopularConfig[]; expiresAt: number } | null = null;
 
 /**
+ * Bumped on every drop. The statement runs for tens of seconds, so a deploy
+ * warm-up can easily land while an earlier copy is still executing — and
+ * without this that copy would repopulate the fallback with pre-deploy data
+ * *after* the drop, which is the one thing the warm-up exists to prevent. A
+ * flight captures the counter before it starts and declines to cache its
+ * result if the number moved underneath it.
+ */
+let fallbackGeneration = 0;
+
+/**
  * The Redis-less twin of deleting REDIS_CACHE_KEY: force the next read to
  * re-query. Called by the deploy warm-up, and by tests so one case cannot
  * answer the next from the previous one's fixture.
  */
 export function dropPopularConfigsFallback(): void {
   localFallbackConfigs = null;
+  fallbackGeneration += 1;
 }
 
 async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
@@ -790,6 +801,8 @@ async function getPopularConfigs(): Promise<CachedPopularConfig[]> {
 }
 
 async function runPopularConfigsQuery(): Promise<CachedPopularConfig[]> {
+  const generationAtStart = fallbackGeneration;
+
   // Query all per-size configs with climb counts filtered by size edges AND set membership.
   // A climb counts for a config only if ALL its holds belong to placements in that config's sets.
   // board_climb_holds.hold_id = board_placements.id (placement ID).
@@ -913,7 +926,7 @@ async function runPopularConfigsQuery(): Promise<CachedPopularConfig[]> {
     } catch (err) {
       logger.error('[PopularConfigs] Redis write failed:', err);
     }
-  } else {
+  } else if (fallbackGeneration === generationAtStart) {
     localFallbackConfigs = { configs, expiresAt: Date.now() + REDISLESS_FALLBACK_TTL_MS };
   }
   return configs;

--- a/packages/backend/src/utils/__tests__/single-flight.test.ts
+++ b/packages/backend/src/utils/__tests__/single-flight.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vite-plus/test';
+
+import { resetSingleFlightForTests, singleFlight } from '../single-flight';
+
+function deferred<Value>() {
+  let resolve!: (value: Value) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<Value>((resolveFn, rejectFn) => {
+    resolve = resolveFn;
+    reject = rejectFn;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  resetSingleFlightForTests();
+});
+
+describe('singleFlight', () => {
+  it('runs once for callers that arrive while the first is still in flight', async () => {
+    const gate = deferred<string>();
+    const run = vi.fn(() => gate.promise);
+
+    const joined = [singleFlight('k', run), singleFlight('k', run), singleFlight('k', run)];
+    // The whole point: three callers, one statement, one pool connection.
+    expect(run).toHaveBeenCalledTimes(1);
+
+    gate.resolve('configs');
+    expect(await Promise.all(joined)).toEqual(['configs', 'configs', 'configs']);
+  });
+
+  it('does not serve a settled result to the next caller', async () => {
+    const run = vi.fn().mockResolvedValueOnce('first').mockResolvedValueOnce('second');
+
+    expect(await singleFlight('k', run)).toBe('first');
+    expect(await singleFlight('k', run)).toBe('second');
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('keys are independent', async () => {
+    const gateA = deferred<string>();
+    const gateB = deferred<string>();
+    const runA = vi.fn(() => gateA.promise);
+    const runB = vi.fn(() => gateB.promise);
+
+    const pendingA = singleFlight('a', runA);
+    const pendingB = singleFlight('b', runB);
+    gateA.resolve('A');
+    gateB.resolve('B');
+
+    expect(await pendingA).toBe('A');
+    expect(await pendingB).toBe('B');
+  });
+
+  it('propagates a rejection to every joined caller and forgets it', async () => {
+    const gate = deferred<string>();
+    const run = vi.fn(() => gate.promise);
+
+    const first = singleFlight('k', run);
+    const second = singleFlight('k', run);
+    gate.reject(new Error('pool gone'));
+
+    await expect(first).rejects.toThrow('pool gone');
+    await expect(second).rejects.toThrow('pool gone');
+
+    // A failed read must not poison the key — the next caller retries.
+    const retry = vi.fn().mockResolvedValue('recovered');
+    expect(await singleFlight('k', retry)).toBe('recovered');
+  });
+
+  it('clears the key when the runner throws synchronously', async () => {
+    const throwing = vi.fn(() => {
+      throw new Error('sync boom');
+    });
+
+    await expect(singleFlight('k', throwing as unknown as () => Promise<string>)).rejects.toThrow('sync boom');
+
+    const retry = vi.fn().mockResolvedValue('ok');
+    expect(await singleFlight('k', retry)).toBe('ok');
+  });
+});

--- a/packages/backend/src/utils/single-flight.ts
+++ b/packages/backend/src/utils/single-flight.ts
@@ -29,6 +29,18 @@
  */
 const inFlightByKey = new Map<string, Promise<unknown>>();
 
+/**
+ * How long a Redis-less deployment (local dev, the e2e CI stack) may answer
+ * one of those reads from a process-local copy.
+ *
+ * Single-flight alone still re-runs the statement for the first caller after
+ * every completion, which on an 82 s statement is a permanent one-connection
+ * burn and permanent database load. Shared by both call sites so the two do
+ * not drift; never consulted when Redis is connected, so production freshness
+ * is still decided by the shared cache and the deploy-time DELETE.
+ */
+export const REDISLESS_FALLBACK_TTL_MS = 10 * 60 * 1000;
+
 export function singleFlight<Result>(key: string, run: () => Promise<Result>): Promise<Result> {
   const joined = inFlightByKey.get(key) as Promise<Result> | undefined;
   if (joined) return joined;

--- a/packages/backend/src/utils/single-flight.ts
+++ b/packages/backend/src/utils/single-flight.ts
@@ -1,0 +1,48 @@
+/**
+ * Collapse concurrent callers of one expensive read onto a single in-flight
+ * promise, per process.
+ *
+ * The home page's two reads — `popularBoardConfigs` and `recentBetaLinks` —
+ * are Redis-cached with a long TTL, and both fall through to a heavy SQL
+ * statement on a miss. The fall-through had no concurrency control of any
+ * kind: N simultaneous requests during a cold window meant N simultaneous
+ * copies of the statement, each holding one of the pool's ten connections
+ * until it finished. Once the pool was gone every OTHER query in the process
+ * queued behind it forever — postgres.js's acquire queue is unbounded and
+ * untimed (docs/db-connectivity.md) — so an anonymous `board(boardUuid:)`
+ * that normally answers in 50 ms never answered at all, while `{ __typename }`
+ * kept answering in single-digit milliseconds through the same event loop.
+ *
+ * That is the shape #4463 chased for weeks through the e2e suite: the CI
+ * backend runs with no `REDIS_URL`, so every home-page render was a cold
+ * window, and `/embed/**` renders (which wait on the backend over HTTP) hung
+ * for the whole test budget.
+ *
+ * The distributed Redis lock the warm-up jobs take is not a substitute: it
+ * only stops a second NODE from refreshing, and it is not held on the resolver
+ * path at all.
+ *
+ * Deliberately not a cache. The promise is dropped the moment it settles, so a
+ * caller that arrives afterwards runs the read again and no stale value is
+ * ever served. Rejections propagate to every joined caller and are likewise
+ * not remembered.
+ */
+const inFlightByKey = new Map<string, Promise<unknown>>();
+
+export function singleFlight<Result>(key: string, run: () => Promise<Result>): Promise<Result> {
+  const joined = inFlightByKey.get(key) as Promise<Result> | undefined;
+  if (joined) return joined;
+
+  // `run()` is invoked inside the async wrapper so a synchronous throw becomes
+  // a rejected promise that still clears the map entry.
+  const started = (async () => run())().finally(() => {
+    inFlightByKey.delete(key);
+  });
+  inFlightByKey.set(key, started);
+  return started;
+}
+
+/** Test-only: drop every tracked promise so one test cannot leak into the next. */
+export function resetSingleFlightForTests(): void {
+  inFlightByKey.clear();
+}

--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -1,18 +1,31 @@
-import { test, expect, type APIResponse } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { test, expect, type APIRequestContext, type APIResponse } from '@playwright/test';
+import { waitForBoardListReady } from './helpers/waits';
 
-// The `aa-` prefix is load-bearing: Playwright orders spec files
-// alphabetically within a shard, and this file's raw APIRequestContext
-// requests hang for 60s+ if certain browser-driven specs run against the
-// same server first — first-in-shard they pass every time, and the whole
-// suite is green. Do not rename this file below its neighbours.
+// This file used to be `aa-embed-headers.spec.ts`. The prefix was load-bearing:
+// Playwright orders spec files alphabetically inside a shard, and these raw
+// APIRequestContext requests hung for 60s+ when browser-driven specs had run
+// against the same server first. #4463 root-caused that and removed it. The
+// short version, so nobody re-derives it:
 //
-// Half of that is fixed: #4463 gave the embed/kiosk SSR backend fetches a 3 s
-// deadline, so a stalled backend now renders the retry screen instead of
-// hanging the request. The other half is not: why the backend stalls on those
-// queries only after browser specs have run is still unexplained, and #4463
-// stays open on it. Nothing about this file is a Playwright state leak — the
-// `request` fixture builds a fresh APIRequestContext per test, and the suite
-// installs no service worker, storageState, or route interception.
+//  - Nothing here was a Playwright state leak. The `request` fixture builds a
+//    fresh APIRequestContext per test, and the suite installs no service
+//    worker, storageState, or route interception.
+//  - The stall was never in the web server. The GraphQL backend's connection
+//    pool was exhausted by concurrent copies of one uncached statement — the
+//    home page's `popularBoardConfigs`, which the CI backend can never cache
+//    because it runs with no REDIS_URL. Every spec that loaded `/` added
+//    another copy. postgres.js's acquire queue is unbounded and untimed, so
+//    every other backend read then waited forever, `/embed/**` renders
+//    included. `{ __typename }` kept answering in milliseconds throughout,
+//    which is why it looked like something subtler than saturation.
+//  - Two fixes closed it: the backend now runs one copy of those cold reads at
+//    a time, and the SSR fetches that wait on the backend carry
+//    SSR_BACKEND_FETCH_TIMEOUT_MS, so a slow backend paints the retry screen —
+//    a 200 these assertions already accept.
+//
+// The ordering dependency is pinned explicitly at the bottom of this file
+// instead of through the filename, so it survives the next spec being added.
 
 // These are raw APIRequestContext gets against a server that is concurrently
 // SSR-ing front-door pages for the other worker's browser tests. On a 2-core
@@ -149,5 +162,64 @@ test.describe('embed security headers', () => {
     expect(frenchLocation.pathname).toBe(`/embed/gym/${MISSING_GYM_UUID}/leaderboard`);
     // The redirect preserves the widget's query string.
     expect(frenchLocation.search).toBe('?period=day&board=abc');
+  });
+});
+
+/**
+ * The ordering pin, written down instead of encoded in the filename.
+ *
+ * `--shard=N/8` reshuffles which specs share a server every time a test is
+ * added or removed, so the `aa-` prefix only ever protected one particular
+ * arrangement — and hid the defect rather than testing it. This drives the
+ * browser preamble explicitly, in-file, so the raw-request path is checked
+ * against a warmed-up server in EVERY run regardless of how the shards land.
+ *
+ * The budget is deliberately far above the 3 s SSR deadline and far below the
+ * 60 s+ the un-deadlined fetch used to burn: a stalled backend must reach the
+ * retry screen, not hold the socket. Measured wall clock, not just the request
+ * timeout, so a response that arrives at 14.9 s still reads as a pass and a
+ * regression to "hangs until Playwright gives up" reads as a fail.
+ */
+const PREAMBLE_BOARD_PATH = '/kilter/original/12x12-square/screw_bolt/40';
+/** 5× the SSR deadline. Anything slower than this is the stall, not latency. */
+const POST_PREAMBLE_BUDGET_MS = 15_000;
+
+async function timedGet(
+  request: APIRequestContext,
+  path: string,
+): Promise<{ response: APIResponse; elapsedMs: number }> {
+  const startedAt = Date.now();
+  const response = await request.get(path, { maxRedirects: 0, timeout: POST_PREAMBLE_BUDGET_MS });
+  return { response, elapsedMs: Date.now() - startedAt };
+}
+
+test.describe.serial('raw embed requests survive a browser-driven preamble', () => {
+  test('the embed and kiosk raw requests still answer after front-door page loads', async ({ page, request }) => {
+    // The preamble board-route-teardown.spec.ts drives: the SSR front door,
+    // scrolled to the bottom so everything below the fold mounts, then a climb
+    // view. Both read the database on the server and both were in the shard
+    // that stalled.
+    await page.goto(`${PREAMBLE_BOARD_PATH}/list`, { waitUntil: 'load' });
+    await waitForBoardListReady(page);
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    const climbHref = await page.locator(`a[href*="${PREAMBLE_BOARD_PATH}/view/"]`).first().getAttribute('href');
+    expect(climbHref).toBeTruthy();
+    await page.goto(climbHref!, { waitUntil: 'load' });
+
+    // /embed/board/** is the render that awaits the backend over HTTP — the
+    // one that used to hang. A uuid nothing has asked for keeps it off the
+    // Data Cache fast path (`revalidate: 300` would otherwise answer this from
+    // the entry the first test in this file wrote), so it always exercises a
+    // cold backend read.
+    const embed = await timedGet(request, `/embed/board/${randomUUID()}`);
+    expect([200, 404]).toContain(embed.response.status());
+    expect(headerValue(embed.response, 'content-security-policy')).toContain('frame-ancestors *');
+    expect(embed.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
+
+    // /kiosk/** is the same shape one route tree over, and it hung in CI too.
+    const kiosk = await timedGet(request, `/kiosk/${randomUUID()}`);
+    expect(headerValue(kiosk.response, 'x-frame-options')).toBe('SAMEORIGIN');
+    expect(kiosk.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
   });
 });

--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -195,10 +195,30 @@ async function timedGet(
 
 test.describe.serial('raw embed requests survive a browser-driven preamble', () => {
   test('the embed and kiosk raw requests still answer after front-door page loads', async ({ page, request }) => {
-    // The preamble board-route-teardown.spec.ts drives: the SSR front door,
-    // scrolled to the bottom so everything below the fold mounts, then a climb
-    // view. Both read the database on the server and both were in the shard
-    // that stalled.
+    // Six cold server renders before the two assertions. On a 2-core runner
+    // that is comfortably past the 60 s per-test default, and a timeout here
+    // would read as the stall this guard exists to detect.
+    test.setTimeout(180_000);
+
+    // CONCURRENT home-page renders first. This is the load that caused the
+    // stall, and the concurrency is the whole mechanism: `/` is the only
+    // surface that reads `popularBoardConfigs` + `recentBetaLinks`, the two
+    // cold backend reads that used to take one pool connection each, and the
+    // web's 3 s deadline aborts them before Next can cache the result — so
+    // every `/` render is a cold read, forever. Ten at once used to leave the
+    // backend's ten-connection pool with nothing for anything else.
+    //
+    // Sequential `page.goto`s do NOT reproduce this (verified: a four-locale
+    // sequential preamble stays green against the un-fixed backend), which is
+    // why these are parallel raw requests rather than navigations.
+    const HOME_RENDER_FANOUT = 10;
+    await Promise.all(
+      Array.from({ length: HOME_RENDER_FANOUT }, () => request.get('/', { timeout: POST_PREAMBLE_BUDGET_MS })),
+    );
+
+    // Then the preamble board-route-teardown.spec.ts drives: the SSR front
+    // door, scrolled to the bottom so everything below the fold mounts, then a
+    // climb view. Both read the database on the server.
     await page.goto(`${PREAMBLE_BOARD_PATH}/list`, { waitUntil: 'load' });
     await waitForBoardListReady(page);
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));

--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -238,7 +238,11 @@ test.describe.serial('raw embed requests survive a browser-driven preamble', () 
     expect(embed.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
 
     // /kiosk/** is the same shape one route tree over, and it hung in CI too.
+    // Same two-status contract as the embed: 404 when the backend answers "no
+    // such kiosk", 200 when the fetch degrades to the retry screen. Asserted
+    // so a 5xx reads as a 5xx instead of as a missing header.
     const kiosk = await timedGet(request, `/kiosk/${randomUUID()}`);
+    expect([200, 404]).toContain(kiosk.response.status());
     expect(headerValue(kiosk.response, 'x-frame-options')).toBe('SAMEORIGIN');
     expect(kiosk.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
   });

--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -21,8 +21,16 @@ import { waitForBoardListReady } from './helpers/waits';
 //    which is why it looked like something subtler than saturation.
 //  - Two fixes closed it: the backend now runs one copy of those cold reads at
 //    a time, and the SSR fetches that wait on the backend carry
-//    SSR_BACKEND_FETCH_TIMEOUT_MS, so a slow backend paints the retry screen —
-//    a 200 these assertions already accept.
+//    SSR_BACKEND_FETCH_TIMEOUT_MS, so a slow backend paints the retry screen
+//    instead of holding the socket open.
+//
+// Those two fixes need separate oracles, and only one of them is cheap. The
+// deadline is pinned by unit tests (embed-fetchers.server.test.ts,
+// kiosk-fetch-deadline.test.ts). The pool exhaustion is what the block at the
+// bottom of this file exists for, and the assertion that carries it is the
+// STATUS, not the clock: with the deadline in place a starved backend answers
+// in three seconds with the retry screen, so a wall-clock budget alone can
+// never fail. See the block for why 404 is the only non-degraded outcome.
 //
 // The ordering dependency is pinned explicitly at the bottom of this file
 // instead of through the filename, so it survives the next spec being added.
@@ -174,14 +182,12 @@ test.describe('embed security headers', () => {
  * browser preamble explicitly, in-file, so the raw-request path is checked
  * against a warmed-up server in EVERY run regardless of how the shards land.
  *
- * The budget is deliberately far above the 3 s SSR deadline and far below the
- * 60 s+ the un-deadlined fetch used to burn: a stalled backend must reach the
- * retry screen, not hold the socket. Measured wall clock, not just the request
- * timeout, so a response that arrives at 14.9 s still reads as a pass and a
- * regression to "hangs until Playwright gives up" reads as a fail.
+ * The wall-clock budget below is the weaker of the two oracles and is kept
+ * only as a latency backstop — with the SSR deadline in place nothing on these
+ * two routes can exceed it. The discriminating assertion is the 404.
  */
 const PREAMBLE_BOARD_PATH = '/kilter/original/12x12-square/screw_bolt/40';
-/** 5× the SSR deadline. Anything slower than this is the stall, not latency. */
+/** 5× the SSR deadline — headroom for a loaded 2-core runner, not an oracle. */
 const POST_PREAMBLE_BUDGET_MS = 15_000;
 
 async function timedGet(
@@ -195,18 +201,25 @@ async function timedGet(
 
 test.describe.serial('raw embed requests survive a browser-driven preamble', () => {
   test('the embed and kiosk raw requests still answer after front-door page loads', async ({ page, request }) => {
-    // Six cold server renders before the two assertions. On a 2-core runner
-    // that is comfortably past the 60 s per-test default, and a timeout here
-    // would read as the stall this guard exists to detect.
+    // Twelve cold server renders before the two assertions (ten concurrent `/`
+    // plus the two page loads). On a 2-core runner that is comfortably past
+    // the 60 s per-test default, and a timeout here would read as the stall
+    // this guard exists to detect.
     test.setTimeout(180_000);
 
     // CONCURRENT home-page renders first. This is the load that caused the
-    // stall, and the concurrency is the whole mechanism: `/` is the only
-    // surface that reads `popularBoardConfigs` + `recentBetaLinks`, the two
-    // cold backend reads that used to take one pool connection each, and the
-    // web's 3 s deadline aborts them before Next can cache the result — so
-    // every `/` render is a cold read, forever. Ten at once used to leave the
-    // backend's ten-connection pool with nothing for anything else.
+    // stall, and the concurrency is the whole mechanism. `/` reads
+    // `popularBoardConfigs` + `recentBetaLinks`, the two cold backend reads
+    // that used to take one pool connection each. (`/` is the surface this
+    // test drives, not the only reader: the sitemap's boards shard and the
+    // climb shards issue the same `popularBoardConfigs` statement through
+    // `getAllBoardConfigsOrThrow`, which is why that module carries its own
+    // in-process TTL + single-flight — the prior art the backend fix copies.)
+    // Neither read is deduped web-side: `unstable_cache` does not collapse
+    // concurrent misses, and the 3 s deadline aborts each one before Next can
+    // write the entry, so ten simultaneous renders are ten simultaneous
+    // statements. Against the un-fixed backend that left its ten-connection
+    // pool with nothing for anything else.
     //
     // Sequential `page.goto`s do NOT reproduce this (verified: a four-locale
     // sequential preamble stays green against the un-fixed backend), which is
@@ -232,17 +245,33 @@ test.describe.serial('raw embed requests survive a browser-driven preamble', () 
     // Data Cache fast path (`revalidate: 300` would otherwise answer this from
     // the entry the first test in this file wrote), so it always exercises a
     // cold backend read.
+    //
+    // 404 is the assertion that carries this test, and unlike the seven header
+    // checks above it does NOT accept 200. `board(boardUuid:)` on a fresh uuid
+    // is one indexed select; a backend that can reach the database answers
+    // "no such board" in milliseconds and the route notFound()s. A 200 here is
+    // by construction the retry screen — the SSR fetch hit its 3 s deadline —
+    // which for this uuid means the backend could not get a pool connection.
+    // That is exactly the regression the preamble above is staged to provoke,
+    // so it has to read as a failure rather than as an accepted degrade.
     const embed = await timedGet(request, `/embed/board/${randomUUID()}`);
-    expect([200, 404]).toContain(embed.response.status());
+    expect(
+      embed.response.status(),
+      'the embed render degraded to the retry screen while the home-page herd was in flight — the backend could not answer a one-row uuid lookup inside the SSR deadline (#4463 pool exhaustion)',
+    ).toBe(404);
     expect(headerValue(embed.response, 'content-security-policy')).toContain('frame-ancestors *');
     expect(embed.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
 
     // /kiosk/** is the same shape one route tree over, and it hung in CI too.
-    // Same two-status contract as the embed: 404 when the backend answers "no
-    // such kiosk", 200 when the fetch degrades to the retry screen. Asserted
-    // so a 5xx reads as a 5xx instead of as a missing header.
+    // A random uuid is a valid gym slug (lowercase hex + hyphens pass
+    // GYM_SLUG_PATTERN), so the resolver really does reach the database and
+    // really does answer null → 404. Same reasoning as the embed: 200 is the
+    // retry screen, which here means starvation.
     const kiosk = await timedGet(request, `/kiosk/${randomUUID()}`);
-    expect([200, 404]).toContain(kiosk.response.status());
+    expect(
+      kiosk.response.status(),
+      'the kiosk render degraded to the retry screen while the home-page herd was in flight (#4463 pool exhaustion)',
+    ).toBe(404);
     expect(headerValue(kiosk.response, 'x-frame-options')).toBe('SAMEORIGIN');
     expect(kiosk.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
   });

--- a/packages/web/e2e/global-setup.ts
+++ b/packages/web/e2e/global-setup.ts
@@ -62,11 +62,11 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
       );
     }
 
-    // 3. Pre-warm the SSR routes bottom-tab-bar navigates to. They call
-    //    cached GraphQL on the server and trigger
-    //    Next.js's compile-on-first-hit in dev. Without this, the first
-    //    navigation in a test races a cold backend round-trip against the
-    //    per-navigation timeout — the recurring shard-5 / shard-4 flake mode.
+    // 3. Pre-warm the remaining SSR routes the specs navigate to. They call
+    //    cached GraphQL on the server and trigger Next.js's compile-on-first-hit
+    //    in dev. Without this, the first navigation in a test races a cold
+    //    backend round-trip against the per-navigation timeout — the recurring
+    //    shard-5 / shard-4 flake mode.
     for (const path of WARMUP_PATHS) {
       await page.goto(path, { timeout: 60_000, waitUntil: 'domcontentloaded' }).catch(() => {
         // Soft-fail: warmup is best-effort. If a warmup route is genuinely

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -21,20 +21,26 @@ export default defineConfig({
    * parallelism carries the wall-clock and a second in-shard worker only adds
    * contention on a 2-core runner.
    *
-   * Two mechanisms this comment used to blame have been ruled out. It is not
-   * web DB-pool contention (#4461): `/embed/**` issues zero web-side Postgres
-   * statements, it fetches the backend over HTTP. It is not the web event loop
-   * being pegged by `/api/internal/board-render` WASM renders either: in run
-   * 31857179523's shard 7 the same server answered `/embed/gym/...` in 201 ms
-   * and `/` in 3.2 s while a `/embed/board/...` request started 1.3 s earlier
-   * sat stuck for 30 s. A blocked event loop cannot do that.
+   * Two mechanisms this comment used to blame were both wrong, and the record
+   * is worth keeping. It was not web DB-pool contention (#4461): `/embed/**`
+   * issues zero web-side Postgres statements, it fetches the backend over
+   * HTTP. It was not the web event loop being pegged by
+   * `/api/internal/board-render` WASM renders either: in run 31857179523's
+   * shard 7 the same server answered `/embed/gym/...` in 201 ms (a warm Next
+   * Data Cache entry, no backend round trip) and `/` in 3.2 s (its own 3 s
+   * backend deadline firing) while a `/embed/board/...` request sat stuck
+   * for 30 s.
    *
-   * What that shard actually showed was one un-deadlined SSR backend fetch
-   * hanging while the rest of the server stayed healthy. #4463 put a deadline
-   * on those fetches so a stall degrades in 3 s. What is still unexplained is
-   * why the backend stalled on that one query only after browser specs had run
-   * — until that is understood, 1 worker is the setting we can defend, and the
-   * `aa-embed-headers.spec.ts` ordering pin stays. */
+   * #4463 found it: the GraphQL BACKEND's connection pool, exhausted by
+   * concurrent copies of the home page's uncached `popularBoardConfigs`
+   * statement — 82 s each on the dev database, and uncacheable here because
+   * the CI backend runs with no REDIS_URL. Every spec that loaded `/` added
+   * another copy, postgres.js's acquire queue is unbounded and untimed, and
+   * every other backend read then waited forever. The backend now runs one
+   * copy of those cold reads at a time, the SSR fetches that wait on it carry
+   * SSR_BACKEND_FETCH_TIMEOUT_MS, and the `aa-` filename pin on the embed spec
+   * is gone — the ordering it stood for is driven explicitly inside
+   * e2e/embed-headers.spec.ts. */
   workers: process.env.CI ? 1 : undefined,
   /* Global per-test timeout — some tests (zoom, login flows) need more than Playwright's 30 s default */
   timeout: 60_000,

--- a/packages/web/scripts/__tests__/e2e-spec-ordering.test.ts
+++ b/packages/web/scripts/__tests__/e2e-spec-ordering.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+
+/**
+ * Guards against re-pinning an e2e spec by filename.
+ *
+ * `aa-embed-headers.spec.ts` carried an alphabetical prefix for weeks because
+ * Playwright orders spec files alphabetically inside a shard and those raw
+ * HTTP checks hung when browser specs ran first (#4463). The prefix hid the
+ * defect instead of testing it, and it only ever protected one particular
+ * `--shard=N/8` arrangement — adding or removing a single test elsewhere
+ * reshuffles the whole split and quietly retires the protection.
+ *
+ * A rename is the cheapest possible "fix" for the next ordering flake, and it
+ * leaves nothing behind that explains itself. This makes that rename fail
+ * loudly and points at the issue that recorded the actual mechanism.
+ */
+
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+
+const E2E_DIR = join(import.meta.dirname, '..', '..', 'e2e');
+
+/**
+ * A doubled leading letter followed by `-` — `aa-`, `zzz-`, `aa_`-style
+ * sorting hacks at either end of the alphabet. Real spec names never start
+ * that way, so the pattern costs no false positives.
+ */
+const ORDERING_PREFIX = /^([a-z])\1+[-_]/;
+
+function e2eSpecBasenames(): string[] {
+  return readdirSync(E2E_DIR).filter((entry) => entry.endsWith('.spec.ts'));
+}
+
+describe('e2e spec filenames carry no alphabetical ordering pin', () => {
+  it('has no spec whose name starts with a doubled letter', () => {
+    const pinned = e2eSpecBasenames().filter((basename) => ORDERING_PREFIX.test(basename));
+
+    expect(
+      pinned,
+      'An e2e spec is pinned by filename so it sorts first (or last) inside its shard. ' +
+        'That is the workaround #4463 removed: it hides an ordering-dependent failure ' +
+        'instead of testing it, and it silently stops working the next time a test is ' +
+        'added anywhere in the suite. Drive the ordering explicitly inside the spec ' +
+        '(see the describe.serial block in e2e/embed-headers.spec.ts) instead.',
+    ).toEqual([]);
+  });
+
+  it('still has the embed-header spec under its un-pinned name', () => {
+    // If this file is renamed back, the check above would pass vacuously.
+    expect(e2eSpecBasenames()).toContain('embed-headers.spec.ts');
+  });
+});

--- a/packages/web/scripts/__tests__/e2e-spec-ordering.test.ts
+++ b/packages/web/scripts/__tests__/e2e-spec-ordering.test.ts
@@ -22,19 +22,30 @@ import { describe, expect, it } from 'vite-plus/test';
 const E2E_DIR = join(import.meta.dirname, '..', '..', 'e2e');
 
 /**
- * A doubled leading letter followed by `-` — `aa-`, `zzz-`, `aa_`-style
- * sorting hacks at either end of the alphabet. Real spec names never start
- * that way, so the pattern costs no false positives.
+ * The three cheap ways to buy a sort position, all of which work and all of
+ * which a reviewer reads as a typo rather than as a workaround. Real spec
+ * names start with a whole lowercase word, so none of these costs a false
+ * positive.
+ *
+ * This catches sorting hacks that *look* like hacks. It cannot catch a plain
+ * word that happens to sort first (`aardvark-embed.spec.ts`) — nothing short
+ * of a committed order manifest could, and that would make every added spec a
+ * two-file change. The point is that the obvious rename now fails loudly and
+ * says why.
  */
-const ORDERING_PREFIX = /^([a-z])\1+[-_]/;
+const ORDERING_PREFIXES: readonly RegExp[] = [
+  /^[^a-z]/, // a leading digit or `_` sorts before every letter
+  /^[a-z][-_]/, // `a-`, `z_` — one letter plus a separator sorts ahead of any real name
+  /^([a-z])\1+[-_]/, // `aa-`, `zzz_` — the original pin
+];
 
 function e2eSpecBasenames(): string[] {
   return readdirSync(E2E_DIR).filter((entry) => entry.endsWith('.spec.ts'));
 }
 
 describe('e2e spec filenames carry no alphabetical ordering pin', () => {
-  it('has no spec whose name starts with a doubled letter', () => {
-    const pinned = e2eSpecBasenames().filter((basename) => ORDERING_PREFIX.test(basename));
+  it('has no spec whose name buys a sort position', () => {
+    const pinned = e2eSpecBasenames().filter((basename) => ORDERING_PREFIXES.some((pattern) => pattern.test(basename)));
 
     expect(
       pinned,


### PR DESCRIPTION
## Summary

The home page's two server reads — `popularBoardConfigs` and `recentBetaLinks` — are Redis-cached with a long TTL and both fall through to a heavy statement on a miss. The fall-through had **no concurrency control at all**, so N simultaneous visitors during a cold window meant N simultaneous copies of the statement, each holding one of the pool's ten connections until it finished.

Once the pool was gone, every *other* query in the process queued behind it forever — postgres.js's acquire queue is unbounded and untimed (`docs/db-connectivity.md`). An anonymous `board(boardUuid:)` that normally answers in 50 ms never answered at all, while `{ __typename }` kept answering in single-digit milliseconds through the same event loop. That asymmetry is exactly what CI showed in #4463 and what made it look like a web-server problem for weeks.

The distributed Redis lock the two warm-up jobs take is not a substitute: it only stops a second **node** from refreshing, and it is not held on the resolver path at all.

### Measured, dev-db image, idle 10-core box

| | before | after |
|---|---|---|
| one `popularBoardConfigs` execution | 82 s (51 listed configs, 648k `board_climbs`) | unchanged — 82 s |
| 12 concurrent copies in flight | 12 statements, 12 pool connections | 1 statement, 1 connection |
| `board(boardUuid:)` during that herd | no answer past 45 s | **137 ms** |
| `{ __typename }` during that herd | 36 ms | 10 ms |

The statement itself is untouched. Making it cheap is its own piece of work; the stale `~31 configs, ~750ms worst case per LATERAL` header on it is corrected to the measured number so the next reader is not misled.

**82 s is the dev image, not production.** The only production observation on record for this read is **~10 s cold**, measured through the sitemap's copy of it (`packages/web/app/lib/server-popular-configs.ts`) — which already wraps the same statement in an in-process TTL + single-flight for exactly this reason, and is the prior art the backend fix copies. Ten seconds of one connection per concurrent visitor is still a pool. Both numbers are now on the statement and in `docs/db-connectivity.md`; neither is presented as the other.

### What changed

- `utils/single-flight.ts` — join concurrent callers of one key onto one promise, per process. Deliberately not a cache: the promise is dropped the moment it settles, so nothing stale is ever served and a rejection is not remembered.
- Both cold reads go through it.
- A generation counter on the process-local copy, so a statement that was already running when the copy was dropped returns its rows to the callers joined to it but does **not** write them back. Without it a pre-drop snapshot undoes the invalidation for the full 10-minute TTL — on a statement that runs for tens of seconds that is an easy window to hit.
- A process-local copy (10 min) for deployments with **no Redis** — local dev and the e2e CI stack. Without it, single-flight alone still re-runs the 82 s statement for the first caller after every completion, forever. **Never read or written when Redis is connected**, so the deliberate cache DELETE that `warmPopularConfigsCache` does on every deploy still decides freshness in production. `invalidateRecentBetaLinksCache` and `warmPopularConfigsCache` drop it too, so the Redis-less path has the same invalidation points as the Redis one.

### Why this is #4463

The CI backend runs with no `REDIS_URL`, so **every** home-page render in the e2e suite was a cold window. Specs that load `/` (site-chrome, the locale suites, the deleted tab-bar spec) filled the backend pool, and the `/embed/**` renders that wait on the backend over HTTP hung for the whole test budget. That is the "a browser spec poisons the web server" symptom, and the poisoning was never in the web server.

`docs/db-connectivity.md` gains the mechanism next to the deadline section it belongs beside — the deadlines there bound how long a caller waits, and nothing bounded how many connections one logical read could hold at once.

Refs #4463 — the `aa-` ordering pin comes off in the stacked PR (#4679), once repeated e2e dispatches confirm it.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `packages/backend/src/utils/__tests__/single-flight.test.ts` — one run per key while in flight, no stale result afterwards, keys independent, rejection propagates to every joined caller and is forgotten, sync throw still clears the key.
- `packages/backend/src/__tests__/popular-configs-stampede.test.ts` — five concurrent resolver calls issue **one** `db.execute`; a later caller is served from the process-local copy when Redis is absent; with Redis connected every call still `GET`s and `SET`s and still runs the statement (production path unchanged).
- `beta-link-queries.test.ts` gains the matching stampede case for the other half of the home page's cold read.
- Two cases added after review found the Redis-less **invalidation** points had no oracle at all: `warmPopularConfigsCache` re-runs the statement instead of being answered from the previous run's copy, and `invalidateRecentBetaLinksCache` drops the copy so a newly posted beta link reaches the home strip. Before them, deleting either `drop*Fallback()` call left the entire backend suite green.
- **Mutation-verified**, each applied, watched red, reverted:
  - delete the `singleFlight(...)` wrapper on `popularBoardConfigs` → the five-concurrent-callers test fails (5 executes).
  - delete the process-local read → the later-caller test fails (2 executes).
  - make the beta-links flight key unique per call → the four-concurrent-callers test fails, and **only** that test.
  - delete `dropPopularConfigsFallback()` from the warm-up → the warm-up test fails (1 execute, not 2).
  - delete `dropRecentBetaLinksFallback()` from `invalidateRecentBetaLinksCache` → the invalidation test fails (1 execute, not 2).
  - relax either generation check back to a plain `else` → the two pre-invalidation-flight tests fail, and **only** those two.
- `beta-link-queries.test.ts` needed the new fallback cleared in two `beforeEach`es — without that it goes red, which is the guard working: the memo really does answer the second call.
- Full `vp test run --project backend`: 272 files, 3741 tests, green. `vp check`, `vp run typecheck`, `--project web`, `--project i18n`, `check:i18n`, `check:i18n:orphans` all clean.
- End-to-end discrimination is measured in the stacked PR (#4679): on a 2-CPU production harness the embed spec is green three runs out of three against this backend, and red — on the attempt and the retry — against the pre-#4668 backend with the same web build.
- End-to-end locally: backend under `tsx src/index.ts` against the dev-db image, 12-way herd — numbers in the table above.


