### PR TITLE
feat(web): name which path served the climb sitemap, and page when it is the slow one

### DIFF
--- a/docs/sitemap.md
+++ b/docs/sitemap.md
@@ -101,6 +101,44 @@ the 51 s path, correct and never worse than before the store existed. There is n
 staleness bound on pages; the summary row's 48 h shout covers the store as a whole,
 since both tables share one refresh.
 
+### Saying which path served (#4583)
+
+The fallback is correct, and that is exactly the problem: an empty store produces a
+complete, correct sitemap, so nothing external goes red while every crawler fetch
+behind it pays the scan. The climbs shard was absent from the production index on
+every request from the day W-23 landed until #4661, and the reason it stayed there
+for weeks is that a degrade only ever reached a `console.error`.
+
+So a fallback names itself, on two channels:
+
+- **`X-Sitemap-Climbs-Source: store | live`** on `/sitemap.xml` and on every
+  `/sitemaps/climbs/N.xml`. Set from the `source` the summary and page builds have
+  already returned — never a fresh read. That matters: the index races each summary
+  against `SHARD_DEADLINE_MS` and `withDeadline` cannot cancel the loser, so a
+  diagnostic that issued its own query could outlive the deadline it describes and
+  hold the whole index open to `maxDuration`. A rejected or timed-out summary
+  reports no source at all rather than guessing, since `X-Sitemap-Degraded` already
+  covers that case. On a page the build's own answer wins over the summary's: a
+  fresh summary row against an empty URL table is exactly the state the deploy that
+  added the store was in.
+- **A Sentry event**, from `reportStoreFallback` in `climb-store.ts`, at most once
+  per reason per instance per six hours (`summary-empty`, `summary-read-failed`,
+  `page-empty`, `page-read-failed`). The page-path event fires _before_ the 51 s
+  fallback build, so a Vercel timeout cannot swallow it.
+
+`scripts/production-smoke.ts` reads the header off the index response it already
+fetches — no extra request — and reports `live` as a **warning**, not a failure:
+the index it just validated is complete either way, so this is "the fast path is not
+the one running", not "the sitemap is broken". A missing header is not a finding; a
+deploy that predates it and a summary that never settled both leave it absent.
+
+One honest limit, shared with `X-Sitemap-Degraded`: the header rides a CDN-cached
+response. A healthy index is `s-maxage=3600` and the shard pages are
+`s-maxage=21600`, and Vercel's edge ignores the smoke's `Cache-Control: no-cache`
+request header, so the value read can be up to that old in either direction. It is a
+signal that a wedged store gets noticed within the hour, not a live probe. The Sentry
+event has no such lag.
+
 ### Who refreshes it
 
 1. **The cron** — `/api/internal/refresh-sitemap-climbs`, six-hourly, in

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-shards.test.ts
@@ -42,6 +42,9 @@ const climbs = vi.hoisted(() => ({
   /** What the per-page lastmod aggregate answers; empty means "store empty, use the uniform value". */
   pageLastmods: [] as (Date | null)[],
   pageLastmodsThrow: false,
+  /** Which path the store says answered. `undefined` is a build that reports none. */
+  summarySource: 'store' as 'store' | 'live' | undefined,
+  pageSource: 'store' as 'store' | 'live' | undefined,
 }));
 
 // The index and the shard route both read the store (#4523/#4552): the summary
