### PR TITLE
chore(web): drop the e2e ordering pin now the stall is explained

### DIFF
--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -1,18 +1,31 @@
-import { test, expect, type APIResponse } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+import { test, expect, type APIRequestContext, type APIResponse } from '@playwright/test';
+import { waitForBoardListReady } from './helpers/waits';
 
-// The `aa-` prefix is load-bearing: Playwright orders spec files
-// alphabetically within a shard, and this file's raw APIRequestContext
-// requests hang for 60s+ if certain browser-driven specs run against the
-// same server first — first-in-shard they pass every time, and the whole
-// suite is green. Do not rename this file below its neighbours.
+// This file used to be `aa-embed-headers.spec.ts`. The prefix was load-bearing:
+// Playwright orders spec files alphabetically inside a shard, and these raw
+// APIRequestContext requests hung for 60s+ when browser-driven specs had run
+// against the same server first. #4463 root-caused that and removed it. The
+// short version, so nobody re-derives it:
 //
-// Half of that is fixed: #4463 gave the embed/kiosk SSR backend fetches a 3 s
-// deadline, so a stalled backend now renders the retry screen instead of
-// hanging the request. The other half is not: why the backend stalls on those
-// queries only after browser specs have run is still unexplained, and #4463
-// stays open on it. Nothing about this file is a Playwright state leak — the
-// `request` fixture builds a fresh APIRequestContext per test, and the suite
-// installs no service worker, storageState, or route interception.
+//  - Nothing here was a Playwright state leak. The `request` fixture builds a
+//    fresh APIRequestContext per test, and the suite installs no service
+//    worker, storageState, or route interception.
+//  - The stall was never in the web server. The GraphQL backend's connection
+//    pool was exhausted by concurrent copies of one uncached statement — the
+//    home page's `popularBoardConfigs`, which the CI backend can never cache
+//    because it runs with no REDIS_URL. Every spec that loaded `/` added
+//    another copy. postgres.js's acquire queue is unbounded and untimed, so
+//    every other backend read then waited forever, `/embed/**` renders
+//    included. `{ __typename }` kept answering in milliseconds throughout,
+//    which is why it looked like something subtler than saturation.
+//  - Two fixes closed it: the backend now runs one copy of those cold reads at
+//    a time, and the SSR fetches that wait on the backend carry
+//    SSR_BACKEND_FETCH_TIMEOUT_MS, so a slow backend paints the retry screen —
+//    a 200 these assertions already accept.
+//
+// The ordering dependency is pinned explicitly at the bottom of this file
+// instead of through the filename, so it survives the next spec being added.
 
 // These are raw APIRequestContext gets against a server that is concurrently
 // SSR-ing front-door pages for the other worker's browser tests. On a 2-core
