### PR TITLE
ci(web): actually run the REST-surface oracles on the PR that breaks them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,15 @@ jobs:
       # `listing-guards` job (see below).
       storeMetadata: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.storeMetadata }}
       mobileLocales: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.mobileLocales }}
+      # The two REST-surface oracles walk packages/web/app/api/** and
+      # packages/web/vercel.json with readdirSync/readFileSync at run time, so
+      # Vitest's `--changed` module-graph analysis can never relate them to a
+      # diff that only adds or deletes a route file — the exact diff shape they
+      # exist to catch. Measured on #4663: adding app/api/internal/probe-route/
+      # route.ts, and separately deleting app/api/og/setter/route.tsx, each
+      # selected ZERO specs under `vp test run --project web --changed`. Gates
+      # the `rest-surface` job (see below).
+      restSurface: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.restSurface }}
       # PR-only guard signal: did this PR edit the OTA-owned changelog data file?
       # Defaults false off PRs (the OTA bot legitimately rewrites it on push).
       changelogData: ${{ github.event_name == 'pull_request' && steps.filter.outputs.changelogData || 'false' }}
@@ -67,10 +76,10 @@ jobs:
       # ci-location-sync-workflow.test.ts asserts on its terms; keep it in sync
       # with the job `if:`s below so a future job can gate on it again.
       runAny: ${{ github.event_name != 'pull_request' || steps.filter.outputs.anyJs == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.i18nCatalogs == 'true' || steps.filter.outputs.sharedSchema == 'true' || steps.filter.outputs.sharedDeps == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ocr == 'true' || steps.filter.outputs.locationSync == 'true' || steps.filter.outputs.rootCi == 'true' }}
-      # NOTE: deployConfig, storeMetadata, and mobileLocales are deliberately
-      # NOT part of runAny — the deploy-config and listing-guards jobs below
-      # gate on their own filters, so a PR touching only their files runs
-      # nothing else.
+      # NOTE: deployConfig, storeMetadata, mobileLocales, and restSurface are
+      # deliberately NOT part of runAny — the deploy-config, listing-guards and
+      # rest-surface jobs below gate on their own filters, so a PR touching only
+      # their files runs nothing else.
     steps:
       # No actions/checkout here on purpose: on `pull_request` dorny/paths-filter
       # reads the changed-file list from the REST API (no working tree needed),
@@ -176,6 +185,17 @@ jobs:
             mobileLocales:
               - 'packages/mobile/locales/**'
               - 'scripts/mobile-locales-parity.test.ts'
+            # Everything the two REST-surface oracles read via fs at run time,
+            # plus the specs themselves and the api-docs module the OpenAPI one
+            # statically imports. `packages/web/app/api/**` is the load-bearing
+            # glob: a route-file-only diff matches anyJs (so test-default runs)
+            # but selects neither spec there, which is why this job exists.
+            restSurface:
+              - 'packages/web/app/api/**'
+              - 'packages/web/vercel.json'
+              - 'packages/web/app/lib/api-docs/**'
+              - 'packages/web/app/__tests__/rest-surface-inventory.test.ts'
+              - 'scripts/__tests__/ci-rest-surface-workflow.test.ts'
             rootCi:
               - '.github/workflows/ci.yml'
               - 'vite.config.ts'
@@ -537,6 +557,41 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Validate store listing copy and mobile locale parity
         run: vp test run --project scripts scripts/store-metadata-limits.test.ts scripts/mobile-locales-parity.test.ts
+
+  rest-surface:
+    needs: [changes]
+    # Deliberately not `--changed`-filtered, same rationale as deploy-config and
+    # listing-guards one job up: both specs reconcile the REST surface against
+    # the filesystem at run time (readdirSync over packages/web/app/api/**,
+    # readFileSync of vercel.json, existsSync per registered OpenAPI path), so
+    # Vitest's module-graph analysis in test-default never selects them for a
+    # diff that only adds or deletes a route file. That is precisely the diff
+    # each one guards, so inside test-default they were inert on PRs and only
+    # ever reddened post-merge on main. Run both unfiltered whenever the API
+    # tree, vercel.json, or the specs' own inputs change. Do not fold these into
+    # test-default and do not add `--changed` here.
+    if: needs.changes.outputs.restSurface == 'true' || needs.changes.outputs.rootCi == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Validate the REST surface inventory and the published OpenAPI spec
+        run: >-
+          vp test run --project web
+          packages/web/app/__tests__/rest-surface-inventory.test.ts
+          packages/web/app/lib/api-docs/__tests__/openapi-document.test.ts
+      # Same fs-reading blind spot one level up: this spec reads ci.yml itself,
+      # so nothing in test-default relates it to a diff that narrows this job.
+      # It is what stops the gate above from being quietly reverted.
+      - name: Validate this job's own gate
+        run: vp test run --project scripts scripts/__tests__/ci-rest-surface-workflow.test.ts
 
   test-default:
     needs: [changes]
