### PR TITLE
fix(web): stop /api/internal/board-render OOM-killing its instances

### DIFF
--- a/packages/shared/board-render/src/__tests__/board-dimensions.test.ts
+++ b/packages/shared/board-render/src/__tests__/board-dimensions.test.ts
@@ -1,0 +1,37 @@
+import { BOARD_IMAGE_DIMENSIONS } from '@boardsesh/board-config';
+import { describe, expect, it } from 'vitest';
+import { MAX_RENDER_OUTPUT_PIXELS } from '../validation';
+
+/**
+ * Tripwire for the render route's pixel ceiling.
+ *
+ * A full-size render is the board image's own dimensions, so the ceiling has to
+ * stay above the largest board art we ship. If a future board is taller than
+ * this allows, that must surface as a red test here — not as a 400 for every
+ * request for that board in production.
+ */
+describe('board art fits under the render pixel ceiling', () => {
+  const boardImages = Object.entries(BOARD_IMAGE_DIMENSIONS).flatMap(([boardName, images]) =>
+    Object.entries(images).map(([imageName, { width, height }]) => ({
+      label: `${boardName}/${imageName}`,
+      pixels: width * height,
+      width,
+      height,
+    })),
+  );
+
+  it('covers every board image', () => {
+    expect(boardImages.length).toBeGreaterThan(100);
+  });
+
+  it('leaves the largest board under MAX_RENDER_OUTPUT_PIXELS', () => {
+    const largest = boardImages.reduce((worst, image) => (image.pixels > worst.pixels ? image : worst));
+
+    expect(
+      largest.pixels,
+      `${largest.label} renders at ${largest.width}×${largest.height} (${largest.pixels} px), over the ` +
+        `${MAX_RENDER_OUTPUT_PIXELS} px ceiling in validation.ts. Raise the ceiling (and the route's memory ` +
+        'budget with it) rather than letting this board 400 in production.',
+    ).toBeLessThan(MAX_RENDER_OUTPUT_PIXELS);
+  });
+});

--- a/packages/shared/board-render/src/__tests__/lru.test.ts
+++ b/packages/shared/board-render/src/__tests__/lru.test.ts
@@ -64,6 +64,23 @@ describe('BoundedLru', () => {
     expect(cache.get('huge')).toBeUndefined();
   });
 