@@ -149,5 +162,64 @@ test.describe('embed security headers', () => {
     expect(frenchLocation.pathname).toBe(`/embed/gym/${MISSING_GYM_UUID}/leaderboard`);
     // The redirect preserves the widget's query string.
     expect(frenchLocation.search).toBe('?period=day&board=abc');
+  });
+});
+
+/**
+ * The ordering pin, written down instead of encoded in the filename.
+ *
+ * `--shard=N/8` reshuffles which specs share a server every time a test is
+ * added or removed, so the `aa-` prefix only ever protected one particular
+ * arrangement — and hid the defect rather than testing it. This drives the
+ * browser preamble explicitly, in-file, so the raw-request path is checked
+ * against a warmed-up server in EVERY run regardless of how the shards land.
+ *
+ * The budget is deliberately far above the 3 s SSR deadline and far below the
+ * 60 s+ the un-deadlined fetch used to burn: a stalled backend must reach the
+ * retry screen, not hold the socket. Measured wall clock, not just the request
+ * timeout, so a response that arrives at 14.9 s still reads as a pass and a
+ * regression to "hangs until Playwright gives up" reads as a fail.
+ */
+const PREAMBLE_BOARD_PATH = '/kilter/original/12x12-square/screw_bolt/40';
+/** 5× the SSR deadline. Anything slower than this is the stall, not latency. */
+const POST_PREAMBLE_BUDGET_MS = 15_000;
+
+async function timedGet(
+  request: APIRequestContext,
+  path: string,
+): Promise<{ response: APIResponse; elapsedMs: number }> {
+  const startedAt = Date.now();
+  const response = await request.get(path, { maxRedirects: 0, timeout: POST_PREAMBLE_BUDGET_MS });
+  return { response, elapsedMs: Date.now() - startedAt };
+}
+
+test.describe.serial('raw embed requests survive a browser-driven preamble', () => {
+  test('the embed and kiosk raw requests still answer after front-door page loads', async ({ page, request }) => {
+    // The preamble board-route-teardown.spec.ts drives: the SSR front door,
+    // scrolled to the bottom so everything below the fold mounts, then a climb
+    // view. Both read the database on the server and both were in the shard
+    // that stalled.
+    await page.goto(`${PREAMBLE_BOARD_PATH}/list`, { waitUntil: 'load' });
+    await waitForBoardListReady(page);
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+    const climbHref = await page.locator(`a[href*="${PREAMBLE_BOARD_PATH}/view/"]`).first().getAttribute('href');
+    expect(climbHref).toBeTruthy();
+    await page.goto(climbHref!, { waitUntil: 'load' });
+
+    // /embed/board/** is the render that awaits the backend over HTTP — the
+    // one that used to hang. A uuid nothing has asked for keeps it off the
+    // Data Cache fast path (`revalidate: 300` would otherwise answer this from
+    // the entry the first test in this file wrote), so it always exercises a
+    // cold backend read.
+    const embed = await timedGet(request, `/embed/board/${randomUUID()}`);
+    expect([200, 404]).toContain(embed.response.status());
+    expect(headerValue(embed.response, 'content-security-policy')).toContain('frame-ancestors *');
+    expect(embed.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
+
+    // /kiosk/** is the same shape one route tree over, and it hung in CI too.
+    const kiosk = await timedGet(request, `/kiosk/${randomUUID()}`);
+    expect(headerValue(kiosk.response, 'x-frame-options')).toBe('SAMEORIGIN');
+    expect(kiosk.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
   });
 });

--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -195,10 +195,30 @@ async function timedGet(
 
 test.describe.serial('raw embed requests survive a browser-driven preamble', () => {
   test('the embed and kiosk raw requests still answer after front-door page loads', async ({ page, request }) => {
-    // The preamble board-route-teardown.spec.ts drives: the SSR front door,
-    // scrolled to the bottom so everything below the fold mounts, then a climb
-    // view. Both read the database on the server and both were in the shard
-    // that stalled.
+    // Six cold server renders before the two assertions. On a 2-core runner
+    // that is comfortably past the 60 s per-test default, and a timeout here
+    // would read as the stall this guard exists to detect.
+    test.setTimeout(180_000);
+
+    // CONCURRENT home-page renders first. This is the load that caused the
+    // stall, and the concurrency is the whole mechanism: `/` is the only
+    // surface that reads `popularBoardConfigs` + `recentBetaLinks`, the two
+    // cold backend reads that used to take one pool connection each, and the
+    // web's 3 s deadline aborts them before Next can cache the result — so
+    // every `/` render is a cold read, forever. Ten at once used to leave the
+    // backend's ten-connection pool with nothing for anything else.
+    //
+    // Sequential `page.goto`s do NOT reproduce this (verified: a four-locale
+    // sequential preamble stays green against the un-fixed backend), which is
+    // why these are parallel raw requests rather than navigations.
+    const HOME_RENDER_FANOUT = 10;
+    await Promise.all(
+      Array.from({ length: HOME_RENDER_FANOUT }, () => request.get('/', { timeout: POST_PREAMBLE_BUDGET_MS })),
+    );
+
+    // Then the preamble board-route-teardown.spec.ts drives: the SSR front
+    // door, scrolled to the bottom so everything below the fold mounts, then a
+    // climb view. Both read the database on the server.
     await page.goto(`${PREAMBLE_BOARD_PATH}/list`, { waitUntil: 'load' });
     await waitForBoardListReady(page);
     await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));

--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -238,7 +238,11 @@ test.describe.serial('raw embed requests survive a browser-driven preamble', () 
     expect(embed.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
 
     // /kiosk/** is the same shape one route tree over, and it hung in CI too.
+    // Same two-status contract as the embed: 404 when the backend answers "no
+    // such kiosk", 200 when the fetch degrades to the retry screen. Asserted
+    // so a 5xx reads as a 5xx instead of as a missing header.
     const kiosk = await timedGet(request, `/kiosk/${randomUUID()}`);
+    expect([200, 404]).toContain(kiosk.response.status());
     expect(headerValue(kiosk.response, 'x-frame-options')).toBe('SAMEORIGIN');
     expect(kiosk.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
   });

--- a/packages/web/e2e/embed-headers.spec.ts
+++ b/packages/web/e2e/embed-headers.spec.ts
@@ -21,8 +21,16 @@ import { waitForBoardListReady } from './helpers/waits';
 //    which is why it looked like something subtler than saturation.
 //  - Two fixes closed it: the backend now runs one copy of those cold reads at
 //    a time, and the SSR fetches that wait on the backend carry
-//    SSR_BACKEND_FETCH_TIMEOUT_MS, so a slow backend paints the retry screen —
-//    a 200 these assertions already accept.
+//    SSR_BACKEND_FETCH_TIMEOUT_MS, so a slow backend paints the retry screen
+//    instead of holding the socket open.
+//
+// Those two fixes need separate oracles, and only one of them is cheap. The
+// deadline is pinned by unit tests (embed-fetchers.server.test.ts,
+// kiosk-fetch-deadline.test.ts). The pool exhaustion is what the block at the
+// bottom of this file exists for, and the assertion that carries it is the
+// STATUS, not the clock: with the deadline in place a starved backend answers
+// in three seconds with the retry screen, so a wall-clock budget alone can
+// never fail. See the block for why 404 is the only non-degraded outcome.
 //
 // The ordering dependency is pinned explicitly at the bottom of this file
 // instead of through the filename, so it survives the next spec being added.
@@ -174,14 +182,12 @@ test.describe('embed security headers', () => {
  * browser preamble explicitly, in-file, so the raw-request path is checked
  * against a warmed-up server in EVERY run regardless of how the shards land.
  *
- * The budget is deliberately far above the 3 s SSR deadline and far below the
- * 60 s+ the un-deadlined fetch used to burn: a stalled backend must reach the
- * retry screen, not hold the socket. Measured wall clock, not just the request
- * timeout, so a response that arrives at 14.9 s still reads as a pass and a
- * regression to "hangs until Playwright gives up" reads as a fail.
+ * The wall-clock budget below is the weaker of the two oracles and is kept
+ * only as a latency backstop — with the SSR deadline in place nothing on these
+ * two routes can exceed it. The discriminating assertion is the 404.
  */
 const PREAMBLE_BOARD_PATH = '/kilter/original/12x12-square/screw_bolt/40';
-/** 5× the SSR deadline. Anything slower than this is the stall, not latency. */
+/** 5× the SSR deadline — headroom for a loaded 2-core runner, not an oracle. */
 const POST_PREAMBLE_BUDGET_MS = 15_000;
 
 async function timedGet(
@@ -195,18 +201,25 @@ async function timedGet(
 
 test.describe.serial('raw embed requests survive a browser-driven preamble', () => {
   test('the embed and kiosk raw requests still answer after front-door page loads', async ({ page, request }) => {
-    // Six cold server renders before the two assertions. On a 2-core runner
-    // that is comfortably past the 60 s per-test default, and a timeout here
-    // would read as the stall this guard exists to detect.
+    // Twelve cold server renders before the two assertions (ten concurrent `/`
+    // plus the two page loads). On a 2-core runner that is comfortably past
+    // the 60 s per-test default, and a timeout here would read as the stall
+    // this guard exists to detect.
     test.setTimeout(180_000);
 
     // CONCURRENT home-page renders first. This is the load that caused the
-    // stall, and the concurrency is the whole mechanism: `/` is the only
-    // surface that reads `popularBoardConfigs` + `recentBetaLinks`, the two
-    // cold backend reads that used to take one pool connection each, and the
-    // web's 3 s deadline aborts them before Next can cache the result — so
-    // every `/` render is a cold read, forever. Ten at once used to leave the
-    // backend's ten-connection pool with nothing for anything else.
+    // stall, and the concurrency is the whole mechanism. `/` reads
+    // `popularBoardConfigs` + `recentBetaLinks`, the two cold backend reads
+    // that used to take one pool connection each. (`/` is the surface this
+    // test drives, not the only reader: the sitemap's boards shard and the
+    // climb shards issue the same `popularBoardConfigs` statement through
+    // `getAllBoardConfigsOrThrow`, which is why that module carries its own
+    // in-process TTL + single-flight — the prior art the backend fix copies.)
+    // Neither read is deduped web-side: `unstable_cache` does not collapse
+    // concurrent misses, and the 3 s deadline aborts each one before Next can
+    // write the entry, so ten simultaneous renders are ten simultaneous
+    // statements. Against the un-fixed backend that left its ten-connection
+    // pool with nothing for anything else.
     //
     // Sequential `page.goto`s do NOT reproduce this (verified: a four-locale
     // sequential preamble stays green against the un-fixed backend), which is
@@ -232,17 +245,33 @@ test.describe.serial('raw embed requests survive a browser-driven preamble', () 
     // Data Cache fast path (`revalidate: 300` would otherwise answer this from
     // the entry the first test in this file wrote), so it always exercises a
     // cold backend read.
+    //
+    // 404 is the assertion that carries this test, and unlike the seven header
+    // checks above it does NOT accept 200. `board(boardUuid:)` on a fresh uuid
+    // is one indexed select; a backend that can reach the database answers
+    // "no such board" in milliseconds and the route notFound()s. A 200 here is
+    // by construction the retry screen — the SSR fetch hit its 3 s deadline —
+    // which for this uuid means the backend could not get a pool connection.
+    // That is exactly the regression the preamble above is staged to provoke,
+    // so it has to read as a failure rather than as an accepted degrade.
     const embed = await timedGet(request, `/embed/board/${randomUUID()}`);
-    expect([200, 404]).toContain(embed.response.status());
+    expect(
+      embed.response.status(),
+      'the embed render degraded to the retry screen while the home-page herd was in flight — the backend could not answer a one-row uuid lookup inside the SSR deadline (#4463 pool exhaustion)',
+    ).toBe(404);
     expect(headerValue(embed.response, 'content-security-policy')).toContain('frame-ancestors *');
     expect(embed.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
 
     // /kiosk/** is the same shape one route tree over, and it hung in CI too.
-    // Same two-status contract as the embed: 404 when the backend answers "no
-    // such kiosk", 200 when the fetch degrades to the retry screen. Asserted
-    // so a 5xx reads as a 5xx instead of as a missing header.
+    // A random uuid is a valid gym slug (lowercase hex + hyphens pass
+    // GYM_SLUG_PATTERN), so the resolver really does reach the database and
+    // really does answer null → 404. Same reasoning as the embed: 200 is the
+    // retry screen, which here means starvation.
     const kiosk = await timedGet(request, `/kiosk/${randomUUID()}`);
-    expect([200, 404]).toContain(kiosk.response.status());
+    expect(
+      kiosk.response.status(),
+      'the kiosk render degraded to the retry screen while the home-page herd was in flight (#4463 pool exhaustion)',
+    ).toBe(404);
     expect(headerValue(kiosk.response, 'x-frame-options')).toBe('SAMEORIGIN');
     expect(kiosk.elapsedMs).toBeLessThan(POST_PREAMBLE_BUDGET_MS);
   });

--- a/packages/web/e2e/global-setup.ts
+++ b/packages/web/e2e/global-setup.ts
@@ -62,11 +62,11 @@ export default async function globalSetup(config: FullConfig): Promise<void> {
       );
     }
 
-    // 3. Pre-warm the SSR routes bottom-tab-bar navigates to. They call
-    //    cached GraphQL on the server and trigger
-    //    Next.js's compile-on-first-hit in dev. Without this, the first
-    //    navigation in a test races a cold backend round-trip against the
-    //    per-navigation timeout — the recurring shard-5 / shard-4 flake mode.
+    // 3. Pre-warm the remaining SSR routes the specs navigate to. They call
+    //    cached GraphQL on the server and trigger Next.js's compile-on-first-hit
+    //    in dev. Without this, the first navigation in a test races a cold
+    //    backend round-trip against the per-navigation timeout — the recurring
+    //    shard-5 / shard-4 flake mode.
     for (const path of WARMUP_PATHS) {
       await page.goto(path, { timeout: 60_000, waitUntil: 'domcontentloaded' }).catch(() => {
         // Soft-fail: warmup is best-effort. If a warmup route is genuinely

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -21,20 +21,26 @@ export default defineConfig({
    * parallelism carries the wall-clock and a second in-shard worker only adds
    * contention on a 2-core runner.
    *
-   * Two mechanisms this comment used to blame have been ruled out. It is not
-   * web DB-pool contention (#4461): `/embed/**` issues zero web-side Postgres
-   * statements, it fetches the backend over HTTP. It is not the web event loop
-   * being pegged by `/api/internal/board-render` WASM renders either: in run
-   * 31857179523's shard 7 the same server answered `/embed/gym/...` in 201 ms
-   * and `/` in 3.2 s while a `/embed/board/...` request started 1.3 s earlier
-   * sat stuck for 30 s. A blocked event loop cannot do that.
+   * Two mechanisms this comment used to blame were both wrong, and the record
+   * is worth keeping. It was not web DB-pool contention (#4461): `/embed/**`
+   * issues zero web-side Postgres statements, it fetches the backend over
+   * HTTP. It was not the web event loop being pegged by
+   * `/api/internal/board-render` WASM renders either: in run 31857179523's
+   * shard 7 the same server answered `/embed/gym/...` in 201 ms (a warm Next
+   * Data Cache entry, no backend round trip) and `/` in 3.2 s (its own 3 s
+   * backend deadline firing) while a `/embed/board/...` request sat stuck
+   * for 30 s.
    *
-   * What that shard actually showed was one un-deadlined SSR backend fetch
-   * hanging while the rest of the server stayed healthy. #4463 put a deadline
-   * on those fetches so a stall degrades in 3 s. What is still unexplained is
-   * why the backend stalled on that one query only after browser specs had run
-   * — until that is understood, 1 worker is the setting we can defend, and the
-   * `aa-embed-headers.spec.ts` ordering pin stays. */
+   * #4463 found it: the GraphQL BACKEND's connection pool, exhausted by
+   * concurrent copies of the home page's uncached `popularBoardConfigs`
+   * statement — 82 s each on the dev database, and uncacheable here because
+   * the CI backend runs with no REDIS_URL. Every spec that loaded `/` added
+   * another copy, postgres.js's acquire queue is unbounded and untimed, and
+   * every other backend read then waited forever. The backend now runs one
+   * copy of those cold reads at a time, the SSR fetches that wait on it carry
+   * SSR_BACKEND_FETCH_TIMEOUT_MS, and the `aa-` filename pin on the embed spec
+   * is gone — the ordering it stood for is driven explicitly inside
+   * e2e/embed-headers.spec.ts. */
   workers: process.env.CI ? 1 : undefined,
   /* Global per-test timeout — some tests (zoom, login flows) need more than Playwright's 30 s default */
   timeout: 60_000,

--- a/packages/web/scripts/__tests__/e2e-spec-ordering.test.ts
+++ b/packages/web/scripts/__tests__/e2e-spec-ordering.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+
+/**
+ * Guards against re-pinning an e2e spec by filename.
+ *
+ * `aa-embed-headers.spec.ts` carried an alphabetical prefix for weeks because
+ * Playwright orders spec files alphabetically inside a shard and those raw
+ * HTTP checks hung when browser specs ran first (#4463). The prefix hid the
+ * defect instead of testing it, and it only ever protected one particular
+ * `--shard=N/8` arrangement — adding or removing a single test elsewhere
+ * reshuffles the whole split and quietly retires the protection.
+ *
+ * A rename is the cheapest possible "fix" for the next ordering flake, and it
+ * leaves nothing behind that explains itself. This makes that rename fail
+ * loudly and points at the issue that recorded the actual mechanism.
+ */
+
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+
+const E2E_DIR = join(import.meta.dirname, '..', '..', 'e2e');
+
+/**
+ * A doubled leading letter followed by `-` — `aa-`, `zzz-`, `aa_`-style
+ * sorting hacks at either end of the alphabet. Real spec names never start
+ * that way, so the pattern costs no false positives.
+ */
+const ORDERING_PREFIX = /^([a-z])\1+[-_]/;
+
+function e2eSpecBasenames(): string[] {
+  return readdirSync(E2E_DIR).filter((entry) => entry.endsWith('.spec.ts'));
+}
+
+describe('e2e spec filenames carry no alphabetical ordering pin', () => {
+  it('has no spec whose name starts with a doubled letter', () => {
+    const pinned = e2eSpecBasenames().filter((basename) => ORDERING_PREFIX.test(basename));
+
+    expect(
+      pinned,
+      'An e2e spec is pinned by filename so it sorts first (or last) inside its shard. ' +
+        'That is the workaround #4463 removed: it hides an ordering-dependent failure ' +
+        'instead of testing it, and it silently stops working the next time a test is ' +
+        'added anywhere in the suite. Drive the ordering explicitly inside the spec ' +
+        '(see the describe.serial block in e2e/embed-headers.spec.ts) instead.',
+    ).toEqual([]);
+  });
+
+  it('still has the embed-header spec under its un-pinned name', () => {
+    // If this file is renamed back, the check above would pass vacuously.
+    expect(e2eSpecBasenames()).toContain('embed-headers.spec.ts');
+  });
+});

--- a/packages/web/scripts/__tests__/e2e-spec-ordering.test.ts
+++ b/packages/web/scripts/__tests__/e2e-spec-ordering.test.ts
@@ -22,19 +22,30 @@ import { describe, expect, it } from 'vite-plus/test';
 const E2E_DIR = join(import.meta.dirname, '..', '..', 'e2e');
 
 /**
- * A doubled leading letter followed by `-` — `aa-`, `zzz-`, `aa_`-style
- * sorting hacks at either end of the alphabet. Real spec names never start
- * that way, so the pattern costs no false positives.
+ * The three cheap ways to buy a sort position, all of which work and all of
+ * which a reviewer reads as a typo rather than as a workaround. Real spec
+ * names start with a whole lowercase word, so none of these costs a false
+ * positive.
+ *
+ * This catches sorting hacks that *look* like hacks. It cannot catch a plain
+ * word that happens to sort first (`aardvark-embed.spec.ts`) — nothing short
+ * of a committed order manifest could, and that would make every added spec a
+ * two-file change. The point is that the obvious rename now fails loudly and
+ * says why.
  */
-const ORDERING_PREFIX = /^([a-z])\1+[-_]/;
+const ORDERING_PREFIXES: readonly RegExp[] = [
+  /^[^a-z]/, // a leading digit or `_` sorts before every letter
+  /^[a-z][-_]/, // `a-`, `z_` — one letter plus a separator sorts ahead of any real name
+  /^([a-z])\1+[-_]/, // `aa-`, `zzz_` — the original pin
+];
 
 function e2eSpecBasenames(): string[] {
   return readdirSync(E2E_DIR).filter((entry) => entry.endsWith('.spec.ts'));
 }
 
 describe('e2e spec filenames carry no alphabetical ordering pin', () => {
-  it('has no spec whose name starts with a doubled letter', () => {
-    const pinned = e2eSpecBasenames().filter((basename) => ORDERING_PREFIX.test(basename));
+  it('has no spec whose name buys a sort position', () => {
+    const pinned = e2eSpecBasenames().filter((basename) => ORDERING_PREFIXES.some((pattern) => pattern.test(basename)));
 
     expect(
       pinned,


### PR DESCRIPTION
## Summary

Removes the `aa-` filename prefix on the embed-header e2e spec. It was there because Playwright orders spec files alphabetically inside a shard and those raw `APIRequestContext` requests hung for 60 s+ when browser-driven specs had run against the same server first — first-in-shard they passed every time. Nobody knew why, and the file said so.

Stacked on #4668, which fixes the cause.

### What the prefix was hiding

The web server was never the problem. The GraphQL **backend's connection pool** was exhausted by concurrent copies of the home page's uncached `popularBoardConfigs` statement — 82 s each on the dev database, and never cacheable in CI because the e2e backend runs with no `REDIS_URL`. Every spec that loaded `/` added another copy; postgres.js's acquire queue is unbounded and untimed, so every other backend read then waited forever, `/embed/**` renders included. `{ __typename }` kept answering in milliseconds through the same event loop the whole time, which is why three previous theories all looked plausible and all were wrong.

Measured directly: ten parallel `GET /` against the pre-fix backend leaves **eleven** copies of that statement `active` in `pg_stat_activity`, and `board(boardUuid:)` then does not answer inside 30 s.

### Why the prefix had to go rather than stay

`--shard=N/8` re-splits the whole suite whenever a test is added or removed anywhere. The prefix only ever protected one arrangement — it retires itself silently, and the next victim is a different file presenting as an unrelated new flake. It is also the cheapest possible answer to the next ordering problem, and it leaves nothing behind that explains itself.

So the ordering is now driven **explicitly, in-file**: a `describe.serial` block that fans out ten concurrent `/` renders, then does the front-door + climb-view page loads `board-route-teardown.spec.ts` drives, then hits `/embed/board/<fresh uuid>` and `/kiosk/<fresh uuid>` as raw requests. That runs in every shard arrangement instead of one.

Also corrects two comments that still described specs deleted by #4467, and adds a repo guard against re-pinning by filename.

Closes #4463

### The oracle is the status, not the clock

The first version of this block asserted `expect([200, 404]).toContain(status)` plus a 15 s wall-clock budget, and **that combination cannot fail while the SSR deadline exists**. For a fresh uuid both routes do exactly one deadline-wrapped backend fetch, so a starved backend paints the retry screen at 3 s — a 200 the assertion accepted, inside a budget it could not exceed. The table in the first draft of this description showed it plainly and I did not read it that way: `SSR deadline, pre-fix backend` passed. That row is the whole test.

Both requests now assert `404` and nothing else. A fresh uuid is one indexed select on the backend; a backend that can reach the database answers "no such board / no such kiosk" in milliseconds and the route `notFound()`s. **A 200 is by construction the retry screen**, which for these uuids means the fetch hit its 3 s deadline — i.e. the pool was gone. The wall-clock budget stays as a latency backstop and is no longer load-bearing.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

Local 2-CPU-confined production harness — prebuilt `next start` + the backend under `tsx src/index.ts` + a **migrated** `boardsesh-dev-db` container, all pinned to two CPUs, Playwright under `CI=1`, running `e2e/embed-headers.spec.ts` (8 tests: the 7 header checks plus the new serial block). Re-measured from scratch for this revision; these numbers supersede the earlier table.

| backend build | result |
|---|---|
| single-flight (this stack), run 1 | **8 passed** |
| single-flight, run 2 | **8 passed** |
| single-flight, run 3 | **8 passed** |
| pre-#4668 (`git show 25322da86:` for both resolvers, `single-flight.ts` deleted) | **1 failed** — `/embed/board/<uuid>` returned 200, on the attempt **and** the retry |

Same web build, same database, same SSR deadline in both columns, so the single discriminating variable is #4668. The other 7 tests passed in every run.

One methodology note worth recording: the first attempt at the pre-fix column produced a *false* red — the fresh dev-db container was 14 migrations behind, so `user_boards.presence_seq` / `merged_into_board_uuid` did not exist and **every** board and gym query failed from the first test onward, in both columns. `vp run db:migrate` against the harness database, then re-measure. A harness whose baseline column is also red is not a harness.

Guard mutations, each applied, watched red, reverted:
- `packages/web/e2e/1-probe.spec.ts` → `e2e-spec-ordering.test.ts` fails naming it.
- `a-probe.spec.ts` → fails. `aa-probe.spec.ts` → fails. `_probe.spec.ts` → fails.
- Removing all four → green again. Before this revision the first, second and fourth of those were **green**: the pattern only matched a doubled leading letter, so `1-`, `a-` and `_` were all still effective pins. The guard now rejects a leading non-letter, a single letter plus separator, and the doubled letter.
- rename `embed-headers.spec.ts` away → the second assertion fails, so the first cannot pass vacuously.

The guard catches sorting hacks that read as hacks. It cannot catch a plain word that happens to sort first (`aardvark-embed.spec.ts`) — only a committed order manifest could, and that makes every added spec a two-file change. The file says so.

CI: `e2e-tests.yml` dispatched on this branch. The oracle is the **eight `E2E (shard N)` jobs**, not the workflow conclusion — `Expo-web smoke` is a separate task (`vp run test:e2e:expo-web`) that CLAUDE.md already keeps out of per-PR CI and that has failed independently on several recent dispatches. Results in a comment below as each dispatch lands.
