### PR TITLE
fix(web): compact and dedupe hot-path error logging, stop OG 500s echoing SQL

### DIFF
--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -110,8 +110,8 @@ rather than an error.
 
 `packages/web/app/lib/db/read-deadline.ts` bounds one read client-side. It races
 the pending query against a timer and rejects with `DbReadTimeoutError`
-(`code: 'DB_READ_TIMEOUT'`) when the timer wins. It is wired at the four
-front-door reads only — the two statements behind `getClimb`, the all-angles
+(`code: 'DB_READ_TIMEOUT'`) when the timer wins. It is wired at four
+front-door reads — the two statements behind `getClimb`, the all-angles
 stats select, and the shared climb search — and deliberately **not** inside
 `withConnectRetry` or `packages/db`, where it would change behaviour for the
 backend, the sync runners and every script.
@@ -139,6 +139,18 @@ puts one deadline timestamp in React's per-render `cache` scope and hands each
 read whatever the earlier ones left, floored at 500 ms. Outside a render scope
 (scripts, unit tests) React's `cache` is a passthrough and each read gets its own
 deadline.
+
+**Since #4650 the same helper also wraps four more reads: the unauthenticated
+OG image routes**, one `withReadDeadline` call around each route's whole DB
+phase — `og-setter`, `og-profile`, `og-playlist`, `og-session` (`/api/og/climb`
+needs nothing; its `getClimb` read is already covered above). Those add a
+third outcome to the table below: a timed-out or rejected OG read does not
+404 or 500, it redirects to `/opengraph-image` — the existing DB-free branded
+card — with a 60 s CDN `s-maxage`. Unfurlers render nothing on a bare 5xx and
+cache that failed scrape for days, so a degraded-but-present card beats a
+blank embed for that whole window, and the short `s-maxage` lets the CDN
+answer a burst of scraper retries during the brownout without sending each
+one at the database.
 
 ### What the reader sees when it fires
 

--- a/packages/web/app/api/og/climb/route.tsx
+++ b/packages/web/app/api/og/climb/route.tsx
@@ -4,6 +4,7 @@ import { getBoardDetailsForBoard } from '@/app/lib/board-utils';
 import { parseBoardRouteParamsWithSlugs } from '@/app/lib/url-utils.server';
 import { buildOgBoardRenderUrl } from '@/app/components/board-renderer/util';
 import { createOgImageHeaders } from '@/app/lib/seo/og';
+import { ogErrorResponse } from '@/app/lib/seo/og-error';
 
 export const runtime = 'nodejs';
 
@@ -67,8 +68,6 @@ export async function GET(request: NextRequest) {
 
     return response;
   } catch (error) {
-    console.error('Error redirecting climb OG image:', error);
-    const message = error instanceof Error ? error.message : String(error);
-    return new Response(`Error generating image: ${message}`, { status: 500 });
+    return ogErrorResponse('climb', error);
   }
 }

--- a/packages/web/app/api/og/playlist/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/playlist/__tests__/route.test.tsx
@@ -202,7 +202,7 @@ describe('api/og/playlist route', () => {
     expect(collectText(playlistRouteState.capturedElement)).toContain('SP');
   });
 