@@ -1089,6 +1144,7 @@ jobs:
       - changelog-owned
       - deploy-config
       - listing-guards
+      - rest-surface
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/packages/backend/MIGRATION_PLAN.md
+++ b/packages/backend/MIGRATION_PLAN.md
@@ -226,14 +226,8 @@ curl http://localhost:8080/graphql -H "Content-Type: application/json" \
 
 ### Parity Tests
 
-REST vs GraphQL parity tests compare responses from the public REST API against the local GraphQL implementation.
-
-```bash
-# Run parity tests locally (requires dev database)
-bun run test -w boardsesh-backend -- --config vitest.parity.config.ts
-```
-
-**Note:** Parity tests are excluded from CI (`vitest.config.ts` excludes `*parity*.test.ts`). They require:
-
-- Local development database running (`bun run db:up`)
-- Access to public REST API at www.boardsesh.com
+Removed in #4663. The REST vs GraphQL parity suite fetched the live public API
+at www.boardsesh.com from a developer's machine, ran under its own vitest
+config, and was excluded from CI — nothing kept it honest and it had gone
+stale. Compare a resolver against its REST route by hand, or add a
+fixture-backed test to the normal `backend` project.

--- a/packages/web/app/__tests__/rest-surface-inventory.test.ts
+++ b/packages/web/app/__tests__/rest-surface-inventory.test.ts
@@ -15,6 +15,14 @@
  *    entry disk doesn't" direction — this is the one a subset-only check
  *    (`expect(derived).toContain(...)`) would silently survive, which is why
  *    both directions are asserted.