@@ -56,12 +59,16 @@ vi.mock('../climb-store', () => ({
     if (climbs.summaryThrows) throw new Error('climbs summary unavailable');
     // A summary that never settles: the failure a try/catch cannot see.
     if (climbs.summaryHangs) return new Promise<never>(() => {});
-    return { itemCount: climbs.itemCount, lastModified: new Date('2026-05-04T11:22:33.000Z') };
+    return {
+      itemCount: climbs.itemCount,
+      lastModified: new Date('2026-05-04T11:22:33.000Z'),
+      source: climbs.summarySource,
+    };
   },
   buildClimbShardPage: async (page: number) => {
     climbs.buildCalls += 1;
     if (climbs.buildThrows) throw new Error('climbs builder exploded');
-    if (climbs.buildsEmpty) return { items: [], totalItems: 0 };
+    if (climbs.buildsEmpty) return { items: [], totalItems: 0, source: climbs.pageSource };
     // Padding lives in the PATH, so the byte guard is driven by a real rendered
     // body rather than by mutating the constant it is supposed to enforce.
     const padding = climbs.pathLength > 0 ? 'x'.repeat(climbs.pathLength) : '';
@@ -70,7 +77,7 @@ vi.mock('../climb-store', () => ({
       lastModified: new Date('2026-05-04T11:22:33.000Z'),
     })) satisfies SitemapItem[];
     const start = (page - 1) * 10_000;
-    return { items: built.slice(start, start + 10_000), totalItems: built.length };
+    return { items: built.slice(start, start + 10_000), totalItems: built.length, source: climbs.pageSource };
   },
   fetchStoredClimbPageLastmods: async () => {
     if (climbs.pageLastmodsThrow) throw new Error('lastmod aggregate unavailable');
@@ -78,7 +85,13 @@ vi.mock('../climb-store', () => ({
   },
 }));
 
-const { PAGED_SHARD_REGISTRY, buildSitemapIndexXml, pagedShardRouteHandler } = await import('../shard-registry');
+const {
+  CLIMB_SOURCE_HEADER,
+  PAGED_SHARD_REGISTRY,
+  buildSitemapIndexXml,
+  pagedShardRouteHandler,
+  sitemapIndexRouteHandler,
+} = await import('../shard-registry');
 
 beforeEach(() => {
   climbs.itemCount = 3;
@@ -91,6 +104,8 @@ beforeEach(() => {
   climbs.buildCalls = 0;
   climbs.pageLastmods = [];
   climbs.pageLastmodsThrow = false;
+  climbs.summarySource = 'store';
+  climbs.pageSource = 'store';
 });
 
 describe('the paged climbs shard', () => {
@@ -308,6 +323,68 @@ describe('the index and the climbs shard', () => {
     expect(errors.mock.calls.flat().join(' ')).toContain('expects URLs but its summary reports 0');
     errors.mockRestore();
   });
+});
+
+/**
+ * `X-Sitemap-Climbs-Source` (#4583).
+ *
+ * `X-Sitemap-Degraded` answers "did the index publish this shard". It cannot
+ * answer "and is the fast path the one serving it", and that second question is
+ * the one nobody could answer for the weeks the climbs shard was missing: an
+ * empty store still yields a complete, correct sitemap, so every external
+ * detector stays green while each page fetch behind it rebuilds the whole
+ * ordered list.
+ */
+describe('the climbs source header', () => {
+  it('names the store on a healthy page', async () => {
+    const response = await pagedShardRouteHandler('climbs', '1.xml');
+
+    expect(response.headers.get(CLIMB_SOURCE_HEADER)).toBe('store');
+  });
+
+  it("lets the page's own answer override the summary's", async () => {
+    // The exact state the deploy that added `sitemap_climb_urls` was in: a fresh
+    // summary row (the older cron kept writing it) over an empty URL table. A
+    // header taken from the summary alone would have called that healthy.
+    climbs.summarySource = 'store';
+    climbs.pageSource = 'live';
+
+    const response = await pagedShardRouteHandler('climbs', '1.xml');
+
+    expect(response.headers.get(CLIMB_SOURCE_HEADER)).toBe('live');
+  });
+
+  it('falls back to the summary when the page build reports no source', async () => {
+    climbs.summarySource = 'live';
+    climbs.pageSource = undefined;
+
+    const response = await pagedShardRouteHandler('climbs', '1.xml');
+
+    expect(response.headers.get(CLIMB_SOURCE_HEADER)).toBe('live');
+  });
+
+  it('names the path on the index too, alongside the degraded header', async () => {
+    climbs.summarySource = 'live';
+
+    const response = await sitemapIndexRouteHandler();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get(CLIMB_SOURCE_HEADER)).toBe('live');
+  });
+
+  it('claims nothing when the summary never settled', async () => {
+    // A summary that loses the SHARD_DEADLINE_MS race never said which path it
+    // was on. Reporting `live` there would be a measurement nobody took, and
+    // `X-Sitemap-Degraded` already covers the case.
+    climbs.summaryHangs = true;
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await sitemapIndexRouteHandler();
+
+    expect(response.headers.get('x-sitemap-degraded')).toContain('climbs');
+    expect(response.headers.get(CLIMB_SOURCE_HEADER)).toBeNull();
+    errors.mockRestore();
+  }, 15_000);
 });
 
 describe('the deferred work stays deferred', () => {

--- a/packages/web/app/lib/seo/sitemap/__tests__/climb-store.test.ts
+++ b/packages/web/app/lib/seo/sitemap/__tests__/climb-store.test.ts
@@ -31,6 +31,8 @@ const live = vi.hoisted(() => ({
   /** What the CACHED item fallback returns when the URL store is empty. */
   fallbackItems: [] as { path: string; lastModified: Date | null }[],
   fallbackItemCalls: 0,
+  /** Lets a test observe WHEN the fallback build starts, relative to the report. */
+  onFallbackItems: null as null | (() => void),
 }));
 
 vi.mock('../climb-query', () => ({
@@ -45,6 +47,7 @@ vi.mock('../climb-query', () => ({
   },
   buildTier2ClimbItems: async () => {
     live.fallbackItemCalls += 1;
+    live.onFallbackItems?.();
     return live.fallbackItems;
   },
 }));
@@ -69,6 +72,20 @@ const schema = vi.hoisted(() => ({
 }));
 
 vi.mock('@/app/lib/db/schema', () => schema);
+
+/**
+ * Every Sentry event the store fired, in order. `console.error` alone is what
+ * #4583 proved insufficient — it is the channel the climbs shard went missing on
+ * for weeks — so "did this page anyone" is asserted separately from "was it
+ * logged".
+ */
+const sentry = vi.hoisted(() => ({ messages: [] as { message: string; level: string }[] }));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: (message: string, level: string) => {
+    sentry.messages.push({ message, level });
+  },
+}));
 
 const store = vi.hoisted(() => ({
   row: null as StoredRow | null,
@@ -269,6 +286,7 @@ beforeEach(() => {
   live.fallbackSummaryCalls = 0;
   live.fallbackItems = [];
   live.fallbackItemCalls = 0;
+  live.onFallbackItems = null;
   store.row = null;
   store.urlRows = [];
   store.readThrows = false;
@@ -277,6 +295,7 @@ beforeEach(() => {
   store.urlWrites = [];
   store.transactionOps = [];
   store.executed = [];
+  sentry.messages = [];
   resetClimbStoreStateForTests();
 });
 
@@ -288,22 +307,32 @@ describe('reading the climbs shard summary', () => {
 
     expect(summary.itemCount).toBe(51_842);
     expect(summary.lastModified).toEqual(new Date('2026-05-04T11:22:33.000Z'));
+    expect(summary.source).toBe('store');
     // The assertion the whole change rests on: no sixteen-scan question is asked
     // on the path racing SHARD_DEADLINE_MS.
     expect(live.fallbackSummaryCalls).toBe(0);
     expect(live.buildCalls).toBe(0);
+    // A healthy read pages nobody. Without this the six-hour floor could be
+    // "fires once and never again" and every test below would still pass.
+    expect(sentry.messages).toEqual([]);
   });
 
-  it('falls back to the live summary when nothing has been stored yet', async () => {
+  it('falls back to the live summary when nothing has been stored yet, and says so', async () => {
     // The first request after this deploy, and local dev. Never WORSE than main —
-    // it is exactly main's path — but it is still the slow one, which is why the
-    // rollout runs one refresh by hand.
+    // it is exactly main's path — but it is still the slow one, and #4583 is the
+    // proof that "slow but correct" goes unnoticed unless it announces itself.
     store.row = null;
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const summary = await fetchClimbShardSummary();
 
     expect(summary.itemCount).toBe(999);
+    expect(summary.source).toBe('live');
     expect(live.fallbackSummaryCalls).toBe(1);
+    expect(sentry.messages).toHaveLength(1);
+    expect(sentry.messages[0].level).toBe('error');
+    expect(sentry.messages[0].message).toContain('summary-empty');
+    errors.mockRestore();
   });
 
   it('falls back rather than propagating when the store read throws', async () => {
@@ -316,7 +345,32 @@ describe('reading the climbs shard summary', () => {
     const summary = await fetchClimbShardSummary();
 
     expect(summary.itemCount).toBe(999);
-    expect(errors.mock.calls.flat().join(' ')).toContain('could not read the stored climbs summary');
+    expect(summary.source).toBe('live');
+    expect(errors.mock.calls.flat().join(' ')).toContain('could not read sitemap_shard_refreshes');
+    // One event, not two: a throw is `summary-read-failed`, and the `!stored`
+    // branch it falls through to must not ALSO report `summary-empty` — the same
+    // degradation reported twice under two names is what makes a Sentry channel
+    // unreadable.
+    expect(sentry.messages.map((event) => event.message)).toHaveLength(1);
+    expect(sentry.messages[0].message).toContain('summary-read-failed');
+    errors.mockRestore();
+  });
+
+  it('pages once per reason per instance, however many crawlers arrive', async () => {
+    // A cold crawl is /sitemap.xml plus one request per page landing together. A
+    // wedged store degrades all of them, and one event per request would bury the
+    // signal in its own volume.
+    store.row = null;
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await fetchClimbShardSummary();
+    await fetchClimbShardSummary();
+    await fetchClimbShardSummary();
+
+    expect(sentry.messages).toHaveLength(1);
+    // The log is NOT floored — every occurrence stays greppable once you know to
+    // look, which is a different job from paging someone.
+    expect(errors.mock.calls.length).toBe(3);
     errors.mockRestore();
   });
 
@@ -545,7 +599,9 @@ describe('buildClimbShardPage', () => {
     expect(page.items).toHaveLength(3);
     expect(page.totalItems).toBe(3);
     expect(page.items[0].lastModified).toEqual(new Date('2026-05-04T11:22:33.000Z'));
+    expect(page.source).toBe('store');
     expect(live.fallbackItemCalls).toBe(0);
+    expect(sentry.messages).toEqual([]);
   });
 
   it('falls back to the live build, slicing the same way, when the store is empty', async () => {
@@ -556,12 +612,37 @@ describe('buildClimbShardPage', () => {
       path: `/live-${index}`,
       lastModified: null,
     }));
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const page = await buildClimbShardPage(2);
 
     expect(live.fallbackItemCalls).toBe(1);
     expect(page.totalItems).toBe(PER_PAGE + 2);
     expect(page.items.map((item) => item.path)).toEqual([`/live-${PER_PAGE}`, `/live-${PER_PAGE + 1}`]);
+    expect(page.source).toBe('live');
+    // Nothing outside this process ever looked at the page path — the smoke reads
+    // the index's `<loc>` entries, not the pages — so before this event an empty
+    // URL table meant every crawler fetch paid 51 s in silence.
+    expect(sentry.messages).toHaveLength(1);
+    expect(sentry.messages[0].message).toContain('page-empty');
+    errors.mockRestore();
+  });
+
+  it('reports the page fallback BEFORE running the 51 s build', async () => {
+    // Ordering, not decoration. The fallback build is the slow path by
+    // definition, and a Vercel invocation that times out inside it never reaches
+    // a line placed after it — the event would be lost exactly when it matters.
+    const order: string[] = [];
+    live.fallbackItems = [{ path: '/live-0', lastModified: null }];
+    live.onFallbackItems = () => order.push('built');
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {
+      order.push('reported');
+    });
+
+    await buildClimbShardPage(1);
+
+    expect(order).toEqual(['reported', 'built']);
+    errors.mockRestore();
   });
 
   it('falls back rather than propagating when the store read throws', async () => {
@@ -575,7 +656,10 @@ describe('buildClimbShardPage', () => {
     const page = await buildClimbShardPage(1);
 
     expect(page.items.map((item) => item.path)).toEqual(['/live-0']);
-    expect(errors.mock.calls.flat().join(' ')).toContain('could not read the stored climb URLs');
+    expect(page.source).toBe('live');
+    expect(errors.mock.calls.flat().join(' ')).toContain('could not read sitemap_climb_urls');
+    expect(sentry.messages).toHaveLength(1);
+    expect(sentry.messages[0].message).toContain('page-read-failed');
     errors.mockRestore();
   });
 });

--- a/packages/web/app/lib/seo/sitemap/climb-store.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-store.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import * as Sentry from '@sentry/nextjs';
 import { and, asc, eq, gte, lt, sql } from 'drizzle-orm';
 import { dbz } from '@/app/lib/db/db';
 import { sitemapClimbUrls, sitemapShardRefreshes } from '@/app/lib/db/schema';
@@ -38,6 +39,48 @@ export const CLIMBS_SHARD_ID = 'climbs';
  * slightly behind".
  */
 export const SITEMAP_CLIMB_STORE_MAX_AGE_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * Which path answered: the materialised store, or the live scan it falls back to.
+ *
+ * The fallback is correct and deliberate — it is why truncating either table
+ * loses nothing — but it is also the 51 s page build and the summary that cannot
+ * meet `SHARD_DEADLINE_MS`. #4583 was live in production for weeks precisely
+ * because a degrade left no trace anyone was watching, so the store says which
+ * path it took: `reportStoreFallback` puts it in Sentry, and the registry puts it
+ * on the response as `X-Sitemap-Climbs-Source`.
+ */
+export type ClimbShardSource = 'store' | 'live';
+
+/**
+ * Per-reason floor on Sentry emission, per instance.
+ *
+ * A crawl burst is `/sitemap.xml` plus one request per page arriving together,
+ * and an empty store degrades every one of them. Without a floor, one wedged
+ * store is one event per request; with it, it is one event per reason per
+ * instance per six hours — still loud, still deduplicated by Sentry on top.
+ */
+const FALLBACK_REPORT_FLOOR_MS = 6 * 60 * 60 * 1000;
+
+const lastFallbackReportAt = new Map<string, number>();
+
+/**
+ * Log every time, page at most once per reason per `FALLBACK_REPORT_FLOOR_MS`.
+ *
+ * `console.error` alone is what this fixes: on Vercel it lands in a log stream
+ * nobody reads, which is how the climbs shard stayed absent from the index from
+ * the day W-23 landed until #4661.
+ */
+function reportStoreFallback(reason: string, detail: string): void {
+  const message = `[sitemap] climb store fallback (${reason}): ${detail}`;
+  console.error(message);
+
+  const now = Date.now();
+  const previous = lastFallbackReportAt.get(reason);
+  if (previous !== undefined && now - previous < FALLBACK_REPORT_FLOOR_MS) return;
+  lastFallbackReportAt.set(reason, now);
+  Sentry.captureMessage(message, 'error');
+}
 
 /**
  * Transaction-scoped advisory-lock slot for the sitemap refresh write.
@@ -109,19 +152,29 @@ export async function fetchStoredClimbRefresh(): Promise<StoredShardRefresh | nu
  * rather than propagating: an index that degrades because its speed-up is missing
  * would be a worse outage than the one this replaced.
  */
-export async function fetchClimbShardSummary(): Promise<Tier2Summary> {
+export async function fetchClimbShardSummary(): Promise<Tier2Summary & { source: ClimbShardSource }> {
   let stored: StoredShardRefresh | null = null;
+  let readFailed = false;
   try {
     stored = await fetchStoredClimbRefresh();
   } catch (err) {
-    console.error(
-      '[sitemap] could not read the stored climbs summary — falling back to the live scan:',
-      err instanceof Error ? err.message : err,
+    readFailed = true;
+    reportStoreFallback(
+      'summary-read-failed',
+      `could not read sitemap_shard_refreshes, so /sitemap.xml is racing the live scan against SHARD_DEADLINE_MS: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
     );
   }
 
   if (!stored) {
-    return fetchTier2Summary();
+    if (!readFailed) {
+      reportStoreFallback(
+        'summary-empty',
+        'no sitemap_shard_refreshes row for the climbs shard — /sitemap.xml is racing the live scan against SHARD_DEADLINE_MS. The after() self-heal should fix this within one crawl; if it does not, run /api/internal/refresh-sitemap-climbs.',
+      );
+    }
+    return { ...(await fetchTier2Summary()), source: 'live' };
   }
 
   const ageMs = Date.now() - stored.computedAt.getTime();
@@ -133,7 +186,7 @@ export async function fetchClimbShardSummary(): Promise<Tier2Summary> {
     );
   }
 
-  return { itemCount: stored.itemCount, lastModified: stored.lastModified };
+  return { itemCount: stored.itemCount, lastModified: stored.lastModified, source: 'store' };
 }
 
 /** Why a refresh declined to write. `null` means it wrote. */
@@ -322,6 +375,9 @@ async function runRefresh(force: boolean): Promise<ClimbStoreRefreshResult> {
 /** One shard page from the store, or null when the URL table has never been populated. */
 export type StoredClimbPage = { items: SitemapItem[]; totalItems: number };
 
+/** One shard page plus which path built it, which is what the route header reports. */
+export type ClimbShardPage = StoredClimbPage & { source: ClimbShardSource };
+
 /**
  * Page N of the stored URL list: `ordinal >= start AND ordinal < start + perPage`,
  * a primary-key range scan measured at ~21 ms for a 10,000-row page.
@@ -369,23 +425,36 @@ export async function fetchStoredClimbPage(page: number): Promise<StoredClimbPag
  * propagating": the realistic throw is the migration not yet applied, and a page
  * that 503s because its speed-up is missing would be a worse outage than the
  * slow path it replaced.
+ *
+ * The fallback is never quiet. Nothing in this suite used to look at the page
+ * path at all — the smoke asserts the index's `<loc>` entries, not the pages —
+ * so an empty URL table meant every crawler fetch paid 51 s with no signal
+ * anywhere. It now fires a Sentry event and returns `source: 'live'`, which the
+ * route turns into `X-Sitemap-Climbs-Source: live`.
  */
-export async function buildClimbShardPage(page: number): Promise<StoredClimbPage> {
+export async function buildClimbShardPage(page: number): Promise<ClimbShardPage> {
+  let reason = 'page-empty';
+  let detail =
+    'sitemap_climb_urls holds no rows, so every /sitemaps/climbs/N.xml is rebuilding the whole ordered list (51 s cold in production, once per page per cold lambda). The after() self-heal on /sitemap.xml should fix this within one crawl; if it does not, run /api/internal/refresh-sitemap-climbs.';
   try {
     const stored = await fetchStoredClimbPage(page);
     if (stored) {
-      return stored;
+      return { ...stored, source: 'store' };
     }
   } catch (err) {
-    console.error(
-      '[sitemap] could not read the stored climb URLs — falling back to the live page build:',
-      err instanceof Error ? err.message : err,
-    );
+    reason = 'page-read-failed';
+    detail = `could not read sitemap_climb_urls, so /sitemaps/climbs/N.xml is rebuilding the whole ordered list: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
   }
+
+  // Reported BEFORE the fallback build, not after: the build is the 51 s path,
+  // and on a Vercel timeout an event fired afterwards is an event nobody gets.
+  reportStoreFallback(reason, detail);
 
   const items = await buildTier2ClimbItems();
   const start = (page - 1) * CLIMB_URLS_PER_SHARD;
-  return { items: items.slice(start, start + CLIMB_URLS_PER_SHARD), totalItems: items.length };
+  return { items: items.slice(start, start + CLIMB_URLS_PER_SHARD), totalItems: items.length, source: 'live' };
 }
 
 /**
@@ -482,8 +551,9 @@ export async function refreshClimbStoreIfStale(): Promise<void> {
   }
 }
 
-/** Test seam: drops the per-instance single-flight and self-heal floor. */
+/** Test seam: drops the per-instance single-flight, self-heal floor and report floor. */
 export function resetClimbStoreStateForTests(): void {
   refreshInFlight = null;
   lastSelfHealAt = 0;
+  lastFallbackReportAt.clear();
 }

--- a/packages/web/app/lib/seo/sitemap/climb-store.ts
+++ b/packages/web/app/lib/seo/sitemap/climb-store.ts
@@ -49,6 +49,12 @@ export const SITEMAP_CLIMB_STORE_MAX_AGE_MS = 48 * 60 * 60 * 1000;
  * because a degrade left no trace anyone was watching, so the store says which
  * path it took: `reportStoreFallback` puts it in Sentry, and the registry puts it
  * on the response as `X-Sitemap-Climbs-Source`.
+ *
+ * Spelled out here rather than imported as the registry's `PagedShardSource`,
+ * which is the identical union: `shard-registry.ts` imports this module, so the
+ * registry owns the CONTRACT ("a paged shard may report which path answered") and
+ * this file owns its own answer. Pointing one at the other would close the loop
+ * for the sake of two string literals.
  */
 export type ClimbShardSource = 'store' | 'live';
 

--- a/packages/web/app/lib/seo/sitemap/shard-registry.ts
+++ b/packages/web/app/lib/seo/sitemap/shard-registry.ts
@@ -93,6 +93,17 @@ const DEGRADED_CACHE_CONTROL = 'public, s-maxage=60, must-revalidate';
 const DEGRADED_HEADER = 'X-Sitemap-Degraded';
 
 /**
+ * Names which path served the climbs shard: `store` or `live`.
+ *
+ * Same precedent as `X-Sitemap-Degraded` — legible from a `curl -I` rather than
+ * only from a log line — and for the failure one layer down. `X-Sitemap-Degraded`
+ * answers "did the index publish this shard"; a wedged store can leave that answer
+ * "yes" while every page fetch behind it quietly rebuilds the whole ordered list.
+ * Exported because `scripts/production-smoke.ts` asserts on it.
+ */
+export const CLIMB_SOURCE_HEADER = 'X-Sitemap-Climbs-Source';
+
+/**
  * Climb shards get a far longer window than the hourly one the small shards use.
  * Google refetches a sitemap on the order of days, tier 2 changes on the order of
  * hours, and the CDN is what absorbs a crawl burst across a dozen pages before it
@@ -242,10 +253,23 @@ export type PagedShardId = 'climbs';
  * The deadline below stays regardless: the live scan is still the fallback while
  * the store is empty, and `playlists` has no precomputation at all.
  */
-export type PagedShardSummary = { itemCount: number; lastModified: Date | null };
+export type PagedShardSummary = { itemCount: number; lastModified: Date | null; source?: PagedShardSource };
 
 /** One page's slice, plus the length of the list it was sliced from. */
-export type PagedShardPage = { items: SitemapItem[]; totalItems: number };
+export type PagedShardPage = { items: SitemapItem[]; totalItems: number; source?: PagedShardSource };
+
+/**
+ * Which path a paged shard's answer came from, for shards that have more than one.
+ *
+ * `climbs` reads a materialised store and falls back to the live scan when the
+ * store is empty or unreadable (#4552). That fallback is CORRECT — the tables are
+ * a cache, truncating them loses nothing — and also invisible: the summary
+ * fallback blows `SHARD_DEADLINE_MS`, the page fallback costs 51 s, and neither
+ * left a mark outside a `console.error`. Reporting it here is how a `curl -I` and
+ * the post-deploy smoke can tell "fast path" from "the store is wedged and every
+ * crawler fetch is paying for it", which is the state #4583 lived in for weeks.
+ */
+export type PagedShardSource = 'store' | 'live';
 
 /**
  * A shard too large for one file, split across `/sitemaps/<dir>/1.xml … N.xml`.
@@ -272,6 +296,16 @@ export type PagedSitemapShard = {
    * any page this cannot name, and a failure here never degrades the shard.
    */
   pageLastmods?: () => Promise<(Date | null)[]>;
+  /**
+   * Response header that names the `source` this shard's summary and pages report.
+   *
+   * Set from values the handler ALREADY has — never a fresh read. The index races
+   * every summary against `SHARD_DEADLINE_MS` and `withDeadline` cannot cancel the
+   * loser, so a diagnostic that issued its own query would be free to outlive the
+   * deadline it is meant to describe and hold the whole index to `maxDuration`.
+   * Deriving it from the settled summary makes that impossible by construction.
+   */
+  sourceHeader?: string;
 };
 
 export const PAGED_SHARD_REGISTRY: readonly PagedSitemapShard[] = [
@@ -291,6 +325,7 @@ export const PAGED_SHARD_REGISTRY: readonly PagedSitemapShard[] = [
     // exists to retire.
     buildPage: (page: number) => buildClimbShardPage(page),
     pageLastmods: () => fetchStoredClimbPageLastmods(),
+    sourceHeader: CLIMB_SOURCE_HEADER,
   },
 ];
 
@@ -323,13 +358,18 @@ export async function pagedShardRouteHandler(id: PagedShardId, rawPage: string):
   }
 
   let body: string;
+  let source: PagedShardSource | undefined;
   try {
     const summary = await shard.summary();
     if (page > pagedShardPageCount(summary, shard.urlsPerShard)) {
       return notFoundResponse();
     }
 
-    const { items, totalItems } = await shard.buildPage(page);
+    const { items, totalItems, source: pageSource } = await shard.buildPage(page);
+    // The page's own answer wins over the summary's: they read different tables,
+    // and a populated summary row against an empty URL table is exactly the state
+    // the deploy that added the store was in.
+    source = pageSource ?? summary.source;
     // The summary and the URL rows are written in ONE transaction (#4552), so
     // steady-state they cannot disagree. What this still catches: a torn read
     // across a mid-flight refresh (the two reads land on different epochs), and
@@ -374,7 +414,12 @@ export async function pagedShardRouteHandler(id: PagedShardId, rawPage: string):
     return unavailableResponse();
   }
 
-  return xmlResponse(body, shard.cacheControl);
+  return xmlResponse(body, shard.cacheControl, sourceHeaders(shard, source));
+}
+
+/** `{ 'X-Sitemap-Climbs-Source': 'live' }`, or nothing when the shard reported none. */
+function sourceHeaders(shard: PagedSitemapShard, source: PagedShardSource | undefined): Record<string, string> {
+  return shard.sourceHeader && source ? { [shard.sourceHeader]: source } : {};
 }
 
 /**
@@ -479,7 +524,17 @@ async function buildIndexEntry(shard: SitemapShard): Promise<SitemapIndexEntry |
   return { loc: absoluteUrl(shard.path), lastModified: latestLastModified(items) };
 }
 
-async function buildPagedIndexEntries(shard: PagedSitemapShard): Promise<SitemapIndexEntry[] | null> {
+/**
+ * A paged shard's `<sitemap>` entries, plus which path its summary came from.
+ *
+ * The source rides back with the entries rather than being fetched again by the
+ * handler: `summary()` has already settled by the time this returns, so naming it
+ * on the response costs nothing and — unlike a second read — cannot outlive the
+ * `SHARD_DEADLINE_MS` race it describes.
+ */
+type PagedIndexResult = { entries: SitemapIndexEntry[] | null; source?: PagedShardSource };
+
+async function buildPagedIndexEntries(shard: PagedSitemapShard): Promise<PagedIndexResult> {
   // `summary()`, NEVER `buildPage()`. Running the full climb-item build on every
   // `/sitemap.xml` hit is the pool-starvation failure (#4461) this split avoids.
   const summary = await withDeadline(shard.summary(), SHARD_DEADLINE_MS, `paged shard "${shard.id}" summary`);
@@ -491,7 +546,7 @@ async function buildPagedIndexEntries(shard: PagedSitemapShard): Promise<Sitemap
         `[sitemap] paged shard "${shard.id}" expects URLs but its summary reports 0 — the entire surface is absent from the index`,
       );
     }
-    return null;
+    return { entries: null, source: summary.source };
   }
 
   // Per-page `<lastmod>` where the shard can supply it. The uniform shard-wide
@@ -516,19 +571,29 @@ async function buildPagedIndexEntries(shard: PagedSitemapShard): Promise<Sitemap
     }
   }
 
-  return Array.from({ length: pageCount }, (_, pageIndex) => ({
-    loc: absoluteUrl(shard.pagePath(pageIndex + 1)),
-    // `??` also covers a page the aggregate could not name (a summary/URL-store
-    // tear mid-refresh): stamp the shard-wide value rather than dropping the
-    // entry.
-    lastModified: pageLastmods[pageIndex] ?? summary.lastModified,
-  }));
+  return {
+    entries: Array.from({ length: pageCount }, (_, pageIndex) => ({
+      loc: absoluteUrl(shard.pagePath(pageIndex + 1)),
+      // `??` also covers a page the aggregate could not name (a summary/URL-store
+      // tear mid-refresh): stamp the shard-wide value rather than dropping the
+      // entry.
+      lastModified: pageLastmods[pageIndex] ?? summary.lastModified,
+    })),
+    source: summary.source,
+  };
 }
 
 export type SitemapIndexShardId = ShardId | PagedShardId;
 
-/** The index XML plus the shards it had to drop, so the caller can pick a cache window. */
-export type SitemapIndexResult = { xml: string; degradedShards: SitemapIndexShardId[] };
+/**
+ * The index XML plus the shards it had to drop, so the caller can pick a cache
+ * window, and the source headers the paged shards asked for.
+ */
+export type SitemapIndexResult = {
+  xml: string;
+  degradedShards: SitemapIndexShardId[];
+  sourceHeaders: Record<string, string>;
+};
 
 /**
  * The index lists only shards that carry at least one URL — pointing Google at
@@ -568,6 +633,7 @@ export async function buildSitemapIndexXml(): Promise<SitemapIndexResult> {
   const entries: SitemapIndexEntry[] = [];
   const degradedShards: SitemapIndexShardId[] = [];
   const emptyShards: SitemapIndexShardId[] = [];
+  const indexSourceHeaders: Record<string, string> = {};
 
   fixedSettled.forEach((outcome, index) => {
     const shard = SHARD_REGISTRY[index];
@@ -590,17 +656,21 @@ export async function buildSitemapIndexXml(): Promise<SitemapIndexResult> {
     const shard = PAGED_SHARD_REGISTRY[index];
     if (outcome.status === 'rejected') {
       degradedShards.push(shard.id);
+      // No source header on this branch, deliberately: a rejected or timed-out
+      // summary never told us which path it was on, and guessing `live` would put
+      // a claim on the response that nothing measured.
       console.error(
         `[sitemap] paged shard "${shard.id}" failed — serving the index WITHOUT its pages:`,
         outcome.reason instanceof Error ? outcome.reason.message : outcome.reason,
       );
       return;
     }
-    if (outcome.value === null) {
+    Object.assign(indexSourceHeaders, sourceHeaders(shard, outcome.value.source));
+    if (outcome.value.entries === null) {
       emptyShards.push(shard.id);
       return;
     }
-    entries.push(...outcome.value);
+    entries.push(...outcome.value.entries);
   });
 
   if (emptyShards.length > 0) {
@@ -617,16 +687,19 @@ export async function buildSitemapIndexXml(): Promise<SitemapIndexResult> {
     );
   }
 
-  return { xml: renderSitemapIndex(entries), degradedShards };
+  return { xml: renderSitemapIndex(entries), degradedShards, sourceHeaders: indexSourceHeaders };
 }
 
 export async function sitemapIndexRouteHandler(): Promise<Response> {
   try {
-    const { xml, degradedShards } = await buildSitemapIndexXml();
+    const { xml, degradedShards, sourceHeaders: shardSources } = await buildSitemapIndexXml();
     if (degradedShards.length === 0) {
-      return xmlResponse(xml);
+      return xmlResponse(xml, CACHE_CONTROL, shardSources);
     }
-    return xmlResponse(xml, DEGRADED_CACHE_CONTROL, { [DEGRADED_HEADER]: degradedShards.join(',') });
+    return xmlResponse(xml, DEGRADED_CACHE_CONTROL, {
+      ...shardSources,
+      [DEGRADED_HEADER]: degradedShards.join(','),
+    });
   } catch (err) {
     console.error('[sitemap] index failed to build:', err instanceof Error ? err.message : err);
     return unavailableResponse();

--- a/scripts/production-smoke.test.ts
+++ b/scripts/production-smoke.test.ts
@@ -246,6 +246,64 @@ describe('www production smoke checks', () => {
     expect(check.degradation?.(healthy) ?? null).toBeNull();
   });
 
+  it('warns when the climbs shard is served from the live scan rather than the store', () => {
+    // The gap `x-sitemap-degraded` structurally cannot see (#4583). An empty or
+    // unreadable store still produces a complete, correct index, so the body has
+    // every `<loc>` and no shard is declared dropped — while each
+    // `/sitemaps/climbs/N.xml` behind it rebuilds the whole ordered list. That is
+    // the shape the climbs shard sat in from W-23 until #4661.
+    const check = checkNamed('sitemap index');
+    const completeIndex =
+      '<sitemapindex>' +
+      '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
+      '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
+      '<sitemap><loc>https://www.boardsesh.com/sitemaps/playlists.xml</loc></sitemap>' +
+      '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap>' +
+      '</sitemapindex>';
+
+    const liveSource = response({
+      contentType: 'application/xml',
+      body: completeIndex,
+      headers: { 'x-sitemap-climbs-source': 'live' },
+    });
+    // A WARN, never a FAIL: the index it just validated is complete either way.
+    expect(check.assert(liveSource)).toBeNull();
+    expect(check.degradation?.(liveSource)).toMatch(/live scan/);
+    expect(check.degradation?.(liveSource)).toMatch(/refresh-sitemap-climbs/);
+
+    // The fast path says nothing.
+    expect(
+      check.degradation?.(
+        response({
+          contentType: 'application/xml',
+          body: completeIndex,
+          headers: { 'x-sitemap-climbs-source': 'store' },
+        }),
+      ) ?? null,
+    ).toBeNull();
+
+    // Neither does an absent header — a deploy that predates it, or a summary
+    // that lost the 3 s race and never reported a path. The `x-sitemap-degraded`
+    // branch already covers the second one, and inventing a finding from silence
+    // would make every older deployment warn.
+    expect(check.degradation?.(response({ contentType: 'application/xml', body: completeIndex })) ?? null).toBeNull();
+
+    // Both signals at once read as both reasons, not one swallowing the other.
+    const bothWrong = response({
+      contentType: 'application/xml',
+      body:
+        '<sitemapindex>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/static.xml</loc></sitemap>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/boards.xml</loc></sitemap>' +
+        '<sitemap><loc>https://www.boardsesh.com/sitemaps/climbs/1.xml</loc></sitemap>' +
+        '</sitemapindex>',
+      headers: { 'x-sitemap-degraded': 'playlists', 'x-sitemap-climbs-source': 'live' },
+    });
+    expect(check.assert(bothWrong)).toBeNull();
+    expect(check.degradation?.(bothWrong)).toMatch(/playlists/);
+    expect(check.degradation?.(bothWrong)).toMatch(/live scan/);
+  });
+
   it('rejects an empty static sitemap shard', () => {
     const check = checkNamed('static sitemap shard');
     expect(

--- a/scripts/production-smoke.ts
+++ b/scripts/production-smoke.ts
@@ -150,6 +150,20 @@ const MIN_RENDERED_PAGE_CHARS = 4_000;
 const SITEMAP_DEGRADED_HEADER = 'x-sitemap-degraded';
 
 /**
+ * The header `sitemapIndexRouteHandler` sets naming which path served the climbs
+ * shard: `store` (the materialised `sitemap_climb_urls` / `sitemap_shard_refreshes`
+ * read) or `live` (the scan they replaced).
+ *
+ * `X-Sitemap-Degraded` cannot see this. A store that is empty or unreadable still
+ * produces a complete, correct index — the live scan is the documented fallback —
+ * so the shard keeps its `<loc>` and nothing here goes red, while every
+ * `/sitemaps/climbs/N.xml` behind it rebuilds the whole ordered list at 51 s a
+ * page. That is the shape #4583 sat in from W-23 until #4661, unnoticed, so it
+ * gets its own signal.
+ */
+const SITEMAP_CLIMBS_SOURCE_HEADER = 'x-sitemap-climbs-source';
+
+/**
  * Shards the index must always list.
  *
  * `gyms` and `setters` are legitimately empty, so a missing entry there proves
@@ -282,11 +296,31 @@ export const WWW_CHECKS: SmokeCheck[] = [
         : `response body has no ${unexcused.map((shard) => shard.id).join(', ')} shard <loc> entry that the ${SITEMAP_DEGRADED_HEADER} header excuses`;
     },
     degradation: (response) => {
+      const reasons: string[] = [];
+
       const declared = declaredDegradedShards(response);
-      if (declared.length === 0) return null;
-      const missing = missingRequiredShards(response).map((shard) => shard.id);
-      const requiredNote = missing.length > 0 ? ` — including the required ${missing.join(', ')}` : '';
-      return `index published WITHOUT ${declared.join(', ')}${requiredNote} (${SITEMAP_DEGRADED_HEADER}: ${declared.join(',')})`;
+      if (declared.length > 0) {
+        const missing = missingRequiredShards(response).map((shard) => shard.id);
+        const requiredNote = missing.length > 0 ? ` — including the required ${missing.join(', ')}` : '';
+        reasons.push(
+          `index published WITHOUT ${declared.join(', ')}${requiredNote} (${SITEMAP_DEGRADED_HEADER}: ${declared.join(',')})`,
+        );
+      }
+
+      // A WARN and not an `assert`, on the same reasoning the header comment
+      // gives: the served index is complete and correct either way, so this is
+      // "the fast path is not the one running", not "the sitemap is broken".
+      // A missing header is not a finding — a deploy that predates the header,
+      // or a summary that lost the 3 s race and never reported a path, both
+      // leave it absent, and the `x-sitemap-degraded` branch above already
+      // covers the second one.
+      if (response.headers[SITEMAP_CLIMBS_SOURCE_HEADER] === 'live') {
+        reasons.push(
+          `the climbs shard is being served from the live scan, not the materialised store (${SITEMAP_CLIMBS_SOURCE_HEADER}: live) — every /sitemaps/climbs/N.xml is rebuilding the whole ordered list. Run /api/internal/refresh-sitemap-climbs`,
+        );
+      }
+
+      return reasons.length === 0 ? null : reasons.join('; ');
     },
   },
   {


### PR DESCRIPTION
## Summary

**Read this first: the tier-2 summary table this branch was originally opened for is already in production.** #4661 merged at 2026-08-22T00:23Z and #4583 was closed `COMPLETED` fifteen minutes later, verified against production. The work I was handed (`sitemap_tier2_groups` + `sitemap_tier2_climbs`, a nightly GH Actions cron, a predicate fingerprint, migration 0204) was cut from `c69611d0b` — the commit immediately *before* main landed its own materialisation at the same migration number. Two of the review findings say so directly, and both are right. Full accounting in the "What happened to the original branch" section below.

So this PR is not that branch. It is the one thing #4661 left open from the #4583 ruling's own scope notes:

> Keep the existing live-query path as a fallback, and **make a fallback loud rather than silent** — the whole lesson of this issue is that a quiet degrade hid a real regression.

Today that fallback is a `console.error`.

### The gap

The climbs shard reads a materialised store and falls back to the live scan when the store is empty or unreadable. The fallback is *correct* — the tables are a cache, truncating them loses nothing — and that is exactly the problem. It still produces a valid, complete sitemap, so:

- `X-Sitemap-Degraded` stays absent (the index published every shard);
- `REQUIRED_SITEMAP_SHARDS` stays satisfied (page 1's `<loc>` is right there);
- the smoke never fetches a climb page at all, so the **page** path — the 51 s rebuild, once per page per cold lambda — has no external signal of any kind.

That is the shape #4583 lived in from the day W-23 landed until #4661: the largest surface on the site, absent from the index on every request, for weeks, because the only trace was a log line.

### What this adds

**1. `X-Sitemap-Climbs-Source: store | live`**, on `/sitemap.xml` and on every `/sitemaps/climbs/N.xml`.

Derived from the `source` the summary and page builds have *already returned* — never a fresh read. That constraint is load-bearing and is the whole reason the earlier draft's version of this header was a major finding: the index races each summary against `SHARD_DEADLINE_MS`, and `withDeadline` is a `Promise.race` that cannot cancel the loser. A diagnostic that issued its own query after the index body was built would be free to outlive the deadline it describes and hold the whole response open to `maxDuration = 300`. Threading the value back through `buildPagedIndexEntries` makes that impossible by construction: there is no second await to run long.

Two smaller calls inside it:
- a rejected or timed-out summary reports **no** source rather than guessing `live` — it never told us which path it was on, and `X-Sitemap-Degraded` already covers that case;
- on a page, the **page build's** answer wins over the summary's. A fresh summary row over an empty URL table is not hypothetical — it is exactly the state the deploy that added `sitemap_climb_urls` was in, and a header taken from the summary alone would have called it healthy.

**2. A Sentry event** from `reportStoreFallback`, at most once per reason per instance per six hours (`summary-empty`, `summary-read-failed`, `page-empty`, `page-read-failed`). The log still fires every time; the floor is only on paging someone, because a cold crawl is the index plus one request per page arriving together and one event per request buries its own signal. The page-path event fires **before** the fallback build, not after — that build is the slow path by definition, and a platform timeout inside it would swallow an event placed on the far side.

**3. The smoke reads the header** off the index response it already fetches — no extra request, no 2 MB page download. `live` is a **warning**, not a failure: the index it just validated is complete either way, so this is "the fast path is not the one running", not "the sitemap is broken". A missing header is not a finding.

**4. `docs/sitemap.md`** gets the header contract, the Sentry reasons, and the one honest limit — the header rides a CDN-cached response (`s-maxage=3600` on the index, `21600` on pages, and Vercel's edge ignores the smoke's `no-cache` request header), so the value read can be up to that old in either direction. It is "a wedged store gets noticed within the hour", not a live probe. The Sentry event has no such lag.

## Production measurements, taken today

Read-only, authorized. Stated as measured rather than carried forward.

| probe | result |
|---|---|
| `sitemap_climb_urls` | 53,230 rows, `max(ordinal)` 53,229 |
| `sitemap_shard_refreshes` (`climbs`) | `item_count` 53,230, `computed_at` 2026-08-22T00:36Z |
| `/sitemaps/climbs/1.xml`, cache-busted | 200, 2,247,529 bytes, **4.95 s** origin miss |
| `/sitemaps/climbs/3.xml` | 200, 2,025,415 bytes, 1.72 s |
| `/sitemaps/climbs/6.xml` | 200, 677,932 bytes, 1.43 s |
| `/sitemap.xml`, 3 cache-busted requests | **1 of 3 still returned `x-sitemap-degraded: climbs`, at 4.74 s**; the other two 1.34 s / 1.23 s clean |

The store is healthy and #4661's win is real. But that last row is the point of this PR in one line: the index *still* degrades on a genuinely cold lambda roughly a third of the time, and **from outside there is no way to tell whether that was a cold connection over a healthy store or the store being empty.** With this change it is one header.

The earlier draft's "27.4 s cold page" figure is not carried forward — it is no longer production's cost, and a review finding was right to flag it.

## What happened to the original branch

`feat/4583-tier2-summary-table` (`85698f298`, +15,366 lines) is superseded and is not being pushed. Fourteen findings came back across two review lenses; here is where each landed.

**Stands, and is why the branch is abandoned rather than fixed:**

- **[major] page slices torn across a 5-minute cached summary.** The branch computed every `(group, offset, limit)` triple from a cached group summary and then read the rows live, with no epoch column tying the two. The lens reproduced it on the dev image: a mid-window refresh silently dropped 1,500 URLs off page 3, and a larger shrink 503'd the shard. `main` cannot have this bug — `fetchStoredClimbPage` reads `WHERE ordinal >= start AND ordinal < start + 10000`, one statement, self-consistent by construction. The branch replaced a stored ordinal with a derived offset and regressed the exact property it claimed to add.
- **[major] the diagnostic header defeated the index deadline.** `Object.assign(shardHeaders, await safeShardHeaders(shard))` ran after `buildSitemapIndexXml()` returned, outside `withDeadline`, on a promise (`verdictInFlight`) that a lost 3 s race leaves pending forever. Verified: `withDeadline` is a bare `Promise.race`, `safeShardHeaders` had a try/catch and no timeout, and the route sets `maxDuration = 300`. **This PR's header is the corrected shape** — the value comes back with the entries, so there is no second await to run long.
- **[major] per-page `<lastmod>` was gone.** Not a deletion by the branch (it predates #4661) but a real regression once rebased, and the comment justifying its absence was factually wrong: `main` gets it from one `max(last_modified) GROUP BY (ordinal / 10000)` aggregate, no item build. Rebasing onto `main` keeps it.
- **[minor] `docs/sitemap.md` untouched** while the branch added two tables, a cron, four headers and a Sentry channel. Verified: `git diff --stat` over `docs/` was empty. **Fixed here** — `main` documented its own store, and this PR documents what it adds on top.
- **[minor] `climbs` flipped to `degradable: false`** in the same change that shipped empty tables. Not carried over; `main`'s `degradable: true` is kept, and the new source check is a warning for the same reason.
- **[minor] the 24 h cron staleness was documented in one direction only** (a climb *entering* tier 2), never the delist / draft / angle-flip direction. Moot: `main`'s cron is six-hourly and matches the shard's own `s-maxage=21600`, so no layer is staler than another.
- **[minor] a failed `workflow_dispatch` notified nobody** — the Discord step was gated on `github.event_name == 'schedule'`, and the header told operators to dispatch by hand right after the migration. Moot with the workflow gone; the "a silent fallback reaches nobody" half of that finding is what this PR fixes.
- **[minor] `X-Sitemap-Tier2-Drift` was dead in a serverless fleet** — per-instance module state written in `after()` and read on a later request to the *same* lambda, behind an hour of CDN cache. Correct, and it is why this PR's header carries only values measured **in the same request**, and why the drift detector is not reintroduced.
- **[minor] the claimed benchmark numbers did not reproduce** (0.13 ms summary measured at 1.10–2 ms; 6.7 ms page measured at 20–75 ms SQL-only). Not carried forward; the table above is what I measured today.
- **[minor] `MIN_EXPECTED_TIER2_ITEMS = 40,000` had 3.2% headroom** on the dev image with no override. Moot.
- **[nit] SQL `ORDER BY` vs the JS comparator** could disagree under `en_US.utf8` for a board type containing punctuation. Moot.
- **[nit] `lastAuditWarnings` never cleared on the early-return path**, so a stale drift value kept being emitted after the condition cleared. Moot.

**Verified and stands, worth recording because it is a general trap:**

- **[minor] literal NUL bytes** in `packages/db/src/queries/sitemap/tier2-fingerprint.ts` — `hash.update('\0')` written with a raw `0x00` instead of the escape, at offsets `0x86b` and `0x8ab`. Confirmed: `file` reports `data` and `git diff --stat` renders it `Bin 0 -> 2271 bytes`, so the one file defining the drift detector could not be reviewed in a diff. Moot here, but worth a wider look: if any other source file in this repo carries a raw NUL it is silently unreviewable the same way.

**Rebutted:** none. Every finding held up. Two ("per-page lastmod deleted", "no ordinal") describe a divergence from a `main` that did not exist when the branch was cut rather than something the branch removed, but the conclusion each draws — do not ship this shape — is correct either way.

## Test plan

- `vp run typecheck` — clean.
- `vp test run --reporter=agent --project web` — 4,030 passed. 3 failures, all pre-existing flakes under full parallel load in unrelated component tests (`location-sync-freezes-panel`, `profile-tab`, `claim-gym-dialog`); `location-sync-freezes-panel` also fails on `origin/main` in isolation, and all three pass in isolation on this branch. None import sitemap code.
- `vp test run --reporter=agent scripts/production-smoke.test.ts` — 21 passed.
- `vp check` — 2 errors, both pre-existing `@gorhom/bottom-sheet` TS2307s from the mobile web-shim's nested install, unrelated.
- **Mutation-tested, every one applied and watched go red, then reverted:**
  - report moved to *after* the fallback build → the ordering test fails.
  - report floor removed → the "pages once per reason" test fails.
  - `if (!readFailed)` forced true → the double-report guard fails.
  - fallback labelled `store` → five source assertions fail.
  - `summary.source ?? pageSource` instead of `pageSource ?? summary.source` → the page-overrides-summary test fails.
  - index header guessed as `live` on a rejected summary → the "claims nothing when the summary never settled" test fails.
  - both `sourceHeaders(...)` calls dropped → four header tests fail.
  - smoke's `=== 'live'` widened to `!== 'store'` → two smoke tests fail (an absent header would warn).
  - smoke's reasons joined → last-only → the "both signals at once" test fails.

## Production targets

`packages/web` and `scripts/` only. **Nothing in the mobile graph, no OTA.** No migration, no schema change, no new env var, no new secret, no new cron. One new response header and one new Sentry message channel.

Refs #4583

## Release Notes

- [x] No release note needed (internal / technical change)

The user-visible half of #4583 — tier-2 climbs actually reaching Google — shipped in #4661 and was verified in production there. What is left here is observability: nothing a climber sees, and a "What's New" line about a sitemap response header would be noise.
