### PR TITLE
fix(web): bound OG image DB reads and serve a cacheable fallback card on failure

### DIFF
--- a/docs/db-connectivity.md
+++ b/docs/db-connectivity.md
@@ -110,8 +110,8 @@ rather than an error.
 
 `packages/web/app/lib/db/read-deadline.ts` bounds one read client-side. It races
 the pending query against a timer and rejects with `DbReadTimeoutError`
-(`code: 'DB_READ_TIMEOUT'`) when the timer wins. It is wired at the four
-front-door reads only — the two statements behind `getClimb`, the all-angles
+(`code: 'DB_READ_TIMEOUT'`) when the timer wins. It is wired at four
+front-door reads — the two statements behind `getClimb`, the all-angles
 stats select, and the shared climb search — and deliberately **not** inside
 `withConnectRetry` or `packages/db`, where it would change behaviour for the
 backend, the sync runners and every script.
@@ -139,6 +139,18 @@ puts one deadline timestamp in React's per-render `cache` scope and hands each
 read whatever the earlier ones left, floored at 500 ms. Outside a render scope
 (scripts, unit tests) React's `cache` is a passthrough and each read gets its own
 deadline.
+
+**Since #4650 the same helper also wraps four more reads: the unauthenticated
+OG image routes**, one `withReadDeadline` call around each route's whole DB
+phase — `og-setter`, `og-profile`, `og-playlist`, `og-session` (`/api/og/climb`
+needs nothing; its `getClimb` read is already covered above). Those add a
+third outcome to the table below: a timed-out or rejected OG read does not
+404 or 500, it redirects to `/opengraph-image` — the existing DB-free branded
+card — with a 60 s CDN `s-maxage`. Unfurlers render nothing on a bare 5xx and
+cache that failed scrape for days, so a degraded-but-present card beats a
+blank embed for that whole window, and the short `s-maxage` lets the CDN
+answer a burst of scraper retries during the brownout without sending each
+one at the database.
 
 ### What the reader sees when it fires
 

--- a/packages/web/app/api/og/playlist/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/playlist/__tests__/route.test.tsx
@@ -202,7 +202,7 @@ describe('api/og/playlist route', () => {
     expect(collectText(playlistRouteState.capturedElement)).toContain('SP');
   });
 