+ *  - A Vercel cron target labelled as if in-repo code called it reds a third
+ *    check, which reads the schedules out of vercel.json rather than trusting
+ *    the comment next to the row. Set equality alone never looks at verdicts.
+ *
+ * This file reads the API tree with readdirSync at run time, so nothing
+ * relates it to a route-file diff in test-default's `--changed` run. It is
+ * run unfiltered by the `rest-surface` job in .github/workflows/ci.yml —
+ * without that job the guarantees above only hold post-merge on main.
  *
  * `keep-external` = published surface with no in-repo runtime caller by
  * design (an ESP32 firmware target, a documented `/api/v1/*` route, a Vercel
@@ -24,7 +32,7 @@
  * delete" — see issue #1889 for the full reasoning per route.
  */
 import { describe, expect, it } from 'vite-plus/test';
-import { readdirSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -55,11 +63,15 @@ const VERDICTS: Record<string, Verdict> = {
   // NODE_ENV=development) — the only machine-readable way to confirm which
   // QA notes a running dev server started with.
   'app/api/internal/dev-metadata/route.ts': 'keep-external',
+  // Vercel cron targets. Their only trigger is Vercel's scheduler reading
+  // packages/web/vercel.json — no in-repo code ever calls them, which is the
+  // intended steady state, not evidence of deadness. Pinned against that file
+  // by `classifies every Vercel cron target as an external surface` below.
+  'app/api/internal/cleanup/route.ts': 'keep-external',
+  'app/api/internal/prewarm-heatmap/[board_name]/route.ts': 'keep-external',
+  'app/api/internal/profile-percentiles/route.ts': 'keep-external',
+  'app/api/internal/refresh-sitemap-climbs/route.ts': 'keep-external',
   'app/api/internal/beta-link-thumbnail/route.ts': 'keep-caller',
-  'app/api/internal/cleanup/route.ts': 'keep-caller',
-  'app/api/internal/prewarm-heatmap/[board_name]/route.ts': 'keep-caller',
-  'app/api/internal/profile-percentiles/route.ts': 'keep-caller',
-  'app/api/internal/refresh-sitemap-climbs/route.ts': 'keep-caller',
   'app/api/internal/revalidate-climb/route.ts': 'keep-caller',
   'app/api/internal/climb-search-cache/revalidate/route.ts': 'keep-caller',
   'app/api/internal/controllers/route.ts': 'keep-caller',
@@ -116,6 +128,31 @@ function toWebRelative(absolutePath: string): string {
     .join('/');
 }
 
+type VercelConfig = { crons?: { path: string }[] };
+
+function readCronPaths(): string[] {
+  const config = JSON.parse(readFileSync(join(WEB_ROOT, 'vercel.json'), 'utf8')) as VercelConfig;
+  return (config.crons ?? []).map((cron) => cron.path);
+}
+
+/**
+ * Resolve a scheduled URL (`/api/internal/prewarm-heatmap/kilter`) to the route
+ * key that serves it (`app/api/internal/prewarm-heatmap/[board_name]/route.ts`),
+ * treating a `[param]` segment as a wildcard. Returns undefined when no route
+ * file can serve the schedule at all.
+ */
+function routeKeyForCronPath(cronPath: string, routeKeys: string[]): string | undefined {
+  const urlSegments = cronPath.replace(/^\//, '').split('/');
+  return routeKeys.find((routeKey) => {
+    const routeSegments = routeKey
+      .replace(/^app\//, '')
+      .replace(/\/route\.tsx?$/, '')
+      .split('/');
+    if (routeSegments.length !== urlSegments.length) return false;
+    return routeSegments.every((segment, index) => segment.startsWith('[') || segment === urlSegments[index]);
+  });
+}
+
 describe('REST surface inventory (issue #1889)', () => {
   const derived = new Set(collectRouteFiles(API_ROOT).map(toWebRelative));
   const pinned = new Map(Object.entries(VERDICTS));
@@ -133,6 +170,26 @@ describe('REST surface inventory (issue #1889)', () => {
   it('pins the two never-delete external surfaces', () => {
     expect(pinned.get('app/api/internal/board-render/route.ts')).toBe('keep-external');
     expect(pinned.get('app/api/internal/ws-auth/route.ts')).toBe('keep-external');
+  });
+
+  it('classifies every Vercel cron target as an external surface', () => {
+    // Nothing else reconciles the verdict COLUMN against reality — the two
+    // set-equality checks above only look at keys, so a cron route silently
+    // relabelled `keep-caller` (which is how all four shipped in #4663) would
+    // read as "something in the repo calls this" and invite a future audit to
+    // delete it when the grep comes back empty. The expected list is derived
+    // from vercel.json, so adding a schedule for a route that doesn't exist,
+    // or for one classified as having an in-repo caller, reds.
+    const cronPaths = readCronPaths();
+    expect(cronPaths.length).toBeGreaterThan(0);
+
+    const routeKeys = [...pinned.keys()];
+    const classified = cronPaths.map((cronPath) => {
+      const routeKey = routeKeyForCronPath(cronPath, routeKeys);
+      return { cronPath, verdict: routeKey ? pinned.get(routeKey) : 'no-route-file' };
+    });
+
+    expect(classified).toEqual(cronPaths.map((cronPath) => ({ cronPath, verdict: 'keep-external' })));
   });
 
   it('counts exactly the audited surface', () => {

--- a/packages/web/app/lib/api-docs/__tests__/openapi-document.test.ts
+++ b/packages/web/app/lib/api-docs/__tests__/openapi-document.test.ts
@@ -79,6 +79,11 @@ describe('generated OpenAPI document', () => {
     // generated document (never from readdir), so an over-broad delete that
     // also removes a still-registered route file reds this, rather than the
     // check trivially agreeing with itself.
+    //
+    // existsSync is not a static import, so test-default's `--changed` never
+    // relates this spec to the route-file-only diff it guards. The
+    // `rest-surface` job in .github/workflows/ci.yml runs it unfiltered — see
+    // the note in packages/web/app/__tests__/rest-surface-inventory.test.ts.
     const missing = paths.filter((path) => !routeFileExists(path));
     expect(missing).toEqual([]);
   });

--- a/scripts/__tests__/ci-rest-surface-workflow.test.ts
+++ b/scripts/__tests__/ci-rest-surface-workflow.test.ts
@@ -1,0 +1,98 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const WORKFLOW_PATH = '.github/workflows/ci.yml';
+const workflowSource = readFileSync(WORKFLOW_PATH, 'utf8');
+
+/**
+ * Return one YAML mapping entry by exact key and indentation. Copied from
+ * ci-lint-scope.test.ts / ci-location-sync-workflow.test.ts on purpose: the
+ * repo declares no YAML parser, and a CI contract test is not worth the
+ * dependency churn.
+ */
+function mappingEntry(source: string, key: string, indentation: number): string {
+  const lines = source.split('\n');
+  const prefix = `${' '.repeat(indentation)}${key}:`;
+  const startIndex = lines.findIndex((line) => line.startsWith(prefix));
+  if (startIndex < 0) {
+    throw new Error(`missing ${key} mapping at indentation ${indentation}`);
+  }
+
+  let endIndex = lines.length;
+  for (let lineIndex = startIndex + 1; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    const lineIndentation = line.length - line.trimStart().length;
+    if (lineIndentation <= indentation) {
+      endIndex = lineIndex;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex, endIndex).join('\n');
+}
+
+/** Strip `#` comment lines so a job's rationale can never satisfy an assertion. */
+function withoutComments(source: string): string {
+  return source
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('#'))
+    .join('\n');
+}
+
+/**
+ * The two REST-surface oracles reconcile the spec/verdict tables against the
+ * filesystem at run time — readdirSync over packages/web/app/api/**, readFileSync
+ * of vercel.json, existsSync per registered OpenAPI path. None of that is a
+ * static import, so Vitest's `--changed` module-graph analysis in test-default
+ * never selects them for a route-file-only diff, which is the one diff shape
+ * they exist to catch. Measured on #4663: adding a route file and, separately,
+ * deleting one each selected ZERO specs. The dedicated `rest-surface` job is the
+ * fix; this contract stops a future narrowing from quietly undoing it.
+ */
+describe('rest-surface CI job contract', () => {
+  const changesJob = mappingEntry(workflowSource, 'changes', 2);
+  const restSurfaceJob = mappingEntry(workflowSource, 'rest-surface', 2);
+  const restSurfaceSteps = withoutComments(restSurfaceJob);
+  const ciStatusJob = withoutComments(mappingEntry(workflowSource, 'ci-status', 2));
+
+  it('gates on the API tree and everything the two oracles read', () => {
+    expect(changesJob).toContain(
+      "restSurface: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.restSurface }}",
+    );
+
+    const filter = withoutComments(mappingEntry(changesJob, 'restSurface', 12));
+    // packages/web/app/api/** is the load-bearing glob: a route-file-only diff
+    // matches anyJs (so test-default runs) but selects neither oracle there.
+    expect(filter).toContain("- 'packages/web/app/api/**'");
+    expect(filter).toContain("- 'packages/web/vercel.json'");
+    expect(filter).toContain("- 'packages/web/app/lib/api-docs/**'");
+    expect(filter).toContain("- 'packages/web/app/__tests__/rest-surface-inventory.test.ts'");
+  });
+
+  it('runs whenever the API tree or the shared CI config changes', () => {
+    expect(restSurfaceSteps).toContain(
+      "if: needs.changes.outputs.restSurface == 'true' || needs.changes.outputs.rootCi == 'true'",
+    );
+  });
+
+  it('runs both oracles unfiltered', () => {
+    expect(restSurfaceSteps).toContain('packages/web/app/__tests__/rest-surface-inventory.test.ts');
+    expect(restSurfaceSteps).toContain('packages/web/app/lib/api-docs/__tests__/openapi-document.test.ts');
+    // The whole point of the job. `--changed` here would restore the blind spot.
+    expect(restSurfaceSteps).not.toContain('--changed');
+  });
+
+  it('runs this contract spec from inside the job it guards', () => {
+    // Without this step nothing un-filtered reads ci.yml, so the gate above
+    // could be narrowed by a ci.yml-only diff with nothing going red on the PR
+    // — the same blind spot, one level up.
+    expect(restSurfaceSteps).toContain('scripts/__tests__/ci-rest-surface-workflow.test.ts');
+  });
+
+  it('makes the aggregate status depend on the job', () => {
+    expect(ciStatusJob).toContain('- rest-surface');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #4663. That PR added two oracles meant to keep the REST surface honest, but neither could ever be selected by CI on the pull request that would break them — and one of the four documents it de-staled kept a section pointing at a file it deleted.

**1. Both oracles were inert on PRs.** `test-default` runs `vp test run --changed "origin/$BASE_REF"` (ci.yml:604). `rest-surface-inventory.test.ts` imports nothing from the repo — it walks `app/api/**` with `readdirSync` — so Vitest's module graph never relates a route add or delete to it. `openapi-document.test.ts` is statically related to the *registry*, so `--changed` selects it when a registration changes, but not when only a route file moves, which is exactly the diff its new `never advertises a registered path whose route file is gone` check was written for.

Measured on the merged #4663 tree, working tree otherwise clean:

| probe | selected specs |
| --- | --- |
| add `app/api/internal/probe-route/route.ts` | `No test files found, exiting with code 0` |
| delete `app/api/og/setter/route.tsx` | `No test files found, exiting with code 0` |
| delete `app/api/v1/[board_name]/slugs/layout/[slug]` (OpenAPI-registered) | `No test files found, exiting with code 0` |
| control: append a comment to `app/lib/url-utils.ts` | 53 files, 731 tests |

The oracles themselves bite fine — force-selected, the third probe gives `× never advertises a registered path whose route file is gone`. It was CI's *selection* that was blind, so every guarantee in their docstrings only held post-merge on `main`.

The fix follows the pattern ci.yml already uses for its other fs-reading oracles (`deploy-config` at 479–513, `listing-guards` at 515–539): a small dedicated `rest-surface` job that is **not** `--changed`-filtered, gated on a `restSurface` path filter covering `packages/web/app/api/**`, `vercel.json`, `app/lib/api-docs/**`, and the specs themselves. `scripts/__tests__/ci-rest-surface-workflow.test.ts` pins that job's shape — the job runs it as its own second step, because a spec that reads `ci.yml` has the same blind spot one level up.

With the job in place, the same three probes red:

| probe | result |
| --- | --- |
| add a route file | `classifies every route file on disk`, `counts exactly the audited surface` |
| delete an unregistered route | `never classifies a route file that no longer exists`, `counts exactly the audited surface` |
| delete a registered route | those two plus `never advertises a registered path whose route file is gone` |

**2. The verdict taxonomy contradicted itself.** The docstring defines `keep-external` as a published surface with no in-repo runtime caller by design, naming "a Vercel cron target" as an example — yet all four cron targets shipped as `keep-caller`, leaving that clause with zero members. Grepping non-test, non-`.next` callers for `cleanup`, `prewarm-heatmap`, `profile-percentiles` and `refresh-sitemap-climbs` returns only `vercel.json`, their own route tests, and `docs/sitemap.md` — no in-repo runtime caller, which is the file's own definition of `keep-external`. Relabelled all four, and added a check that derives the expected set from `vercel.json` (treating `[param]` as a wildcard) rather than pinning literals, so a future mislabel isn't silent. Nothing asserted verdict *values* before this beyond the two pinned externals.

**3. `packages/backend/MIGRATION_PLAN.md` still documented the deleted parity suite.** Its `### Parity Tests` section told the reader to run `--config vitest.parity.config.ts` (deleted by #4663) and asserted the suite was excluded from CI via a `*parity*.test.ts` glob (removed from `packages/backend/vite.config.ts` by #4663). Replaced with a note saying it was removed and why.

Production targets: web/CI only. No mobile package, no `packages/shared/**`, no `bun.lock` — no native fingerprint change and no OTA.

Refs #4663, #1889, #4358.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` — format clean across all 4878 files. The three lint errors are the known local-install artefacts CI does not have (`@gorhom/bottom-sheet` ×2 from the nested `packages/mobile/web-runtime` install, `canvas` from moonboard-ocr); none of the changed files appear anywhere in the output.
- `vp run typecheck`, `vp test run --project web`, `--project scripts`, `--project i18n`, `vp run check:i18n`, `vp run check:i18n:orphans`.
- Mutation-tested the new cron oracle, four directions, each reverted from a pristine copy: relabel a cron route `keep-caller` → red; schedule a cron for a route that doesn't exist → red; schedule a cron for a real `keep-caller` route → red; empty the `crons` array → red.
- Mutation-tested `ci-rest-surface-workflow.test.ts`, seven directions: add `--changed` to the run step → red; drop `rootCi` from the gate → red; drop `packages/web/app/api/**` from the filter → red; drop the `restSurface` output line → red; drop `- rest-surface` from `ci-status` → red; drop the OpenAPI spec from the run line → red; drop the contract-spec step itself → red. The spec strips `#` comment lines first, so the job's own rationale can't satisfy an assertion.
- End-to-end: ran the exact command the new job runs against each of the three route probes above and confirmed it reds, then confirmed a clean tree is green.
- The job fails closed if either spec is renamed without updating the workflow: `vp test run --project web <missing path>` exits 1, it does not quietly run nothing.