+  it('drops every entry and its byte total on clear', () => {
+    const cache = byteLru(3, 100);
+    cache.set('first', Buffer.alloc(10));
+    cache.set('second', Buffer.alloc(10));
+
+    cache.clear();
+
+    expect(cache.size).toBe(0);
+    expect(cache.byteSize).toBe(0);
+    expect(cache.get('first')).toBeUndefined();
+
+    // Still usable afterwards.
+    cache.set('third', Buffer.alloc(10));
+    expect(cache.size).toBe(1);
+    expect(cache.byteSize).toBe(10);
+  });
+
   it('returns undefined for missing keys and tracks sizes accurately across evictions', () => {
     const cache = byteLru(3, 100);
     expect(cache.get('missing')).toBeUndefined();

--- a/packages/shared/board-render/src/__tests__/pipeline.test.ts
+++ b/packages/shared/board-render/src/__tests__/pipeline.test.ts
@@ -1,0 +1,275 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import sharp from 'sharp';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { BoundedLru } from '../lru';
+import { composeBoardBaseBuffer, renderBoardImageBuffer, type OgBaseResult, type ResolveImagePath } from '../pipeline';
+import type { RenderableBoardDetails } from '../types';
+
+const SIZE = 8;
+const PIXELS = SIZE * SIZE;
+
+const fixtureDir = mkdtempSync(join(tmpdir(), 'board-render-pipeline-'));
+afterAll(() => rmSync(fixtureDir, { recursive: true, force: true }));
+
+/** Write a solid-colour PNG the pipeline can decode as a board photo layer. */
+function writeLayer(name: string, rgb: { r: number; g: number; b: number }, alpha = 1): Promise<string> {
+  const path = join(fixtureDir, name);
+  return sharp({ create: { width: SIZE, height: SIZE, channels: 4, background: { ...rgb, alpha } } })
+    .png()
+    .toFile(path)
+    .then(() => path);
+}
+
+/** Map board-relative image keys to fixture files; anything unmapped resolves to null. */
+let filesByRelPath = new Map<string, string>();
+let resolveCalls: string[] = [];
+const resolveImagePath: ResolveImagePath = (relPath) => {
+  resolveCalls.push(relPath);
+  return filesByRelPath.get(relPath) ?? null;
+};
+
+beforeEach(() => {
+  filesByRelPath = new Map();
+  resolveCalls = [];
+});
+
+function boardWithLayers(imageKeys: string[]): RenderableBoardDetails {
+  return {
+    board_name: 'kilter',
+    boardWidth: SIZE,
+    boardHeight: SIZE,
+    holdsData: [],
+    images_to_holds: Object.fromEntries(imageKeys.map((key) => [key, []])),
+  };
+}
+
+/** `getBackgroundRelPaths` turns "layer-a.png" into "images/kilter/layer-a.webp". */
+const relPathFor = (imageKey: string) => `images/kilter/${imageKey.replace(/\.png$/, '.webp')}`;
+
+/** A fully transparent overlay: composites without changing the base pixels. */
+const transparentOverlay = () => Buffer.alloc(PIXELS * 4, 0);
+
+const readPixel = (raw: Buffer, index = 0) => [
+  raw[index * 4],
+  raw[index * 4 + 1],
+  raw[index * 4 + 2],
+  raw[index * 4 + 3],
+];
+
+describe('composeBoardBaseBuffer', () => {
+  it('returns one raw RGBA plane of exactly width × height × 4 bytes', async () => {
+    filesByRelPath.set(relPathFor('layer-a.png'), await writeLayer('a.png', { r: 255, g: 0, b: 0 }));
+
+    const base = await composeBoardBaseBuffer({
+      boardDetails: boardWithLayers(['layer-a.png']),
+      width: SIZE,
+      height: SIZE,
+      thumbnail: false,
+      dimBackground: 0,
+      resolveImagePath,
+    });
+
+    expect(base).not.toBeNull();
+    expect(base?.length).toBe(PIXELS * 4);
+    expect(readPixel(base as Buffer)).toEqual([255, 0, 0, 255]);
+  });
+
+  it('folds layers in order, later layers painting over earlier ones', async () => {
+    filesByRelPath.set(relPathFor('layer-a.png'), await writeLayer('order-a.png', { r: 255, g: 0, b: 0 }));
+    filesByRelPath.set(relPathFor('layer-b.png'), await writeLayer('order-b.png', { r: 0, g: 0, b: 255 }));
+
+    const base = await composeBoardBaseBuffer({
+      boardDetails: boardWithLayers(['layer-a.png', 'layer-b.png']),
+      width: SIZE,
+      height: SIZE,
+      thumbnail: false,
+      dimBackground: 0,
+      resolveImagePath,
+    });
+
+    // Opaque blue on top of opaque red: blue wins. Reversed order would be red.
+    expect(readPixel(base as Buffer)).toEqual([0, 0, 255, 255]);
+    expect(base?.length).toBe(PIXELS * 4);
+  });
+
+  it('dims by scaling RGB, leaving alpha untouched', async () => {
+    filesByRelPath.set(relPathFor('layer-a.png'), await writeLayer('dim.png', { r: 200, g: 100, b: 50 }));
+
+    const base = await composeBoardBaseBuffer({
+      boardDetails: boardWithLayers(['layer-a.png']),
+      width: SIZE,
+      height: SIZE,
+      thumbnail: false,
+      dimBackground: 0.18,
+      resolveImagePath,
+    });
+
+    const [red, green, blue, alpha] = readPixel(base as Buffer);
+    // Compositing black at 0.18 over an opaque photo is exactly rgb × 0.82.
+    expect(Math.abs(red - 200 * 0.82)).toBeLessThanOrEqual(1);
+    expect(Math.abs(green - 100 * 0.82)).toBeLessThanOrEqual(1);
+    expect(Math.abs(blue - 50 * 0.82)).toBeLessThanOrEqual(1);
+    expect(alpha).toBe(255);
+  });
+
+  it('skips a layer that fails to decode and keeps the rest', async () => {
+    filesByRelPath.set(relPathFor('good.png'), await writeLayer('good.png', { r: 12, g: 34, b: 56 }));
+    const corruptPath = join(fixtureDir, 'corrupt.png');
+    writeFileSync(corruptPath, 'this is not an image');
+    filesByRelPath.set(relPathFor('bad.png'), corruptPath);
+
+    const base = await composeBoardBaseBuffer({
+      boardDetails: boardWithLayers(['good.png', 'bad.png']),
+      width: SIZE,
+      height: SIZE,
+      thumbnail: false,
+      dimBackground: 0,
+      resolveImagePath,
+    });
+
+    expect(base?.length).toBe(PIXELS * 4);
+    expect(readPixel(base as Buffer)).toEqual([12, 34, 56, 255]);
+  });
+
+  it('returns null when no background image resolves', async () => {
+    const base = await composeBoardBaseBuffer({
+      boardDetails: boardWithLayers(['missing.png']),
+      width: SIZE,
+      height: SIZE,
+      thumbnail: false,
+      dimBackground: 0,
+      resolveImagePath,
+    });
+
+    expect(base).toBeNull();
+    expect(resolveCalls).toEqual([relPathFor('missing.png')]);
+  });
+
+  it('returns null when every layer fails to decode', async () => {
+    const corruptPath = join(fixtureDir, 'all-bad.png');
+    writeFileSync(corruptPath, 'not an image either');
+    filesByRelPath.set(relPathFor('bad.png'), corruptPath);
+
+    const base = await composeBoardBaseBuffer({
+      boardDetails: boardWithLayers(['bad.png']),
+      width: SIZE,
+      height: SIZE,
+      thumbnail: false,
+      dimBackground: 0,
+      resolveImagePath,
+    });
+
+    expect(base).toBeNull();
+  });
+});
+
+describe('renderBoardImageBuffer with caches', () => {
+  const baseParams = {
+    width: SIZE,
+    height: SIZE,
+    thumbnail: false,
+    includeBackground: true,
+    dimBackground: 0,
+    resolveImagePath,
+  };
+
+  it('composes the board base once and serves later renders from the cache', async () => {
+    filesByRelPath.set(relPathFor('layer-a.png'), await writeLayer('cached.png', { r: 10, g: 200, b: 30 }));
+    const boardBase = new BoundedLru<Buffer>({
+      maxEntries: 4,
+      maxBytes: 4 * 1024 * 1024,
+      sizeOf: (buffer) => buffer.length,
+    });
+    const params = {
+      ...baseParams,
+      overlayBuffer: transparentOverlay(),
+      isOgVariant: false,
+      format: 'webp' as const,
+      boardDetails: boardWithLayers(['layer-a.png']),
+      caches: { boardBase },
+    };
+
+    const first = await renderBoardImageBuffer(params);
+    expect(first.cache).toBe('miss');
+    expect(resolveCalls).toHaveLength(1);
+
+    const second = await renderBoardImageBuffer(params);
+    expect(second.cache).toBe('hit');
+    // The cached base means no second trip to the filesystem.
+    expect(resolveCalls).toHaveLength(1);
+    expect(second.buffer.equals(first.buffer)).toBe(true);
+    expect(second.contentType).toBe('image/webp');
+
+    const metadata = await sharp(second.buffer).metadata();
+    expect(metadata.width).toBe(SIZE);
+    expect(metadata.height).toBe(SIZE);
+  });
+
+  it('reports `none` when no cache is supplied', async () => {
+    filesByRelPath.set(relPathFor('layer-a.png'), await writeLayer('uncached.png', { r: 1, g: 2, b: 3 }));
+
+    const result = await renderBoardImageBuffer({
+      ...baseParams,
+      overlayBuffer: transparentOverlay(),
+      isOgVariant: false,
+      format: 'webp',
+      boardDetails: boardWithLayers(['layer-a.png']),
+    });
+
+    expect(result.cache).toBe('none');
+    expect(result.contentType).toBe('image/webp');
+  });
+
+  it('falls back to an overlay-only render when the board photos are missing', async () => {
+    const boardBase = new BoundedLru<Buffer>({
+      maxEntries: 4,
+      maxBytes: 4 * 1024 * 1024,
+      sizeOf: (buffer) => buffer.length,
+    });
+
+    const result = await renderBoardImageBuffer({
+      ...baseParams,
+      overlayBuffer: transparentOverlay(),
+      isOgVariant: false,
+      format: 'png',
+      boardDetails: boardWithLayers(['missing.png']),
+      caches: { boardBase },
+    });
+
+    expect(result.contentType).toBe('image/png');
+    const metadata = await sharp(result.buffer).metadata();
+    expect(metadata.width).toBe(SIZE);
+    expect(metadata.height).toBe(SIZE);
+  });
+
+  it('renders the OG card on the social canvas and reuses its cached base', async () => {
+    filesByRelPath.set(relPathFor('layer-a.png'), await writeLayer('og.png', { r: 90, g: 90, b: 90 }));
+    const ogBase = new BoundedLru<OgBaseResult>({
+      maxEntries: 2,
+      maxBytes: 8 * 1024 * 1024,
+      sizeOf: (value) => value.base.length,
+    });
+    const params = {
+      ...baseParams,
+      overlayBuffer: transparentOverlay(),
+      isOgVariant: true,
+      format: 'png' as const,
+      boardDetails: boardWithLayers(['layer-a.png']),
+      caches: { ogBase },
+    };
+
+    const first = await renderBoardImageBuffer(params);
+    expect(first.cache).toBe('miss');
+    const metadata = await sharp(first.buffer).metadata();
+    expect(metadata.width).toBe(1200);
+    expect(metadata.height).toBe(630);
+
+    const resolveCallsAfterFirst = resolveCalls.length;
+    const second = await renderBoardImageBuffer(params);
+    expect(second.cache).toBe('hit');
+    expect(resolveCalls).toHaveLength(resolveCallsAfterFirst);
+    expect(second.buffer.equals(first.buffer)).toBe(true);
+  });
+});

--- a/packages/shared/board-render/src/__tests__/pipeline.test.ts
+++ b/packages/shared/board-render/src/__tests__/pipeline.test.ts
@@ -272,13 +272,14 @@ describe('renderBoardImageBuffer with caches', () => {
     });
     // Different climbs, same board: one base, two overlays. 0x00 is a fully
     // transparent overlay, 0xff an opaque white one — visibly different output.
+    const boardBaseInFlight = new Map<string, Promise<Buffer | null>>();
     const paramsFor = (overlayFill: number) => ({
       ...baseParams,
       overlayBuffer: Buffer.alloc(PIXELS * 4, overlayFill),
       isOgVariant: false,
       format: 'webp' as const,
       boardDetails: boardWithLayers(['layer-a.png']),
-      caches: { boardBase },
+      caches: { boardBase, boardBaseInFlight },
     });
 
     const [first, second] = await Promise.all([
@@ -290,6 +291,30 @@ describe('renderBoardImageBuffer with caches', () => {
     expect(resolveCalls).toHaveLength(1);
     expect(first.buffer.equals(second.buffer)).toBe(false);
     expect(boardBase.size).toBe(1);
+    // The entry is dropped once the compose settles — nothing is held alive.
+    expect(boardBaseInFlight.size).toBe(0);
+  });
+
+  it('composes per render when no in-flight map is supplied', async () => {
+    filesByRelPath.set(relPathFor('layer-a.png'), await writeLayer('uncoalesced.png', { r: 7, g: 8, b: 9 }));
+    const boardBase = new BoundedLru<Buffer>({
+      maxEntries: 4,
+      maxBytes: 4 * 1024 * 1024,
+      sizeOf: (buffer) => buffer.length,
+    });
+    const params = {
+      ...baseParams,
+      overlayBuffer: transparentOverlay(),
+      isOgVariant: false,
+      format: 'webp' as const,
+      boardDetails: boardWithLayers(['layer-a.png']),
+      caches: { boardBase },
+    };
+
+    await Promise.all([renderBoardImageBuffer(params), renderBoardImageBuffer(params)]);
+
+    // Coalescing is opt-in: without the map both races compose their own base.
+    expect(resolveCalls).toHaveLength(2);
   });
 
   it('reports `none` when no cache is supplied', async () => {

--- a/packages/shared/board-render/src/__tests__/pipeline.test.ts
+++ b/packages/shared/board-render/src/__tests__/pipeline.test.ts
@@ -22,6 +22,28 @@ function writeLayer(name: string, rgb: { r: number; g: number; b: number }, alph
     .then(() => path);
 }
 
+/**
+ * Write a PNG shaped like a real board photo: opaque where the holds are (the
+ * left half here), fully transparent everywhere else.
+ */
+async function writePartlyTransparentLayer(name: string, rgb: { r: number; g: number; b: number }): Promise<string> {
+  const path = join(fixtureDir, name);
+  const raw = Buffer.alloc(PIXELS * 4, 0);
+  for (let y = 0; y < SIZE; y += 1) {
+    for (let x = 0; x < SIZE / 2; x += 1) {
+      const offset = (y * SIZE + x) * 4;
+      raw[offset] = rgb.r;
+      raw[offset + 1] = rgb.g;
+      raw[offset + 2] = rgb.b;
+      raw[offset + 3] = 255;
+    }
+  }
+  await sharp(raw, { raw: { width: SIZE, height: SIZE, channels: 4 } })
+    .png()
+    .toFile(path);
+  return path;
+}
+
 /** Map board-relative image keys to fixture files; anything unmapped resolves to null. */
 let filesByRelPath = new Map<string, string>();
 let resolveCalls: string[] = [];
@@ -94,8 +116,16 @@ describe('composeBoardBaseBuffer', () => {
     expect(base?.length).toBe(PIXELS * 4);
   });
 
-  it('dims by scaling RGB, leaving alpha untouched', async () => {
-    filesByRelPath.set(relPathFor('layer-a.png'), await writeLayer('dim.png', { r: 200, g: 100, b: 50 }));
+  it('dims full-bleed: transparent board pixels darken too', async () => {
+    // Real board photos are transparent everywhere except the holds, and
+    // `dim_background` is a wash over the whole image — the iOS Live Activity
+    // widget and mobile's LayeredClimbImage both draw it that way. Scaling RGB
+    // by (1 - dim) instead would leave every transparent pixel untouched, so
+    // this pins the transparent half explicitly.
+    filesByRelPath.set(
+      relPathFor('layer-a.png'),
+      await writePartlyTransparentLayer('dim-alpha.png', { r: 200, g: 100, b: 50 }),
+    );
 
     const base = await composeBoardBaseBuffer({
       boardDetails: boardWithLayers(['layer-a.png']),
@@ -106,12 +136,38 @@ describe('composeBoardBaseBuffer', () => {
       resolveImagePath,
     });
 
-    const [red, green, blue, alpha] = readPixel(base as Buffer);
-    // Compositing black at 0.18 over an opaque photo is exactly rgb × 0.82.
+    // A fully transparent source pixel picks up the scrim's own alpha.
+    const transparentPixelIndex = SIZE / 2;
+    const [dimRed, dimGreen, dimBlue, dimAlpha] = readPixel(base as Buffer, transparentPixelIndex);
+    expect(dimAlpha).toBe(Math.round(0.18 * 255));
+    expect(dimRed).toBe(0);
+    expect(dimGreen).toBe(0);
+    expect(dimBlue).toBe(0);
+
+    // An opaque one darkens by (1 - dim) and stays opaque.
+    const [red, green, blue, alpha] = readPixel(base as Buffer, 0);
     expect(Math.abs(red - 200 * 0.82)).toBeLessThanOrEqual(1);
     expect(Math.abs(green - 100 * 0.82)).toBeLessThanOrEqual(1);
     expect(Math.abs(blue - 50 * 0.82)).toBeLessThanOrEqual(1);
     expect(alpha).toBe(255);
+  });
+
+  it('leaves a transparent pixel alone when dim is off', async () => {
+    filesByRelPath.set(
+      relPathFor('layer-a.png'),
+      await writePartlyTransparentLayer('no-dim-alpha.png', { r: 200, g: 100, b: 50 }),
+    );
+
+    const base = await composeBoardBaseBuffer({
+      boardDetails: boardWithLayers(['layer-a.png']),
+      width: SIZE,
+      height: SIZE,
+      thumbnail: false,
+      dimBackground: 0,
+      resolveImagePath,
+    });
+
+    expect(readPixel(base as Buffer, SIZE / 2)[3]).toBe(0);
   });
 
   it('skips a layer that fails to decode and keeps the rest', async () => {
@@ -205,6 +261,35 @@ describe('renderBoardImageBuffer with caches', () => {
     const metadata = await sharp(second.buffer).metadata();
     expect(metadata.width).toBe(SIZE);
     expect(metadata.height).toBe(SIZE);
+  });
+
+  it('composes the base once for two concurrent misses on the same board', async () => {
+    filesByRelPath.set(relPathFor('layer-a.png'), await writeLayer('coalesced.png', { r: 40, g: 50, b: 60 }));
+    const boardBase = new BoundedLru<Buffer>({
+      maxEntries: 4,
+      maxBytes: 4 * 1024 * 1024,
+      sizeOf: (buffer) => buffer.length,
+    });
+    // Different climbs, same board: one base, two overlays. 0x00 is a fully
+    // transparent overlay, 0xff an opaque white one — visibly different output.
+    const paramsFor = (overlayFill: number) => ({
+      ...baseParams,
+      overlayBuffer: Buffer.alloc(PIXELS * 4, overlayFill),
+      isOgVariant: false,
+      format: 'webp' as const,
+      boardDetails: boardWithLayers(['layer-a.png']),
+      caches: { boardBase },
+    });
+
+    const [first, second] = await Promise.all([
+      renderBoardImageBuffer(paramsFor(0x00)),
+      renderBoardImageBuffer(paramsFor(0xff)),
+    ]);
+
+    // Both raced past the cache, but only one of them composed the base.
+    expect(resolveCalls).toHaveLength(1);
+    expect(first.buffer.equals(second.buffer)).toBe(false);
+    expect(boardBase.size).toBe(1);
   });
 
   it('reports `none` when no cache is supplied', async () => {

--- a/packages/shared/board-render/src/__tests__/semaphore.test.ts
+++ b/packages/shared/board-render/src/__tests__/semaphore.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { createSemaphore } from '../semaphore';
+
+/** A promise plus the handles to settle it from the test body. */
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Drain the microtask queue so a just-released slot has reached its waiter. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('createSemaphore', () => {
+  it('never runs more than `limit` tasks at once', async () => {
+    const semaphore = createSemaphore(3);
+    let running = 0;
+    let highWaterMark = 0;
+
+    const tasks = Array.from({ length: 10 }, () =>
+      semaphore.run(async () => {
+        running += 1;
+        highWaterMark = Math.max(highWaterMark, running);
+        // Yield across a few microtask turns so overlapping tasks can pile up.
+        await Promise.resolve();
+        await Promise.resolve();
+        running -= 1;
+      }),
+    );
+
+    await Promise.all(tasks);
+
+    expect(highWaterMark).toBe(3);
+    expect(semaphore.active).toBe(0);
+    expect(semaphore.pending).toBe(0);
+  });
+
+  it('serves waiters in arrival order', async () => {
+    const semaphore = createSemaphore(1);
+    const started: number[] = [];
+    const gates = [deferred(), deferred(), deferred()];
+
+    const tasks = gates.map((gate, index) =>
+      semaphore.run(async () => {
+        started.push(index);
+        await gate.promise;
+      }),
+    );
+
+    // Only the first task holds the single slot; the rest are queued.
+    await flush();
+    expect(started).toEqual([0]);
+    expect(semaphore.active).toBe(1);
+    expect(semaphore.pending).toBe(2);
+
+    gates[0].resolve();
+    await tasks[0];
+    await flush();
+    expect(started).toEqual([0, 1]);
+
+    gates[1].resolve();
+    await tasks[1];
+    await flush();
+    expect(started).toEqual([0, 1, 2]);
+
+    gates[2].resolve();
+    await Promise.all(tasks);
+    expect(semaphore.active).toBe(0);
+  });
+
+  it('releases the slot when a task throws', async () => {
+    const semaphore = createSemaphore(1);
+
+    await expect(
+      semaphore.run(async () => {
+        throw new Error('render exploded');
+      }),
+    ).rejects.toThrow('render exploded');
+
+    expect(semaphore.active).toBe(0);
+    expect(semaphore.pending).toBe(0);
+
+    // The slot is reusable — a stranded one would hang this forever.
+    await expect(semaphore.run(async () => 'ok')).resolves.toBe('ok');
+  });
+
+  it('clamps a nonsensical limit to one slot instead of deadlocking', async () => {
+    const semaphore = createSemaphore(Number.NaN);
+    let running = 0;
+    let highWaterMark = 0;
+
+    await Promise.all(
+      Array.from({ length: 4 }, () =>
+        semaphore.run(async () => {
+          running += 1;
+          highWaterMark = Math.max(highWaterMark, running);
+          await Promise.resolve();
+          running -= 1;
+        }),
+      ),
+    );
+
+    expect(highWaterMark).toBe(1);
+  });
+});

--- a/packages/shared/board-render/src/index.ts
+++ b/packages/shared/board-render/src/index.ts
@@ -9,3 +9,4 @@ export * from './background';
 export * from './headers';
 export * from './render-config';
 export * from './lru';
+export * from './semaphore';

--- a/packages/shared/board-render/src/lru.ts
+++ b/packages/shared/board-render/src/lru.ts
@@ -47,6 +47,12 @@ export class BoundedLru<V> {
     this.evictIfNeeded();
   }
 
+  /** Drop every entry. Used to isolate process-lifetime caches between tests. */
+  clear(): void {
+    this.store.clear();
+    this.totalBytes = 0;
+  }
+
   get size(): number {
     return this.store.size;
   }

--- a/packages/shared/board-render/src/pipeline.ts
+++ b/packages/shared/board-render/src/pipeline.ts
@@ -226,7 +226,9 @@ export async function renderBoardImageBuffer({
     // the board, so the composed base is cached and only the overlay composite
     // + encode runs per climb.
     const bgT0 = performance.now();
-    const ogKey = `${bgRelPaths.join('|')}:${width}x${height}:og`;
+    // The OG base always composes full-size photos, so key it on those paths —
+    // not on `bgRelPaths`, which honours `thumbnail`.
+    const ogKey = `${getBackgroundRelPaths(boardDetails, false).join('|')}:${width}x${height}:og`;
     let ogBase = caches?.ogBase?.get(ogKey);
     if (ogBase) {
       cache = 'hit';

--- a/packages/shared/board-render/src/pipeline.ts
+++ b/packages/shared/board-render/src/pipeline.ts
@@ -137,10 +137,16 @@ async function encodeRendered(
  * raw planes no matter how many hold-set images a board has. A layer that fails
  * to decode is skipped (the board still renders with whatever did load).
  *
- * Dimming is a linear scale rather than a composited black scrim: over an
- * opaque photo, compositing black at opacity `d` is exactly `rgb × (1 - d)`, so
- * the output is identical while a full W×H×4 scrim allocation disappears. It is
- * baked into the base because the caller's cache key includes the dim value.
+ * Dimming stays a composited black scrim, deliberately. Scaling RGB by
+ * `1 - dim` looks equivalent and allocates nothing, but only for *opaque*
+ * pixels: QA measured every board WebP and they all carry alpha — the board
+ * photos are transparent everywhere except the holds, so ~77% of pixels would
+ * come out with different alpha and up to 127 of RGB delta. `dim_background` is
+ * supposed to be a full-bleed wash over the whole image, which is what the iOS
+ * Live Activity widget asks for with `dim_background=0.18` and what mobile's
+ * LayeredClimbImage draws as a full-bleed `rgba(0, 0, 0, 0.18)` view. The scrim
+ * is composited over the *folded* base and baked into it, so a board pays for
+ * it once on a cold cache rather than once per request as before.
  *
  * Returns null when no background image resolves — the caller then falls back
  * to an overlay-only render.
@@ -181,9 +187,32 @@ export async function composeBoardBaseBuffer(params: {
   if (base === null) return null;
   if (dimBackground <= 0) return base;
 
-  const keep = 1 - dimBackground;
-  return sharp(base, { raw: rawLayer }).linear([keep, keep, keep, 1], [0, 0, 0, 0]).raw().toBuffer();
+  // Composited straight from a `create` descriptor: same pixels the old
+  // per-request PNG scrim produced, without encoding and decoding it first.
+  return sharp(base, { raw: rawLayer })
+    .composite([
+      {
+        input: { create: { width, height, channels: 4, background: { r: 0, g: 0, b: 0, alpha: dimBackground } } },
+        blend: 'over',
+      },
+    ])
+    .raw()
+    .toBuffer();
 }
+
+/**
+ * Concurrent composes of the same base, keyed exactly like the caller's cache.
+ * Two climbs on one board arriving together would otherwise each decode and
+ * fold that board's photos (~10 MB of planes for the tallest Kilter board) to
+ * produce identical bytes. Entries are removed as soon as the compose settles,
+ * so this never holds a buffer alive.
+ *
+ * Only used when the caller supplied a `boardBase` cache: the key describes the
+ * board and the output size, not the caller's `resolveImagePath`, so sharing it
+ * assumes one resolver per process (true today — the web route is the only
+ * consumer).
+ */
+const inFlightBoardBases = new Map<string, Promise<Buffer | null>>();
 
 /**
  * Single-shot render used by the web `board-render` route: takes the WASM
@@ -214,7 +243,6 @@ export async function renderBoardImageBuffer({
   let outputContentType = 'image/png';
   let bgMs = 0;
   let composeMs = 0;
-  let didCompositeBackground = false;
   let cache: RenderBoardImageResult['cache'] = 'none';
 
   const overlayOnlyImage = () => sharp(overlayBuffer, { raw: rawPlane });
@@ -248,7 +276,6 @@ export async function renderBoardImageBuffer({
     outputBuffer = encoded.buffer;
     outputContentType = encoded.contentType;
     composeMs = performance.now() - composeT0;
-    didCompositeBackground = true;
   } else if (includeBackground && isOgVariant) {
     // Dimmed OG card: no caller asks for this today, so it keeps the original
     // uncached composite rather than growing a third cache key.
@@ -280,7 +307,6 @@ export async function renderBoardImageBuffer({
         ])
         .png(DEFAULT_PNG_OPTIONS)
         .toBuffer();
-      didCompositeBackground = true;
     } else {
       imageBuffer = await overlayOnlyImage().png(DEFAULT_PNG_OPTIONS).toBuffer();
     }
@@ -294,15 +320,21 @@ export async function renderBoardImageBuffer({
     if (base) {
       cache = 'hit';
     } else {
-      base =
-        (await composeBoardBaseBuffer({
-          boardDetails,
-          width,
-          height,
-          thumbnail,
-          dimBackground,
-          resolveImagePath,
-        })) ?? undefined;
+      const composeParams = { boardDetails, width, height, thumbnail, dimBackground, resolveImagePath };
+      let composed: Buffer | null;
+      if (caches?.boardBase) {
+        const alreadyComposing = inFlightBoardBases.get(baseKey);
+        const composePromise =
+          alreadyComposing ??
+          composeBoardBaseBuffer(composeParams).finally(() => {
+            inFlightBoardBases.delete(baseKey);
+          });
+        if (!alreadyComposing) inFlightBoardBases.set(baseKey, composePromise);
+        composed = await composePromise;
+      } else {
+        composed = await composeBoardBaseBuffer(composeParams);
+      }
+      base = composed ?? undefined;
       if (base) caches?.boardBase?.set(baseKey, base);
       cache = caches?.boardBase ? 'miss' : 'none';
     }
@@ -322,7 +354,6 @@ export async function renderBoardImageBuffer({
       outputBuffer = encoded.outputBuffer;
       imageBuffer = encoded.imageBuffer;
       outputContentType = encoded.contentType;
-      didCompositeBackground = true;
     } else {
       // No background image resolved — fall back to overlay-only lossless.
       const encoded = await encodeRendered(overlayOnlyImage(), {
@@ -369,18 +400,10 @@ export async function renderBoardImageBuffer({
       outputBuffer = await ogImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
       outputContentType = 'image/png';
     }
-  } else if (outputBuffer === null && imageBuffer && format === 'webp') {
-    const getWebpOptions = () => {
-      if (thumbnail) return THUMBNAIL_WEBP_OPTIONS;
-      if (didCompositeBackground) return DEFAULT_WEBP_OPTIONS;
-      return { lossless: true };
-    };
-    outputBuffer = await sharp(imageBuffer).webp(getWebpOptions()).toBuffer();
-    outputContentType = 'image/webp';
-  } else if (outputBuffer === null && imageBuffer && format === 'jpeg') {
-    outputBuffer = await sharp(imageBuffer).jpeg(getJpegOptions(thumbnail)).toBuffer();
-    outputContentType = 'image/jpeg';
   } else if (outputBuffer === null && imageBuffer) {
+    // Only PNG lands here: every branch above hands back finished bytes for
+    // WebP and JPEG, and the OG variant is taken by the branch above this one.
+    // There is nothing left to re-encode.
     outputBuffer = imageBuffer;
     outputContentType = 'image/png';
   }

--- a/packages/shared/board-render/src/pipeline.ts
+++ b/packages/shared/board-render/src/pipeline.ts
@@ -60,6 +60,15 @@ export type RenderBoardImageCaches = {
   boardBase?: BoundedLru<Buffer>;
   /** Gradient backdrop + board photos (raw RGBA) for the OG social-card path. */
   ogBase?: BoundedLru<OgBaseResult>;
+  /**
+   * Composes of `boardBase` entries currently running, so two climbs on the
+   * same board arriving together fold that board's photos once instead of
+   * twice (~10 MB of planes for the tallest Kilter board). Owned by the caller
+   * because the key describes the board and output size, not the caller's
+   * `resolveImagePath` — sharing one across resolvers would serve the wrong
+   * images. Omit it and each render composes its own base.
+   */
+  boardBaseInFlight?: Map<string, Promise<Buffer | null>>;
 };
 
 export type RenderBoardImageParams = {
@@ -201,20 +210,6 @@ export async function composeBoardBaseBuffer(params: {
 }
 
 /**
- * Concurrent composes of the same base, keyed exactly like the caller's cache.
- * Two climbs on one board arriving together would otherwise each decode and
- * fold that board's photos (~10 MB of planes for the tallest Kilter board) to
- * produce identical bytes. Entries are removed as soon as the compose settles,
- * so this never holds a buffer alive.
- *
- * Only used when the caller supplied a `boardBase` cache: the key describes the
- * board and the output size, not the caller's `resolveImagePath`, so sharing it
- * assumes one resolver per process (true today — the web route is the only
- * consumer).
- */
-const inFlightBoardBases = new Map<string, Promise<Buffer | null>>();
-
-/**
  * Single-shot render used by the web `board-render` route: takes the WASM
  * overlay RGBA and produces the final encoded image, optionally compositing
  * background board photos and (for the OG variant) the social-card backdrop.
@@ -294,15 +289,14 @@ export async function renderBoardImageBuffer({
       .map((result) => result.value);
 
     if (firstBg) {
-      const dimLayer = await sharp({
-        create: { width, height, channels: 4, background: { r: 0, g: 0, b: 0, alpha: dimBackground } },
-      })
-        .png()
-        .toBuffer();
       imageBuffer = await sharp(firstBg)
         .composite([
           ...restBgs.map((buf) => ({ input: buf, blend: 'over' as const })),
-          { input: dimLayer, blend: 'over' as const },
+          {
+            // Same `create` descriptor the cached path uses — no PNG round-trip.
+            input: { create: { width, height, channels: 4, background: { r: 0, g: 0, b: 0, alpha: dimBackground } } },
+            blend: 'over' as const,
+          },
           { input: overlayBuffer, raw: rawPlane, blend: 'over' as const },
         ])
         .png(DEFAULT_PNG_OPTIONS)
@@ -321,15 +315,16 @@ export async function renderBoardImageBuffer({
       cache = 'hit';
     } else {
       const composeParams = { boardDetails, width, height, thumbnail, dimBackground, resolveImagePath };
+      const inFlightBases = caches?.boardBaseInFlight;
       let composed: Buffer | null;
-      if (caches?.boardBase) {
-        const alreadyComposing = inFlightBoardBases.get(baseKey);
+      if (inFlightBases) {
+        const alreadyComposing = inFlightBases.get(baseKey);
         const composePromise =
           alreadyComposing ??
           composeBoardBaseBuffer(composeParams).finally(() => {
-            inFlightBoardBases.delete(baseKey);
+            inFlightBases.delete(baseKey);
           });
-        if (!alreadyComposing) inFlightBoardBases.set(baseKey, composePromise);
+        if (!alreadyComposing) inFlightBases.set(baseKey, composePromise);
         composed = await composePromise;
       } else {
         composed = await composeBoardBaseBuffer(composeParams);

--- a/packages/shared/board-render/src/pipeline.ts
+++ b/packages/shared/board-render/src/pipeline.ts
@@ -1,6 +1,7 @@
 import sharp from 'sharp';
 import { createOgBackgroundBuffer, getBackgroundRelPaths } from './background';
 import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from './headers';
+import type { BoundedLru } from './lru';
 import type { OutputFormat, RenderableBoardDetails } from './types';
 
 const THUMBNAIL_WEBP_OPTIONS: sharp.WebpOptions = {
@@ -48,6 +49,19 @@ function getJpegOptions(thumbnail: boolean): sharp.JpegOptions {
 /** Resolve a public/-relative image path to an absolute filesystem path, or null if absent. */
 export type ResolveImagePath = (relPath: string) => string | null;
 
+/**
+ * Process-lifetime caches a caller can hand in so repeat renders of the same
+ * board skip re-decoding its photos. Both hold raw RGBA planes keyed by board
+ * config, which is what the board photo composite costs — the per-climb overlay
+ * is never cached here (the caller's byte cache covers that).
+ */
+export type RenderBoardImageCaches = {
+  /** Folded board photos (raw RGBA, dim already baked in) for the plain render path. */
+  boardBase?: BoundedLru<Buffer>;
+  /** Gradient backdrop + board photos (raw RGBA) for the OG social-card path. */
+  ogBase?: BoundedLru<OgBaseResult>;
+};
+
 export type RenderBoardImageParams = {
   /** Raw RGBA overlay pixels from the WASM renderer (already header-stripped). */
   overlayBuffer: Buffer;
@@ -61,6 +75,8 @@ export type RenderBoardImageParams = {
   dimBackground: number;
   boardDetails: RenderableBoardDetails;
   resolveImagePath: ResolveImagePath;
+  /** Optional background caches. Omitted = every render composes its own base. */
+  caches?: RenderBoardImageCaches;
 };
 
 export type RenderTimings = {
@@ -74,12 +90,109 @@ export type RenderBoardImageResult = {
   buffer: Buffer;
   contentType: string;
   timings: RenderTimings;
+  /**
+   * Whether the board-photo base came from the caller's cache. `none` means no
+   * cache was in play (no caller cache, or a path that doesn't use one).
+   */
+  cache?: 'hit' | 'miss' | 'none';
 };
+
+type EncodedImage = {
+  /** Set when the final bytes are already encoded. */
+  outputBuffer: Buffer | null;
+  /** Set for the PNG intermediate the OG canvas composite consumes. */
+  imageBuffer: Buffer | null;
+  contentType: string;
+};
+
+/**
+ * Encode a prepared sharp pipeline in the requested format. The OG variant
+ * always lands on a PNG intermediate — its final encode happens after the
+ * social canvas composite.
+ */
+async function encodeRendered(
+  image: sharp.Sharp,
+  options: { isOgVariant: boolean; format: OutputFormat; thumbnail: boolean; webpOptions: sharp.WebpOptions },
+): Promise<EncodedImage> {
+  const { isOgVariant, format, thumbnail, webpOptions } = options;
+  if (!isOgVariant && format === 'webp') {
+    return { outputBuffer: await image.webp(webpOptions).toBuffer(), imageBuffer: null, contentType: 'image/webp' };
+  }
+  if (!isOgVariant && format === 'jpeg') {
+    return {
+      outputBuffer: await image.jpeg(getJpegOptions(thumbnail)).toBuffer(),
+      imageBuffer: null,
+      contentType: 'image/jpeg',
+    };
+  }
+  return { outputBuffer: null, imageBuffer: await image.png(DEFAULT_PNG_OPTIONS).toBuffer(), contentType: 'image/png' };
+}
+
+/**
+ * Compose the board's background photos into a single raw RGBA plane at the
+ * requested output size, with the dim scrim already baked in.
+ *
+ * Layers are decoded one at a time and folded into the accumulator as raw
+ * pixels: no layer is ever re-encoded, and peak memory stays at roughly three
+ * raw planes no matter how many hold-set images a board has. A layer that fails
+ * to decode is skipped (the board still renders with whatever did load).
+ *
+ * Dimming is a linear scale rather than a composited black scrim: over an
+ * opaque photo, compositing black at opacity `d` is exactly `rgb × (1 - d)`, so
+ * the output is identical while a full W×H×4 scrim allocation disappears. It is
+ * baked into the base because the caller's cache key includes the dim value.
+ *
+ * Returns null when no background image resolves — the caller then falls back
+ * to an overlay-only render.
+ */
+export async function composeBoardBaseBuffer(params: {
+  boardDetails: RenderableBoardDetails;
+  width: number;
+  height: number;
+  thumbnail: boolean;
+  dimBackground: number;
+  resolveImagePath: ResolveImagePath;
+}): Promise<Buffer | null> {
+  const { boardDetails, width, height, thumbnail, dimBackground, resolveImagePath } = params;
+  const rawLayer = { width, height, channels: 4 as const };
+
+  const bgFsPaths = getBackgroundRelPaths(boardDetails, thumbnail)
+    .map((relPath) => resolveImagePath(relPath))
+    .filter((fsPath): fsPath is string => fsPath !== null);
+  if (bgFsPaths.length === 0) return null;
+
+  let base: Buffer | null = null;
+  for (const fsPath of bgFsPaths) {
+    try {
+      const layer = await sharp(fsPath).resize(width, height, { fit: 'fill' }).ensureAlpha().raw().toBuffer();
+      if (base === null) {
+        base = layer;
+        continue;
+      }
+      base = await sharp(base, { raw: rawLayer })
+        .composite([{ input: layer, raw: rawLayer, blend: 'over' }])
+        .raw()
+        .toBuffer();
+    } catch {
+      // A single unreadable board photo must not fail the whole render.
+    }
+  }
+
+  if (base === null) return null;
+  if (dimBackground <= 0) return base;
+
+  const keep = 1 - dimBackground;
+  return sharp(base, { raw: rawLayer }).linear([keep, keep, keep, 1], [0, 0, 0, 0]).raw().toBuffer();
+}
 
 /**
  * Single-shot render used by the web `board-render` route: takes the WASM
  * overlay RGBA and produces the final encoded image, optionally compositing
  * background board photos and (for the OG variant) the social-card backdrop.
+ *
+ * Pass `caches` to reuse the board-photo base across requests. Without it every
+ * call re-decodes the board photos, which at ~50k renders/day is the bulk of
+ * both the CPU and the peak memory.
  */
 export async function renderBoardImageBuffer({
   overlayBuffer,
@@ -92,111 +205,147 @@ export async function renderBoardImageBuffer({
   dimBackground,
   boardDetails,
   resolveImagePath,
+  caches,
 }: RenderBoardImageParams): Promise<RenderBoardImageResult> {
   const sharpT0 = performance.now();
+  const rawPlane = { width, height, channels: 4 as const };
   let imageBuffer: Buffer | null = null;
   let outputBuffer: Buffer | null = null;
   let outputContentType = 'image/png';
   let bgMs = 0;
   let composeMs = 0;
   let didCompositeBackground = false;
+  let cache: RenderBoardImageResult['cache'] = 'none';
 
-  if (includeBackground) {
+  const overlayOnlyImage = () => sharp(overlayBuffer, { raw: rawPlane });
+  const overlayWebpOptions: sharp.WebpOptions = thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true };
+  const bgRelPaths = includeBackground ? getBackgroundRelPaths(boardDetails, thumbnail) : [];
+
+  if (includeBackground && isOgVariant && dimBackground === 0) {
+    // OG social card: backdrop + board photos are identical for every climb on
+    // the board, so the composed base is cached and only the overlay composite
+    // + encode runs per climb.
     const bgT0 = performance.now();
-    const bgRelPaths = getBackgroundRelPaths(boardDetails, thumbnail);
-    const bgFsPaths = bgRelPaths
-      .map((relPath) => resolveImagePath(relPath))
-      .filter((path): path is string => path !== null);
+    const ogKey = `${bgRelPaths.join('|')}:${width}x${height}:og`;
+    let ogBase = caches?.ogBase?.get(ogKey);
+    if (ogBase) {
+      cache = 'hit';
+    } else {
+      ogBase = await composeOgBaseBuffer({ boardDetails, boardWidth: width, boardHeight: height, resolveImagePath });
+      caches?.ogBase?.set(ogKey, ogBase);
+      cache = caches?.ogBase ? 'miss' : 'none';
+    }
     bgMs = performance.now() - bgT0;
 
-    if (bgFsPaths.length > 0) {
-      // Load and resize background images, skipping any that fail.
-      const results = await Promise.allSettled(
-        bgFsPaths.map((fsPath) => sharp(fsPath).resize(width, height, { fit: 'fill' }).toBuffer()),
-      );
-      const resizedBuffers = results
-        .filter((result): result is PromiseFulfilledResult<Buffer> => result.status === 'fulfilled')
-        .map((result) => result.value);
+    const composeT0 = performance.now();
+    const encoded = await encodeOgImage({
+      base: ogBase.base,
+      overlay: { buffer: overlayBuffer, width, height, left: ogBase.left, top: ogBase.top },
+      format,
+    });
+    outputBuffer = encoded.buffer;
+    outputContentType = encoded.contentType;
+    composeMs = performance.now() - composeT0;
+    didCompositeBackground = true;
+  } else if (includeBackground && isOgVariant) {
+    // Dimmed OG card: no caller asks for this today, so it keeps the original
+    // uncached composite rather than growing a third cache key.
+    const bgT0 = performance.now();
+    const bgFsPaths = bgRelPaths
+      .map((relPath) => resolveImagePath(relPath))
+      .filter((fsPath): fsPath is string => fsPath !== null);
+    bgMs = performance.now() - bgT0;
 
-      const [firstBg, ...restBgs] = resizedBuffers;
+    const composeT0 = performance.now();
+    const results = await Promise.allSettled(
+      bgFsPaths.map((fsPath) => sharp(fsPath).resize(width, height, { fit: 'fill' }).toBuffer()),
+    );
+    const [firstBg, ...restBgs] = results
+      .filter((result): result is PromiseFulfilledResult<Buffer> => result.status === 'fulfilled')
+      .map((result) => result.value);
 
-      if (firstBg) {
-        // Composite: first background as base → remaining backgrounds → optional
-        // dim scrim → WASM overlay on top.
-        const composeT0 = performance.now();
-        const dimLayer =
-          dimBackground > 0
-            ? await sharp({
-                create: { width, height, channels: 4, background: { r: 0, g: 0, b: 0, alpha: dimBackground } },
-              })
-                .png()
-                .toBuffer()
-            : null;
-        const compositedImage = sharp(firstBg).composite([
+    if (firstBg) {
+      const dimLayer = await sharp({
+        create: { width, height, channels: 4, background: { r: 0, g: 0, b: 0, alpha: dimBackground } },
+      })
+        .png()
+        .toBuffer();
+      imageBuffer = await sharp(firstBg)
+        .composite([
           ...restBgs.map((buf) => ({ input: buf, blend: 'over' as const })),
-          ...(dimLayer ? [{ input: dimLayer, blend: 'over' as const }] : []),
-          {
-            input: overlayBuffer,
-            raw: { width, height, channels: 4 as const },
-            blend: 'over' as const,
-          },
-        ]);
-        if (!isOgVariant && format === 'webp') {
-          outputBuffer = await compositedImage
-            .webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : DEFAULT_WEBP_OPTIONS)
-            .toBuffer();
-          outputContentType = 'image/webp';
-        } else if (!isOgVariant && format === 'jpeg') {
-          outputBuffer = await compositedImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
-          outputContentType = 'image/jpeg';
-        } else {
-          imageBuffer = await compositedImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
-        }
-        composeMs = performance.now() - composeT0;
-        didCompositeBackground = true;
-      } else {
-        // All background loads failed — fall back to overlay-only.
-        const composeT0 = performance.now();
-        const overlayImage = sharp(overlayBuffer, { raw: { width, height, channels: 4 } });
-        if (!isOgVariant && format === 'webp') {
-          outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
-          outputContentType = 'image/webp';
-        } else if (!isOgVariant && format === 'jpeg') {
-          outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
-          outputContentType = 'image/jpeg';
-        } else {
-          imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
-        }
-        composeMs = performance.now() - composeT0;
-      }
+          { input: dimLayer, blend: 'over' as const },
+          { input: overlayBuffer, raw: rawPlane, blend: 'over' as const },
+        ])
+        .png(DEFAULT_PNG_OPTIONS)
+        .toBuffer();
+      didCompositeBackground = true;
     } else {
-      // No background images found — fall back to overlay-only lossless.
-      const composeT0 = performance.now();
-      const overlayImage = sharp(overlayBuffer, { raw: { width, height, channels: 4 } });
-      if (!isOgVariant && format === 'webp') {
-        outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
-        outputContentType = 'image/webp';
-      } else if (!isOgVariant && format === 'jpeg') {
-        outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
-        outputContentType = 'image/jpeg';
-      } else {
-        imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
-      }
-      composeMs = performance.now() - composeT0;
+      imageBuffer = await overlayOnlyImage().png(DEFAULT_PNG_OPTIONS).toBuffer();
     }
+    composeMs = performance.now() - composeT0;
+  } else if (includeBackground) {
+    // Board photos folded to one raw RGBA plane (dim baked in), cached per board
+    // config + size. The per-climb work is then a single decode-free composite.
+    const bgT0 = performance.now();
+    const baseKey = `${bgRelPaths.join('|')}:${width}x${height}:d${dimBackground}`;
+    let base = caches?.boardBase?.get(baseKey);
+    if (base) {
+      cache = 'hit';
+    } else {
+      base =
+        (await composeBoardBaseBuffer({
+          boardDetails,
+          width,
+          height,
+          thumbnail,
+          dimBackground,
+          resolveImagePath,
+        })) ?? undefined;
+      if (base) caches?.boardBase?.set(baseKey, base);
+      cache = caches?.boardBase ? 'miss' : 'none';
+    }
+    bgMs = performance.now() - bgT0;
+
+    const composeT0 = performance.now();
+    if (base) {
+      const composited = sharp(base, { raw: rawPlane }).composite([
+        { input: overlayBuffer, raw: rawPlane, blend: 'over' as const },
+      ]);
+      const encoded = await encodeRendered(composited, {
+        isOgVariant,
+        format,
+        thumbnail,
+        webpOptions: thumbnail ? THUMBNAIL_WEBP_OPTIONS : DEFAULT_WEBP_OPTIONS,
+      });
+      outputBuffer = encoded.outputBuffer;
+      imageBuffer = encoded.imageBuffer;
+      outputContentType = encoded.contentType;
+      didCompositeBackground = true;
+    } else {
+      // No background image resolved — fall back to overlay-only lossless.
+      const encoded = await encodeRendered(overlayOnlyImage(), {
+        isOgVariant,
+        format,
+        thumbnail,
+        webpOptions: overlayWebpOptions,
+      });
+      outputBuffer = encoded.outputBuffer;
+      imageBuffer = encoded.imageBuffer;
+      outputContentType = encoded.contentType;
+    }
+    composeMs = performance.now() - composeT0;
   } else {
     // Default: overlay-only lossless WebP (25-30% smaller than PNG).
     const composeT0 = performance.now();
-    const overlayImage = sharp(overlayBuffer, { raw: { width, height, channels: 4 } });
-    if (!isOgVariant && format === 'webp') {
-      outputBuffer = await overlayImage.webp(thumbnail ? THUMBNAIL_WEBP_OPTIONS : { lossless: true }).toBuffer();
-      outputContentType = 'image/webp';
-    } else if (!isOgVariant && format === 'jpeg') {
-      outputBuffer = await overlayImage.jpeg(getJpegOptions(thumbnail)).toBuffer();
-      outputContentType = 'image/jpeg';
-    } else {
-      imageBuffer = await overlayImage.png(DEFAULT_PNG_OPTIONS).toBuffer();
-    }
+    const encoded = await encodeRendered(overlayOnlyImage(), {
+      isOgVariant,
+      format,
+      thumbnail,
+      webpOptions: overlayWebpOptions,
+    });
+    outputBuffer = encoded.outputBuffer;
+    imageBuffer = encoded.imageBuffer;
+    outputContentType = encoded.contentType;
     composeMs = performance.now() - composeT0;
   }
 
@@ -245,6 +394,7 @@ export async function renderBoardImageBuffer({
     buffer: outputBuffer,
     contentType: outputContentType,
     timings: { sharpMs, composeMs, encodeMs, bgMs },
+    cache,
   };
 }
 

--- a/packages/shared/board-render/src/semaphore.ts
+++ b/packages/shared/board-render/src/semaphore.ts
@@ -1,0 +1,64 @@
+/**
+ * A minimal FIFO concurrency limiter.
+ *
+ * Board rendering is CPU- *and* memory-heavy: every concurrent render holds a
+ * WASM overlay plane plus libvips working buffers, so an unbounded number of
+ * simultaneous requests is what turns a busy minute into an OOM kill rather
+ * than a slow response. Queueing keeps peak memory proportional to `limit`
+ * instead of to the arrival rate — requests wait instead of the instance dying.
+ *
+ * Waiters are served in arrival order; a slot is released in `finally`, so a
+ * rejecting task never strands one.
+ */
+export type Semaphore = {
+  run<T>(fn: () => Promise<T>): Promise<T>;
+  /** Tasks currently holding a slot. */
+  readonly active: number;
+  /** Tasks waiting for a slot. */
+  readonly pending: number;
+};
+
+export function createSemaphore(limit: number): Semaphore {
+  // A non-finite or sub-1 limit would deadlock every caller — clamp instead.
+  const slots = Number.isFinite(limit) && limit >= 1 ? Math.floor(limit) : 1;
+
+  const waiters: Array<() => void> = [];
+  let active = 0;
+
+  const acquire = (): Promise<void> =>
+    new Promise<void>((resolve) => {
+      if (active < slots) {
+        active += 1;
+        resolve();
+        return;
+      }
+      waiters.push(resolve);
+    });
+
+  const release = (): void => {
+    const next = waiters.shift();
+    if (next) {
+      // Hand the slot straight to the next waiter — `active` stays put.
+      next();
+      return;
+    }
+    active -= 1;
+  };
+
+  return {
+    async run<T>(fn: () => Promise<T>): Promise<T> {
+      await acquire();
+      try {
+        return await fn();
+      } finally {
+        release();
+      }
+    },
+    get active() {
+      return active;
+    },
+    get pending() {
+      return waiters.length;
+    },
+  };
+}

--- a/packages/shared/board-render/src/validation.ts
+++ b/packages/shared/board-render/src/validation.ts
@@ -19,6 +19,16 @@ export const MAX_FRAMES_LENGTH = 16_384;
 
 export const MAX_SET_IDS = 10;
 
+/**
+ * Hard ceiling on the rendered pixel count. Every in-flight plane costs 4 bytes
+ * a pixel, so this is what stops a hand-crafted request from sizing a render
+ * past what the process can hold. The largest real board is Kilter's 1080×2498
+ * (~2.70 MP) — `board-dimensions.test.ts` fails if a board ever grows past this
+ * number, so a new board shows up as a red test rather than a 400 in
+ * production. Oversized requests are rejected, never resampled.
+ */
+export const MAX_RENDER_OUTPUT_PIXELS = 3_000_000;
+
 export function normalizeOutputFormat(format: string): OutputFormat | null {
   if (format === 'jpg') return 'jpeg';
   if (format === 'webp' || format === 'png' || format === 'jpeg') return format;

--- a/packages/web/app/api/internal/board-render/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/board-render/__tests__/route.test.ts
@@ -657,6 +657,11 @@ describe('board-render API route', () => {
   it.each([
     // label, params both requests share, the one param that differs, whether
     // the mocked encoder can show the difference in the response body.
+    ['board_name', {}, { board_name: 'tension' }, false],
+    ['layout_id', {}, { layout_id: '8' }, false],
+    ['size_id', {}, { size_id: '17' }, false],
+    ['set_ids', {}, { set_ids: '1,27' }, false],
+    ['frames', {}, { frames: 'p1073r44' }, false],
     ['format', {}, { format: 'png' }, true],
     ['thumbnail', {}, { thumbnail: '1' }, true],
     ['include_background', {}, { include_background: '0' }, true],

--- a/packages/web/app/api/internal/board-render/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/board-render/__tests__/route.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 import { NextRequest } from 'next/server';
+import { resetBoardRenderCaches } from '@/app/lib/board-render-cache';
 import { GET } from '../route';
 
 // Mock WASM module - returns raw RGBA with 8-byte dimension header
@@ -34,13 +35,17 @@ vi.mock('fs', () => ({
   existsSync: (path: string) => mockExistsSync(path),
 }));
 
-// Mock sharp - tracks calls to composite() and webp() options
+// Mock sharp - tracks the chained operations the pipeline drives.
 const mockComposite = vi.fn();
 const mockResize = vi.fn();
+const mockLinear = vi.fn();
 const mockWebpOptions = vi.fn();
 const mockPngOptions = vi.fn();
 const mockJpegOptions = vi.fn();
-const mockSharpInstance = () => {
+// Substrings of an input path whose decode should reject, per test.
+const failingInputPaths: string[] = [];
+
+const mockSharpInstance = (shouldFail: boolean) => {
   const instance = {
     composite: vi.fn((...args: unknown[]) => {
       mockComposite(...args);
@@ -48,8 +53,18 @@ const mockSharpInstance = () => {
     }),
     resize: vi.fn((...args: unknown[]) => {
       mockResize(...args);
-      return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0xb0]))) };
+      return instance;
     }),
+    ensureAlpha: vi.fn(() => instance),
+    raw: vi.fn(() => instance),
+    linear: vi.fn((...args: unknown[]) => {
+      mockLinear(...args);
+      return instance;
+    }),
+    // Raw-pixel output: the board base and the per-layer decodes.
+    toBuffer: vi.fn(() =>
+      shouldFail ? Promise.reject(new Error('corrupt image')) : Promise.resolve(Buffer.from([0xb0])),
+    ),
     webp: vi.fn((opts: unknown) => {
       mockWebpOptions(opts);
       return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0x52, 0x49, 0x46, 0x46]))) };
@@ -65,9 +80,15 @@ const mockSharpInstance = () => {
   };
   return instance;
 };
-const mockSharpDefault = vi.fn((_input?: unknown, _options?: unknown) => mockSharpInstance());
+const mockSharpDefault = vi.fn((input?: unknown, _options?: unknown) =>
+  mockSharpInstance(typeof input === 'string' && failingInputPaths.some((fragment) => input.includes(fragment))),
+);
 vi.mock('sharp', () => ({
-  default: (input?: unknown, options?: unknown) => mockSharpDefault(input, options),
+  // `cache`/`concurrency` are called once at route module load (sharp-runtime).
+  default: Object.assign((input?: unknown, options?: unknown) => mockSharpDefault(input, options), {
+    cache: () => undefined,
+    concurrency: () => undefined,
+  }),
 }));
 
 vi.mock('@/app/lib/board-utils', () => ({
@@ -136,11 +157,12 @@ vi.mock('@/app/components/board-renderer/types', () => ({
 vi.mock('@/app/lib/seo/og', () => ({
   OG_IMAGE_WIDTH: 1200,
   OG_IMAGE_HEIGHT: 630,
-  createOgImageHeaders: vi.fn(({ contentType }: { contentType: string }) => ({
+  createOgImageHeaders: vi.fn(({ contentType, serverTiming }: { contentType: string; serverTiming?: string }) => ({
     'Content-Type': contentType,
     'Cache-Control': 'public, max-age=31536000, s-maxage=31536000, immutable',
     'CDN-Cache-Control': 'public, s-maxage=31536000, immutable',
     'Vercel-CDN-Cache-Control': 'public, s-maxage=31536000, immutable',
+    ...(serverTiming ? { 'Server-Timing': serverTiming } : {}),
   })),
 }));
 
@@ -164,6 +186,10 @@ describe('board-render API route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExistsSync.mockReturnValue(true);
+    failingInputPaths.length = 0;
+    // Module-level caches outlive a request by design — reset them so one
+    // test's render can't serve another test's request.
+    resetBoardRenderCaches();
   });
 
   it('returns 200 with WebP content for valid request', async () => {
@@ -434,22 +460,33 @@ describe('board-render API route', () => {
     expect(mockWebpOptions).toHaveBeenCalledWith({ lossless: true });
   });
 
-  it('adds a dim scrim layer to the composite when dim_background is set', async () => {
+  it('dims the board base with a linear scale instead of compositing a scrim', async () => {
     const response = await GET(
       makeRequest({ ...validParams, thumbnail: '1', include_background: '1', dim_background: '0.18' }),
     );
     expect(response.status).toBe(200);
+
+    // rgb × (1 - 0.18), alpha untouched — no W×H×4 black scrim allocated.
+    expect(mockLinear).toHaveBeenCalledTimes(1);
+    const [multipliers, offsets] = mockLinear.mock.calls[0] as [number[], number[]];
+    expect(multipliers[0]).toBeCloseTo(0.82, 10);
+    expect(multipliers[1]).toBeCloseTo(0.82, 10);
+    expect(multipliers[2]).toBeCloseTo(0.82, 10);
+    expect(multipliers[3]).toBe(1);
+    expect(offsets).toEqual([0, 0, 0, 0]);
+
+    // Only the holds overlay is composited onto the base.
     expect(mockComposite).toHaveBeenCalledTimes(1);
-    // The single background is the base; the composite array is [dim scrim, holds overlay].
     const layers = mockComposite.mock.calls[0][0] as unknown[];
-    expect(layers).toHaveLength(2);
+    expect(layers).toHaveLength(1);
   });
 
-  it('does not add a dim scrim when dim_background is absent', async () => {
+  it('does not dim when dim_background is absent', async () => {
     const response = await GET(makeRequest({ ...validParams, thumbnail: '1', include_background: '1' }));
     expect(response.status).toBe(200);
+    expect(mockLinear).not.toHaveBeenCalled();
     expect(mockComposite).toHaveBeenCalledTimes(1);
-    // composite array is [holds overlay] only — no scrim.
+    // composite array is [holds overlay] only.
     const layers = mockComposite.mock.calls[0][0] as unknown[];
     expect(layers).toHaveLength(1);
   });
@@ -500,46 +537,107 @@ describe('board-render API route', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
-    // Make sharp fail for paths containing "layer-bad" but succeed for others
-    let callIndex = 0;
-    mockSharpDefault.mockImplementation(() => {
-      const idx = callIndex++;
-      // First call is the WASM overlay sharp (raw buffer), calls after are backgrounds.
-      // Background calls: index 0 = good, index 1 = bad, index 2 = good
-      const instance = {
-        composite: vi.fn((...args: unknown[]) => {
-          mockComposite(...args);
-          return instance;
-        }),
-        resize: vi.fn((...args: unknown[]) => {
-          mockResize(...args);
-          if (idx === 1) {
-            // Second background image fails
-            return { toBuffer: vi.fn(() => Promise.reject(new Error('corrupt image'))) };
-          }
-          return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0xb0]))) };
-        }),
-        webp: vi.fn((opts: unknown) => {
-          mockWebpOptions(opts);
-          return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0x52, 0x49, 0x46, 0x46]))) };
-        }),
-        png: vi.fn((opts: unknown) => {
-          mockPngOptions(opts);
-          return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0x89, 0x50, 0x4e, 0x47]))) };
-        }),
-        jpeg: vi.fn((opts: unknown) => {
-          mockJpegOptions(opts);
-          return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0xff, 0xd8, 0xff]))) };
-        }),
-      };
-      return instance;
-    });
+    // The middle layer's decode rejects; the other two must still land.
+    failingInputPaths.push('layer-bad');
 
     const response = await GET(makeRequest({ ...validParams, include_background: '1' }));
     expect(response.status).toBe(200);
-    // Composite should still be called with the surviving backgrounds + overlay
-    expect(mockComposite).toHaveBeenCalled();
+    // Two surviving layers fold into the base (1 composite) + the overlay (1).
+    expect(mockComposite).toHaveBeenCalledTimes(2);
     // Should use lossy WebP (composited output) not lossless (fallback)
     expect(mockWebpOptions).toHaveBeenCalledWith({ quality: 80 });
+  });
+
+  it('serves an identical repeat request from the byte cache without re-rendering', async () => {
+    const params = { ...validParams, include_background: '1' };
+
+    const first = await GET(makeRequest(params));
+    expect(first.status).toBe(200);
+    expect(mockRenderOverlay).toHaveBeenCalledTimes(1);
+    const firstBytes = new Uint8Array(await first.arrayBuffer());
+
+    const second = await GET(makeRequest(params));
+    expect(second.status).toBe(200);
+    // No second WASM render, no second sharp pipeline.
+    expect(mockRenderOverlay).toHaveBeenCalledTimes(1);
+    expect(second.headers.get('Server-Timing')).toContain('cache;desc=hit');
+    expect(second.headers.get('Content-Type')).toBe(first.headers.get('Content-Type'));
+    expect(new Uint8Array(await second.arrayBuffer())).toEqual(firstBytes);
+  });
+
+  it('reports a board-base cache hit once the board photos are composed', async () => {
+    await GET(makeRequest({ ...validParams, include_background: '1' }));
+    // Same board, different climb — the base is reused, the overlay is not.
+    const response = await GET(makeRequest({ ...validParams, include_background: '1', frames: 'p1073r44' }));
+
+    expect(response.status).toBe(200);
+    expect(mockRenderOverlay).toHaveBeenCalledTimes(2);
+    expect(response.headers.get('Server-Timing')).toContain('cache;desc=base-hit');
+  });
+
+  it('coalesces concurrent identical requests into a single render', async () => {
+    const params = { ...validParams, include_background: '1' };
+
+    const [first, second] = await Promise.all([GET(makeRequest(params)), GET(makeRequest(params))]);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(mockRenderOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the queue wait in Server-Timing', async () => {
+    const response = await GET(makeRequest({ ...validParams, include_background: '1' }));
+    expect(response.headers.get('Server-Timing')).toMatch(/queue;dur=\d/);
+  });
+
+  it('returns 400 when the requested render exceeds the pixel ceiling', async () => {
+    const { getBoardDetailsForBoard } = await import('@/app/lib/board-utils');
+    vi.mocked(getBoardDetailsForBoard).mockReturnValueOnce({
+      board_name: 'kilter',
+      layout_id: 1,
+      size_id: 7,
+      set_ids: [1, 20],
+      boardWidth: 2000,
+      boardHeight: 3000,
+      holdsData: [{ id: 1073, mirroredHoldId: null, cx: 200, cy: 300, r: 20 }],
+      images_to_holds: { 'huge.png': [] },
+      edge_left: 0,
+      edge_right: 144,
+      edge_bottom: 0,
+      edge_top: 180,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const response = await GET(makeRequest(validParams));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain('3000000');
+    // Nothing is rendered or allocated for an oversized request.
+    expect(mockRenderOverlay).not.toHaveBeenCalled();
+    expect(mockSharpDefault).not.toHaveBeenCalled();
+  });
+
+  it('still renders a board at the largest real size', async () => {
+    const { getBoardDetailsForBoard } = await import('@/app/lib/board-utils');
+    vi.mocked(getBoardDetailsForBoard).mockReturnValueOnce({
+      board_name: 'kilter',
+      layout_id: 5,
+      size_id: 15,
+      set_ids: [24],
+      // Kilter's tallest board: 1080×2498 ≈ 2.70 MP, just under the ceiling.
+      boardWidth: 1080,
+      boardHeight: 2498,
+      holdsData: [{ id: 1073, mirroredHoldId: null, cx: 200, cy: 300, r: 20 }],
+      images_to_holds: { 'tall.png': [] },
+      edge_left: 0,
+      edge_right: 144,
+      edge_bottom: 0,
+      edge_top: 180,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const response = await GET(makeRequest({ ...validParams, layout_id: '5', size_id: '15', set_ids: '24' }));
+    expect(response.status).toBe(200);
   });
 });

--- a/packages/web/app/api/internal/board-render/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/board-render/__tests__/route.test.ts
@@ -631,6 +631,15 @@ describe('board-render API route', () => {
     expect(new Uint8Array(await second.arrayBuffer())).toEqual(firstBytes);
   });
 
+  it('reports cache;desc=none for an overlay-only render', async () => {
+    // No background means no base to cache — reporting it as a `miss` would
+    // read as a cache the route keeps failing to fill.
+    const response = await GET(makeRequest(validParams));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Server-Timing')).toContain('cache;desc=none');
+  });
+
   it('reports a board-base cache hit once the board photos are composed', async () => {
     await GET(makeRequest({ ...validParams, include_background: '1' }));
     // Same board, different climb — the base is reused, the overlay is not.

--- a/packages/web/app/api/internal/board-render/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/board-render/__tests__/route.test.ts
@@ -1,12 +1,46 @@
 // @vitest-environment node
 
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vite-plus/test';
 import { NextRequest } from 'next/server';
 import { resetBoardRenderCaches } from '@/app/lib/board-render-cache';
 import { GET } from '../route';
 
+// The route builds its semaphore once, at module load, from this env var —
+// hoisted so it is set before `../route` is imported. One slot makes the
+// concurrency and load-shedding behaviour observable with a handful of requests.
+vi.hoisted(() => {
+  process.env.BOARD_RENDER_CONCURRENCY = '1';
+});
+
+// Renders in flight right now, and the most that ever overlapped. Incremented
+// when a render starts its WASM pass, decremented when its encode finishes.
+let activeRenders = 0;
+let peakActiveRenders = 0;
+// When set, every encode parks here — holds renders open so a test can watch
+// what the semaphore admits.
+let renderGate: Promise<void> | null = null;
+
+let releaseRenderGate: (() => void) | null = null;
+
+function openRenderGate(): () => void {
+  let resolveGate!: () => void;
+  renderGate = new Promise<void>((resolve) => {
+    resolveGate = resolve;
+  });
+  releaseRenderGate = () => {
+    renderGate = null;
+    resolveGate();
+  };
+  return releaseRenderGate;
+}
+
+/** Let every pending microtask (and timer callback) settle. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 // Mock WASM module - returns raw RGBA with 8-byte dimension header
 const mockRenderOverlay = vi.fn((_config: string) => {
+  activeRenders += 1;
+  peakActiveRenders = Math.max(peakActiveRenders, activeRenders);
   // 2x2 pixel image: 8 bytes header + 16 bytes RGBA data
   const buf = new Uint8Array(8 + 16);
   const view = new DataView(buf.buffer);
@@ -45,6 +79,21 @@ const mockJpegOptions = vi.fn();
 // Substrings of an input path whose decode should reject, per test.
 const failingInputPaths: string[] = [];
 
+/**
+ * Terminal encode: the bytes carry the format and its options, so two renders
+ * that differ only in encode settings (thumbnail vs full, lossless vs lossy)
+ * produce visibly different bodies. Also the point where a render is counted as
+ * finished, and where the gate parks it.
+ */
+const terminalEncode = (kind: string, options: unknown) => {
+  const bytes = Buffer.from(`${kind}:${JSON.stringify(options ?? null)}`);
+  return vi.fn(async () => {
+    if (renderGate) await renderGate;
+    activeRenders = Math.max(0, activeRenders - 1);
+    return bytes;
+  });
+};
+
 const mockSharpInstance = (shouldFail: boolean) => {
   const instance = {
     composite: vi.fn((...args: unknown[]) => {
@@ -67,15 +116,15 @@ const mockSharpInstance = (shouldFail: boolean) => {
     ),
     webp: vi.fn((opts: unknown) => {
       mockWebpOptions(opts);
-      return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0x52, 0x49, 0x46, 0x46]))) };
+      return { toBuffer: terminalEncode('webp', opts) };
     }),
     png: vi.fn((opts: unknown) => {
       mockPngOptions(opts);
-      return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0x89, 0x50, 0x4e, 0x47]))) };
+      return { toBuffer: terminalEncode('png', opts) };
     }),
     jpeg: vi.fn((opts: unknown) => {
       mockJpegOptions(opts);
-      return { toBuffer: vi.fn(() => Promise.resolve(Buffer.from([0xff, 0xd8, 0xff]))) };
+      return { toBuffer: terminalEncode('jpeg', opts) };
     }),
   };
   return instance;
@@ -187,9 +236,23 @@ describe('board-render API route', () => {
     vi.clearAllMocks();
     mockExistsSync.mockReturnValue(true);
     failingInputPaths.length = 0;
+    activeRenders = 0;
+    peakActiveRenders = 0;
+    renderGate = null;
+    releaseRenderGate = null;
     // Module-level caches outlive a request by design — reset them so one
     // test's render can't serve another test's request.
     resetBoardRenderCaches();
+  });
+
+  afterEach(async () => {
+    // A failing gated test would otherwise leave its renders parked forever,
+    // holding the semaphore and timing out every test after it. Release the
+    // gate and drain the queue so a failure stays local to its own test.
+    releaseRenderGate?.();
+    releaseRenderGate = null;
+    await flush();
+    await flush();
   });
 
   it('returns 200 with WebP content for valid request', async () => {
@@ -460,25 +523,27 @@ describe('board-render API route', () => {
     expect(mockWebpOptions).toHaveBeenCalledWith({ lossless: true });
   });
 
-  it('dims the board base with a linear scale instead of compositing a scrim', async () => {
+  it('composites a full-bleed black scrim into the base when dim_background is set', async () => {
     const response = await GET(
       makeRequest({ ...validParams, thumbnail: '1', include_background: '1', dim_background: '0.18' }),
     );
     expect(response.status).toBe(200);
 
-    // rgb × (1 - 0.18), alpha untouched — no W×H×4 black scrim allocated.
-    expect(mockLinear).toHaveBeenCalledTimes(1);
-    const [multipliers, offsets] = mockLinear.mock.calls[0] as [number[], number[]];
-    expect(multipliers[0]).toBeCloseTo(0.82, 10);
-    expect(multipliers[1]).toBeCloseTo(0.82, 10);
-    expect(multipliers[2]).toBeCloseTo(0.82, 10);
-    expect(multipliers[3]).toBe(1);
-    expect(offsets).toEqual([0, 0, 0, 0]);
+    // Two composites onto the cached base: the scrim, then the holds overlay.
+    // The scrim must be a real layer — scaling RGB instead would leave the
+    // transparent parts of the board photo undimmed (see pipeline.ts).
+    expect(mockComposite).toHaveBeenCalledTimes(2);
+    expect(mockLinear).not.toHaveBeenCalled();
 
-    // Only the holds overlay is composited onto the base.
-    expect(mockComposite).toHaveBeenCalledTimes(1);
-    const layers = mockComposite.mock.calls[0][0] as unknown[];
-    expect(layers).toHaveLength(1);
+    const scrimLayers = mockComposite.mock.calls[0][0] as Array<{
+      input?: { create?: { channels?: number; background?: { r?: number; alpha?: number } } };
+    }>;
+    expect(scrimLayers).toHaveLength(1);
+    expect(scrimLayers[0].input?.create?.background).toEqual({ r: 0, g: 0, b: 0, alpha: 0.18 });
+    expect(scrimLayers[0].input?.create?.channels).toBe(4);
+
+    const overlayLayers = mockComposite.mock.calls[1][0] as unknown[];
+    expect(overlayLayers).toHaveLength(1);
   });
 
   it('does not dim when dim_background is absent', async () => {
@@ -486,9 +551,10 @@ describe('board-render API route', () => {
     expect(response.status).toBe(200);
     expect(mockLinear).not.toHaveBeenCalled();
     expect(mockComposite).toHaveBeenCalledTimes(1);
-    // composite array is [holds overlay] only.
-    const layers = mockComposite.mock.calls[0][0] as unknown[];
+    // composite array is [holds overlay] only — no scrim.
+    const layers = mockComposite.mock.calls[0][0] as Array<{ input?: { create?: unknown } }>;
     expect(layers).toHaveLength(1);
+    expect(layers[0].input).not.toHaveProperty('create');
   });
 
   it('returns 400 when dim_background is out of range', async () => {
@@ -583,6 +649,112 @@ describe('board-render API route', () => {
     expect(first.status).toBe(200);
     expect(second.status).toBe(200);
     expect(mockRenderOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  // Every param that changes a pixel has to be in the byte-cache key. Drop one
+  // and the second request of its pair is served the first one's bytes — so
+  // each case asserts a genuine second render, not just a 200.
+  it.each([
+    // label, params both requests share, the one param that differs, whether
+    // the mocked encoder can show the difference in the response body.
+    ['format', {}, { format: 'png' }, true],
+    ['thumbnail', {}, { thumbnail: '1' }, true],
+    ['include_background', {}, { include_background: '0' }, true],
+    ['dim_background', {}, { dim_background: '0.18' }, false],
+    ['variant', { format: 'png' }, { variant: 'og' }, false],
+  ] as Array<[string, Record<string, string>, Record<string, string>, boolean]>)(
+    'keys the byte cache on %s',
+    async (_label, shared, override, expectDistinctBody) => {
+      const params = { ...validParams, include_background: '1', ...shared };
+
+      const first = await GET(makeRequest(params));
+      expect(first.status).toBe(200);
+      expect(mockRenderOverlay).toHaveBeenCalledTimes(1);
+      const firstBytes = Buffer.from(await first.arrayBuffer());
+
+      const second = await GET(makeRequest({ ...params, ...override }));
+      expect(second.status).toBe(200);
+      // A key missing this param would have served the cached bytes instead.
+      expect(mockRenderOverlay).toHaveBeenCalledTimes(2);
+      expect(second.headers.get('Server-Timing')).not.toContain('cache;desc=hit');
+
+      if (expectDistinctBody) {
+        const secondBytes = Buffer.from(await second.arrayBuffer());
+        const differs =
+          !secondBytes.equals(firstBytes) || second.headers.get('Content-Type') !== first.headers.get('Content-Type');
+        expect(differs).toBe(true);
+      }
+    },
+  );
+
+  it('never runs more renders at once than the concurrency limit', async () => {
+    const closeGate = openRenderGate();
+
+    const inFlight = ['p2001r42', 'p2002r42', 'p2003r42'].map((frames) =>
+      GET(makeRequest({ ...validParams, include_background: '1', frames })),
+    );
+    // Everything that can start has started; the rest are queued on the semaphore.
+    await flush();
+    expect(peakActiveRenders).toBe(1);
+
+    closeGate();
+    const responses = await Promise.all(inFlight);
+
+    expect(responses.map((response) => response.status)).toEqual([200, 200, 200]);
+    expect(mockRenderOverlay).toHaveBeenCalledTimes(3);
+    // Held across the whole drain, not just the first moment.
+    expect(peakActiveRenders).toBe(1);
+    expect(activeRenders).toBe(0);
+  });
+
+  it('sheds with 503 + Retry-After once the render queue is saturated', async () => {
+    const closeGate = openRenderGate();
+
+    // One render holds the single slot; the next 41 queue up. The 43rd arrives
+    // to a queue past the ceiling and is shed rather than made to wait.
+    const queued = Array.from({ length: 42 }, (_unused, index) =>
+      GET(makeRequest({ ...validParams, frames: `p${3000 + index}r42` })),
+    );
+    await flush();
+
+    const shed = await GET(makeRequest({ ...validParams, frames: 'p3999r42' }));
+
+    expect(shed.status).toBe(503);
+    expect(shed.headers.get('Retry-After')).toBe('5');
+    expect(shed.headers.get('Cache-Control')).toBe('no-store');
+    const body = await shed.json();
+    expect(body.error).toContain('saturated');
+
+    closeGate();
+    const drained = await Promise.all(queued);
+    expect(drained.every((response) => response.status === 200)).toBe(true);
+    // The shed request never rendered; the 42 that queued all did.
+    expect(mockRenderOverlay).toHaveBeenCalledTimes(42);
+  });
+
+  it('does not shed a request that can join an in-flight render', async () => {
+    const closeGate = openRenderGate();
+
+    const params = { ...validParams, frames: 'p4242r42' };
+    const queued = [
+      GET(makeRequest(params)),
+      ...Array.from({ length: 41 }, (_unused, index) =>
+        GET(makeRequest({ ...validParams, frames: `p${4300 + index}r42` })),
+      ),
+    ];
+    await flush();
+
+    // Same bytes as the render already in flight: it costs nothing to serve, so
+    // it must not be shed even with the queue over the ceiling.
+    const coalescedPromise = GET(makeRequest(params));
+    closeGate();
+
+    const coalesced = await coalescedPromise;
+    expect(coalesced.status).toBe(200);
+
+    await Promise.all(queued);
+    // 42 renders for 43 requests — the coalesced one paid for nothing.
+    expect(mockRenderOverlay).toHaveBeenCalledTimes(42);
   });
 
   it('reports the queue wait in Server-Timing', async () => {

--- a/packages/web/app/api/internal/board-render/__tests__/route.test.ts
+++ b/packages/web/app/api/internal/board-render/__tests__/route.test.ts
@@ -692,6 +692,24 @@ describe('board-render API route', () => {
     },
   );
 
+  it('serves cached bytes for a param the renderer never reads', async () => {
+    const params = { ...validParams, include_background: '1' };
+
+    await GET(makeRequest(params));
+    expect(mockRenderOverlay).toHaveBeenCalledTimes(1);
+
+    // `angle` is a board-config param elsewhere in the app, but this route
+    // never reads it and nothing angle-shaped reaches the WASM config — so the
+    // cached bytes are the right answer for it. The day angle (or any new
+    // param) starts changing pixels, this test goes red and the param belongs
+    // in the byte key above, not in this exclusion.
+    const second = await GET(makeRequest({ ...params, angle: '40' }));
+
+    expect(second.status).toBe(200);
+    expect(mockRenderOverlay).toHaveBeenCalledTimes(1);
+    expect(second.headers.get('Server-Timing')).toContain('cache;desc=hit');
+  });
+
   it('never runs more renders at once than the concurrency limit', async () => {
     const closeGate = openRenderGate();
 

--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -263,7 +263,8 @@ export async function GET(request: NextRequest) {
     }
 
     const queueT0 = performance.now();
-    // 0 for a coalesced request: it waited on another render, not on a slot.
+    // Time spent waiting before this request's own work could start: a slot for
+    // the request that renders, the whole shared render for one that coalesces.
     let queueMs = 0;
     const inFlight = inFlightRenders.get(byteKey);
     const renderPromise =
@@ -287,6 +288,7 @@ export async function GET(request: NextRequest) {
     if (!inFlight) inFlightRenders.set(byteKey, renderPromise);
 
     const rendered = await renderPromise;
+    if (inFlight) queueMs = performance.now() - queueT0;
 
     byteCache.set(byteKey, { buffer: rendered.buffer, contentType: rendered.contentType });
 

--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -8,16 +8,58 @@ import type { BoardName } from '@/app/lib/types';
 import { createOgImageHeaders } from '@/app/lib/seo/og';
 import {
   buildRenderConfig,
+  createSemaphore,
   isValidFramesString,
   MAX_FRAMES_LENGTH,
   normalizeOutputFormat,
   VALID_BOARD_NAMES,
+  type OutputFormat,
+  type RenderableBoardDetails,
+  type WasmRenderConfig,
 } from '@boardsesh/board-render';
 import { createOverlayRenderer } from '@boardsesh/board-render/wasm';
-import { renderBoardImageBuffer } from '@boardsesh/board-render/pipeline';
+import { renderBoardImageBuffer, type RenderTimings, type ResolveImagePath } from '@boardsesh/board-render/pipeline';
+import { boardBaseCache, byteCache, ogBaseCache } from '@/app/lib/board-render-cache';
+import { configureSharpForServerless } from '@/app/lib/sharp-runtime';
 
 // Node.js runtime for reliable WASM loading via filesystem
 export const runtime = 'nodejs';
+
+// libvips defaults assume a long-lived server; shrink its cache and thread pool
+// before the first render on this instance. See sharp-runtime.ts.
+configureSharpForServerless();
+
+/**
+ * Hard ceiling on the rendered pixel count. The largest real board is Kilter's
+ * 1080×2498 (~2.70 MP); anything past 3 MP is a hand-crafted request, and each
+ * one costs ~4 bytes/pixel per in-flight plane. Rejected outright rather than
+ * resampled — a caller asking for a size no board has is a bug, not a photo.
+ */
+const MAX_OUTPUT_PIXELS = 3_000_000;
+
+/**
+ * Renders allowed to hold libvips buffers at once. Requests past the limit
+ * queue instead of each allocating their own planes, which is what turns a
+ * traffic spike into an OOM kill. Two keeps a 3 GB instance comfortable;
+ * BOARD_RENDER_CONCURRENCY tunes it without a deploy.
+ */
+const renderSemaphore = createSemaphore(Number(process.env.BOARD_RENDER_CONCURRENCY) || 2);
+
+/**
+ * Coalesces concurrent requests for the same uncached image into one render —
+ * a list page warming twelve overlays must not pay WASM + sharp twice for
+ * identical bytes.
+ */
+const inFlightRenders = new Map<string, Promise<RenderedImage>>();
+
+type RenderedImage = {
+  buffer: Buffer;
+  contentType: string;
+  /** Whether the board-photo base was already composed for this board. */
+  cache: 'base-hit' | 'miss';
+  wasmMs: number;
+  timings: RenderTimings;
+};
 
 /**
  * Resolve the board-renderer WASM binary. Probes the candidate paths that
@@ -57,7 +99,7 @@ const overlayRenderer = createOverlayRenderer(async () => {
  * candidate directories to work across dev, monorepo root, and Vercel standalone
  * builds. Injected into the shared render pipeline as its image resolver.
  */
-function findPublicImagePath(relPath: string): string | null {
+const findPublicImagePath: ResolveImagePath = (relPath) => {
   const candidates = [
     join(process.cwd(), 'public', relPath),
     join(process.cwd(), 'packages/web/public', relPath),
@@ -68,6 +110,56 @@ function findPublicImagePath(relPath: string): string | null {
     if (existsSync(candidate)) return candidate;
   }
   return null;
+};
+
+/** Wrap encoded image bytes in the shared immutable-cache response. */
+function imageResponse(buffer: Buffer, contentType: string, timingParts: string[]): NextResponse {
+  return new NextResponse(new Uint8Array(buffer), {
+    headers: {
+      ...createOgImageHeaders({
+        contentType,
+        version: 'immutable',
+        serverTiming: timingParts.join(', '),
+      }),
+    },
+  });
+}
+
+/**
+ * The expensive half of a request: the WASM overlay render plus the sharp
+ * composite + encode. Runs inside the concurrency semaphore, so everything that
+ * allocates a plane is counted against the limit.
+ */
+async function renderImage(params: {
+  config: WasmRenderConfig;
+  boardDetails: RenderableBoardDetails;
+  isOgVariant: boolean;
+  format: OutputFormat;
+  thumbnail: boolean;
+  includeBackground: boolean;
+  dimBackground: number;
+}): Promise<RenderedImage> {
+  const wasmT0 = performance.now();
+  const { width, height, rgba } = await overlayRenderer.render(JSON.stringify(params.config));
+  const wasmMs = performance.now() - wasmT0;
+
+  const overlayBuffer = Buffer.from(rgba.buffer, rgba.byteOffset, rgba.byteLength);
+
+  const { buffer, contentType, timings, cache } = await renderBoardImageBuffer({
+    overlayBuffer,
+    width,
+    height,
+    isOgVariant: params.isOgVariant,
+    format: params.format,
+    thumbnail: params.thumbnail,
+    includeBackground: params.includeBackground,
+    dimBackground: params.dimBackground,
+    boardDetails: params.boardDetails,
+    resolveImagePath: findPublicImagePath,
+    caches: { boardBase: boardBaseCache, ogBase: ogBaseCache },
+  });
+
+  return { buffer, contentType, cache: cache === 'hit' ? 'base-hit' : 'miss', wasmMs, timings };
 }
 
 export async function GET(request: NextRequest) {
@@ -116,6 +208,26 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'dim_background must be a number between 0 and 1' }, { status: 400 });
     }
 
+    // Final-bytes cache first: a hit costs nothing and never enters the render
+    // queue. Keyed on every param that changes a pixel.
+    const byteKey = [
+      boardName,
+      layoutId,
+      sizeId,
+      setIds,
+      frames,
+      thumbnail ? '1' : '0',
+      includeBackground ? '1' : '0',
+      dimBackground,
+      isOgVariant ? 'og' : 'std',
+      format,
+    ].join(':');
+
+    const cachedBytes = byteCache.get(byteKey);
+    if (cachedBytes) {
+      return imageResponse(cachedBytes.buffer, cachedBytes.contentType, ['cache;desc=hit', 'queue;dur=0.0']);
+    }
+
     const parsedSetIds = setIds
       .split(',')
       .map(Number)
@@ -139,43 +251,55 @@ export async function GET(request: NextRequest) {
       thumbnailWidth: THUMBNAIL_WIDTH,
     });
 
-    // Initialize WASM if needed and render the overlay.
-    const wasmT0 = performance.now();
-    const { width, height, rgba } = await overlayRenderer.render(JSON.stringify(config));
-    const wasmMs = performance.now() - wasmT0;
+    // Reject oversized renders before allocating anything for them.
+    const outputHeight = Math.round((config.output_width * config.board_height) / config.board_width);
+    if (config.output_width * outputHeight > MAX_OUTPUT_PIXELS) {
+      return NextResponse.json(
+        {
+          error: `Requested render is ${config.output_width}x${outputHeight}, over the ${MAX_OUTPUT_PIXELS}px limit`,
+        },
+        { status: 400 },
+      );
+    }
 
-    const overlayBuffer = Buffer.from(rgba.buffer, rgba.byteOffset, rgba.byteLength);
+    const queueT0 = performance.now();
+    // 0 for a coalesced request: it waited on another render, not on a slot.
+    let queueMs = 0;
+    const inFlight = inFlightRenders.get(byteKey);
+    const renderPromise =
+      inFlight ??
+      renderSemaphore
+        .run(() => {
+          queueMs = performance.now() - queueT0;
+          return renderImage({
+            config,
+            boardDetails,
+            isOgVariant,
+            format,
+            thumbnail,
+            includeBackground,
+            dimBackground,
+          });
+        })
+        .finally(() => {
+          inFlightRenders.delete(byteKey);
+        });
+    if (!inFlight) inFlightRenders.set(byteKey, renderPromise);
 
-    const { buffer, contentType, timings } = await renderBoardImageBuffer({
-      overlayBuffer,
-      width,
-      height,
-      isOgVariant,
-      format,
-      thumbnail,
-      includeBackground,
-      dimBackground,
-      boardDetails,
-      resolveImagePath: findPublicImagePath,
-    });
+    const rendered = await renderPromise;
+
+    byteCache.set(byteKey, { buffer: rendered.buffer, contentType: rendered.contentType });
 
     const timingParts = [
-      `wasm;dur=${wasmMs.toFixed(1)}`,
-      `sharp;dur=${timings.sharpMs.toFixed(1)}`,
-      `compose;dur=${timings.composeMs.toFixed(1)}`,
-      `encode;dur=${timings.encodeMs.toFixed(1)}`,
+      `wasm;dur=${rendered.wasmMs.toFixed(1)}`,
+      `sharp;dur=${rendered.timings.sharpMs.toFixed(1)}`,
+      `compose;dur=${rendered.timings.composeMs.toFixed(1)}`,
+      `encode;dur=${rendered.timings.encodeMs.toFixed(1)}`,
     ];
-    if (timings.bgMs > 0) timingParts.push(`bg;dur=${timings.bgMs.toFixed(1)}`);
+    if (rendered.timings.bgMs > 0) timingParts.push(`bg;dur=${rendered.timings.bgMs.toFixed(1)}`);
+    timingParts.push(`cache;desc=${rendered.cache}`, `queue;dur=${Math.max(0, queueMs).toFixed(1)}`);
 
-    return new NextResponse(new Uint8Array(buffer), {
-      headers: {
-        ...createOgImageHeaders({
-          contentType,
-          version: 'immutable',
-          serverTiming: timingParts.join(', '),
-        }),
-      },
-    });
+    return imageResponse(rendered.buffer, rendered.contentType, timingParts);
   } catch (error) {
     console.error('Board render error:', error);
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -20,7 +20,7 @@ import {
 } from '@boardsesh/board-render';
 import { createOverlayRenderer } from '@boardsesh/board-render/wasm';
 import { renderBoardImageBuffer, type RenderTimings, type ResolveImagePath } from '@boardsesh/board-render/pipeline';
-import { boardBaseCache, byteCache, ogBaseCache } from '@/app/lib/board-render-cache';
+import { boardBaseCache, boardBaseInFlight, byteCache, ogBaseCache } from '@/app/lib/board-render-cache';
 import { configureSharpForServerless } from '@/app/lib/sharp-runtime';
 
 // Node.js runtime for reliable WASM loading via filesystem
@@ -163,7 +163,7 @@ async function renderImage(params: {
     dimBackground: params.dimBackground,
     boardDetails: params.boardDetails,
     resolveImagePath: findPublicImagePath,
-    caches: { boardBase: boardBaseCache, ogBase: ogBaseCache },
+    caches: { boardBase: boardBaseCache, ogBase: ogBaseCache, boardBaseInFlight },
   });
 
   const baseCacheState = cache === 'hit' ? 'base-hit' : (cache ?? 'none');

--- a/packages/web/app/api/internal/board-render/route.ts
+++ b/packages/web/app/api/internal/board-render/route.ts
@@ -11,6 +11,7 @@ import {
   createSemaphore,
   isValidFramesString,
   MAX_FRAMES_LENGTH,
+  MAX_RENDER_OUTPUT_PIXELS,
   normalizeOutputFormat,
   VALID_BOARD_NAMES,
   type OutputFormat,
@@ -30,20 +31,23 @@ export const runtime = 'nodejs';
 configureSharpForServerless();
 
 /**
- * Hard ceiling on the rendered pixel count. The largest real board is Kilter's
- * 1080×2498 (~2.70 MP); anything past 3 MP is a hand-crafted request, and each
- * one costs ~4 bytes/pixel per in-flight plane. Rejected outright rather than
- * resampled — a caller asking for a size no board has is a bug, not a photo.
- */
-const MAX_OUTPUT_PIXELS = 3_000_000;
-
-/**
  * Renders allowed to hold libvips buffers at once. Requests past the limit
  * queue instead of each allocating their own planes, which is what turns a
  * traffic spike into an OOM kill. Two keeps a 3 GB instance comfortable;
  * BOARD_RENDER_CONCURRENCY tunes it without a deploy.
  */
 const renderSemaphore = createSemaphore(Number(process.env.BOARD_RENDER_CONCURRENCY) || 2);
+
+/**
+ * How deep the render queue may get before new work is shed.
+ *
+ * Two renders in parallel at ~0.35–1.9s each clears roughly 30–60 queued
+ * requests inside the function's 30s budget. Past that a queued request would
+ * spend its whole budget waiting and then 504 — having already made everyone
+ * behind it wait — and the client retries straight back into the same queue.
+ * A fast 503 with `Retry-After` sheds the load instead of burning it.
+ */
+const MAX_QUEUED_RENDERS = 40;
 
 /**
  * Coalesces concurrent requests for the same uncached image into one render —
@@ -55,8 +59,11 @@ const inFlightRenders = new Map<string, Promise<RenderedImage>>();
 type RenderedImage = {
   buffer: Buffer;
   contentType: string;
-  /** Whether the board-photo base was already composed for this board. */
-  cache: 'base-hit' | 'miss';
+  /**
+   * Whether the board-photo base was already composed for this board.
+   * `none` is an overlay-only render, which has no base to cache.
+   */
+  cache: 'base-hit' | 'miss' | 'none';
   wasmMs: number;
   timings: RenderTimings;
 };
@@ -159,7 +166,8 @@ async function renderImage(params: {
     caches: { boardBase: boardBaseCache, ogBase: ogBaseCache },
   });
 
-  return { buffer, contentType, cache: cache === 'hit' ? 'base-hit' : 'miss', wasmMs, timings };
+  const baseCacheState = cache === 'hit' ? 'base-hit' : (cache ?? 'none');
+  return { buffer, contentType, cache: baseCacheState, wasmMs, timings };
 }
 
 export async function GET(request: NextRequest) {
@@ -253,10 +261,10 @@ export async function GET(request: NextRequest) {
 
     // Reject oversized renders before allocating anything for them.
     const outputHeight = Math.round((config.output_width * config.board_height) / config.board_width);
-    if (config.output_width * outputHeight > MAX_OUTPUT_PIXELS) {
+    if (config.output_width * outputHeight > MAX_RENDER_OUTPUT_PIXELS) {
       return NextResponse.json(
         {
-          error: `Requested render is ${config.output_width}x${outputHeight}, over the ${MAX_OUTPUT_PIXELS}px limit`,
+          error: `Requested render is ${config.output_width}x${outputHeight}, over the ${MAX_RENDER_OUTPUT_PIXELS}px limit`,
         },
         { status: 400 },
       );
@@ -267,6 +275,17 @@ export async function GET(request: NextRequest) {
     // the request that renders, the whole shared render for one that coalesces.
     let queueMs = 0;
     const inFlight = inFlightRenders.get(byteKey);
+
+    // Shed rather than queue behind more work than the budget can clear. A
+    // request joining an in-flight render adds nothing to the queue, so it is
+    // always let through.
+    if (!inFlight && renderSemaphore.pending > MAX_QUEUED_RENDERS) {
+      return NextResponse.json(
+        { error: 'Render queue is saturated' },
+        { status: 503, headers: { 'Retry-After': '5', 'Cache-Control': 'no-store' } },
+      );
+    }
+
     const renderPromise =
       inFlight ??
       renderSemaphore

--- a/packages/web/app/lib/board-render-cache.ts
+++ b/packages/web/app/lib/board-render-cache.ts
@@ -25,6 +25,15 @@ export const boardBaseCache = new BoundedLru<Buffer>({
   sizeOf: (buffer) => buffer.length,
 });
 
+/**
+ * Board-base composes running right now, so two climbs on the same board
+ * arriving together fold that board's photos once. Owned here rather than
+ * inside the shared pipeline: the key describes the board and output size, not
+ * this route's `findPublicImagePath`, so it must not be shared with a consumer
+ * that resolves images differently.
+ */
+export const boardBaseInFlight = new Map<string, Promise<Buffer | null>>();
+
 /** OG social-card bases (backdrop + board photos, raw RGBA at 1200×630 ≈ 3 MB each). */
 export const ogBaseCache = new BoundedLru<OgBaseResult>({
   maxEntries: 8,
@@ -55,4 +64,5 @@ export function resetBoardRenderCaches(): void {
   boardBaseCache.clear();
   ogBaseCache.clear();
   byteCache.clear();
+  boardBaseInFlight.clear();
 }

--- a/packages/web/app/lib/board-render-cache.ts
+++ b/packages/web/app/lib/board-render-cache.ts
@@ -33,13 +33,16 @@ export const ogBaseCache = new BoundedLru<OgBaseResult>({
 });
 
 /**
- * Final encoded bytes, keyed by the full canonical param tuple. Entries are
- * small (a thumbnail is a few KB), so this mostly absorbs the list pages
- * re-requesting the same climbs while the CDN entry is still cold.
+ * Final encoded bytes, keyed by the full canonical param tuple. This absorbs
+ * the list pages re-requesting the same climbs while the CDN entry is still
+ * cold. Entry sizes span two orders of magnitude — a thumbnail is a few KB but
+ * a full-size lossless-WebP render measured 326 KB — so 32 MB is what makes the
+ * 2000-entry ceiling reachable for thumbnails while still holding ~100
+ * full-size renders.
  */
 export const byteCache = new BoundedLru<{ buffer: Buffer; contentType: string }>({
   maxEntries: 2000,
-  maxBytes: 16 * 1024 * 1024,
+  maxBytes: 32 * 1024 * 1024,
   sizeOf: (value) => value.buffer.length,
 });
 

--- a/packages/web/app/lib/board-render-cache.ts
+++ b/packages/web/app/lib/board-render-cache.ts
@@ -1,0 +1,55 @@
+import { BoundedLru } from '@boardsesh/board-render';
+import type { OgBaseResult } from '@boardsesh/board-render/pipeline';
+
+/**
+ * Process-lifetime caches for `/api/internal/board-render`.
+ *
+ * The route used to re-decode every board photo on every request — at ~50k
+ * renders/day that is the bulk of both the CPU time and the peak memory that
+ * was OOM-killing the function. These mirror the pattern the long-running
+ * backend OG renderer has used since #3829: one cache for the composed board
+ * photos, one for the final encoded bytes.
+ *
+ * They live outside route.ts because an App Router route module may only export
+ * handlers and route config — a test-visible reset has to hang off a sibling.
+ */
+
+/**
+ * Folded board photos (raw RGBA, dim baked in) keyed by board config + size +
+ * dim. Roughly 10 MB for the biggest board, so the byte budget — not the entry
+ * count — is what bounds this.
+ */
+export const boardBaseCache = new BoundedLru<Buffer>({
+  maxEntries: 24,
+  maxBytes: 64 * 1024 * 1024,
+  sizeOf: (buffer) => buffer.length,
+});
+
+/** OG social-card bases (backdrop + board photos, raw RGBA at 1200×630 ≈ 3 MB each). */
+export const ogBaseCache = new BoundedLru<OgBaseResult>({
+  maxEntries: 8,
+  maxBytes: 32 * 1024 * 1024,
+  sizeOf: (value) => value.base.length,
+});
+
+/**
+ * Final encoded bytes, keyed by the full canonical param tuple. Entries are
+ * small (a thumbnail is a few KB), so this mostly absorbs the list pages
+ * re-requesting the same climbs while the CDN entry is still cold.
+ */
+export const byteCache = new BoundedLru<{ buffer: Buffer; contentType: string }>({
+  maxEntries: 2000,
+  maxBytes: 16 * 1024 * 1024,
+  sizeOf: (value) => value.buffer.length,
+});
+
+/**
+ * Test-only: drop every entry so one test's render can't serve another's
+ * request. Never called in production — these caches are meant to outlive
+ * requests.
+ */
+export function resetBoardRenderCaches(): void {
+  boardBaseCache.clear();
+  ogBaseCache.clear();
+  byteCache.clear();
+}

--- a/packages/web/app/lib/sharp-runtime.ts
+++ b/packages/web/app/lib/sharp-runtime.ts
@@ -18,6 +18,13 @@ let configured = false;
  * limit instead of to core count. Route-level only — the long-running backend
  * renderer keeps libvips' defaults.
  *
+ * Both settings are process-global, not per-instance: they apply to every sharp
+ * call in whatever process runs this module. That is exactly what we want on
+ * Vercel, where each function gets its own isolated process, and it is
+ * currently a no-op elsewhere — `/api/internal/board-render` is the only route
+ * in `packages/web` that imports sharp at all. Anything else that starts using
+ * sharp in this app shares these limits, so give it a look first.
+ *
  * Idempotent: safe to call from any module's top level.
  */
 export function configureSharpForServerless(): void {

--- a/packages/web/app/lib/sharp-runtime.ts
+++ b/packages/web/app/lib/sharp-runtime.ts
@@ -1,0 +1,28 @@
+import sharp from 'sharp';
+
+let configured = false;
+
+/**
+ * Tune libvips for a serverless function instance.
+ *
+ * The defaults assume a long-lived server with the machine to itself: libvips
+ * sizes its operation cache at 50 MB / 20 000 items and runs one worker thread
+ * per core. Inside a Vercel function that is memory we don't have and
+ * parallelism we can't use — several concurrent renders each spawn a full
+ * thread pool over multi-megapixel board photos, and the instance gets
+ * OOM-killed rather than slowed down (507 kills in three days on
+ * `/api/internal/board-render`).
+ *
+ * A 16 MB / 100-item cache still absorbs the repeat board-photo reads, and one
+ * thread per operation keeps peak RSS proportional to the render concurrency
+ * limit instead of to core count. Route-level only — the long-running backend
+ * renderer keeps libvips' defaults.
+ *
+ * Idempotent: safe to call from any module's top level.
+ */
+export function configureSharpForServerless(): void {
+  if (configured) return;
+  configured = true;
+  sharp.cache({ memory: 16, files: 4, items: 100 });
+  sharp.concurrency(1);
+}

--- a/packages/web/scripts/board-render-memory-harness.mjs
+++ b/packages/web/scripts/board-render-memory-harness.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * Manual load harness for `/api/internal/board-render`. NOT wired into CI —
+ * it needs a running server and a few minutes of wall clock.
+ *
+ * What it answers: does the render path still grow RSS without bound? It fires
+ * two phases at the largest Kilter board (layout 5 / size 15 / set 24 →
+ * 1080×2498, ~2.70 MP) with `include_background=1`:
+ *
+ *   phase 1 — 200 requests, a unique `frames` per request. Nothing can hit the
+ *             byte cache, so every request pays a full WASM render + encode and
+ *             only the board-photo base is shared. This is the shape that was
+ *             OOM-killing the function.
+ *   phase 2 — 200 requests cycling 10 `frames` values, i.e. the steady state a
+ *             warm list page produces. Should be almost all byte-cache hits.
+ *
+ * While requesting it samples the server process's VmRSS from /proc every
+ * 500 ms and prints peak/final RSS plus p50/p95 latency per phase. A healthy
+ * run: phase 2 latency an order of magnitude below phase 1, and final RSS close
+ * to peak rather than climbing monotonically across phases.
+ *
+ * Usage (from anywhere in the repo):
+ *
+ *   vp run dev                      # or: bun run --filter=@boardsesh/web dev
+ *   node packages/web/scripts/board-render-memory-harness.mjs
+ *
+ * Options:
+ *   --base <url>        server origin (default http://localhost:3000)
+ *   --pid <pid>         server pid to sample; auto-detected from the listening
+ *                       port when omitted (Linux /proc only)
+ *   --requests <n>      requests per phase (default 200)
+ *   --concurrency <n>   in-flight requests (default 8)
+ *   --board <name> --layout <id> --size <id> --sets <csv>
+ *   --thumbnail         request the thumbnail variant instead
+ *
+ * Compare a before/after by running it against the branch and against main.
+ */
+
+import { readFileSync, readdirSync, readlinkSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const index = args.indexOf(`--${name}`);
+  return index === -1 ? fallback : args[index + 1];
+};
+const hasFlag = (name) => args.includes(`--${name}`);
+
+const baseUrl = flag('base', 'http://localhost:3000').replace(/\/$/, '');
+const requestsPerPhase = Number(flag('requests', '200'));
+const concurrency = Number(flag('concurrency', '8'));
+const boardName = flag('board', 'kilter');
+const layoutId = flag('layout', '5');
+const sizeId = flag('size', '15');
+const setIds = flag('sets', '24');
+const thumbnail = hasFlag('thumbnail');
+const SAMPLE_INTERVAL_MS = 500;
+
+/** Build a frames string that renders `count` distinct holds. */
+function framesFor(seed) {
+  const holdId = 1000 + (seed % 500);
+  return `p${holdId}r42p${holdId + 1}r43`;
+}
+
+function renderUrl(frames) {
+  const params = new URLSearchParams({
+    board_name: boardName,
+    layout_id: layoutId,
+    size_id: sizeId,
+    set_ids: setIds,
+    frames,
+    include_background: '1',
+  });
+  if (thumbnail) params.set('thumbnail', '1');
+  return `${baseUrl}/api/internal/board-render?${params}`;
+}
+
+/** Read a process's resident set size in MB, or null if it's gone. */
+function readRssMb(pid) {
+  try {
+    const status = readFileSync(`/proc/${pid}/status`, 'utf8');
+    const match = status.match(/^VmRSS:\s+(\d+) kB$/m);
+    return match ? Number(match[1]) / 1024 : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the pid listening on the base URL's port by matching /proc/net/tcp
+ * inodes against each process's open sockets. Linux only; returns null if it
+ * can't tell (pass --pid then).
+ */
+function findListeningPid(port) {
+  const hexPort = port.toString(16).toUpperCase().padStart(4, '0');
+  const inodes = new Set();
+  for (const table of ['/proc/net/tcp', '/proc/net/tcp6']) {
+    let lines;
+    try {
+      lines = readFileSync(table, 'utf8').split('\n').slice(1);
+    } catch {
+      continue;
+    }
+    for (const line of lines) {
+      const fields = line.trim().split(/\s+/);
+      if (fields.length < 10) continue;
+      // 0A = TCP_LISTEN
+      if (fields[3] !== '0A') continue;
+      if (!fields[1].endsWith(`:${hexPort}`)) continue;
+      inodes.add(fields[9]);
+    }
+  }
+  if (inodes.size === 0) return null;
+
+  for (const entry of readdirSync('/proc')) {
+    if (!/^\d+$/.test(entry)) continue;
+    let fds;
+    try {
+      fds = readdirSync(`/proc/${entry}/fd`);
+    } catch {
+      continue;
+    }
+    for (const fd of fds) {
+      try {
+        const target = readlinkSync(`/proc/${entry}/fd/${fd}`);
+        const match = target.match(/^socket:\[(\d+)\]$/);
+        if (match && inodes.has(match[1])) return Number(entry);
+      } catch {
+        // fd vanished mid-scan
+      }
+    }
+  }
+  return null;
+}
+
+function percentile(sorted, fraction) {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.floor(sorted.length * fraction));
+  return sorted[index];
+}
+
+/** Run `total` requests at fixed concurrency, returning latency stats. */
+async function runPhase(label, framesForIndex, total) {
+  const latencies = [];
+  const statuses = new Map();
+  const cacheStates = new Map();
+  let next = 0;
+  const started = Date.now();
+
+  const worker = async () => {
+    for (;;) {
+      const index = next++;
+      if (index >= total) return;
+      const requestStarted = performance.now();
+      try {
+        const response = await fetch(renderUrl(framesForIndex(index)));
+        const body = await response.arrayBuffer();
+        latencies.push(performance.now() - requestStarted);
+        statuses.set(response.status, (statuses.get(response.status) ?? 0) + 1);
+        const timing = response.headers.get('server-timing') ?? '';
+        const cache = timing.match(/cache;desc=([a-z-]+)/)?.[1] ?? 'unknown';
+        cacheStates.set(cache, (cacheStates.get(cache) ?? 0) + 1);
+        if (body.byteLength === 0) console.warn(`empty body for request ${index}`);
+      } catch (error) {
+        latencies.push(performance.now() - requestStarted);
+        statuses.set('error', (statuses.get('error') ?? 0) + 1);
+        if (statuses.get('error') === 1) console.error(`  first error: ${error.message}`);
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: concurrency }, worker));
+
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const elapsedSeconds = (Date.now() - started) / 1000;
+  console.log(`\n${label}`);
+  console.log(`  requests      ${total} at concurrency ${concurrency} in ${elapsedSeconds.toFixed(1)}s`);
+  console.log(`  throughput    ${(total / elapsedSeconds).toFixed(1)} req/s`);
+  console.log(`  latency p50   ${percentile(sorted, 0.5).toFixed(0)} ms`);
+  console.log(`  latency p95   ${percentile(sorted, 0.95).toFixed(0)} ms`);
+  console.log(`  latency max   ${sorted.at(-1)?.toFixed(0) ?? 0} ms`);
+  console.log(`  statuses      ${[...statuses].map(([code, count]) => `${code}×${count}`).join(' ')}`);
+  console.log(`  cache         ${[...cacheStates].map(([state, count]) => `${state}×${count}`).join(' ')}`);
+}
+
+async function main() {
+  const port = Number(new URL(baseUrl).port || 3000);
+  const pid = Number(flag('pid', '')) || findListeningPid(port);
+  if (pid) {
+    console.log(`Sampling RSS of pid ${pid} (port ${port}) every ${SAMPLE_INTERVAL_MS}ms`);
+  } else {
+    console.warn(`Could not find the server pid for port ${port} — pass --pid to enable RSS sampling.`);
+  }
+
+  const samples = [];
+  const sampler = pid
+    ? setInterval(() => {
+        const rss = readRssMb(pid);
+        if (rss !== null) samples.push(rss);
+      }, SAMPLE_INTERVAL_MS)
+    : null;
+
+  const startRss = pid ? readRssMb(pid) : null;
+
+  // Warm the process (JIT, WASM init, first board base) before measuring.
+  await fetch(renderUrl(framesFor(999))).then((response) => response.arrayBuffer());
+
+  await runPhase(
+    'PHASE 1 — unique climb per request (byte cache always misses)',
+    (index) => framesFor(index),
+    requestsPerPhase,
+  );
+  const phaseOneSamples = samples.length;
+
+  await runPhase(
+    'PHASE 2 — 10 repeating climbs (steady-state list traffic)',
+    (index) => framesFor(index % 10),
+    requestsPerPhase,
+  );
+
+  if (sampler) clearInterval(sampler);
+
+  if (samples.length > 0) {
+    const peak = Math.max(...samples);
+    const phaseOnePeak = Math.max(...samples.slice(0, phaseOneSamples || 1));
+    console.log('\nRSS');
+    console.log(`  start         ${startRss?.toFixed(1) ?? '?'} MB`);
+    console.log(`  phase 1 peak  ${phaseOnePeak.toFixed(1)} MB`);
+    console.log(`  peak          ${peak.toFixed(1)} MB`);
+    console.log(`  final         ${samples.at(-1).toFixed(1)} MB`);
+    console.log(`  samples       ${samples.length}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "bunx bun@1.3.14 install --frozen-lockfile",
   "buildCommand": "bun run --filter=@boardsesh/web build",
   "framework": "nextjs",

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -3,6 +3,12 @@
   "buildCommand": "bun run --filter=@boardsesh/web build",
   "framework": "nextjs",
   "git": { "deploymentEnabled": false },
+  "functions": {
+    "app/api/internal/board-render/route.ts": {
+      "memory": 3009,
+      "maxDuration": 30
+    }
+  },
   "crons": [
     {
       "path": "/api/internal/prewarm-heatmap/kilter",


### PR DESCRIPTION
## Summary

`/api/internal/board-render` OOM-killed its Vercel instances **507 times in three days** — 61% of all error volume — at roughly 50k renders/day. Three things were stacked on top of each other:

1. **Per-request decode → encode → decode waste.** Every request loaded each board photo, resized it, re-encoded it to WebP, then handed the first buffer straight back to sharp to be decoded again for compositing. `dim_background` then allocated and PNG-encoded a full W×H×4 black scrim, and the OG variant rasterised a blurred 1200×630 SVG per request. On the tallest Kilter board (1080×2498) that is several 10 MB planes per request, none of them reusable.
2. **No caching at all.** The long-running backend OG renderer has cached its composed base and its final bytes in a `BoundedLru` pair since #3829; the web route cached nothing, so every climb on a board re-did that board's photos.
3. **Untuned libvips + unbounded concurrency.** sharp's defaults (50 MB operation cache, one worker thread per core) assume a long-lived server with the machine to itself, and nothing limited how many renders ran at once — so peak memory tracked the arrival rate, and a traffic spike killed the instance instead of slowing it down.

What changed:

- **`composeBoardBaseBuffer`** decodes layers one at a time and folds them as raw RGBA, so peak stays around three planes regardless of layer count and nothing is re-encoded. The OG variant reuses the cached `composeOgBaseBuffer` + `encodeOgImage` pair the backend already uses.
- **Three module-level caches in the route**: composed board base (64 MB / 24), OG base (32 MB / 8), final encoded bytes (32 MB / 2000, keyed on the full canonical param tuple). Plus in-flight coalescing at two levels — one render per identical request, and one *base compose* per board, so two climbs on the same board arriving together don't each fold that board's ~10 MB of photos.
- **A FIFO semaphore** (`BOARD_RENDER_CONCURRENCY`, default 2) around the WASM render and the sharp pipeline, `sharp.cache({ memory: 16, files: 4, items: 100 })` + `sharp.concurrency(1)` at the route (the backend keeps libvips defaults), and a 3 MP output guard — the largest real board is 1080×2498 ≈ 2.70 MP, so anything larger is hand-crafted and gets a 400 rather than being resampled. A data-driven test fails if a future board grows past that ceiling, so it surfaces as a red test rather than a production 400.
- **Load shedding**: past 40 queued renders, new work gets a fast `503` + `Retry-After: 5` + `no-store` instead of a slot in a queue it can't clear inside the 30s budget. A request that can join an in-flight render is never shed — it costs nothing to serve.
- **`vercel.json`**: 3009 MB / 30s for this function as the stopgap that stops the bleeding while the above lands.

`Server-Timing` now carries `cache;desc=hit|base-hit|miss|none` and `queue;dur=<ms>`, so the hit rate and queue depth are readable straight off production traces.

Measured by QA: roughly **2× lighter and faster** on the render path.

Part of #4650 (Vercel burn hunt). The Rust follow-up that moves this render off Node entirely is #4664 — this is the fix that stops the kills today, not a replacement for it.

## Byte-level changes

Output bytes are not identical to `main` everywhere. Every affected URL is immutable and content-addressed by its params, so an old and a new copy simply coexist in the CDN.

- **`dim_background` output is unchanged — deliberately.** An earlier revision replaced the black scrim with an RGB scale (`rgb × (1 - dim)`), which is equivalent only for opaque pixels. QA measured every board WebP: they all carry alpha, and the photos are transparent everywhere except the holds, so ~77% of pixels came out with different alpha and up to 127 of RGB delta. `dim_background` is a full-bleed wash — that is what the iOS Live Activity widget asks for with `dim_background=0.18`, and what mobile's `LayeredClimbImage` draws as a full-bleed `rgba(0, 0, 0, 0.18)` view. The scrim composite is restored; the saving is kept by baking it into the *cached* base, so a board pays for it once on a cold cache instead of once per request.
- **Non-dim background renders change slightly.** The old path pushed every background layer through a lossy WebP q80 encode before compositing; the new one composites the decoded pixels directly. The new bytes are the more faithful render — the old ones carried an extra generation of WebP loss.
- **Two OG param combos with no live caller changed.** `variant=og&format=webp` used to silently return PNG and now returns WebP; `variant=og&format=jpeg` now encodes with the OG JPEG options (mozjpeg q85, full chroma) instead of the generic q90. Both fall out of reusing the backend's `encodeOgImage`. `variant=og&thumbnail=1` now composes full-size photos (it always did — only its cache key wrongly said otherwise).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck` — passes (46 tasks).
- `vp test run --project board-render` — **76 passed / 8 files**, including three new suites:
  - `pipeline.test.ts` drives **real sharp** over 8×8 fixture PNGs: the base is exactly `w*h*4` bytes, layers fold in order, a corrupt layer is skipped, nothing resolving returns `null`, a cached base makes the second render byte-identical with one filesystem probe total, two concurrent misses on one board compose the base once (and compose twice when the in-flight map is not supplied), and the OG path decodes to 1200×630 and reuses its base. Dim is pinned at full-bleed semantics: a **fully transparent** source pixel comes out at `alpha = round(0.18 × 255) = 46` (exactly what the rejected linear approach failed), while an opaque one darkens by ×0.82.
  - `semaphore.test.ts` pins the high-water mark under 10 concurrent runs, FIFO order, and slot release on a throwing task.
  - `board-dimensions.test.ts` is the ceiling tripwire: `max(width × height)` over `BOARD_IMAGE_DIMENSIONS` must stay under `MAX_RENDER_OUTPUT_PIXELS`.
- `packages/web/app/api/internal/board-render/__tests__/route.test.ts` — **56 passed**, extended with a byte-cache key pair for every param that changes a pixel (`board_name`, `layout_id`, `size_id`, `set_ids`, `frames`, `format`, `thumbnail`, `include_background`, `dim_background`, `variant`), each asserting a genuine second render; the counterpart case that a param the route never reads (`angle`) is *served* from the cache; the concurrency limit (3 concurrent requests, gated renders, high-water mark 1); load shedding (42 queued → 43rd gets 503 + `Retry-After: 5` + `no-store`; a coalescable request is never shed); in-flight coalescing; the queue timing header; the 3 MP 400; and a 1080×2498 board still rendering.
- **Mutation-tested every guard**, each failing exactly its own test(s) and nothing else: stripping the five render-option params from the byte key (5 cases red), dropping just `thumbnail` (1 case red), dropping the four identity params (exactly those 4 red), `createSemaphore(100000)`, `MAX_QUEUED_RENDERS = 100000`, `MAX_RENDER_OUTPUT_PIXELS = 2_000_000` (tripwire names the offending board), disabling `byteCache.set`, bypassing the base-compose coalescing map, and reverting the dim scrim to the linear scale. The queue-ceiling mutation also exposed a test-isolation hazard — a failing gated test stranded its renders and timed out every test after it — now fixed with an `afterEach` that releases the gate and drains the queue, so a failure stays local to its own test.
- `vp run test:web` — 4023 passed / 9 failed. All nine are pre-existing flakes in admin/auth/gym component suites (`location-sync-freezes-panel`, `gym-owner-reassign-panel`, `overview-tab`, `auth-modal-server-errors`, …); re-running them in isolation on this branch gives a different failure set each time (1, then 4, same code), none import anything this PR touches, and CI's `test-default` shards are green.
- `packages/web/scripts/board-render-memory-harness.mjs` is the manual RSS harness for a before/after against `main` (needs a running dev server; not wired into CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016aZ1zjpqkXScoo4jyzL49X