-  it('returns a generic 500 with no-store instead of leaking the underlying error', async () => {
+  it('redirects to the branded fallback card instead of leaking the underlying error', async () => {
     playlistRouteState.getPlaylistOgSummaryMock.mockRejectedValue(
       Object.assign(new Error('Failed query: SELECT * FROM playlists WHERE uuid = $1 params: leaky-playlist'), {
         name: 'DrizzleQueryError',
@@ -212,9 +212,9 @@ describe('api/og/playlist route', () => {
     const response = await GET(makeRequest({ uuid: 'leaky-playlist' }));
     const body = await response.text();
 
-    expect(response.status).toBe(500);
-    expect(response.headers.get('Cache-Control')).toBe('no-store');
-    expect(body).toBe('Error generating image');
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/opengraph-image');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
     expect(body).not.toContain('SELECT');
     expect(body).not.toContain('leaky-playlist');
   });

--- a/packages/web/app/api/og/playlist/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/playlist/__tests__/route.test.tsx
@@ -14,6 +14,10 @@ vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
   getPlaylistOgSummary: playlistRouteState.getPlaylistOgSummaryMock,
 }));
 
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
 vi.mock('@/app/theme/theme-config', () => ({
   themeTokens: {
     neutral: {
@@ -73,6 +77,16 @@ function makeRequest(params: Record<string, string>): NextRequest {
     url.searchParams.set(key, value);
   }
   return new NextRequest(url);
+}
+
+/**
+ * Mirrors real drizzle-orm@0.45.2's `DrizzleQueryError`: `.name` stays the
+ * inherited "Error" (the class never overrides it), the message embeds the
+ * full SQL + params, and `.cause` is always the underlying driver error.
+ */
+function makeDrizzleQueryError(sql: string, params: string, causeMessage = 'CONNECT_TIMEOUT'): Error {
+  const cause = Object.assign(new Error(causeMessage), { code: causeMessage });
+  return Object.assign(new Error(`Failed query: ${sql}\nparams: ${params}`), { cause });
 }
 
 function collectText(node: unknown): string {
@@ -203,10 +217,9 @@ describe('api/og/playlist route', () => {
   });
 
   it('redirects to the branded fallback card instead of leaking the underlying error', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     playlistRouteState.getPlaylistOgSummaryMock.mockRejectedValue(
-      Object.assign(new Error('Failed query: SELECT * FROM playlists WHERE uuid = $1 params: leaky-playlist'), {
-        name: 'DrizzleQueryError',
-      }),
+      makeDrizzleQueryError('SELECT * FROM playlists WHERE uuid = $1', 'leaky-playlist'),
     );
 
     const response = await GET(makeRequest({ uuid: 'leaky-playlist' }));
@@ -217,5 +230,12 @@ describe('api/og/playlist route', () => {
     expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
     expect(body).not.toContain('SELECT');
     expect(body).not.toContain('leaky-playlist');
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const [, loggedMessage] = consoleErrorSpy.mock.calls[0] as [string, string];
+    expect(loggedMessage).not.toContain('SELECT');
+    expect(loggedMessage).not.toContain('leaky-playlist');
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/packages/web/app/api/og/playlist/route.tsx
+++ b/packages/web/app/api/og/playlist/route.tsx
@@ -6,6 +6,7 @@ import { formatBoardDisplayName } from '@/app/lib/string-utils';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getPlaylistOgSummary } from '@/app/lib/seo/dynamic-og-data';
 import { ogErrorResponse } from '@/app/lib/seo/og-error';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 export const runtime = 'nodejs';
 
@@ -56,7 +57,7 @@ export async function GET(request: NextRequest) {
     }
 
     const dbT0 = performance.now();
-    const playlist = await getPlaylistOgSummary(uuid);
+    const playlist = await withReadDeadline('og-playlist', getPlaylistOgSummary(uuid));
     const dbMs = performance.now() - dbT0;
 
     if (!playlist) {

--- a/packages/web/app/api/og/profile/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/profile/__tests__/route.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { NextRequest } from 'next/server';
+import { GET } from '../route';
+
+/**
+ * `sqlTagMock` stands in for the tagged-template function `getReadPool()`
+ * returns. Tests control exactly when it "resolves" — the mechanism the
+ * first test below depends on to catch a specific regression: the route used
+ * to do `rowsFromResult(await sql\`...\`)` *inside* the `Promise.all` array
+ * literal, which resolves the query before `Promise.all`/`withReadDeadline`
+ * ever run, silently leaving it unbounded despite the deadline wrap.
+ */
+const profileRouteState = vi.hoisted(() => ({
+  getProfileOgSummaryMock: vi.fn(),
+  sqlTagMock: vi.fn(),
+  recordedReads: [] as { label: string; ms: number | undefined }[],
+  capturedElement: null as unknown,
+}));
+
+vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
+  getProfileOgSummary: profileRouteState.getProfileOgSummaryMock,
+}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  getReadPool: () => profileRouteState.sqlTagMock,
+  rowsFromResult: (result: unknown) => (Array.isArray(result) ? result : []),
+}));
+
+vi.mock('@/app/lib/db/read-deadline', () => ({
+  withReadDeadline: async (label: string, pending: Promise<unknown>, ms?: number) => {
+    profileRouteState.recordedReads.push({ label, ms });
+    return pending;
+  },
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    neutral: {
+      200: '#E0E0E0',
+      300: '#D0D0D0',
+      400: '#B0B0B0',
+      500: '#909090',
+      900: '#101010',
+    },
+  },
+}));
+
+vi.mock('@/app/lib/grade-colors', () => ({
+  FONT_GRADE_COLORS: {
+    v5: '#00AAFF',
+  },
+  getGradeColorWithOpacity: vi.fn(() => 'rgba(0, 170, 255, 0.5)'),
+}));
+
+vi.mock('@/app/lib/board-data', () => ({
+  BOULDER_GRADES: [{ difficulty_id: 10, font_grade: 'V5' }],
+}));
+
+vi.mock('@/app/lib/seo/og', () => ({
+  OG_IMAGE_WIDTH: 1200,
+  OG_IMAGE_HEIGHT: 630,
+  createOgImageHeaders: vi.fn(
+    ({ contentType, version, serverTiming }: { contentType: string; version?: string; serverTiming?: string }) => ({
+      'Content-Type': contentType,
+      'Cache-Control': version
+        ? 'public, max-age=31536000, s-maxage=31536000, immutable'
+        : 'public, max-age=0, s-maxage=300, stale-while-revalidate=86400',
+      'CDN-Cache-Control': version
+        ? 'public, s-maxage=31536000, immutable'
+        : 'public, s-maxage=300, stale-while-revalidate=86400',
+      'Vercel-CDN-Cache-Control': version
+        ? 'public, s-maxage=31536000, immutable'
+        : 'public, s-maxage=300, stale-while-revalidate=86400',
+      'Server-Timing': serverTiming ?? '',
+    }),
+  ),
+}));
+
+vi.mock('@vercel/og', () => ({
+  ImageResponse: vi.fn(function ImageResponse(element: unknown, init?: ResponseInit) {
+    profileRouteState.capturedElement = element;
+    return new Response('mock-image', {
+      status: 200,
+      headers: new Headers(init?.headers),
+    });
+  }),
+}));
+
+function makeRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/og/profile');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+describe('api/og/profile route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    profileRouteState.recordedReads.length = 0;
+    profileRouteState.capturedElement = null;
+  });
+
+  it('passes the grade-count query into Promise.all unresolved, so both reads race under one og-profile deadline', async () => {
+    let resolveGradeRows: (rows: unknown[]) => void = () => {};
+    const gradeRowsPromise = new Promise<unknown[]>((resolve) => {
+      resolveGradeRows = resolve;
+    });
+    profileRouteState.sqlTagMock.mockReturnValue(gradeRowsPromise);
+    profileRouteState.getProfileOgSummaryMock.mockResolvedValue({
+      displayName: 'Alex',
+      avatarUrl: null,
+      fallbackImageUrl: null,
+    });
+
+    const responsePromise = GET(makeRequest({ user_id: 'user-1' }));
+
+    // Deliberately asserted before resolving the grade query and before ever
+    // awaiting the route. Calling an async function runs its body
+    // synchronously up to its first `await`, and our `withReadDeadline` mock
+    // records its label before it awaits anything — so 'og-profile' is only
+    // recorded here if the grade-count query was handed into `Promise.all`
+    // still pending. A regression that reintroduces `await sql\`...\`` inside
+    // the array literal would pause GET on that await *before* it ever
+    // reaches `withReadDeadline`, leaving this empty since `sqlTagMock`'s
+    // promise is deliberately never resolved above this line.
+    expect(profileRouteState.recordedReads.map((read) => read.label)).toEqual(['og-profile']);
+
+    resolveGradeRows([]);
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+  });
+
+  it('renders a 200 PNG with the profile summary and grade bars', async () => {
+    profileRouteState.sqlTagMock.mockResolvedValue([{ difficulty: 10, cnt: 3 }]);
+    profileRouteState.getProfileOgSummaryMock.mockResolvedValue({
+      displayName: 'Alex',
+      avatarUrl: null,
+      fallbackImageUrl: null,
+    });
+
+    const response = await GET(makeRequest({ user_id: 'user-1' }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('image/png');
+  });
+
+  it('redirects to the branded fallback card on a DbReadTimeoutError-shaped rejection', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const timeoutError = Object.assign(new Error('[db] front-door read "og-profile" exceeded 6000ms'), {
+      name: 'DbReadTimeoutError',
+      code: 'DB_READ_TIMEOUT',
+    });
+    profileRouteState.getProfileOgSummaryMock.mockRejectedValue(timeoutError);
+    profileRouteState.sqlTagMock.mockResolvedValue([]);
+
+    const response = await GET(makeRequest({ user_id: 'user-1' }));
+    const body = await response.text();
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/opengraph-image');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
+    expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
+    expect(body).not.toContain('SELECT');
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/web/app/api/og/profile/route.tsx
+++ b/packages/web/app/api/og/profile/route.tsx
@@ -8,6 +8,7 @@ import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getProfileOgSummary } from '@/app/lib/seo/dynamic-og-data';
 import { ogErrorResponse } from '@/app/lib/seo/og-error';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 export const runtime = 'nodejs';
 
@@ -34,10 +35,15 @@ export async function GET(request: NextRequest) {
 
     const dbT0 = performance.now();
     const sql = getReadPool();
-    const [summary, gradeRows] = await Promise.all([
-      getProfileOgSummary(userId),
-      rowsFromResult<{ difficulty: number; cnt: number }>(
-        await sql`
+    // The grade-count query is passed unawaited so both reads below actually
+    // start together — an `await` here (the old shape) would resolve before
+    // `Promise.all`/`withReadDeadline` ever runs, defeating the deadline for
+    // this query.
+    const [summary, gradeResult] = await withReadDeadline(
+      'og-profile',
+      Promise.all([
+        getProfileOgSummary(userId),
+        sql`
         SELECT difficulty, COUNT(DISTINCT climb_uuid) as cnt
         FROM boardsesh_ticks
         WHERE user_id = ${userId}
@@ -46,9 +52,10 @@ export async function GET(request: NextRequest) {
         GROUP BY difficulty
         ORDER BY difficulty
       `,
-      ),
-    ]);
+      ]),
+    );
     const dbMs = performance.now() - dbT0;
+    const gradeRows = rowsFromResult<{ difficulty: number; cnt: number }>(gradeResult);
 
     if (!summary) {
       return new Response('User not found', { status: 404 });

--- a/packages/web/app/api/og/session/route.tsx
+++ b/packages/web/app/api/og/session/route.tsx
@@ -7,6 +7,7 @@ import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getSessionOgSummary } from '@/app/lib/seo/dynamic-og-data';
 import { ogErrorResponse } from '@/app/lib/seo/og-error';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 export const runtime = 'nodejs';
 
@@ -50,7 +51,7 @@ export async function GET(request: NextRequest) {
     }
 
     const dbT0 = performance.now();
-    const summary = await getSessionOgSummary(sessionId);
+    const summary = await withReadDeadline('og-session', getSessionOgSummary(sessionId));
     const dbMs = performance.now() - dbT0;
 
     if (!summary.found) {

--- a/packages/web/app/api/og/setter/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/setter/__tests__/route.test.tsx
@@ -23,6 +23,10 @@ vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
   getSetterOgSummary: setterRouteState.getSetterOgSummaryMock,
 }));
 
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+}));
+
 vi.mock('@/app/lib/db/db', () => ({
   dbzRead: setterRouteState.dbzReadSentinel,
   dbz: setterRouteState.dbzSentinel,
@@ -97,6 +101,16 @@ function makeRequest(params: Record<string, string>): NextRequest {
   return new NextRequest(url);
 }
 
+/**
+ * Mirrors real drizzle-orm@0.45.2's `DrizzleQueryError`: `.name` stays the
+ * inherited "Error" (the class never overrides it), the message embeds the
+ * full SQL + params, and `.cause` is always the underlying driver error.
+ */
+function makeDrizzleQueryError(sql: string, params: string, causeMessage = 'CONNECT_TIMEOUT'): Error {
+  const cause = Object.assign(new Error(causeMessage), { code: causeMessage });
+  return Object.assign(new Error(`Failed query: ${sql}\nparams: ${params}`), { cause });
+}
+
 describe('api/og/setter route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -135,9 +149,7 @@ describe('api/og/setter route', () => {
   it('redirects to the branded fallback card and logs a throttled compact message when the DB rejects', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     setterRouteState.getSetterOgSummaryMock.mockRejectedValue(
-      Object.assign(new Error('Failed query: SELECT * FROM boardsesh_ticks WHERE setter_username = $1'), {
-        name: 'DrizzleQueryError',
-      }),
+      makeDrizzleQueryError('SELECT * FROM boardsesh_ticks WHERE setter_username = $1', 'alex'),
     );
     setterRouteState.executeRowsMock.mockResolvedValue([]);
 
@@ -149,11 +161,11 @@ describe('api/og/setter route', () => {
     expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
     expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
     expect(body).not.toContain('SELECT');
+
     expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      '[og] setter render failed:',
-      expect.stringContaining('DrizzleQueryError'),
-    );
+    const [, loggedMessage] = consoleErrorSpy.mock.calls[0] as [string, string];
+    expect(loggedMessage).not.toContain('SELECT');
+    expect(loggedMessage).toBe('Error: CONNECT_TIMEOUT');
 
     consoleErrorSpy.mockRestore();
   });

--- a/packages/web/app/api/og/setter/__tests__/route.test.tsx
+++ b/packages/web/app/api/og/setter/__tests__/route.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { NextRequest } from 'next/server';
+import { GET } from '../route';
+
+/**
+ * Sentinels stand in for the drizzle handles `@/app/lib/db/db` exports.
+ * Asserting on identity (not just "was called") is what actually pins the
+ * replica seam: `executeRows` accepts any drizzle instance, so a regression
+ * back to `dbz` (primary) would still "work" and only this test would catch it.
+ */
+const setterRouteState = vi.hoisted(() => ({
+  getSetterOgSummaryMock: vi.fn(),
+  executeRowsMock: vi.fn(),
+  dbzReadSentinel: { __sentinel: 'dbzRead' } as unknown,
+  dbzSentinel: { __sentinel: 'dbz' } as unknown,
+  recordedReads: [] as { label: string; ms: number | undefined }[],
+  capturedElement: null as unknown,
+}));
+
+vi.mock('@/app/lib/seo/dynamic-og-data', () => ({
+  getSetterOgSummary: setterRouteState.getSetterOgSummaryMock,
+}));
+
+vi.mock('@/app/lib/db/db', () => ({
+  dbzRead: setterRouteState.dbzReadSentinel,
+  dbz: setterRouteState.dbzSentinel,
+  executeRows: setterRouteState.executeRowsMock,
+}));
+
+vi.mock('@/app/lib/db/read-deadline', () => ({
+  withReadDeadline: async (label: string, pending: Promise<unknown>, ms?: number) => {
+    setterRouteState.recordedReads.push({ label, ms });
+    return pending;
+  },
+}));
+
+vi.mock('@/app/theme/theme-config', () => ({
+  themeTokens: {
+    neutral: {
+      200: '#E0E0E0',
+      300: '#D0D0D0',
+      400: '#B0B0B0',
+      500: '#909090',
+      900: '#101010',
+    },
+  },
+}));
+
+vi.mock('@/app/lib/grade-colors', () => ({
+  FONT_GRADE_COLORS: {
+    v5: '#00AAFF',
+  },
+  getGradeColorWithOpacity: vi.fn(() => 'rgba(0, 170, 255, 0.5)'),
+}));
+
+vi.mock('@/app/lib/board-data', () => ({
+  BOULDER_GRADES: [{ difficulty_id: 10, font_grade: 'V5' }],
+}));
+
+vi.mock('@/app/lib/seo/og', () => ({
+  OG_IMAGE_WIDTH: 1200,
+  OG_IMAGE_HEIGHT: 630,
+  createOgImageHeaders: vi.fn(
+    ({ contentType, version, serverTiming }: { contentType: string; version?: string; serverTiming?: string }) => ({
+      'Content-Type': contentType,
+      'Cache-Control': version
+        ? 'public, max-age=31536000, s-maxage=31536000, immutable'
+        : 'public, max-age=0, s-maxage=300, stale-while-revalidate=86400',
+      'CDN-Cache-Control': version
+        ? 'public, s-maxage=31536000, immutable'
+        : 'public, s-maxage=300, stale-while-revalidate=86400',
+      'Vercel-CDN-Cache-Control': version
+        ? 'public, s-maxage=31536000, immutable'
+        : 'public, s-maxage=300, stale-while-revalidate=86400',
+      'Server-Timing': serverTiming ?? '',
+    }),
+  ),
+}));
+
+vi.mock('@vercel/og', () => ({
+  ImageResponse: vi.fn(function ImageResponse(element: unknown, init?: ResponseInit) {
+    setterRouteState.capturedElement = element;
+    return new Response('mock-image', {
+      status: 200,
+      headers: new Headers(init?.headers),
+    });
+  }),
+}));
+
+function makeRequest(params: Record<string, string>): NextRequest {
+  const url = new URL('http://localhost:3000/api/og/setter');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+describe('api/og/setter route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setterRouteState.recordedReads.length = 0;
+    setterRouteState.capturedElement = null;
+  });
+
+  it('reads the tick-aggregate query off the replica seam (dbzRead), not the primary', async () => {
+    setterRouteState.getSetterOgSummaryMock.mockResolvedValue({
+      displayName: 'Alex',
+      avatarUrl: null,
+    });
+    setterRouteState.executeRowsMock.mockResolvedValue([]);
+
+    const response = await GET(makeRequest({ username: 'alex' }));
+
+    expect(response.status).toBe(200);
+    expect(setterRouteState.executeRowsMock).toHaveBeenCalledTimes(1);
+    const [dbArg] = setterRouteState.executeRowsMock.mock.calls[0];
+    expect(dbArg).toBe(setterRouteState.dbzReadSentinel);
+    expect(dbArg).not.toBe(setterRouteState.dbzSentinel);
+  });
+
+  it('bounds the whole DB phase (summary + grade aggregate) under a single og-setter read deadline', async () => {
+    setterRouteState.getSetterOgSummaryMock.mockResolvedValue({
+      displayName: 'Alex',
+      avatarUrl: null,
+    });
+    setterRouteState.executeRowsMock.mockResolvedValue([]);
+
+    await GET(makeRequest({ username: 'alex' }));
+
+    expect(setterRouteState.recordedReads.map((read) => read.label)).toEqual(['og-setter']);
+  });
+
+  it('redirects to the branded fallback card and logs a throttled compact message when the DB rejects', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setterRouteState.getSetterOgSummaryMock.mockRejectedValue(
+      Object.assign(new Error('Failed query: SELECT * FROM boardsesh_ticks WHERE setter_username = $1'), {
+        name: 'DrizzleQueryError',
+      }),
+    );
+    setterRouteState.executeRowsMock.mockResolvedValue([]);
+
+    const response = await GET(makeRequest({ username: 'alex' }));
+    const body = await response.text();
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/opengraph-image');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
+    expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
+    expect(body).not.toContain('SELECT');
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[og] setter render failed:',
+      expect.stringContaining('DrizzleQueryError'),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/packages/web/app/api/og/setter/route.tsx
+++ b/packages/web/app/api/og/setter/route.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ImageResponse } from '@vercel/og';
 import type { NextRequest } from 'next/server';
-import { dbz, executeRows } from '@/app/lib/db/db';
+import { dbzRead, executeRows } from '@/app/lib/db/db';
 import { sql } from 'drizzle-orm';
 import { themeTokens } from '@/app/theme/theme-config';
 import { FONT_GRADE_COLORS, getGradeColorWithOpacity } from '@/app/lib/grade-colors';
@@ -9,6 +9,7 @@ import { BOULDER_GRADES } from '@/app/lib/board-data';
 import { createOgImageHeaders, OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH } from '@/app/lib/seo/og';
 import { getSetterOgSummary } from '@/app/lib/seo/dynamic-og-data';
 import { ogErrorResponse } from '@/app/lib/seo/og-error';
+import { withReadDeadline } from '@/app/lib/db/read-deadline';
 
 export const runtime = 'nodejs';
 
@@ -34,25 +35,28 @@ export async function GET(request: NextRequest) {
     }
 
     const dbT0 = performance.now();
-    const [summary, gradeResult] = await Promise.all([
-      getSetterOgSummary(username),
-      executeRows<{
-        difficulty: number;
-        cnt: number;
-      }>(
-        dbz,
-        sql`
-        SELECT bt.difficulty, COUNT(*) as cnt
-        FROM boardsesh_ticks bt
-        JOIN board_climbs bc ON bc.uuid = bt.climb_uuid
-        WHERE bc.setter_username = ${username}
-          AND bt.status IN ('flash', 'send')
-          AND bt.difficulty IS NOT NULL
-        GROUP BY bt.difficulty
-        ORDER BY bt.difficulty
-      `,
-      ),
-    ]);
+    const [summary, gradeResult] = await withReadDeadline(
+      'og-setter',
+      Promise.all([
+        getSetterOgSummary(username),
+        executeRows<{
+          difficulty: number;
+          cnt: number;
+        }>(
+          dbzRead,
+          sql`
+          SELECT bt.difficulty, COUNT(*) as cnt
+          FROM boardsesh_ticks bt
+          JOIN board_climbs bc ON bc.uuid = bt.climb_uuid
+          WHERE bc.setter_username = ${username}
+            AND bt.status IN ('flash', 'send')
+            AND bt.difficulty IS NOT NULL
+          GROUP BY bt.difficulty
+          ORDER BY bt.difficulty
+        `,
+        ),
+      ]),
+    );
     const dbMs = performance.now() - dbT0;
     const gradeRows = gradeResult;
 

--- a/packages/web/app/lib/seo/__tests__/og-error.test.ts
+++ b/packages/web/app/lib/seo/__tests__/og-error.test.ts
@@ -24,7 +24,7 @@ describe('ogErrorResponse', () => {
     vi.useRealTimers();
   });
 
-  it('returns a generic 500 body with no-store, never the raw error message', async () => {
+  it('redirects to the branded fallback card with a short CDN-cacheable TTL, never the raw error message', async () => {
     const { ogErrorResponse } = await loadModule();
     const leakyError = Object.assign(new Error('Failed query: SELECT * FROM users WHERE email = $1'), {
       name: 'DrizzleQueryError',
@@ -33,9 +33,11 @@ describe('ogErrorResponse', () => {
     const response = ogErrorResponse('setter', leakyError);
     const body = await response.text();
 
-    expect(response.status).toBe(500);
-    expect(response.headers.get('Cache-Control')).toBe('no-store');
-    expect(body).toBe('Error generating image');
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/opengraph-image');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, s-maxage=60');
+    expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
+    expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe('public, s-maxage=60');
     expect(body).not.toContain('SELECT');
   });
 

--- a/packages/web/app/lib/seo/__tests__/og-error.test.ts
+++ b/packages/web/app/lib/seo/__tests__/og-error.test.ts
@@ -1,6 +1,14 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
 
+const { captureExceptionMock } = vi.hoisted(() => ({
+  captureExceptionMock: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: captureExceptionMock,
+}));
+
 type OgErrorModule = typeof import('../og-error');
 
 // Fresh module per test: the throttle map is module state, and a shared
@@ -11,12 +19,28 @@ async function loadModule(): Promise<OgErrorModule> {
   return import('../og-error');
 }
 
+/**
+ * Mirrors real drizzle-orm@0.45.2's `DrizzleQueryError` (see
+ * `node_modules/drizzle-orm/errors.js`): the class never overrides `.name`,
+ * so it stays the inherited "Error" rather than "DrizzleQueryError"; the
+ * message is `Failed query: <sql>\nparams: <params>`; and `.cause` is always
+ * the underlying driver error. Modelling that (instead of a fake with the SQL
+ * inlined and no cause) is what makes the "log never contains SELECT"
+ * assertions below mean something — a bug in `compactErrorMessage`'s
+ * cause-unwrapping would fail them.
+ */
+function makeDrizzleQueryError(sql: string, params: string, causeMessage = 'CONNECT_TIMEOUT'): Error {
+  const cause = Object.assign(new Error(causeMessage), { code: causeMessage });
+  return Object.assign(new Error(`Failed query: ${sql}\nparams: ${params}`), { cause });
+}
+
 describe('ogErrorResponse', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    captureExceptionMock.mockClear();
   });
 
   afterEach(() => {
@@ -26,9 +50,7 @@ describe('ogErrorResponse', () => {
 
   it('redirects to the branded fallback card with a short CDN-cacheable TTL, never the raw error message', async () => {
     const { ogErrorResponse } = await loadModule();
-    const leakyError = Object.assign(new Error('Failed query: SELECT * FROM users WHERE email = $1'), {
-      name: 'DrizzleQueryError',
-    });
+    const leakyError = makeDrizzleQueryError('SELECT * FROM users WHERE email = $1', 'test@boardsesh.com');
 
     const response = ogErrorResponse('setter', leakyError);
     const body = await response.text();
@@ -39,6 +61,24 @@ describe('ogErrorResponse', () => {
     expect(response.headers.get('CDN-Cache-Control')).toBe('public, s-maxage=60');
     expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe('public, s-maxage=60');
     expect(body).not.toContain('SELECT');
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const [, loggedMessage] = consoleErrorSpy.mock.calls[0] as [string, string];
+    expect(loggedMessage).not.toContain('SELECT');
+    expect(loggedMessage).not.toContain('test@boardsesh.com');
+    expect(loggedMessage).toBe('Error: CONNECT_TIMEOUT');
+  });
+
+  it('reports the failure to Sentry, tagged by surface and route, inside the same throttle gate', async () => {
+    const { ogErrorResponse } = await loadModule();
+    const leakyError = makeDrizzleQueryError('SELECT * FROM users WHERE email = $1', 'test@boardsesh.com');
+
+    ogErrorResponse('setter', leakyError);
+    ogErrorResponse('setter', leakyError);
+    ogErrorResponse('setter', leakyError);
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledWith(leakyError, { tags: { surface: 'og', route: 'setter' } });
   });
 
   it('logs a compact message the first time a route fails', async () => {

--- a/packages/web/app/lib/seo/og-error.ts
+++ b/packages/web/app/lib/seo/og-error.ts
@@ -30,18 +30,36 @@ function shouldLog(route: string): boolean {
  *  - They logged (and returned to the caller) `error.message` verbatim. For
  *    the Drizzle-backed routes that message is `DrizzleQueryError`'s own
  *    message, which embeds the full SQL statement and every bound parameter —
- *    an info leak, since these routes are unauthenticated. The body here is
- *    always the same generic string.
+ *    an info leak, since these routes are unauthenticated. The response body
+ *    never echoes the error.
  *  - They logged on every failed render. This throttles to once per route per
  *    {@link OG_ERROR_LOG_INTERVAL_MS}.
+ *
+ * The response itself is a 302 to `/opengraph-image` (the existing DB-free
+ * branded card, `app/opengraph-image.tsx`) rather than a 500. Unfurlers
+ * (Slack, Discord, iMessage, Twitter/X) render nothing on a 5xx and then cache
+ * that failed scrape for days, so the next real crawl of the same URL can be
+ * far off — a degraded-but-present card beats a blank embed for that whole
+ * window. The 60s `s-maxage` lets the CDN answer a burst of scraper retries
+ * during a brownout without sending each one at the DB, while staying short
+ * enough to pick up the real image again shortly after recovery.
+ *
+ * This must NEVER route through `createOgImageHeaders`: its versioned branch
+ * sets a one-year immutable `Cache-Control`, which would pin this fallback
+ * for a year instead of the 60s window above.
  */
 export function ogErrorResponse(route: string, error: unknown): Response {
   if (shouldLog(route)) {
     console.error(`[og] ${route} render failed:`, compactErrorMessage(error));
   }
 
-  return new Response('Error generating image', {
-    status: 500,
-    headers: { 'Cache-Control': 'no-store' },
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: '/opengraph-image',
+      'Cache-Control': 'public, max-age=0, s-maxage=60',
+      'CDN-Cache-Control': 'public, s-maxage=60',
+      'Vercel-CDN-Cache-Control': 'public, s-maxage=60',
+    },
   });
 }

--- a/packages/web/app/lib/seo/og-error.ts
+++ b/packages/web/app/lib/seo/og-error.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { compactErrorMessage } from '@/app/lib/observability/compact-error';
 
 /**
@@ -33,7 +34,9 @@ function shouldLog(route: string): boolean {
  *    an info leak, since these routes are unauthenticated. The response body
  *    never echoes the error.
  *  - They logged on every failed render. This throttles to once per route per
- *    {@link OG_ERROR_LOG_INTERVAL_MS}.
+ *    {@link OG_ERROR_LOG_INTERVAL_MS} — and that same gate bounds the Sentry
+ *    volume too, so a wedged route costs one Sentry event per minute instead
+ *    of one per request.
  *
  * The response itself is a 302 to `/opengraph-image` (the existing DB-free
  * branded card, `app/opengraph-image.tsx`) rather than a 500. Unfurlers
@@ -51,6 +54,7 @@ function shouldLog(route: string): boolean {
 export function ogErrorResponse(route: string, error: unknown): Response {
   if (shouldLog(route)) {
     console.error(`[og] ${route} render failed:`, compactErrorMessage(error));
+    Sentry.captureException(error, { tags: { surface: 'og', route } });
   }
 
   return new Response(null, {


### PR DESCRIPTION
## Summary

Stacks on #4678. Continues the #4650 observability work: `/api/og/setter` (and its sibling OG routes) fail 62+/day with a Postgres `CONNECT_TIMEOUT` after waiting the full 30s connect budget, and social scrapers cache that failed unfurl for days — far longer than the underlying outage.

- **Replica-seam consistency**: the setter route's inline tick-aggregate query rode `dbz` (primary) while its sibling `getSetterOgSummary` already used the `dbzRead` replica seam. Switched to `dbzRead` so the whole route is consistent (profile/playlist already use `getReadPool()`; session has no raw query).
- **Read deadlines on every OG DB phase**: each route's DB phase is now wrapped in one `withReadDeadline` call — `'og-setter'`, `'og-profile'`, `'og-playlist'`, `'og-session'` — using the existing 6s default (env-tunable via `DB_READ_DEADLINE_MS`). This turns today's 30s hang into a fast 6s failure. `/api/og/climb` needed nothing; its `getClimb` is already wrapped upstream. The profile route's grade-count query previously did `await sql\`...\`` *inside* the `Promise.all` array literal, which resolves it before `Promise.all`/`withReadDeadline` ever runs — restructured so the query is actually raced against the deadline instead of silently staying unbounded.
- **Cacheable degraded fallback**: `ogErrorResponse` now returns a 302 to `/opengraph-image` (the existing DB-free branded card) instead of a 500, with a 60s CDN `s-maxage`. Unfurlers render nothing on a 5xx and cache the failed scrape for days; a degraded card beats a blank embed, and 60s at the CDN sheds scraper retries off the DB during a brownout. Deliberately does **not** use `createOgImageHeaders` — its versioned branch sets a one-year immutable `Cache-Control`, which would pin the fallback for a year. The throttled compact-error logging from #4678 is unchanged.
- **Sentry visibility**: `ogErrorResponse` now also calls `Sentry.captureException(error, { tags: { surface: 'og', route } })` inside the existing throttle gate, so a wedged OG route shows up in Sentry (tagged by route), bounded to the same once-per-route-per-60s budget as the console log.
- **Docs**: `docs/db-connectivity.md`'s read-deadline section now covers the four `og-*` labels and the third outcome (302 + cacheable fallback) alongside the original climb-page reads.

**Non-goal**: migrating OG image rendering to the backend (satori) is out of scope here — that's covered by the broader www→Railway migration in #4648, which moves the whole site off Vercel.

## Test plan

- [x] New `packages/web/app/api/og/setter/__tests__/route.test.tsx`: asserts the inline query uses the `dbzRead` sentinel (not `dbz`), asserts the whole DB phase runs under a single `'og-setter'` read-deadline label, and covers the DB-rejection path (302 + `Location: /opengraph-image` + `s-maxage=60` + throttled compact log with the SQL stripped out).
- [x] New `packages/web/app/api/og/profile/__tests__/route.test.tsx`: the load-bearing case controls the grade-count query's resolution via a manually-resolved promise and asserts `'og-profile'` is already recorded by `withReadDeadline`'s mock *before* that promise ever settles — this only holds if the query was handed into `Promise.all` still pending, which is exactly what a regression re-inlining `await sql\`...\`` into the array literal would break. Mutation-tested locally by temporarily reintroducing that exact regression and confirming the assertion fails (`expected [] to deeply equal ['og-profile']`), then reverted. Also covers the happy path (200 + `image/png`) and a `DbReadTimeoutError`-shaped rejection (302 + `s-maxage=60`).
- [x] Fixed the fake `DrizzleQueryError` in `og-error.test.ts`, the playlist route test, and the setter route test to match real drizzle-orm@0.45.2 (`node_modules/drizzle-orm/errors.js`): `.name` stays the inherited `"Error"` (never overridden), the message is `Failed query: <sql>\nparams: <params>`, and `.cause` is always the driver error. The old fakes set `name: 'DrizzleQueryError'` with no `.cause`, which made `compactErrorMessage` fall through to a string that still contained the raw SQL — the response-body assertions passed anyway (the body is generic regardless), silently missing that the *logged* string could leak the query. All three now assert directly on the `console.error` call's second argument with `.not.toContain('SELECT')`.
- [x] Sentry addition covered by a new `og-error.test.ts` case (mocks `@sentry/nextjs`, asserts `captureException` is called once with the error and `{ tags: { surface: 'og', route } }`, throttled by the same gate).
- [x] `vp test run --project web app/api/og app/lib/seo/__tests__/og-error.test.ts` — 6 files / 23 tests passing.
- [x] `vp run typecheck:web` — clean.
- [x] `vp check` — no new lint/format issues (2 pre-existing errors + 259 pre-existing warnings are all in untouched files, e.g. `packages/db/scripts/dedupe-beta-links-helpers.test.ts`, mobile queue-provider tests).

## Release Notes

- Link previews for setter and profile pages recover gracefully when the database is slow

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016aZ1zjpqkXScoo4jyzL49X