-  it('returns a generic 500 with no-store instead of leaking the underlying error', async () => {
+  it('redirects to the branded fallback card instead of leaking the underlying error', async () => {
     playlistRouteState.getPlaylistOgSummaryMock.mockRejectedValue(
       Object.assign(new Error('Failed query: SELECT * FROM playlists WHERE uuid = $1 params: leaky-playlist'), {
         name: 'DrizzleQueryError',
@@ -212,9 +212,9 @@ describe('api/og/playlist route', () => {
     const response = await GET(makeRequest({ uuid: 'leaky-playlist' }));
     const body = await response.text();
 
-    expect(response.status).toBe(500);
-    expect(response.headers.get('Cache-Control')).toBe('no-store');
-    expect(body).toBe('Error generating image');
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/opengraph-image');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
     expect(body).not.toContain('SELECT');
     expect(body).not.toContain('leaky-playlist');
   });

--- a/packages/web/app/api/og/playlist/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/playlist/__tests__/route.test.tsx
@@ -201,4 +201,21 @@ describe('api/og/playlist route', () => {
     await GET(makeRequest({ uuid: 'initials-playlist' }));
     expect(collectText(playlistRouteState.capturedElement)).toContain('SP');
   });
+
+  it('returns a generic 500 with no-store instead of leaking the underlying error', async () => {
+    playlistRouteState.getPlaylistOgSummaryMock.mockRejectedValue(
+      Object.assign(new Error('Failed query: SELECT * FROM playlists WHERE uuid = $1 params: leaky-playlist'), {
+        name: 'DrizzleQueryError',
+      }),
+    );
+
+    const response = await GET(makeRequest({ uuid: 'leaky-playlist' }));
+    const body = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(body).toBe('Error generating image');
+    expect(body).not.toContain('SELECT');
+    expect(body).not.toContain('leaky-playlist');
+  });
 });

--- a/packages/web/app/api/og/playlist/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/playlist/__tests__/route.test.tsx
@@ -14,6 +14,10 @@ vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
   getPlaylistOgSummary: playlistRouteState.getPlaylistOgSummaryMock,
 }));
 
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
 vi.mock('@/app/theme/theme-config', () => ({
   themeTokens: {
     neutral: {
@@ -73,6 +77,16 @@ function makeRequest(params: Record<string, string>): NextRequest {
     url.searchParams.set(key, value);
   }
   return new NextRequest(url);
+}
+
+/**
+ * Mirrors real drizzle-orm@0.45.2's `DrizzleQueryError`: `.name` stays the
+ * inherited "Error" (the class never overrides it), the message embeds the
+ * full SQL + params, and `.cause` is always the underlying driver error.
+ */
+function makeDrizzleQueryError(sql: string, params: string, causeMessage = 'CONNECT_TIMEOUT'): Error {
+  const cause = Object.assign(new Error(causeMessage), { code: causeMessage });
+  return Object.assign(new Error(`Failed query: ${sql}\nparams: ${params}`), { cause });
 }
 
 function collectText(node: unknown): string {
@@ -203,10 +217,9 @@ describe('api/og/playlist route', () => {
   });
 
   it('redirects to the branded fallback card instead of leaking the underlying error', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     playlistRouteState.getPlaylistOgSummaryMock.mockRejectedValue(
-      Object.assign(new Error('Failed query: SELECT * FROM playlists WHERE uuid = $1 params: leaky-playlist'), {
-        name: 'DrizzleQueryError',
-      }),
+      makeDrizzleQueryError('SELECT * FROM playlists WHERE uuid = $1', 'leaky-playlist'),
     );
 
     const response = await GET(makeRequest({ uuid: 'leaky-playlist' }));
@@ -217,5 +230,12 @@ describe('api/og/playlist route', () => {
     expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
     expect(body).not.toContain('SELECT');
     expect(body).not.toContain('leaky-playlist');
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const [, loggedMessage] = consoleErrorSpy.mock.calls[0] as [string, string];
+    expect(loggedMessage).not.toContain('SELECT');
+    expect(loggedMessage).not.toContain('leaky-playlist');
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/packages/web/app/api/og/playlist/route.tsx
+++ b/packages/web/app/api/og/playlist/route.tsx
@@ -5,6 +5,7 @@ import { themeTokens } from '@/app/theme/theme-config';
 import { formatBoardDisplayName } from '@/app/lib/string-utils';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getPlaylistOgSummary } from '@/app/lib/seo/dynamic-og-data';
+import { ogErrorResponse } from '@/app/lib/seo/og-error';
 
 export const runtime = 'nodejs';
 
@@ -200,8 +201,6 @@ export async function GET(request: NextRequest) {
       },
     );
   } catch (error) {
-    console.error('Error generating playlist OG image:', error);
-    const message = error instanceof Error ? error.message : String(error);
-    return new Response(`Error generating image: ${message}`, { status: 500 });
+    return ogErrorResponse('playlist', error);
   }
 }

--- a/packages/web/app/api/og/playlist/route.tsx
+++ b/packages/web/app/api/og/playlist/route.tsx
@@ -6,6 +6,7 @@ import { formatBoardDisplayName } from '@/app/lib/string-utils';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getPlaylistOgSummary } from '@/app/lib/seo/dynamic-og-data';
 import { ogErrorResponse } from '@/app/lib/seo/og-error';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 export const runtime = 'nodejs';
 
@@ -56,7 +57,7 @@ export async function GET(request: NextRequest) {
     }
 
     const dbT0 = performance.now();
-    const playlist = await getPlaylistOgSummary(uuid);
+    const playlist = await withReadDeadline('og-playlist', getPlaylistOgSummary(uuid));
     const dbMs = performance.now() - dbT0;
 
     if (!playlist) {

--- a/packages/web/app/api/og/profile/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/profile/__tests__/route.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { NextRequest } from 'next/server';
+import { GET } from '../route';
+
+/**
+ * `sqlTagMock` stands in for the tagged-template function `getReadPool()`
+ * returns. Tests control exactly when it "resolves" — the mechanism the
+ * first test below depends on to catch a specific regression: the route used
+ * to do `rowsFromResult(await sql\`...\`)` *inside* the `Promise.all` array
+ * literal, which resolves the query before `Promise.all`/`withReadDeadline`
+ * ever run, silently leaving it unbounded despite the deadline wrap.
+ */
+const profileRouteState = vi.hoisted(() => ({
+  getProfileOgSummaryMock: vi.fn(),
+  sqlTagMock: vi.fn(),
+  recordedReads: [] as { label: string; ms: number | undefined }[],
+  capturedElement: null as unknown,
+}));
+
+vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
+  getProfileOgSummary: profileRouteState.getProfileOgSummaryMock,
+}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  getReadPool: () => profileRouteState.sqlTagMock,
+  rowsFromResult: (result: unknown) => (Array.isArray(result) ? result : []),
+}));
+
+vi.mock('@/app/lib/db/read-deadline', () => ({
+  withReadDeadline: async (label: string, pending: Promise<unknown>, ms?: number) => {
+    profileRouteState.recordedReads.push({ label, ms });
+    return pending;
+  },
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    neutral: {
+      200: '#E0E0E0',
+      300: '#D0D0D0',
+      400: '#B0B0B0',
+      500: '#909090',
+      900: '#101010',
+    },
+  },
+}));
+
+vi.mock('@/app/lib/grade-colors', () => ({
+  FONT_GRADE_COLORS: {
+    v5: '#00AAFF',
+  },
+  getGradeColorWithOpacity: vi.fn(() => 'rgba(0, 170, 255, 0.5)'),
+}));
+
+vi.mock('@/app/lib/board-data', () => ({
+  BOULDER_GRADES: [{ difficulty_id: 10, font_grade: 'V5' }],
+}));
+
+vi.mock('@/app/lib/seo/og', () => ({
+  OG_IMAGE_WIDTH: 1200,
+  OG_IMAGE_HEIGHT: 630,
+  createOgImageHeaders: vi.fn(
+    ({ contentType, version, serverTiming }: { contentType: string; version?: string; serverTiming?: string }) => ({
+      'Content-Type': contentType,
+      'Cache-Control': version
+        ? 'public, max-age=31536000, s-maxage=31536000, immutable'
+        : 'public, max-age=0, s-maxage=300, stale-while-revalidate=86400',
+      'CDN-Cache-Control': version
+        ? 'public, s-maxage=31536000, immutable'
+        : 'public, s-maxage=300, stale-while-revalidate=86400',
+      'Vercel-CDN-Cache-Control': version
+        ? 'public, s-maxage=31536000, immutable'
+        : 'public, s-maxage=300, stale-while-revalidate=86400',
+      'Server-Timing': serverTiming ?? '',
+    }),
+  ),
+}));
+
+vi.mock('@vercel/og', () => ({
+  ImageResponse: vi.fn(function ImageResponse(element: unknown, init?: ResponseInit) {
+    profileRouteState.capturedElement = element;
+    return new Response('mock-image', {
+      status: 200,
+      headers: new Headers(init?.headers),
+    });
+  }),
+}));
+
+function makeRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/og/profile');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+describe('api/og/profile route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    profileRouteState.recordedReads.length = 0;
+    profileRouteState.capturedElement = null;
+  });
+
+  it('passes the grade-count query into Promise.all unresolved, so both reads race under one og-profile deadline', async () => {
+    let resolveGradeRows: (rows: unknown[]) => void = () => {};
+    const gradeRowsPromise = new Promise<unknown[]>((resolve) => {
+      resolveGradeRows = resolve;
+    });
+    profileRouteState.sqlTagMock.mockReturnValue(gradeRowsPromise);
+    profileRouteState.getProfileOgSummaryMock.mockResolvedValue({
+      displayName: 'Alex',
+      avatarUrl: null,
+      fallbackImageUrl: null,
+    });
+
+    const responsePromise = GET(makeRequest({ user_id: 'user-1' }));
+
+    // Deliberately asserted before resolving the grade query and before ever
+    // awaiting the route. Calling an async function runs its body
+    // synchronously up to its first `await`, and our `withReadDeadline` mock
+    // records its label before it awaits anything — so 'og-profile' is only
+    // recorded here if the grade-count query was handed into `Promise.all`
+    // still pending. A regression that reintroduces `await sql\`...\`` inside
+    // the array literal would pause GET on that await *before* it ever
+    // reaches `withReadDeadline`, leaving this empty since `sqlTagMock`'s
+    // promise is deliberately never resolved above this line.
+    expect(profileRouteState.recordedReads.map((read) => read.label)).toEqual(['og-profile']);
+
+    resolveGradeRows([]);
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+  });
+
+  it('renders a 200 PNG with the profile summary and grade bars', async () => {
+    profileRouteState.sqlTagMock.mockResolvedValue([{ difficulty: 10, cnt: 3 }]);
+    profileRouteState.getProfileOgSummaryMock.mockResolvedValue({
+      displayName: 'Alex',
+      avatarUrl: null,
+      fallbackImageUrl: null,
+    });
+
+    const response = await GET(makeRequest({ user_id: 'user-1' }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('image/png');
+  });
+
+  it('redirects to the branded fallback card on a DbReadTimeoutError-shaped rejection', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const timeoutError = Object.assign(new Error('[db] front-door read "og-profile" exceeded 6000ms'), {
+      name: 'DbReadTimeoutError',
+      code: 'DB_READ_TIMEOUT',
+    });
+    profileRouteState.getProfileOgSummaryMock.mockRejectedValue(timeoutError);
+    profileRouteState.sqlTagMock.mockResolvedValue([]);
+
+    const response = await GET(makeRequest({ user_id: 'user-1' }));
+    const body = await response.text();
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/opengraph-image');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
+    expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
+    expect(body).not.toContain('SELECT');
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/web/app/api/og/profile/route.tsx
+++ b/packages/web/app/api/og/profile/route.tsx
@@ -8,6 +8,7 @@ import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getProfileOgSummary } from '@/app/lib/seo/dynamic-og-data';
 import { ogErrorResponse } from '@/app/lib/seo/og-error';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 export const runtime = 'nodejs';
 
@@ -34,10 +35,15 @@ export async function GET(request: NextRequest) {
 
     const dbT0 = performance.now();
     const sql = getReadPool();
-    const [summary, gradeRows] = await Promise.all([
-      getProfileOgSummary(userId),
-      rowsFromResult<{ difficulty: number; cnt: number }>(
-        await sql`
+    // The grade-count query is passed unawaited so both reads below actually
+    // start together — an `await` here (the old shape) would resolve before
+    // `Promise.all`/`withReadDeadline` ever runs, defeating the deadline for
+    // this query.
+    const [summary, gradeResult] = await withReadDeadline(
+      'og-profile',
+      Promise.all([
+        getProfileOgSummary(userId),
+        sql`
         SELECT difficulty, COUNT(DISTINCT climb_uuid) as cnt
         FROM boardsesh_ticks
         WHERE user_id = ${userId}
@@ -46,9 +52,10 @@ export async function GET(request: NextRequest) {
         GROUP BY difficulty
         ORDER BY difficulty
       `,
-      ),
-    ]);
+      ]),
+    );
     const dbMs = performance.now() - dbT0;
+    const gradeRows = rowsFromResult<{ difficulty: number; cnt: number }>(gradeResult);
 
     if (!summary) {
       return new Response('User not found', { status: 404 });

--- a/packages/web/app/api/og/profile/route.tsx
+++ b/packages/web/app/api/og/profile/route.tsx
@@ -7,6 +7,7 @@ import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-col
 import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getProfileOgSummary } from '@/app/lib/seo/dynamic-og-data';
+import { ogErrorResponse } from '@/app/lib/seo/og-error';
 
 export const runtime = 'nodejs';
 
@@ -241,8 +242,6 @@ export async function GET(request: NextRequest) {
       },
     );
   } catch (error) {
-    console.error('Error generating profile OG image:', error);
-    const message = error instanceof Error ? error.message : String(error);
-    return new Response(`Error generating image: ${message}`, { status: 500 });
+    return ogErrorResponse('profile', error);
   }
 }

--- a/packages/web/app/api/og/session/route.tsx
+++ b/packages/web/app/api/og/session/route.tsx
@@ -6,6 +6,7 @@ import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-col
 import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getSessionOgSummary } from '@/app/lib/seo/dynamic-og-data';
+import { ogErrorResponse } from '@/app/lib/seo/og-error';
 
 export const runtime = 'nodejs';
 
@@ -486,8 +487,6 @@ export async function GET(request: NextRequest) {
       }),
     });
   } catch (error) {
-    console.error('Error generating session OG image:', error);
-    const message = error instanceof Error ? error.message : String(error);
-    return new Response(`Error generating image: ${message}`, { status: 500 });
+    return ogErrorResponse('session', error);
   }
 }

--- a/packages/web/app/api/og/session/route.tsx
+++ b/packages/web/app/api/og/session/route.tsx
@@ -7,6 +7,7 @@ import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getSessionOgSummary } from '@/app/lib/seo/dynamic-og-data';
 import { ogErrorResponse } from '@/app/lib/seo/og-error';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 export const runtime = 'nodejs';
 
@@ -50,7 +51,7 @@ export async function GET(request: NextRequest) {
     }
 
     const dbT0 = performance.now();
-    const summary = await getSessionOgSummary(sessionId);
+    const summary = await withReadDeadline('og-session', getSessionOgSummary(sessionId));
     const dbMs = performance.now() - dbT0;
 
     if (!summary.found) {

--- a/packages/web/app/api/og/setter/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/setter/__tests__/route.test.tsx
@@ -23,6 +23,10 @@ vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
   getSetterOgSummary: setterRouteState.getSetterOgSummaryMock,
 }));
 
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
 vi.mock('@/app/lib/db/db', () => ({
   dbzRead: setterRouteState.dbzReadSentinel,
   dbz: setterRouteState.dbzSentinel,
@@ -97,6 +101,16 @@ function makeRequest(params: Record<string, string>): NextRequest {
   return new NextRequest(url);
 }
 
+/**
+ * Mirrors real drizzle-orm@0.45.2's `DrizzleQueryError`: `.name` stays the
+ * inherited "Error" (the class never overrides it), the message embeds the
+ * full SQL + params, and `.cause` is always the underlying driver error.
+ */
+function makeDrizzleQueryError(sql: string, params: string, causeMessage = 'CONNECT_TIMEOUT'): Error {
+  const cause = Object.assign(new Error(causeMessage), { code: causeMessage });
+  return Object.assign(new Error(`Failed query: ${sql}\nparams: ${params}`), { cause });
+}
+
 describe('api/og/setter route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -135,9 +149,7 @@ describe('api/og/setter route', () => {
   it('redirects to the branded fallback card and logs a throttled compact message when the DB rejects', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     setterRouteState.getSetterOgSummaryMock.mockRejectedValue(
-      Object.assign(new Error('Failed query: SELECT * FROM boardsesh_ticks WHERE setter_username = $1'), {
-        name: 'DrizzleQueryError',
-      }),
+      makeDrizzleQueryError('SELECT * FROM boardsesh_ticks WHERE setter_username = $1', 'alex'),
     );
     setterRouteState.executeRowsMock.mockResolvedValue([]);
 
@@ -149,11 +161,11 @@ describe('api/og/setter route', () => {
     expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
     expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
     expect(body).not.toContain('SELECT');
+
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      '[og] setter render failed:',
-      expect.stringContaining('DrizzleQueryError'),
-    );
+    const [, loggedMessage] = consoleErrorSpy.mock.calls[0] as [string, string];
+    expect(loggedMessage).not.toContain('SELECT');
+    expect(loggedMessage).toBe('Error: CONNECT_TIMEOUT');
 
     consoleErrorSpy.mockRestore();
   });

--- a/packages/web/app/api/og/setter/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/setter/__tests__/route.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { NextRequest } from 'next/server';
+import { GET } from '../route';
+
+/**
+ * Sentinels stand in for the drizzle handles `@/app/lib/db/db` exports.
+ * Asserting on identity (not just "was called") is what actually pins the
+ * replica seam: `executeRows` accepts any drizzle instance, so a regression
+ * back to `dbz` (primary) would still "work" and only this test would catch it.
+ */
+const setterRouteState = vi.hoisted(() => ({
+  getSetterOgSummaryMock: vi.fn(),
+  executeRowsMock: vi.fn(),
+  dbzReadSentinel: { __sentinel: 'dbzRead' } as unknown,
+  dbzSentinel: { __sentinel: 'dbz' } as unknown,
+  recordedReads: [] as { label: string; ms: number | undefined }[],
+  capturedElement: null as unknown,
+}));
+
+vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
+  getSetterOgSummary: setterRouteState.getSetterOgSummaryMock,
+}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  dbzRead: setterRouteState.dbzReadSentinel,
+  dbz: setterRouteState.dbzSentinel,
+  executeRows: setterRouteState.executeRowsMock,
+}));
+
+vi.mock('@/app/lib/db/read-deadline', () => ({
+  withReadDeadline: async (label: string, pending: Promise<unknown>, ms?: number) => {
+    setterRouteState.recordedReads.push({ label, ms });
+    return pending;
+  },
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    neutral: {
+      200: '#E0E0E0',
+      300: '#D0D0D0',
+      400: '#B0B0B0',
+      500: '#909090',
+      900: '#101010',
+    },
+  },
+}));
+
+vi.mock('@/app/lib/grade-colors', () => ({
+  FONT_GRADE_COLORS: {
+    v5: '#00AAFF',
+  },
+  getGradeColorWithOpacity: vi.fn(() => 'rgba(0, 170, 255, 0.5)'),
+}));
+
+vi.mock('@/app/lib/board-data', () => ({
+  BOULDER_GRADES: [{ difficulty_id: 10, font_grade: 'V5' }],
+}));
+
+vi.mock('@/app/lib/seo/og', () => ({
+  OG_IMAGE_WIDTH: 1200,
+  OG_IMAGE_HEIGHT: 630,
+  createOgImageHeaders: vi.fn(
+    ({ contentType, version, serverTiming }: { contentType: string; version?: string; serverTiming?: string }) => ({
+      'Content-Type': contentType,
+      'Cache-Control': version
+        ? 'public, max-age=31536000, s-maxage=31536000, immutable'
+        : 'public, max-age=0, s-maxage=300, stale-while-revalidate=86400',
+      'CDN-Cache-Control': version
+        ? 'public, s-maxage=31536000, immutable'
+        : 'public, s-maxage=300, stale-while-revalidate=86400',
+      'Vercel-CDN-Cache-Control': version
+        ? 'public, s-maxage=31536000, immutable'
+        : 'public, s-maxage=300, stale-while-revalidate=86400',
+      'Server-Timing': serverTiming ?? '',
+    }),
+  ),
+}));
+
+vi.mock('@vercel/og', () => ({
+  ImageResponse: vi.fn(function ImageResponse(element: unknown, init?: ResponseInit) {
+    setterRouteState.capturedElement = element;
+    return new Response('mock-image', {
+      status: 200,
+      headers: new Headers(init?.headers),
+    });
+  }),
+}));
+
+function makeRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/og/setter');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+describe('api/og/setter route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setterRouteState.recordedReads.length = 0;
+    setterRouteState.capturedElement = null;
+  });
+
+  it('reads the tick-aggregate query off the replica seam (dbzRead), not the primary', async () => {
+    setterRouteState.getSetterOgSummaryMock.mockResolvedValue({
+      displayName: 'Alex',
+      avatarUrl: null,
+    });
+    setterRouteState.executeRowsMock.mockResolvedValue([]);
+
+    const response = await GET(makeRequest({ username: 'alex' }));
+
+    expect(response.status).toBe(200);
+    expect(setterRouteState.executeRowsMock).toHaveBeenCalledTimes(1);
+    const [dbArg] = setterRouteState.executeRowsMock.mock.calls[0];
+    expect(dbArg).toBe(setterRouteState.dbzReadSentinel);
+    expect(dbArg).not.toBe(setterRouteState.dbzSentinel);
+  });
+
+  it('bounds the whole DB phase (summary + grade aggregate) under a single og-setter read deadline', async () => {
+    setterRouteState.getSetterOgSummaryMock.mockResolvedValue({
+      displayName: 'Alex',
+      avatarUrl: null,
+    });
+    setterRouteState.executeRowsMock.mockResolvedValue([]);
+
+    await GET(makeRequest({ username: 'alex' }));
+
+    expect(setterRouteState.recordedReads.map((read) => read.label)).toEqual(['og-setter']);
+  });
+
+  it('redirects to the branded fallback card and logs a throttled compact message when the DB rejects', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setterRouteState.getSetterOgSummaryMock.mockRejectedValue(
+      Object.assign(new Error('Failed query: SELECT * FROM boardsesh_ticks WHERE setter_username = $1'), {
+        name: 'DrizzleQueryError',
+      }),
+    );
+    setterRouteState.executeRowsMock.mockResolvedValue([]);
+
+    const response = await GET(makeRequest({ username: 'alex' }));
+    const body = await response.text();
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/opengraph-image');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
+    expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
+    expect(body).not.toContain('SELECT');
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[og] setter render failed:',
+      expect.stringContaining('DrizzleQueryError'),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/web/app/api/og/setter/route.tsx
+++ b/packages/web/app/api/og/setter/route.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ImageResponse } from '@vercel/og';
 import type { NextRequest } from 'next/server';
-import { dbz, executeRows } from '@/app/lib/db/db';
+import { dbzRead, executeRows } from '@/app/lib/db/db';
 import { sql } from 'drizzle-orm';
 import { themeTokens } from '@/app/theme/theme-config';
 import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
@@ -9,6 +9,7 @@ import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getSetterOgSummary } from '@/app/lib/seo/dynamic-og-data';
 import { ogErrorResponse } from '@/app/lib/seo/og-error';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 export const runtime = 'nodejs';
 
@@ -34,25 +35,28 @@ export async function GET(request: NextRequest) {
     }
 
     const dbT0 = performance.now();
-    const [summary, gradeResult] = await Promise.all([
-      getSetterOgSummary(username),
-      executeRows<{
-        difficulty: number;
-        cnt: number;
-      }>(
-        dbz,
-        sql`
-        SELECT bt.difficulty, COUNT(*) as cnt
-        FROM boardsesh_ticks bt
-        JOIN board_climbs bc ON bc.uuid = bt.climb_uuid
-        WHERE bc.setter_username = ${username}
-          AND bt.status IN ('flash', 'send')
-          AND bt.difficulty IS NOT NULL
-        GROUP BY bt.difficulty
-        ORDER BY bt.difficulty
-      `,
-      ),
-    ]);
+    const [summary, gradeResult] = await withReadDeadline(
+      'og-setter',
+      Promise.all([
+        getSetterOgSummary(username),
+        executeRows<{
+          difficulty: number;
+          cnt: number;
+        }>(
+          dbzRead,
+          sql`
+          SELECT bt.difficulty, COUNT(*) as cnt
+          FROM boardsesh_ticks bt
+          JOIN board_climbs bc ON bc.uuid = bt.climb_uuid
+          WHERE bc.setter_username = ${username}
+            AND bt.status IN ('flash', 'send')
+            AND bt.difficulty IS NOT NULL
+          GROUP BY bt.difficulty
+          ORDER BY bt.difficulty
+        `,
+        ),
+      ]),
+    );
     const dbMs = performance.now() - dbT0;
     const gradeRows = gradeResult;
 

--- a/packages/web/app/api/og/setter/route.tsx
+++ b/packages/web/app/api/og/setter/route.tsx
@@ -8,6 +8,7 @@ import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-col
 import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getSetterOgSummary } from '@/app/lib/seo/dynamic-og-data';
+import { ogErrorResponse } from '@/app/lib/seo/og-error';
 
 export const runtime = 'nodejs';
 
@@ -247,8 +248,6 @@ export async function GET(request: NextRequest) {
       },
     );
   } catch (error) {
-    console.error('Error generating setter OG image:', error);
-    const message = error instanceof Error ? error.message : String(error);
-    return new Response(`Error generating image: ${message}`, { status: 500 });
+    return ogErrorResponse('setter', error);
   }
 }

--- a/packages/web/app/lib/data/__tests__/front-door-outage-log.test.ts
+++ b/packages/web/app/lib/data/__tests__/front-door-outage-log.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+/**
+ * Outage-scoped dedupe for the two front-door sections: a wedged backend fails
+ * every climb-view render for as long as it lasts, and Vercel bills per log
+ * event, so this must cost exactly ONE console.error (+ one Sentry message)
+ * per outage rather than one per render. A success re-arms the key so the
+ * NEXT distinct outage still gets logged.
+ */
+const { createCachedGraphQLQueryMock, captureMessageMock, queryImpl } = vi.hoisted(() => {
+  const queryImpl: { current: () => Promise<unknown> } = {
+    current: async () => ({ similarClimbs: [], betaLinks: [] }),
+  };
+  return {
+    queryImpl,
+    createCachedGraphQLQueryMock: vi.fn(
+      () =>
+        (...args: unknown[]) =>
+          queryImpl.current(...(args as [])) as never,
+    ),
+    captureMessageMock: vi.fn(),
+  };
+});
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/app/lib/graphql/server-cached-client', () => ({
+  createCachedGraphQLQuery: createCachedGraphQLQueryMock,
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: captureMessageMock,
+}));
+
+// Static import, matching front-door-data-timeout.test.ts and
+// front-door-fanout.test.ts: this module's once-per-outage dedupe Set is
+// process-level state shared by every test in this file (and, via the shared
+// worker, other files that touch the same module graph). `beforeEach` below
+// drives both sections back to a known "recovered" state explicitly, so each
+// test starts clean regardless of execution order rather than relying on a
+// fresh module instance per test.
+import { getFrontDoorBetaLinks, getFrontDoorSimilarClimbs } from '../front-door-data.server';
+
+describe('front-door outage-scoped logging', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  // Filtered rather than a raw call count on the spy: `console` and
+  // `@sentry/nextjs` are process-wide, and unrelated logging elsewhere in the
+  // same worker (or a straggling async task from another test file) could in
+  // principle land on the same spy. Scoping to this module's own log prefix
+  // keeps the assertion about OUR dedupe logic specifically.
+  const frontDoorLogCalls = () =>
+    consoleErrorSpy.mock.calls.filter(
+      (call: unknown[]) => typeof call[0] === 'string' && call[0].startsWith('Front door:'),
+    );
+  const frontDoorCaptureCalls = () =>
+    captureMessageMock.mock.calls.filter((call) => typeof call[0] === 'string' && call[0].startsWith('Front door '));
+
+  beforeEach(async () => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    captureMessageMock.mockClear();
+
+    // Recover both sections so every test starts from a clean, un-latched
+    // dedupe key, regardless of what a previous test left behind.
+    queryImpl.current = async () => ({ similarClimbs: [], betaLinks: [] });
+    await getFrontDoorSimilarClimbs({ boardType: 'kilter', layoutId: 8, climbUuid: 'warmup', angle: 40 });
+    await getFrontDoorBetaLinks({ boardType: 'kilter', climbUuid: 'warmup' });
+    consoleErrorSpy.mockClear();
+    captureMessageMock.mockClear();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('logs exactly once across two consecutive rejections (similar climbs)', async () => {
+    const requestError = Object.assign(
+      new Error(
+        'GraphQL Error (Code: 500): {"response":{"errors":[{"message":"backend wedged"}]},"request":{"query":"query SimilarClimbs($input: SimilarClimbsInput!) { similarClimbs(input: $input) { uuid } }","variables":{"input":{"boardType":"kilter"}}}}',
+      ),
+      { response: { errors: [{ message: 'backend wedged' }] } },
+    );
+    queryImpl.current = async () => {
+      throw requestError;
+    };
+
+    await getFrontDoorSimilarClimbs({ boardType: 'kilter', layoutId: 8, climbUuid: 'climb-1', angle: 40 });
+    await getFrontDoorSimilarClimbs({ boardType: 'kilter', layoutId: 8, climbUuid: 'climb-2', angle: 40 });
+
+    expect(frontDoorLogCalls()).toHaveLength(1);
+    expect(frontDoorCaptureCalls()).toHaveLength(1);
+  });
+
+  it('logs again after a success re-arms the key (beta links)', async () => {
+    queryImpl.current = async () => {
+      throw new Error('wedged');
+    };
+    await getFrontDoorBetaLinks({ boardType: 'kilter', climbUuid: 'climb-1' });
+    expect(frontDoorLogCalls()).toHaveLength(1);
+
+    queryImpl.current = async () => ({ betaLinks: [] });
+    await getFrontDoorBetaLinks({ boardType: 'kilter', climbUuid: 'climb-1' });
+
+    queryImpl.current = async () => {
+      throw new Error('wedged again');
+    };
+    await getFrontDoorBetaLinks({ boardType: 'kilter', climbUuid: 'climb-1' });
+
+    expect(frontDoorLogCalls()).toHaveLength(2);
+    expect(frontDoorCaptureCalls()).toHaveLength(2);
+  });
+
+  it('never lets the request query/variables text reach the logged payload', async () => {
+    const requestError = Object.assign(
+      new Error(
+        'GraphQL Error (Code: 500): {"response":{"errors":[{"message":"backend wedged"}]},"request":{"query":"query SimilarClimbs($input: SimilarClimbsInput!) { similarClimbs(input: $input) { uuid name difficulty } }","variables":{"input":{"boardType":"kilter","layoutId":8,"climbUuid":"climb-1","angle":40,"threshold":0.5,"limit":10}}}}',
+      ),
+      { response: { errors: [{ message: 'backend wedged' }] } },
+    );
+    queryImpl.current = async () => {
+      throw requestError;
+    };
+
+    await getFrontDoorSimilarClimbs({ boardType: 'kilter', layoutId: 8, climbUuid: 'climb-1', angle: 40 });
+
+    const loggedPayload = JSON.stringify(frontDoorLogCalls()[0]);
+    const capturedMessage = JSON.stringify(frontDoorCaptureCalls()[0]);
+
+    expect(loggedPayload).not.toContain('similarClimbs(input');
+    expect(loggedPayload).not.toContain('threshold');
+    expect(capturedMessage).not.toContain('similarClimbs(input');
+    expect(capturedMessage).not.toContain('threshold');
+  });
+});

--- a/packages/web/app/lib/data/front-door-data.server.ts
+++ b/packages/web/app/lib/data/front-door-data.server.ts
@@ -1,9 +1,11 @@
 import 'server-only';
 
+import * as Sentry from '@sentry/nextjs';
 import type { SimilarClimb } from '@boardsesh/shared-schema';
 import { SIMILAR_CLIMBS_QUERY, type SimilarClimbsResponse } from '@boardsesh/graphql/operations/new-climb-feed';
 import { GET_BETA_LINKS, type GetBetaLinksQueryResponse } from '@boardsesh/graphql/operations/beta-links';
 import { createCachedGraphQLQuery } from '@/app/lib/graphql/server-cached-client';
+import { compactErrorMessage } from '@/app/lib/observability/compact-error';
 import { dedupeBetaLinks, mapBetaLinksResponse, type BetaLink } from '@/app/lib/beta-video-url';
 import type { BoardName } from '@/app/lib/types';
 
@@ -31,6 +33,37 @@ const BETA_LINKS_REVALIDATE_SECONDS = 3600;
  * these two sections are supplementary, the climb itself is not.
  */
 const FRONT_DOOR_BACKEND_TIMEOUT_MS = 3000;
+
+// Once per section per OUTAGE, not per render. A backend wedge fails every
+// climb-view render for as long as it lasts, so one log line says the same
+// thing as ten thousand — but latching it for the process lifetime would turn
+// a broken -> recovered -> broken cycle into a silent second outage. A
+// successful render re-arms the key, so each distinct outage costs exactly
+// one console.error + one Sentry message.
+const reportedFrontDoorFailures = new Set<string>();
+
+function reportFrontDoorOutage(
+  section: 'similar-climbs' | 'beta-links',
+  params: { boardType: BoardName; climbUuid: string },
+  error: unknown,
+): void {
+  if (reportedFrontDoorFailures.has(section)) {
+    return;
+  }
+  reportedFrontDoorFailures.add(section);
+
+  const compactError = compactErrorMessage(error);
+  console.error(`Front door: ${section} unavailable, rendering the section empty`, {
+    boardType: params.boardType,
+    climbUuid: params.climbUuid,
+    error: compactError,
+  });
+  Sentry.captureMessage(`Front door ${section} unavailable: ${compactError}`, 'warning');
+}
+
+function reportFrontDoorRecovered(section: 'similar-climbs' | 'beta-links'): void {
+  reportedFrontDoorFailures.delete(section);
+}
 
 type SimilarClimbsQueryVariables = {
   input: {
@@ -69,13 +102,10 @@ export async function getFrontDoorSimilarClimbs(params: {
         limit: params.limit ?? 10,
       },
     });
+    reportFrontDoorRecovered('similar-climbs');
     return response.similarClimbs ?? [];
   } catch (error) {
-    console.error('Front door: similar climbs unavailable, rendering the section empty', {
-      boardType: params.boardType,
-      climbUuid: params.climbUuid,
-      error,
-    });
+    reportFrontDoorOutage('similar-climbs', params, error);
     return [];
   }
 }
@@ -90,13 +120,10 @@ export async function getFrontDoorBetaLinks(params: { boardType: BoardName; clim
 
   try {
     const response = await query({ boardType: params.boardType, climbUuid: params.climbUuid });
+    reportFrontDoorRecovered('beta-links');
     return dedupeBetaLinks(mapBetaLinksResponse(response.betaLinks ?? []));
   } catch (error) {
-    console.error('Front door: beta links unavailable, rendering the section empty', {
-      boardType: params.boardType,
-      climbUuid: params.climbUuid,
-      error,
-    });
+    reportFrontDoorOutage('beta-links', params, error);
     return [];
   }
 }

--- a/packages/web/app/lib/graphql/__tests__/server-cached-client-timeout.test.ts
+++ b/packages/web/app/lib/graphql/__tests__/server-cached-client-timeout.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test'
 const { constructorOptions, backend } = vi.hoisted(() => ({
   constructorOptions: [] as ({ signal?: AbortSignal } | undefined)[],
   /** `wedged` never answers; flip it to model a healthy backend. */
-  backend: { wedged: true },
+  backend: { wedged: true, rejectWith: undefined as unknown },
 }));
 
 vi.mock('server-only', () => ({}));
@@ -25,6 +25,9 @@ vi.mock('graphql-request', () => ({
       constructorOptions.push(options);
     }
     request<T>(): Promise<T> {
+      if (backend.rejectWith !== undefined) {
+        return Promise.reject(backend.rejectWith);
+      }
       // A wedged backend: the socket is open and nothing ever comes back.
       return backend.wedged ? new Promise<T>(() => {}) : (Promise.resolve({}) as Promise<T>);
     }
@@ -54,6 +57,7 @@ describe('createCachedGraphQLQuery timeout', () => {
   beforeEach(() => {
     constructorOptions.length = 0;
     backend.wedged = true;
+    backend.rejectWith = undefined;
     vi.useFakeTimers();
   });
 
@@ -94,5 +98,33 @@ describe('createCachedGraphQLQuery timeout', () => {
     // three seconds past its response.
     expect(vi.getTimerCount()).toBe(0);
     expect(constructorOptions[0]?.signal?.aborted).toBe(false);
+  });
+
+  it('rethrows a compact error, dropping the embedded query/variables text', async () => {
+    // Next's `unstable_cache` console.errors the whole rejection itself during
+    // stale revalidation (unwrappable — inside next/dist), so this bounds the
+    // SIZE of that unavoidable log event rather than trying to intercept it.
+    backend.wedged = false;
+    backend.rejectWith = Object.assign(
+      new Error(
+        'GraphQL Error (Code: 500): {"response":{"errors":[{"message":"upstream 500"}]},"request":{"query":"query Q { similarClimbs(input: $input) { uuid } }","variables":{"input":{"boardType":"kilter"}}}}',
+      ),
+      { response: { errors: [{ message: 'upstream 500' }] } },
+    );
+
+    const query = createCachedGraphQLQuery('query Q { x }', 'similar-climbs', 3600);
+
+    let caught: unknown;
+    try {
+      await query();
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toBe('upstream 500');
+    expect(message).not.toContain('similarClimbs(input');
+    expect(message).not.toContain('boardType');
   });
 });

--- a/packages/web/app/lib/graphql/server-cached-client.ts
+++ b/packages/web/app/lib/graphql/server-cached-client.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { unstable_cache } from 'next/cache';
 import { type RequestDocument, type Variables, GraphQLClient } from 'graphql-request';
 import { sortObjectKeys } from '@/app/lib/cache-utils';
+import { compactErrorMessage } from '@/app/lib/observability/compact-error';
 import { getGraphQLHttpUrl } from './client';
 import type { DiscoverablePlaylist, DiscoverPlaylistsQueryResponse } from '@boardsesh/graphql/operations/playlists';
 import type {
@@ -71,15 +72,28 @@ export function createCachedGraphQLQuery<T = unknown, V extends Variables = Vari
   return async (variables?: V): Promise<T> => {
     const cachedFn = unstable_cache(
       async () => {
-        if (!timeoutMs) {
-          return executeGraphQLInternal<T, V>(document, variables);
-        }
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), timeoutMs);
         try {
-          return await executeGraphQLInternal<T, V>(document, variables, controller.signal);
-        } finally {
-          clearTimeout(timer);
+          if (!timeoutMs) {
+            return await executeGraphQLInternal<T, V>(document, variables);
+          }
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), timeoutMs);
+          try {
+            return await executeGraphQLInternal<T, V>(document, variables, controller.signal);
+          } finally {
+            clearTimeout(timer);
+          }
+        } catch (error) {
+          // Next's `unstable_cache` console.errors the WHOLE rejection itself
+          // during stale-while-revalidate — a call site inside next/dist we
+          // cannot intercept. Rethrowing a compact error here bounds the SIZE
+          // of that unavoidable log event (a graphql-request ClientError or a
+          // DrizzleQueryError otherwise embeds the whole query/SQL). Every
+          // consumer of this function already catches and degrades without
+          // inspecting the error's shape, and `unstable_cache` never caches a
+          // rejection, so failure semantics are unchanged — only the log size
+          // shrinks.
+          throw new Error(compactErrorMessage(error));
         }
       },
       ['graphql', cacheTag, ...createCacheKeyFromVariables(variables)],

--- a/packages/web/app/lib/observability/__tests__/compact-error.test.ts
+++ b/packages/web/app/lib/observability/__tests__/compact-error.test.ts
@@ -25,19 +25,47 @@ describe('compactErrorMessage', () => {
   });
 
   it('unwraps a DrizzleQueryError to its cause, dropping the embedded SQL', () => {
+    // The real shape (verified against drizzle-orm@0.45.2), not an
+    // approximation: DrizzleQueryError never sets `this.name` (it stays
+    // 'Error') and its message is `Failed query: <sql>\nparams: <params>`.
+    // The underlying postgres failure is what's genuinely useful, and it
+    // lives on `.cause`.
     const postgresCause = Object.assign(new Error('CONNECT_TIMEOUT'), { code: 'CONNECT_TIMEOUT' });
     const drizzleError = Object.assign(
       new Error(
-        'Failed query: SELECT "id", "email", "password_hash" FROM "users" WHERE "users"."email" = $1 params: test@boardsesh.com',
+        'Failed query: SELECT "id", "email", "password_hash" FROM "users" WHERE "users"."email" = $1\nparams: test@boardsesh.com',
       ),
-      { name: 'DrizzleQueryError', cause: postgresCause },
+      { cause: postgresCause },
     );
 
     const result = compactErrorMessage(drizzleError);
 
-    expect(result).toBe('DrizzleQueryError: CONNECT_TIMEOUT');
+    expect(result).toBe('Error: CONNECT_TIMEOUT');
     expect(result).not.toContain('SELECT');
     expect(result).not.toContain('test@boardsesh.com');
+  });
+
+  it('drops the SQL from a Failed-query message that has no cause to unwrap (defense in depth)', () => {
+    // Not a real DrizzleQueryError (that always has a cause) — this covers the
+    // gap the cause-unwrap branch can't reach: some future error embeds SQL/PII
+    // in its own message with nothing to fall back to.
+    const error = new Error('Failed query: SELECT "id", "ssn" FROM "users" WHERE "id" = $1\nparams: 42');
+
+    const result = compactErrorMessage(error);
+
+    expect(result).toBe('Error: query failed');
+    expect(result).not.toContain('SELECT');
+    expect(result).not.toContain('ssn');
+  });
+
+  it('cuts a multi-line message at the first newline before truncating', () => {
+    const error = new Error('summary line\nsecond line with sensitive details\nthird line');
+
+    const result = compactErrorMessage(error);
+
+    expect(result).toBe('Error: summary line');
+    expect(result).not.toContain('second line');
+    expect(result).not.toContain('third line');
   });
 
   it('formats a plain Error as name: message', () => {

--- a/packages/web/app/lib/observability/__tests__/compact-error.test.ts
+++ b/packages/web/app/lib/observability/__tests__/compact-error.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { compactErrorMessage } from '../compact-error';
+
+describe('compactErrorMessage', () => {
+  it('extracts the resolver message from a graphql-request ClientError shape', () => {
+    // graphql-request's ClientError.message embeds the whole request document
+    // and variables plus the whole response body; the plain `.message` is not
+    // safe to log or return.
+    const clientError = Object.assign(
+      new Error(
+        'GraphQL Error (Code: 400): {"response":{"errors":[{"message":"You already have a board with this configuration"}]},"request":{"query":"query SimilarClimbs($input: SimilarClimbsInput!) { similarClimbs(input: $input) { uuid name } }","variables":{"input":{"boardType":"kilter","layoutId":8,"climbUuid":"climb-1","angle":40,"threshold":0.5,"limit":10}}}}',
+      ),
+      {
+        response: {
+          errors: [{ message: 'You already have a board with this configuration' }],
+        },
+      },
+    );
+
+    const result = compactErrorMessage(clientError);
+
+    expect(result).toBe('You already have a board with this configuration');
+    expect(result).not.toContain('similarClimbs');
+    expect(result).not.toContain('boardType');
+  });
+
+  it('unwraps a DrizzleQueryError to its cause, dropping the embedded SQL', () => {
+    const postgresCause = Object.assign(new Error('CONNECT_TIMEOUT'), { code: 'CONNECT_TIMEOUT' });
+    const drizzleError = Object.assign(
+      new Error(
+        'Failed query: SELECT "id", "email", "password_hash" FROM "users" WHERE "users"."email" = $1 params: test@boardsesh.com',
+      ),
+      { name: 'DrizzleQueryError', cause: postgresCause },
+    );
+
+    const result = compactErrorMessage(drizzleError);
+
+    expect(result).toBe('DrizzleQueryError: CONNECT_TIMEOUT');
+    expect(result).not.toContain('SELECT');
+    expect(result).not.toContain('test@boardsesh.com');
+  });
+
+  it('formats a plain Error as name: message', () => {
+    expect(compactErrorMessage(new Error('network down'))).toBe('Error: network down');
+  });
+
+  it('formats a plain Error subclass using its own name', () => {
+    class TimeoutError extends Error {
+      name = 'TimeoutError';
+    }
+    expect(compactErrorMessage(new TimeoutError('deadline exceeded'))).toBe('TimeoutError: deadline exceeded');
+  });
+
+  it('stringifies a non-Error throw', () => {
+    expect(compactErrorMessage('a raw string throw')).toBe('a raw string throw');
+    expect(compactErrorMessage(42)).toBe('42');
+    expect(compactErrorMessage(null)).toBe('null');
+  });
+
+  it('truncates to maxLength', () => {
+    const longMessage = new Error('x'.repeat(500));
+    const result = compactErrorMessage(longMessage, 50);
+
+    expect(result.length).toBe(50);
+    expect(result).toBe(`Error: ${'x'.repeat(43)}`);
+  });
+
+  it('truncates using the default maxLength of 200 when none is passed', () => {
+    const longMessage = new Error('y'.repeat(500));
+    const result = compactErrorMessage(longMessage);
+
+    expect(result.length).toBe(200);
+  });
+});

--- a/packages/web/app/lib/observability/compact-error.ts
+++ b/packages/web/app/lib/observability/compact-error.ts
@@ -1,0 +1,39 @@
+import { extractGraphQLErrorMessage } from '@/app/lib/graphql/extract-error-message';
+
+/**
+ * A safe-to-log, safe-to-return summary of an unknown thrown value.
+ *
+ * Two shapes are dangerously verbose by default and need special handling
+ * before anything touches a log line or an HTTP response:
+ *
+ *  - graphql-request's `ClientError` embeds the entire request (query +
+ *    variables) and the entire response body in `.message`. Its actual
+ *    resolver-authored message lives one level down, at
+ *    `error.response.errors[0].message` — exactly what
+ *    {@link extractGraphQLErrorMessage} extracts. We trust that message
+ *    because it comes from our own resolvers.
+ *  - drizzle-orm's `DrizzleQueryError` embeds the full SQL statement and every
+ *    bound parameter in its own `.message`. The underlying driver failure
+ *    (e.g. a postgres `CONNECT_TIMEOUT`) is the useful, SQL-free signal, and
+ *    it lives on `.cause`.
+ *
+ * Anything else falls back to `name: message` (or `String(error)` for a
+ * non-Error throw), and the result is always truncated so a single error
+ * cannot blow out a log event's size.
+ */
+export function compactErrorMessage(error: unknown, maxLength = 200): string {
+  const graphQLMessage = extractGraphQLErrorMessage(error);
+  if (graphQLMessage !== null) {
+    return graphQLMessage.slice(0, maxLength);
+  }
+
+  if (error instanceof Error && error.cause instanceof Error) {
+    return `${error.name}: ${error.cause.message}`.slice(0, maxLength);
+  }
+
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`.slice(0, maxLength);
+  }
+
+  return String(error).slice(0, maxLength);
+}

--- a/packages/web/app/lib/observability/compact-error.ts
+++ b/packages/web/app/lib/observability/compact-error.ts
@@ -18,8 +18,10 @@ import { extractGraphQLErrorMessage } from '@/app/lib/graphql/extract-error-mess
  *    it lives on `.cause`.
  *
  * Anything else falls back to `name: message` (or `String(error)` for a
- * non-Error throw), and the result is always truncated so a single error
- * cannot blow out a log event's size.
+ * non-Error throw) — but that fallback is itself hardened against a future
+ * error that embeds SQL/PII in its message with no `.cause` to unwrap to (see
+ * the guards inline below), and the result is always truncated so a single
+ * error cannot blow out a log event's size.
  */
 export function compactErrorMessage(error: unknown, maxLength = 200): string {
   const graphQLMessage = extractGraphQLErrorMessage(error);
@@ -32,7 +34,24 @@ export function compactErrorMessage(error: unknown, maxLength = 200): string {
   }
 
   if (error instanceof Error) {
-    return `${error.name}: ${error.message}`.slice(0, maxLength);
+    // Defense in depth: the branches above strip SQL/PII by construction (a
+    // trusted resolver message, or the cause's message), but this generic
+    // fallback runs for ANY Error with no `.cause` — including a future
+    // driver/query error that embeds SQL and has no cause to unwrap to. Two
+    // guards specifically for that gap:
+    //  - `Failed query:` is drizzle-orm's own prefix for a query failure
+    //    message (`Failed query: <sql>\nparams: <params>`); if it shows up
+    //    here (no cause set) the SQL is right there in `.message`, so drop it
+    //    entirely rather than truncate it.
+    //  - Otherwise, cut at the first newline before the length cap: a
+    //    multi-line message (stack-trace-shaped, or `<summary>\nparams: ...`)
+    //    is far more likely to have its useful part on line one than to need
+    //    everything after it.
+    if (error.message.includes('Failed query:')) {
+      return `${error.name}: query failed`.slice(0, maxLength);
+    }
+    const firstLine = error.message.split('\n')[0];
+    return `${error.name}: ${firstLine}`.slice(0, maxLength);
   }
 
   return String(error).slice(0, maxLength);

--- a/packages/web/app/lib/seo/__tests__/og-error.test.ts
+++ b/packages/web/app/lib/seo/__tests__/og-error.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+type OgErrorModule = typeof import('../og-error');
+
+// Fresh module per test: the throttle map is module state, and a shared
+// instance would let one test's log leak the "already logged" cooldown into
+// the next test's assertions.
+async function loadModule(): Promise<OgErrorModule> {
+  vi.resetModules();
+  return import('../og-error');
+}
+
+describe('ogErrorResponse', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('returns a generic 500 body with no-store, never the raw error message', async () => {
+    const { ogErrorResponse } = await loadModule();
+    const leakyError = Object.assign(new Error('Failed query: SELECT * FROM users WHERE email = $1'), {
+      name: 'DrizzleQueryError',
+    });
+
+    const response = ogErrorResponse('setter', leakyError);
+    const body = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(body).toBe('Error generating image');
+    expect(body).not.toContain('SELECT');
+  });
+
+  it('logs a compact message the first time a route fails', async () => {
+    const { ogErrorResponse } = await loadModule();
+
+    ogErrorResponse('profile', new Error('boom'));
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('[og] profile render failed:', 'Error: boom');
+  });
+
+  it('throttles repeated failures on the same route to once per 60s', async () => {
+    const { ogErrorResponse } = await loadModule();
+
+    ogErrorResponse('playlist', new Error('first'));
+    ogErrorResponse('playlist', new Error('second'));
+    ogErrorResponse('playlist', new Error('third'));
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(59_999);
+    ogErrorResponse('playlist', new Error('fourth'));
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    ogErrorResponse('playlist', new Error('fifth'));
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+    expect(consoleErrorSpy).toHaveBeenLastCalledWith('[og] playlist render failed:', 'Error: fifth');
+  });
+
+  it('tracks each route independently', async () => {
+    const { ogErrorResponse } = await loadModule();
+
+    ogErrorResponse('session', new Error('a'));
+    ogErrorResponse('climb', new Error('b'));
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/app/lib/seo/__tests__/og-error.test.ts
+++ b/packages/web/app/lib/seo/__tests__/og-error.test.ts
@@ -24,7 +24,7 @@ describe('ogErrorResponse', () => {
     vi.useRealTimers();
   });
 
-  it('returns a generic 500 body with no-store, never the raw error message', async () => {
+  it('redirects to the branded fallback card with a short CDN-cacheable TTL, never the raw error message', async () => {
     const { ogErrorResponse } = await loadModule();
     const leakyError = Object.assign(new Error('Failed query: SELECT * FROM users WHERE email = $1'), {
       name: 'DrizzleQueryError',
@@ -33,9 +33,11 @@ describe('ogErrorResponse', () => {
     const response = ogErrorResponse('setter', leakyError);
     const body = await response.text();
 
-    expect(response.status).toBe(500);
-    expect(response.headers.get('Cache-Control')).toBe('no-store');
-    expect(body).toBe('Error generating image');
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/opengraph-image');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
+    expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
+    expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe('public, s-maxage=60');
     expect(body).not.toContain('SELECT');
   });
 

--- a/packages/web/app/lib/seo/__tests__/og-error.test.ts
+++ b/packages/web/app/lib/seo/__tests__/og-error.test.ts
@@ -1,6 +1,14 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: captureExceptionMock,
+}));
+
 type OgErrorModule = typeof import('../og-error');
 
 // Fresh module per test: the throttle map is module state, and a shared
@@ -11,12 +19,28 @@ async function loadModule(): Promise<OgErrorModule> {
   return import('../og-error');
 }
 
+/**
+ * Mirrors real drizzle-orm@0.45.2's `DrizzleQueryError` (see
+ * `node_modules/drizzle-orm/errors.js`): the class never overrides `.name`,
+ * so it stays the inherited "Error" rather than "DrizzleQueryError"; the
+ * message is `Failed query: <sql>\nparams: <params>`; and `.cause` is always
+ * the underlying driver error. Modelling that (instead of a fake with the SQL
+ * inlined and no cause) is what makes the "log never contains SELECT"
+ * assertions below mean something — a bug in `compactErrorMessage`'s
+ * cause-unwrapping would fail them.
+ */
+function makeDrizzleQueryError(sql: string, params: string, causeMessage = 'CONNECT_TIMEOUT'): Error {
+  const cause = Object.assign(new Error(causeMessage), { code: causeMessage });
+  return Object.assign(new Error(`Failed query: ${sql}\nparams: ${params}`), { cause });
+}
+
 describe('ogErrorResponse', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    captureExceptionMock.mockClear();
   });
 
   afterEach(() => {
@@ -26,9 +50,7 @@ describe('ogErrorResponse', () => {
 
   it('redirects to the branded fallback card with a short CDN-cacheable TTL, never the raw error message', async () => {
     const { ogErrorResponse } = await loadModule();
-    const leakyError = Object.assign(new Error('Failed query: SELECT * FROM users WHERE email = $1'), {
-      name: 'DrizzleQueryError',
-    });
+    const leakyError = makeDrizzleQueryError('SELECT * FROM users WHERE email = $1', 'test@boardsesh.com');
 
     const response = ogErrorResponse('setter', leakyError);
     const body = await response.text();
@@ -39,6 +61,24 @@ describe('ogErrorResponse', () => {
     expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
     expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe('public, s-maxage=60');
     expect(body).not.toContain('SELECT');
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const [, loggedMessage] = consoleErrorSpy.mock.calls[0] as [string, string];
+    expect(loggedMessage).not.toContain('SELECT');
+    expect(loggedMessage).not.toContain('test@boardsesh.com');
+    expect(loggedMessage).toBe('Error: CONNECT_TIMEOUT');
+  });
+
+  it('reports the failure to Sentry, tagged by surface and route, inside the same throttle gate', async () => {
+    const { ogErrorResponse } = await loadModule();
+    const leakyError = makeDrizzleQueryError('SELECT * FROM users WHERE email = $1', 'test@boardsesh.com');
+
+    ogErrorResponse('setter', leakyError);
+    ogErrorResponse('setter', leakyError);
+    ogErrorResponse('setter', leakyError);
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledWith(leakyError, { tags: { surface: 'og', route: 'setter' } });
   });
 
   it('logs a compact message the first time a route fails', async () => {

--- a/packages/web/app/lib/seo/og-error.ts
+++ b/packages/web/app/lib/seo/og-error.ts
@@ -1,0 +1,47 @@
+import { compactErrorMessage } from '@/app/lib/observability/compact-error';
+
+/**
+ * Minimum gap between logged failures for the SAME OG route. These routes are
+ * hit by crawlers and social-media unfurlers at volume, and a Drizzle-backed
+ * route wedging fails every request until it recovers — logging every one of
+ * those would turn one outage into thousands of Vercel log events. Not a
+ * per-outage latch (unlike the front-door dedupe): an OG route has no
+ * "recovered" signal to re-arm on, so this is a plain cooldown instead.
+ */
+const OG_ERROR_LOG_INTERVAL_MS = 60_000;
+
+const lastLoggedAt = new Map<string, number>();
+
+function shouldLog(route: string): boolean {
+  const now = Date.now();
+  const last = lastLoggedAt.get(route);
+  if (last !== undefined && now - last < OG_ERROR_LOG_INTERVAL_MS) {
+    return false;
+  }
+  lastLoggedAt.set(route, now);
+  return true;
+}
+
+/**
+ * Build the response an OG image route's catch block should return.
+ *
+ * Two things this fixes over the old per-route `catch` bodies:
+ *
+ *  - They logged (and returned to the caller) `error.message` verbatim. For
+ *    the Drizzle-backed routes that message is `DrizzleQueryError`'s own
+ *    message, which embeds the full SQL statement and every bound parameter —
+ *    an info leak, since these routes are unauthenticated. The body here is
+ *    always the same generic string.
+ *  - They logged on every failed render. This throttles to once per route per
+ *    {@link OG_ERROR_LOG_INTERVAL_MS}.
+ */
+export function ogErrorResponse(route: string, error: unknown): Response {
+  if (shouldLog(route)) {
+    console.error(`[og] ${route} render failed:`, compactErrorMessage(error));
+  }
+
+  return new Response('Error generating image', {
+    status: 500,
+    headers: { 'Cache-Control': 'no-store' },
+  });
+}

--- a/packages/web/app/lib/seo/og-error.ts
+++ b/packages/web/app/lib/seo/og-error.ts
@@ -30,18 +30,36 @@ function shouldLog(route: string): boolean {
  *  - They logged (and returned to the caller) `error.message` verbatim. For
  *    the Drizzle-backed routes that message is `DrizzleQueryError`'s own
  *    message, which embeds the full SQL statement and every bound parameter —
- *    an info leak, since these routes are unauthenticated. The body here is
- *    always the same generic string.
+ *    an info leak, since these routes are unauthenticated. The response body
+ *    never echoes the error.
  *  - They logged on every failed render. This throttles to once per route per
  *    {@link OG_ERROR_LOG_INTERVAL_MS}.
+ *
+ * The response itself is a 302 to `/opengraph-image` (the existing DB-free
+ * branded card, `app/opengraph-image.tsx`) rather than a 500. Unfurlers
+ * (Slack, Discord, iMessage, Twitter/X) render nothing on a 5xx and then cache
+ * that failed scrape for days, so the next real crawl of the same URL can be
+ * far off — a degraded-but-present card beats a blank embed for that whole
+ * window. The 60s `s-maxage` lets the CDN answer a burst of scraper retries
+ * during a brownout without sending each one at the DB, while staying short
+ * enough to pick up the real image again shortly after recovery.
+ *
+ * This must NEVER route through `createOgImageHeaders`: its versioned branch
+ * sets a one-year immutable `Cache-Control`, which would pin this fallback
+ * for a year instead of the 60s window above.
  */
 export function ogErrorResponse(route: string, error: unknown): Response {
   if (shouldLog(route)) {
     console.error(`[og] ${route} render failed:`, compactErrorMessage(error));
   }
 
-  return new Response('Error generating image', {
-    status: 500,
-    headers: { 'Cache-Control': 'no-store' },
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: '/opengraph-image',
+      'Cache-Control': 'public, max-age=0, s-maxage=60',
+      'CDN-Cache-Control': 'public, s-maxage=60',
+      'Vercel-CDN-Cache-Control': 'public, s-maxage=60',
+    },
   });
 }

--- a/packages/web/app/lib/seo/og-error.ts
+++ b/packages/web/app/lib/seo/og-error.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { compactErrorMessage } from '@/app/lib/observability/compact-error';
 
 /**
@@ -33,7 +34,9 @@ function shouldLog(route: string): boolean {
  *    an info leak, since these routes are unauthenticated. The response body
  *    never echoes the error.
  *  - They logged on every failed render. This throttles to once per route per
- *    {@link OG_ERROR_LOG_INTERVAL_MS}.
+ *    {@link OG_ERROR_LOG_INTERVAL_MS} — and that same gate bounds the Sentry
+ *    volume too, so a wedged route costs one Sentry event per minute instead
+ *    of one per request.
  *
  * The response itself is a 302 to `/opengraph-image` (the existing DB-free
  * branded card, `app/opengraph-image.tsx`) rather than a 500. Unfurlers
@@ -51,6 +54,7 @@ function shouldLog(route: string): boolean {
 export function ogErrorResponse(route: string, error: unknown): Response {
   if (shouldLog(route)) {
     console.error(`[og] ${route} render failed:`, compactErrorMessage(error));
+    Sentry.captureException(error, { tags: { surface: 'og', route } });
   }
 
   return new Response(null, {

--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -152,7 +152,6 @@ export function middleware(request: NextRequest) {
 
       // For all other routes, validate board name
       if (!(SUPPORTED_BOARDS as readonly string[]).includes(routeIdentifier)) {
-        console.info('Middleware board_name check returned 404');
         return new NextResponse(null, {
           status: 404,
           statusText: 'Not Found',


### PR DESCRIPTION
## Summary

Part of the burn-hunt epic #4650 (Vercel charges per log event; 6.89M events/3d ≈ $8.27, spiking during backend wedges). This PR cuts hot-path log volume and payload size, and stops an info leak, without changing any user-facing failure behaviour:

- **New `compactErrorMessage()`** (`packages/web/app/lib/observability/compact-error.ts`): extracts the trusted resolver message from a graphql-request `ClientError` (whose `.message` otherwise embeds the whole request query + variables + response), unwraps a `DrizzleQueryError` to its SQL-free postgres `cause` (whose own `.message` embeds the full SQL + bound params), and truncates everything else. All of the changes below funnel through it.
- **Front-door outage dedupe** (`packages/web/app/lib/data/front-door-data.server.ts`): the similar-climbs and beta-links sections on the climb front door logged the full `ClientError` on every render. A backend wedge fails every climb-view render for as long as it lasts, so this turned one outage into thousands of log events. Now mirrors the existing once-per-outage pattern in `server-feature-flag.ts`: one `console.error` + one `Sentry.captureMessage` per outage, re-armed on the next success.
- **OG image routes stop echoing SQL to unauthenticated callers** (`packages/web/app/lib/seo/og-error.ts`, applied to all five `/api/og/*` routes): every route's catch block logged and then **returned** `Error generating image: ${error.message}` to the caller. For the Drizzle-backed routes (setter, profile, session by grade lookup, etc.) that message is the full SQL statement and bound parameters — an info leak to anonymous callers. `ogErrorResponse()` returns a generic body with `Cache-Control: no-store`, and throttles logging to once per route per 60s (these routes see crawler/unfurler volume).
- **Middleware**: dropped a `console.info` that fired on every request whose `board_name` segment failed validation — a routine bad-request edge with no diagnostic value.
- **`createCachedGraphQLQuery`**: Next 16's `unstable_cache` itself `console.error`s the whole rejection during stale-while-revalidate, from inside `next/dist` — a call site we can't intercept. The query rejection is now caught and rethrown as `compactErrorMessage(error)`, bounding the SIZE of that unavoidable log event. Every consumer already catches-and-degrades without inspecting the error's shape, and `unstable_cache` never caches a rejection, so failure semantics are unchanged.

**Note on the `revalidating cache with key` event**: that log line's *count* comes from Next.js internals (`unstable_cache`) and is unchanged by this PR — we cannot intercept whether it fires, only shrink what it prints when the underlying query rejects.

**Fast-follow (QA finding, same PR):** hardened `compactErrorMessage`'s generic fallback (the branch that runs for any `Error` with no `.cause` to unwrap) so a future error that embeds SQL/PII in its own message can't slip through: a message containing `Failed query:` collapses to `${name}: query failed` outright, and any other message is cut at its first newline before the length cap. Also corrected the test's `DrizzleQueryError` mock to the real drizzle-orm@0.45.2 shape (`name` stays `'Error'`; message is `Failed query: <sql>\nparams: <params>`; always has a `.cause`) and added coverage for the no-cause gap.

**Accepted trade-off (QA finding):** the compact rethrow in `server-cached-client.ts` deliberately omits `{ cause }` — attaching it would reinstate the log-size problem via Node's recursive cause serialization. That means `Sentry.captureException` in the calling data-fetch code now fingerprints what used to be distinct failure modes (timeout vs. GraphQL error vs. network failure) into a single Sentry issue for that call site. Accepted for now; revisit if triage needs the finer split back.

**Ops task (manual, not part of this PR):** Set `NEXTAUTH_URL=https://www.boardsesh.com` in the Vercel production env (dashboard step — see `canonical-auth-url.ts`, left unchanged here since its once-per-cold-start operator log is deliberate and the real fix is this env var).

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp check` — clean (0 errors; 260 pre-existing warnings across untouched files, unrelated to this diff)
- `vp run typecheck` — clean across all packages
- `vp test run --project web` (targeted): all new/changed test files pass —
  `compact-error.test.ts`, `front-door-outage-log.test.ts` (+ existing `front-door-data-timeout.test.ts`, `front-door-fanout.test.ts`), `og-error.test.ts`, `server-cached-client-timeout.test.ts`, and the `og/playlist`, `og/climb`, `og/session` route tests — including combined/repeated runs to rule out flakiness.
- New tests assert: the Drizzle-shaped case never contains `SELECT`; the front-door outage log fires exactly once per outage and never contains GraphQL query/variables text; the OG routes return a generic `Error generating image` body with `Cache-Control: no-store` (never the underlying SQL) on a rejection; `createCachedGraphQLQuery` rethrows a message with no embedded query text.
- Full `vp run test:web` was also run; the only failures observed are pre-existing and unrelated to this diff (confirmed to fail in complete isolation with zero files from this PR in the run): `app/lib/seo/__tests__/dynamic-og-data.test.ts` and a handful of `gym-entity/manage` component tests that time out under heavy local CPU contention.
- Fast-follow: `vp test run --project web app/lib/observability/__tests__/compact-error.test.ts` (9/9 passing, including the new no-cause `Failed query:` gap case and the first-newline truncation case) and `vp run typecheck` (clean), both re-run in the foreground after the hardening change.

