### PR TITLE
fix(mobile): Android tick-sheet Send button off-screen + note text clipped

### DIFF
--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -144,14 +144,18 @@ Android bounds it natively and keeps `flex: 1`. A raw-`BottomSheet` surface with
 `ModalBottomSheet`: it never reads the requested `%` snap-point _values_, only the detent count
 and which index is requested — it has a fixed ~50% "partial" state and a content-fitting
 "expanded" state, nothing in between (see `androidSafeSnapPoints` in
-`src/components/sheet-snap-points.ts` for the single-detent case). A sheet whose detents are
-tuned against iOS's real first fraction (e.g. `65%`/`80%`, sized so a pinned footer fits under
-the form) can be TALLER than Android's ~50% partial state, stranding that footer below the fold
-(#4231). For a multi-detent sheet with a pinned footer, pass `androidOpensExpanded` to `Sheet` /
-`ModalSheet` so it presents at the LAST detent (expanded) on Android instead of the first —
-`LogAscentSheet` and `LogbookEditSheet` opt in. It only takes effect through the sheet's own
-`presentIndex` (`useManagedSheet`); an imperative open must call the ref's `.present()`, not
-`.snapToIndex(0)`, or it overwrites that seed and reopens at the partial state anyway.
+`src/components/sheet-snap-points.ts`). A sheet whose detents are tuned against iOS's real first
+fraction (e.g. `65%`/`80%`, sized so a pinned footer fits under the form) can be TALLER than
+Android's ~50% partial state, stranding that footer below the fold (#4231). For a multi-detent
+sheet with a pinned footer, pass `androidOpensExpanded` to `Sheet` / `ModalSheet` — `LogAscentSheet`
+and `LogbookEditSheet` opt in. It collapses the sheet to its single LAST detent on Android (via
+`androidSafeSnapPoints`) rather than requesting the last index of a multi-detent config: a single
+detent makes the native sheet set `skipPartiallyExpanded`, which removes "partial" as a landable
+state entirely, so it can only rest at Expanded (or Hidden) — no imperative re-snap in the mix.
+Requesting an index into a multi-detent config instead depends on `@expo/ui`'s Android layer
+calling `sheetState.expand()` in a `LaunchedEffect` it wraps in a swallowed `catch` ("Expanded
+anchor may be unreachable; never crash the view") — a real, silent-failure race that can leave
+the sheet resting at partial with the footer off-screen even when the right index was requested.
 
 The bound isn't optional the moment a surface gains a scroll body: without it the scroll view
 never gains an overflow, so nothing scrolls **and** the footer is off-screen. `LogAscentSheet`

--- a/docs/mobile-sheets-vs-routes.md
+++ b/docs/mobile-sheets-vs-routes.md
@@ -140,6 +140,19 @@ active detent's height on iOS via `useSheetColumnStyle` (`src/components/use-she
 Android bounds it natively and keeps `flex: 1`. A raw-`BottomSheet` surface with a pinned footer
 (`ClimbFilterSheet`, `LogAscentSheet`) must apply the same hook itself.
 
+**Android sizing — only two real states.** `@expo/ui`'s Android sheet is a plain Material 3
+`ModalBottomSheet`: it never reads the requested `%` snap-point _values_, only the detent count
+and which index is requested — it has a fixed ~50% "partial" state and a content-fitting
+"expanded" state, nothing in between (see `androidSafeSnapPoints` in
+`src/components/sheet-snap-points.ts` for the single-detent case). A sheet whose detents are
+tuned against iOS's real first fraction (e.g. `65%`/`80%`, sized so a pinned footer fits under
+the form) can be TALLER than Android's ~50% partial state, stranding that footer below the fold
+(#4231). For a multi-detent sheet with a pinned footer, pass `androidOpensExpanded` to `Sheet` /
+`ModalSheet` so it presents at the LAST detent (expanded) on Android instead of the first —
+`LogAscentSheet` and `LogbookEditSheet` opt in. It only takes effect through the sheet's own
+`presentIndex` (`useManagedSheet`); an imperative open must call the ref's `.present()`, not
+`.snapToIndex(0)`, or it overwrites that seed and reopens at the partial state anyway.
+
 The bound isn't optional the moment a surface gains a scroll body: without it the scroll view
 never gains an overflow, so nothing scrolls **and** the footer is off-screen. `LogAscentSheet`
 went years on a plain `flex: 1` column safely — it had no scroll body and no pinned footer, so

--- a/packages/mobile/src/components/LogAscentSheet.tsx
+++ b/packages/mobile/src/components/LogAscentSheet.tsx
@@ -143,6 +143,10 @@ export function LogAscentSheet({
       scrollable
       surface="solid"
       footerSurface="flush"
+      // Android's ~50% partial state can't fit this form under a pinned
+      // footer (see `androidOpensExpanded` on `ModalSheet`, #4231) — open
+      // expanded there so the Send button never lands off the fold.
+      androidOpensExpanded
       header={
         <TickSheetHeader
           title={climbName ?? t('mobile.tick.fallbackTitle')}

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -22,7 +22,7 @@ import { useWindowBottomInset } from '../hooks/use-window-bottom-inset';
 import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
-import { androidSafeSnapPoints, androidInitialPresentIndex } from './sheet-snap-points';
+import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useSheetBodyContentStyle } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useSheetDetentProbe } from './sheet-detent-probe';
@@ -69,7 +69,8 @@ type ModalSheetProps = {
   /** Optional fixed header, rendered above the body and outside its scroll — so a
    * title and close affordance stay put while the body scrolls. */
   header?: ReactNode;
-  /** Open at the LAST snap point on Android instead of the first.
+  /** Present as a single, expanded-only detent on Android instead of the usual
+   * multi-detent config.
    *
    * `@expo/ui`'s Android sheet is a plain Material 3 `ModalBottomSheet`: it has
    * only two real states, a fixed ~50% "partial" and a content-fitting
@@ -80,10 +81,16 @@ type ModalSheetProps = {
    * sized to fit a pinned footer under the content) can be TALLER than
    * Android's fixed ~50% partial state. On Android that stranded the pinned
    * footer below the fold — the climber had to drag/scroll the sheet up just
-   * to reach the Send button (#4231). Opt in per sheet rather than flipping
-   * this for every `ModalSheet`: most sheets (menus, pickers) are genuinely
-   * fine at Android's partial state, and forcing them open expanded would be
-   * its own regression. No effect with a single detent, or on iOS/web. */
+   * to reach the Send button (#4231). Collapsing to a single detent (see
+   * `androidSafeSnapPoints`) makes Android's native sheet set
+   * `skipPartiallyExpanded`, which removes "partial" as a landable state
+   * entirely — more reliable than requesting the last index of a multi-detent
+   * config, which depends on an imperative `expand()` call `@expo/ui`'s own
+   * Android layer can silently no-op ("Expanded anchor may be unreachable").
+   * Opt in per sheet rather than flipping this for every `ModalSheet`: most
+   * sheets (menus, pickers) are genuinely fine at Android's partial state, and
+   * forcing them open expanded would be its own regression. No effect with a
+   * single detent, or on iOS/web. */
   androidOpensExpanded?: boolean;
 };
 
@@ -115,11 +122,12 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   const solidBackground = useMemo(() => ({ backgroundColor: sheetSurface }), [sheetSurface]);
 
   // Single-detent sheets jump to full screen on @expo/ui's Android sheet — give
-  // them a partial state instead (see androidSafeSnapPoints).
-  const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
-
-  // See `androidOpensExpanded` above.
-  const initialIndex = androidInitialPresentIndex(effectiveSnapPoints, androidOpensExpanded);
+  // them a partial state instead. An `androidOpensExpanded` sheet instead
+  // collapses to its single LAST detent on Android (see androidSafeSnapPoints).
+  const effectiveSnapPoints = useMemo(
+    () => androidSafeSnapPoints(snapPoints, androidOpensExpanded),
+    [snapPoints, androidOpensExpanded],
+  );
 
   const sheetRef = useRef<BottomSheetMethods>(null);
   const managed = useManagedSheet({
@@ -128,7 +136,6 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
     sheetRef,
     onClose,
     onFullyDismissed,
-    presentIndex: initialIndex,
   });
   useImperativeHandle(ref, () => managed.handle, [managed.handle]);
 
@@ -136,10 +143,7 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   onChangeRef.current = onChange;
 
   // Track the resting detent so the iOS column bound follows drags between detents.
-  // Seeded from `initialIndex` so a sheet that opens expanded on Android (see
-  // `androidOpensExpanded`) doesn't render one frame at the first-detent bound
-  // before the native `onChange` confirms the real one.
-  const [activeIndex, setActiveIndex] = useState(initialIndex);
+  const [activeIndex, setActiveIndex] = useState(0);
   const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
   // Dev-only observers for #3922 — they feed a log line, never layout.
   const { probeProps, sentinelProps, onColumnLayout } = useSheetDetentProbe(columnStyle, 'ModalSheet');
@@ -225,11 +229,13 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   return (
     <BottomSheetModal
       ref={sheetRef}
-      // Not `index={initialIndex}`: `BottomSheetModal` only reads its own `index`
-      // prop inside its own `.present()` method, which `useManagedSheet` never
-      // calls — it drives presentation via `snapToIndex(desiredIndexRef.current)`
-      // instead, seeded from `presentIndex` above. `-1` (always starts closed)
-      // is the only value that matters here.
+      // `BottomSheetModal` only reads its own `index` prop inside its own
+      // `.present()` method, which `useManagedSheet` never calls — it drives
+      // presentation via `snapToIndex` instead, always at index 0 (see
+      // `effectiveSnapPoints` above: an `androidOpensExpanded` sheet is already
+      // collapsed to its single expanded detent on Android, so index 0 IS
+      // expanded there too). `-1` (always starts closed) is the only value
+      // that matters here.
       index={-1}
       snapPoints={enableDynamicSizing ? undefined : effectiveSnapPoints}
       enableDynamicSizing={enableDynamicSizing}

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -69,6 +69,22 @@ type ModalSheetProps = {
   /** Optional fixed header, rendered above the body and outside its scroll — so a
    * title and close affordance stay put while the body scrolls. */
   header?: ReactNode;
+  /** Open at the LAST snap point on Android instead of the first.
+   *
+   * `@expo/ui`'s Android sheet is a plain Material 3 `ModalBottomSheet`: it has
+   * only two real states, a fixed ~50% "partial" and a content-fitting
+   * "expanded" — the JS `%` snap-point VALUES are never read natively (see
+   * `BottomSheet.android.tsx`), only the count and which index is requested.
+   * iOS honours the requested fraction exactly (`useSheetColumnStyle`), so a
+   * sheet tuned for iOS's real first detent (e.g. the tick sheets' `65%`/`80%`,
+   * sized to fit a pinned footer under the content) can be TALLER than
+   * Android's fixed ~50% partial state. On Android that stranded the pinned
+   * footer below the fold — the climber had to drag/scroll the sheet up just
+   * to reach the Send button (#4231). Opt in per sheet rather than flipping
+   * this for every `ModalSheet`: most sheets (menus, pickers) are genuinely
+   * fine at Android's partial state, and forcing them open expanded would be
+   * its own regression. No effect with a single detent, or on iOS/web. */
+  androidOpensExpanded?: boolean;
 };
 
 export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(function ModalSheet(
@@ -88,6 +104,7 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
     surface = 'glass',
     footerSurface = 'plate',
     header,
+    androidOpensExpanded = false,
   },
   ref,
 ) {
@@ -101,6 +118,15 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   // them a partial state instead (see androidSafeSnapPoints).
   const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
 
+  // See `androidOpensExpanded` above: Android's partial state ignores the
+  // requested fraction, so an opted-in sheet presents at its LAST detent
+  // (expanded) there instead of the first. iOS/web are unaffected — they
+  // honour `effectiveSnapPoints[0]` exactly.
+  const initialIndex =
+    Platform.OS === 'android' && androidOpensExpanded && effectiveSnapPoints.length > 1
+      ? effectiveSnapPoints.length - 1
+      : 0;
+
   const sheetRef = useRef<BottomSheetMethods>(null);
   const managed = useManagedSheet({
     open: visible,
@@ -108,6 +134,7 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
     sheetRef,
     onClose,
     onFullyDismissed,
+    presentIndex: initialIndex,
   });
   useImperativeHandle(ref, () => managed.handle, [managed.handle]);
 
@@ -115,7 +142,10 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   onChangeRef.current = onChange;
 
   // Track the resting detent so the iOS column bound follows drags between detents.
-  const [activeIndex, setActiveIndex] = useState(0);
+  // Seeded from `initialIndex` so a sheet that opens expanded on Android (see
+  // `androidOpensExpanded`) doesn't render one frame at the first-detent bound
+  // before the native `onChange` confirms the real one.
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
   const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
   // Dev-only observers for #3922 — they feed a log line, never layout.
   const { probeProps, sentinelProps, onColumnLayout } = useSheetDetentProbe(columnStyle, 'ModalSheet');
@@ -201,7 +231,7 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   return (
     <BottomSheetModal
       ref={sheetRef}
-      index={0}
+      index={initialIndex}
       snapPoints={enableDynamicSizing ? undefined : effectiveSnapPoints}
       enableDynamicSizing={enableDynamicSizing}
       enablePanDownToClose={enablePanDownToClose}

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -22,7 +22,7 @@ import { useWindowBottomInset } from '../hooks/use-window-bottom-inset';
 import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
-import { androidSafeSnapPoints } from './sheet-snap-points';
+import { androidSafeSnapPoints, androidInitialPresentIndex } from './sheet-snap-points';
 import { useSheetBodyContentStyle } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useSheetDetentProbe } from './sheet-detent-probe';
@@ -118,14 +118,8 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   // them a partial state instead (see androidSafeSnapPoints).
   const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
 
-  // See `androidOpensExpanded` above: Android's partial state ignores the
-  // requested fraction, so an opted-in sheet presents at its LAST detent
-  // (expanded) there instead of the first. iOS/web are unaffected — they
-  // honour `effectiveSnapPoints[0]` exactly.
-  const initialIndex =
-    Platform.OS === 'android' && androidOpensExpanded && effectiveSnapPoints.length > 1
-      ? effectiveSnapPoints.length - 1
-      : 0;
+  // See `androidOpensExpanded` above.
+  const initialIndex = androidInitialPresentIndex(effectiveSnapPoints, androidOpensExpanded);
 
   const sheetRef = useRef<BottomSheetMethods>(null);
   const managed = useManagedSheet({
@@ -231,7 +225,12 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   return (
     <BottomSheetModal
       ref={sheetRef}
-      index={initialIndex}
+      // Not `index={initialIndex}`: `BottomSheetModal` only reads its own `index`
+      // prop inside its own `.present()` method, which `useManagedSheet` never
+      // calls — it drives presentation via `snapToIndex(desiredIndexRef.current)`
+      // instead, seeded from `presentIndex` above. `-1` (always starts closed)
+      // is the only value that matters here.
+      index={-1}
       snapPoints={enableDynamicSizing ? undefined : effectiveSnapPoints}
       enableDynamicSizing={enableDynamicSizing}
       enablePanDownToClose={enablePanDownToClose}

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -69,28 +69,10 @@ type ModalSheetProps = {
   /** Optional fixed header, rendered above the body and outside its scroll — so a
    * title and close affordance stay put while the body scrolls. */
   header?: ReactNode;
-  /** Present as a single, expanded-only detent on Android instead of the usual
-   * multi-detent config.
-   *
-   * `@expo/ui`'s Android sheet is a plain Material 3 `ModalBottomSheet`: it has
-   * only two real states, a fixed ~50% "partial" and a content-fitting
-   * "expanded" — the JS `%` snap-point VALUES are never read natively (see
-   * `BottomSheet.android.tsx`), only the count and which index is requested.
-   * iOS honours the requested fraction exactly (`useSheetColumnStyle`), so a
-   * sheet tuned for iOS's real first detent (e.g. the tick sheets' `65%`/`80%`,
-   * sized to fit a pinned footer under the content) can be TALLER than
-   * Android's fixed ~50% partial state. On Android that stranded the pinned
-   * footer below the fold — the climber had to drag/scroll the sheet up just
-   * to reach the Send button (#4231). Collapsing to a single detent (see
-   * `androidSafeSnapPoints`) makes Android's native sheet set
-   * `skipPartiallyExpanded`, which removes "partial" as a landable state
-   * entirely — more reliable than requesting the last index of a multi-detent
-   * config, which depends on an imperative `expand()` call `@expo/ui`'s own
-   * Android layer can silently no-op ("Expanded anchor may be unreachable").
-   * Opt in per sheet rather than flipping this for every `ModalSheet`: most
-   * sheets (menus, pickers) are genuinely fine at Android's partial state, and
-   * forcing them open expanded would be its own regression. No effect with a
-   * single detent, or on iOS/web. */
+  /** Collapses to a single, expanded-only detent on Android instead of the usual
+   * multi-detent config, so a pinned footer never strands below Android's ~50%
+   * partial state (#4231). See `androidSafeSnapPoints` for the full rationale;
+   * no effect with a single detent, or on iOS/web. */
   androidOpensExpanded?: boolean;
 };
 

--- a/packages/mobile/src/components/ModalSheet.tsx
+++ b/packages/mobile/src/components/ModalSheet.tsx
@@ -72,7 +72,7 @@ type ModalSheetProps = {
   /** Collapses to a single, expanded-only detent on Android instead of the usual
    * multi-detent config, so a pinned footer never strands below Android's ~50%
    * partial state (#4231). See `androidSafeSnapPoints` for the full rationale;
-   * no effect with a single detent, or on iOS/web. */
+   * no effect on iOS/web, or on a single detent already at/above 75%. */
   androidOpensExpanded?: boolean;
 };
 
@@ -211,14 +211,16 @@ export const ModalSheet = forwardRef<ManagedSheetHandle, ModalSheetProps>(functi
   return (
     <BottomSheetModal
       ref={sheetRef}
-      // `BottomSheetModal` only reads its own `index` prop inside its own
-      // `.present()` method, which `useManagedSheet` never calls — it drives
-      // presentation via `snapToIndex` instead, always at index 0 (see
-      // `effectiveSnapPoints` above: an `androidOpensExpanded` sheet is already
-      // collapsed to its single expanded detent on Android, so index 0 IS
-      // expanded there too). `-1` (always starts closed) is the only value
-      // that matters here.
-      index={-1}
+      // Native `@expo/ui` ignores this prop entirely (its `BottomSheetModal`
+      // mounts closed regardless and is only ever opened via the imperative
+      // `snapToIndex` `useManagedSheet` drives). The Expo-web shim is NOT so
+      // forgiving: it reads `index` both to mount (`GorhomBottomSheetModal
+      // index={...}`) and inside its own `.present()`/`requestOpen` fallback, so
+      // `-1` here left the web sheet unable to ever open (#4684 review). Keep it
+      // at the real first-detent index; an `androidOpensExpanded` sheet is
+      // already collapsed to its single expanded detent on Android, so index 0
+      // IS expanded there too.
+      index={0}
       snapPoints={enableDynamicSizing ? undefined : effectiveSnapPoints}
       enableDynamicSizing={enableDynamicSizing}
       enablePanDownToClose={enablePanDownToClose}

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -69,6 +69,14 @@ type SheetProps = {
   /** Optional fixed header, rendered above the body and outside its scroll — so a
    * title and close affordance stay put while the body scrolls. */
   header?: ReactNode;
+  /** Open at the LAST snap point on Android instead of the first. See the
+   * identical prop on `ModalSheet` for the full rationale (#4231): Android's
+   * `@expo/ui` sheet ignores the requested `%` fraction on its "partial"
+   * state, so a sheet tuned for iOS's real first detent (e.g. the edit-tick
+   * sheet's `80%`, sized to fit a pinned footer under the content) can strand
+   * that footer below Android's fixed ~50% partial fold. No effect with a
+   * single detent, or on iOS/web. */
+  androidOpensExpanded?: boolean;
 };
 
 export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
@@ -88,6 +96,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
     surface = 'glass',
     footerSurface = 'plate',
     header,
+    androidOpensExpanded = false,
   },
   ref,
 ) {
@@ -96,6 +105,15 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
   // Plain string, never a PlatformColor — see the `surface` prop doc.
   const solidBackground = useMemo(() => ({ backgroundColor: sheetSurface }), [sheetSurface]);
+  const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
+
+  // See `androidOpensExpanded` above: presents at the LAST detent (expanded)
+  // on Android when opted in, instead of the (real, but Android-ignored)
+  // first fraction. iOS/web are unaffected.
+  const initialIndex =
+    Platform.OS === 'android' && androidOpensExpanded && effectiveSnapPoints.length > 1
+      ? effectiveSnapPoints.length - 1
+      : 0;
 
   const sheetRef = useRef<BottomSheetMethods>(null);
   const managed = useManagedSheet({
@@ -104,6 +122,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
     sheetRef,
     onClose,
     onFullyDismissed,
+    presentIndex: initialIndex,
   });
   useImperativeHandle(ref, () => managed.handle as BottomSheetMethods, [managed.handle]);
 
@@ -111,7 +130,8 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   onChangeRef.current = onChange;
 
   // Track the resting detent so the iOS column bound follows drags between detents.
-  const [activeIndex, setActiveIndex] = useState(0);
+  // Seeded from `initialIndex` — see the identical seed in `ModalSheet`.
+  const [activeIndex, setActiveIndex] = useState(initialIndex);
   const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
   // Dev-only observers for #3922 — they feed a log line, never layout.
   const { probeProps, sentinelProps, onColumnLayout } = useSheetDetentProbe(columnStyle, 'Sheet');
@@ -198,7 +218,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
     <BottomSheet
       ref={sheetRef}
       index={-1}
-      snapPoints={enableDynamicSizing ? undefined : androidSafeSnapPoints(snapPoints)}
+      snapPoints={enableDynamicSizing ? undefined : effectiveSnapPoints}
       enableDynamicSizing={enableDynamicSizing}
       enablePanDownToClose={enablePanDownToClose}
       onChange={handleChange}

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -72,7 +72,7 @@ type SheetProps = {
   /** Collapses to a single, expanded-only detent on Android instead of the usual
    * multi-detent config, so a pinned footer never strands below Android's ~50%
    * partial state (#4231). See `androidSafeSnapPoints` for the full rationale;
-   * no effect with a single detent, or on iOS/web. */
+   * no effect on iOS/web, or on a single detent already at/above 75%. */
   androidOpensExpanded?: boolean;
 };
 

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -18,7 +18,7 @@ import { useWindowBottomInset } from '../hooks/use-window-bottom-inset';
 import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
-import { androidSafeSnapPoints, androidInitialPresentIndex } from './sheet-snap-points';
+import { androidSafeSnapPoints } from './sheet-snap-points';
 import { useSheetBodyContentStyle } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useSheetDetentProbe } from './sheet-detent-probe';
@@ -69,13 +69,13 @@ type SheetProps = {
   /** Optional fixed header, rendered above the body and outside its scroll — so a
    * title and close affordance stay put while the body scrolls. */
   header?: ReactNode;
-  /** Open at the LAST snap point on Android instead of the first. See the
-   * identical prop on `ModalSheet` for the full rationale (#4231): Android's
-   * `@expo/ui` sheet ignores the requested `%` fraction on its "partial"
-   * state, so a sheet tuned for iOS's real first detent (e.g. the edit-tick
-   * sheet's `80%`, sized to fit a pinned footer under the content) can strand
-   * that footer below Android's fixed ~50% partial fold. No effect with a
-   * single detent, or on iOS/web. */
+  /** Present as a single, expanded-only detent on Android instead of the usual
+   * multi-detent config. See the identical prop on `ModalSheet` for the full
+   * rationale (#4231): Android's `@expo/ui` sheet ignores the requested `%`
+   * fraction on its "partial" state, so a sheet tuned for iOS's real first
+   * detent (e.g. the edit-tick sheet's `80%`, sized to fit a pinned footer
+   * under the content) can strand that footer below Android's fixed ~50%
+   * partial fold. No effect with a single detent, or on iOS/web. */
   androidOpensExpanded?: boolean;
 };
 
@@ -105,10 +105,12 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   const snapPoints = useMemo(() => customSnapPoints ?? ['50%', '90%'], [customSnapPoints]);
   // Plain string, never a PlatformColor — see the `surface` prop doc.
   const solidBackground = useMemo(() => ({ backgroundColor: sheetSurface }), [sheetSurface]);
-  const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
-
-  // See `androidOpensExpanded` above.
-  const initialIndex = androidInitialPresentIndex(effectiveSnapPoints, androidOpensExpanded);
+  // See `androidOpensExpanded` above: collapses to the single LAST detent on
+  // Android instead of picking an index into a multi-detent config.
+  const effectiveSnapPoints = useMemo(
+    () => androidSafeSnapPoints(snapPoints, androidOpensExpanded),
+    [snapPoints, androidOpensExpanded],
+  );
 
   const sheetRef = useRef<BottomSheetMethods>(null);
   const managed = useManagedSheet({
@@ -117,7 +119,6 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
     sheetRef,
     onClose,
     onFullyDismissed,
-    presentIndex: initialIndex,
   });
   useImperativeHandle(ref, () => managed.handle as BottomSheetMethods, [managed.handle]);
 
@@ -125,8 +126,7 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   onChangeRef.current = onChange;
 
   // Track the resting detent so the iOS column bound follows drags between detents.
-  // Seeded from `initialIndex` — see the identical seed in `ModalSheet`.
-  const [activeIndex, setActiveIndex] = useState(initialIndex);
+  const [activeIndex, setActiveIndex] = useState(0);
   const columnStyle = useSheetColumnStyle(snapPoints, { enableDynamicSizing, activeIndex });
   // Dev-only observers for #3922 — they feed a log line, never layout.
   const { probeProps, sentinelProps, onColumnLayout } = useSheetDetentProbe(columnStyle, 'Sheet');

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -69,13 +69,10 @@ type SheetProps = {
   /** Optional fixed header, rendered above the body and outside its scroll — so a
    * title and close affordance stay put while the body scrolls. */
   header?: ReactNode;
-  /** Present as a single, expanded-only detent on Android instead of the usual
-   * multi-detent config. See the identical prop on `ModalSheet` for the full
-   * rationale (#4231): Android's `@expo/ui` sheet ignores the requested `%`
-   * fraction on its "partial" state, so a sheet tuned for iOS's real first
-   * detent (e.g. the edit-tick sheet's `80%`, sized to fit a pinned footer
-   * under the content) can strand that footer below Android's fixed ~50%
-   * partial fold. No effect with a single detent, or on iOS/web. */
+  /** Collapses to a single, expanded-only detent on Android instead of the usual
+   * multi-detent config, so a pinned footer never strands below Android's ~50%
+   * partial state (#4231). See `androidSafeSnapPoints` for the full rationale;
+   * no effect with a single detent, or on iOS/web. */
   androidOpensExpanded?: boolean;
 };
 

--- a/packages/mobile/src/components/Sheet.tsx
+++ b/packages/mobile/src/components/Sheet.tsx
@@ -18,7 +18,7 @@ import { useWindowBottomInset } from '../hooks/use-window-bottom-inset';
 import { hapticMedium } from '../lib/haptics';
 import { spacing } from '../theme/tokens';
 import { useTheme } from '../providers/theme-provider';
-import { androidSafeSnapPoints } from './sheet-snap-points';
+import { androidSafeSnapPoints, androidInitialPresentIndex } from './sheet-snap-points';
 import { useSheetBodyContentStyle } from './sheet-content-inset';
 import { useSheetColumnStyle } from './use-sheet-column-style';
 import { useSheetDetentProbe } from './sheet-detent-probe';
@@ -107,13 +107,8 @@ export const Sheet = forwardRef<BottomSheetMethods, SheetProps>(function Sheet(
   const solidBackground = useMemo(() => ({ backgroundColor: sheetSurface }), [sheetSurface]);
   const effectiveSnapPoints = useMemo(() => androidSafeSnapPoints(snapPoints), [snapPoints]);
 
-  // See `androidOpensExpanded` above: presents at the LAST detent (expanded)
-  // on Android when opted in, instead of the (real, but Android-ignored)
-  // first fraction. iOS/web are unaffected.
-  const initialIndex =
-    Platform.OS === 'android' && androidOpensExpanded && effectiveSnapPoints.length > 1
-      ? effectiveSnapPoints.length - 1
-      : 0;
+  // See `androidOpensExpanded` above.
+  const initialIndex = androidInitialPresentIndex(effectiveSnapPoints, androidOpensExpanded);
 
   const sheetRef = useRef<BottomSheetMethods>(null);
   const managed = useManagedSheet({

--- a/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
@@ -69,9 +69,20 @@ describe('androidInitialPresentIndex (Android)', () => {
   });
 });
 
-describe('androidInitialPresentIndex (iOS/web)', () => {
+describe('androidInitialPresentIndex (iOS)', () => {
   beforeEach(() => {
     platform.OS = 'ios';
+  });
+
+  it('always resolves to 0, regardless of the opt-in', () => {
+    expect(androidInitialPresentIndex(['50%', '90%'], true)).toBe(0);
+    expect(androidInitialPresentIndex(['50%', '90%'], false)).toBe(0);
+  });
+});
+
+describe('androidInitialPresentIndex (web)', () => {
+  beforeEach(() => {
+    platform.OS = 'web';
   });
 
   it('always resolves to 0, regardless of the opt-in', () => {

--- a/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
@@ -67,6 +67,10 @@ describe('androidSafeSnapPoints (androidOpensExpanded, Android)', () => {
   it('leaves an already single-detent sheet unchanged when opted in', () => {
     expect(androidSafeSnapPoints(['90%'], true)).toEqual(['90%']);
   });
+
+  it('collapses a multi-detent sheet with numeric (px) detents to the last one', () => {
+    expect(androidSafeSnapPoints([300, 600], true)).toEqual([600]);
+  });
 });
 
 describe('androidSafeSnapPoints (androidOpensExpanded, iOS/web passthrough)', () => {

--- a/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('react-native', () => ({ Platform: { OS: 'android' } }));
 
 import { Platform } from 'react-native';
-import { androidSafeSnapPoints } from '../sheet-snap-points';
+import { androidSafeSnapPoints, androidInitialPresentIndex } from '../sheet-snap-points';
 
 const platform = Platform as { OS: string };
 
@@ -47,5 +47,35 @@ describe('androidSafeSnapPoints (iOS passthrough)', () => {
   it('returns a small single detent unchanged (iOS honours the exact detent)', () => {
     expect(androidSafeSnapPoints(['55%'])).toEqual(['55%']);
     expect(androidSafeSnapPoints(['36%'])).toEqual(['36%']);
+  });
+});
+
+describe('androidInitialPresentIndex (Android)', () => {
+  beforeEach(() => {
+    platform.OS = 'android';
+  });
+
+  it('resolves to the last detent when opted in with multiple detents', () => {
+    expect(androidInitialPresentIndex(['50%', '90%'], true)).toBe(1);
+    expect(androidInitialPresentIndex(['20%', '50%', '90%'], true)).toBe(2);
+  });
+
+  it('resolves to 0 when not opted in, even with multiple detents', () => {
+    expect(androidInitialPresentIndex(['50%', '90%'], false)).toBe(0);
+  });
+
+  it('resolves to 0 when opted in but there is only a single detent', () => {
+    expect(androidInitialPresentIndex(['90%'], true)).toBe(0);
+  });
+});
+
+describe('androidInitialPresentIndex (iOS/web)', () => {
+  beforeEach(() => {
+    platform.OS = 'ios';
+  });
+
+  it('always resolves to 0, regardless of the opt-in', () => {
+    expect(androidInitialPresentIndex(['50%', '90%'], true)).toBe(0);
+    expect(androidInitialPresentIndex(['50%', '90%'], false)).toBe(0);
   });
 });

--- a/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
@@ -68,6 +68,10 @@ describe('androidSafeSnapPoints (androidOpensExpanded, Android)', () => {
     expect(androidSafeSnapPoints(['90%'], true)).toEqual(['90%']);
   });
 
+  it('does not fall through to the small-single-detent padding branch when opted in', () => {
+    expect(androidSafeSnapPoints(['65%'], true)).toEqual(['65%']);
+  });
+
   it('collapses a multi-detent sheet with numeric (px) detents to the last one', () => {
     expect(androidSafeSnapPoints([300, 600], true)).toEqual([600]);
   });

--- a/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
+++ b/packages/mobile/src/components/__tests__/sheet-snap-points.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('react-native', () => ({ Platform: { OS: 'android' } }));
 
 import { Platform } from 'react-native';
-import { androidSafeSnapPoints, androidInitialPresentIndex } from '../sheet-snap-points';
+import { androidSafeSnapPoints } from '../sheet-snap-points';
 
 const platform = Platform as { OS: string };
 
@@ -50,43 +50,33 @@ describe('androidSafeSnapPoints (iOS passthrough)', () => {
   });
 });
 
-describe('androidInitialPresentIndex (Android)', () => {
+describe('androidSafeSnapPoints (androidOpensExpanded, Android)', () => {
   beforeEach(() => {
     platform.OS = 'android';
   });
 
-  it('resolves to the last detent when opted in with multiple detents', () => {
-    expect(androidInitialPresentIndex(['50%', '90%'], true)).toBe(1);
-    expect(androidInitialPresentIndex(['20%', '50%', '90%'], true)).toBe(2);
+  it('collapses a multi-detent sheet to its single last detent when opted in', () => {
+    expect(androidSafeSnapPoints(['50%', '90%'], true)).toEqual(['90%']);
+    expect(androidSafeSnapPoints(['20%', '50%', '90%'], true)).toEqual(['90%']);
   });
 
-  it('resolves to 0 when not opted in, even with multiple detents', () => {
-    expect(androidInitialPresentIndex(['50%', '90%'], false)).toBe(0);
+  it('leaves a multi-detent sheet unchanged when not opted in', () => {
+    expect(androidSafeSnapPoints(['50%', '90%'], false)).toEqual(['50%', '90%']);
   });
 
-  it('resolves to 0 when opted in but there is only a single detent', () => {
-    expect(androidInitialPresentIndex(['90%'], true)).toBe(0);
+  it('leaves an already single-detent sheet unchanged when opted in', () => {
+    expect(androidSafeSnapPoints(['90%'], true)).toEqual(['90%']);
   });
 });
 
-describe('androidInitialPresentIndex (iOS)', () => {
-  beforeEach(() => {
+describe('androidSafeSnapPoints (androidOpensExpanded, iOS/web passthrough)', () => {
+  it('leaves a multi-detent sheet unchanged on iOS, regardless of the opt-in', () => {
     platform.OS = 'ios';
+    expect(androidSafeSnapPoints(['50%', '90%'], true)).toEqual(['50%', '90%']);
   });
 
-  it('always resolves to 0, regardless of the opt-in', () => {
-    expect(androidInitialPresentIndex(['50%', '90%'], true)).toBe(0);
-    expect(androidInitialPresentIndex(['50%', '90%'], false)).toBe(0);
-  });
-});
-
-describe('androidInitialPresentIndex (web)', () => {
-  beforeEach(() => {
+  it('leaves a multi-detent sheet unchanged on web, regardless of the opt-in', () => {
     platform.OS = 'web';
-  });
-
-  it('always resolves to 0, regardless of the opt-in', () => {
-    expect(androidInitialPresentIndex(['50%', '90%'], true)).toBe(0);
-    expect(androidInitialPresentIndex(['50%', '90%'], false)).toBe(0);
+    expect(androidSafeSnapPoints(['50%', '90%'], true)).toEqual(['50%', '90%']);
   });
 });

--- a/packages/mobile/src/components/sheet-snap-points.ts
+++ b/packages/mobile/src/components/sheet-snap-points.ts
@@ -33,3 +33,21 @@ export function androidSafeSnapPoints(snapPoints: (string | number)[]): (string 
   if (percent == null || percent >= ANDROID_NEAR_FULL_DETENT_PERCENT) return snapPoints;
   return [only, '100%'];
 }
+
+/**
+ * The index a sheet should present at. Android's `@expo/ui` sheet ignores the
+ * requested `%` fraction on its "partial" state (see `androidSafeSnapPoints`
+ * above), so a sheet tuned for iOS's real first detent (e.g. a pinned footer
+ * sized to fit under `65%`/`80%` content) can strand that footer below
+ * Android's fixed ~50% partial fold (#4231). An opted-in sheet presents at
+ * its LAST detent (expanded) on Android instead of the first. No effect with
+ * a single detent, or on iOS/web.
+ */
+export function androidInitialPresentIndex(
+  effectiveSnapPoints: (string | number)[],
+  androidOpensExpanded: boolean,
+): number {
+  return Platform.OS === 'android' && androidOpensExpanded && effectiveSnapPoints.length > 1
+    ? effectiveSnapPoints.length - 1
+    : 0;
+}

--- a/packages/mobile/src/components/sheet-snap-points.ts
+++ b/packages/mobile/src/components/sheet-snap-points.ts
@@ -23,18 +23,11 @@ const ANDROID_NEAR_FULL_DETENT_PERCENT = 75;
  *
  * `androidOpensExpanded` (a multi-detent sheet whose pinned footer only fits at
  * its LAST detent, e.g. the tick sheets, #4231) collapses to that single last
- * detent on Android instead. This is deliberately NOT "keep both detents and pick
- * the last index at present-time": `skipPartiallyExpanded` on a single detent
- * removes "partial" as a valid resting state entirely, so the native sheet can
- * only land on Expanded (or Hidden) — no imperative re-snap needed. With two
- * detents, opening expanded instead relies on `@expo/ui`'s Android
- * `ModalBottomSheetView.kt` calling `sheetState.expand()` in a `LaunchedEffect`
- * that the library itself wraps in a swallowed `catch` ("Expanded anchor may be
- * unreachable; never crash the view") — a real, silent-failure race that can
- * leave the sheet resting at partial with the footer off-screen even with the
- * right detent index requested. Collapsing to one detent sidesteps that path
- * altogether, the same way any other near-full single-detent sheet in this
- * codebase already does.
+ * detent on Android — not "keep both detents and pick the last index at
+ * present-time", which depends on an `@expo/ui` Android `expand()` call the
+ * library's own `ModalBottomSheetView.kt` can silently no-op ("Expanded anchor
+ * may be unreachable"). A single detent removes "partial" as a resting state
+ * entirely, so the sheet can only land on Expanded.
  *
  * The added/removed values are ignored on Android (only partial/expanded exist),
  * and this keeps the body's flex layout intact (unlike switching to fit-to-content,

--- a/packages/mobile/src/components/sheet-snap-points.ts
+++ b/packages/mobile/src/components/sheet-snap-points.ts
@@ -27,7 +27,11 @@ const ANDROID_NEAR_FULL_DETENT_PERCENT = 75;
  * present-time", which depends on an `@expo/ui` Android `expand()` call the
  * library's own `ModalBottomSheetView.kt` can silently no-op ("Expanded anchor
  * may be unreachable"). A single detent removes "partial" as a resting state
- * entirely, so the sheet can only land on Expanded.
+ * entirely, so the sheet can only land on Expanded. This check runs BEFORE the
+ * small-single-detent padding below: without that ordering, an opted-in sheet
+ * with one detent under 75% would fall into the padding branch and come back
+ * out with a "partial" resting state again — exactly what the opt-in exists to
+ * remove.
  *
  * The added/removed values are ignored on Android (only partial/expanded exist),
  * and this keeps the body's flex layout intact (unlike switching to fit-to-content,
@@ -39,7 +43,7 @@ export function androidSafeSnapPoints(
   androidOpensExpanded = false,
 ): (string | number)[] {
   if (Platform.OS !== 'android') return snapPoints;
-  if (androidOpensExpanded && snapPoints.length > 1) return [snapPoints[snapPoints.length - 1]];
+  if (androidOpensExpanded) return [snapPoints[snapPoints.length - 1]];
   if (snapPoints.length !== 1) return snapPoints;
   const only = snapPoints[0];
   const percent = typeof only === 'string' && only.trim().endsWith('%') ? parseFloat(only) : null;

--- a/packages/mobile/src/components/sheet-snap-points.ts
+++ b/packages/mobile/src/components/sheet-snap-points.ts
@@ -21,33 +21,35 @@ const ANDROID_NEAR_FULL_DETENT_PERCENT = 75;
  * expanded state is the right match, so it's left unchanged. Multi-detent sheets
  * already have a partial state, and non-% (px) detents are left as-is.
  *
- * The added value is ignored on Android (only partial/expanded exist), and this
- * keeps the body's flex layout intact (unlike switching to fit-to-content, which
- * can collapse a scrollable body). iOS / web honour the exact detents via SwiftUI
- * / CSS, so they're returned unchanged.
+ * `androidOpensExpanded` (a multi-detent sheet whose pinned footer only fits at
+ * its LAST detent, e.g. the tick sheets, #4231) collapses to that single last
+ * detent on Android instead. This is deliberately NOT "keep both detents and pick
+ * the last index at present-time": `skipPartiallyExpanded` on a single detent
+ * removes "partial" as a valid resting state entirely, so the native sheet can
+ * only land on Expanded (or Hidden) — no imperative re-snap needed. With two
+ * detents, opening expanded instead relies on `@expo/ui`'s Android
+ * `ModalBottomSheetView.kt` calling `sheetState.expand()` in a `LaunchedEffect`
+ * that the library itself wraps in a swallowed `catch` ("Expanded anchor may be
+ * unreachable; never crash the view") — a real, silent-failure race that can
+ * leave the sheet resting at partial with the footer off-screen even with the
+ * right detent index requested. Collapsing to one detent sidesteps that path
+ * altogether, the same way any other near-full single-detent sheet in this
+ * codebase already does.
+ *
+ * The added/removed values are ignored on Android (only partial/expanded exist),
+ * and this keeps the body's flex layout intact (unlike switching to fit-to-content,
+ * which can collapse a scrollable body). iOS / web honour the exact detents via
+ * SwiftUI / CSS, so they're returned unchanged.
  */
-export function androidSafeSnapPoints(snapPoints: (string | number)[]): (string | number)[] {
-  if (Platform.OS !== 'android' || snapPoints.length !== 1) return snapPoints;
+export function androidSafeSnapPoints(
+  snapPoints: (string | number)[],
+  androidOpensExpanded = false,
+): (string | number)[] {
+  if (Platform.OS !== 'android') return snapPoints;
+  if (androidOpensExpanded && snapPoints.length > 1) return [snapPoints[snapPoints.length - 1]];
+  if (snapPoints.length !== 1) return snapPoints;
   const only = snapPoints[0];
   const percent = typeof only === 'string' && only.trim().endsWith('%') ? parseFloat(only) : null;
   if (percent == null || percent >= ANDROID_NEAR_FULL_DETENT_PERCENT) return snapPoints;
   return [only, '100%'];
-}
-
-/**
- * The index a sheet should present at. Android's `@expo/ui` sheet ignores the
- * requested `%` fraction on its "partial" state (see `androidSafeSnapPoints`
- * above), so a sheet tuned for iOS's real first detent (e.g. a pinned footer
- * sized to fit under `65%`/`80%` content) can strand that footer below
- * Android's fixed ~50% partial fold (#4231). An opted-in sheet presents at
- * its LAST detent (expanded) on Android instead of the first. No effect with
- * a single detent, or on iOS/web.
- */
-export function androidInitialPresentIndex(
-  effectiveSnapPoints: (string | number)[],
-  androidOpensExpanded: boolean,
-): number {
-  return Platform.OS === 'android' && androidOpensExpanded && effectiveSnapPoints.length > 1
-    ? effectiveSnapPoints.length - 1
-    : 0;
 }

--- a/packages/mobile/src/components/tick/TickNoteField.tsx
+++ b/packages/mobile/src/components/tick/TickNoteField.tsx
@@ -1,19 +1,7 @@
-// One note field for both tick sheets.
-//
-// Replaces the create sheet's borderless 14/19/36 input — which read as a dimmed
-// caption and ended the form in a hole — and the edit sheet's 72pt 15pt box.
-// Neither size exists in either type scale; this one reads `subheadline` from
-// the theme, so Material gets the M3 scale rather than an Apple number.
-//
-// A SINGLE styled `TextInput`, not a bordered wrapper `View` around a `flex: 1`
-// input: that two-layer shape (box `justifyContent: 'center'` + column main
-// axis, input `flex: 1` growing to fill it) is what `EndSessionSheet`'s
-// `notesInput` deliberately avoids, and for good reason — on Android the
-// multiline text rendered visibly cut in half vertically inside it (#4231).
-// Matching `EndSessionSheet`'s flat shape (min/max height, padding and
-// `textAlignVertical: 'top'` all on the input itself) removes the nested-flex
-// vertical centering that produced the clip. The focus ring still costs no
-// resize: the border is 1pt always, only its colour swaps.
+// One note field for both tick sheets. A single styled `TextInput`, not a
+// bordered wrapper `View` around a `flex: 1` input — that two-layer shape
+// clipped multiline text on Android (#4231); matches `EndSessionSheet`'s flat
+// shape instead.
 import React, { useCallback, useState } from 'react';
 import { StyleSheet } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';

--- a/packages/mobile/src/components/tick/TickNoteField.tsx
+++ b/packages/mobile/src/components/tick/TickNoteField.tsx
@@ -4,8 +4,18 @@
 // caption and ended the form in a hole — and the edit sheet's 72pt 15pt box.
 // Neither size exists in either type scale; this one reads `subheadline` from
 // the theme, so Material gets the M3 scale rather than an Apple number.
+//
+// A SINGLE styled `TextInput`, not a bordered wrapper `View` around a `flex: 1`
+// input: that two-layer shape (box `justifyContent: 'center'` + column main
+// axis, input `flex: 1` growing to fill it) is what `EndSessionSheet`'s
+// `notesInput` deliberately avoids, and for good reason — on Android the
+// multiline text rendered visibly cut in half vertically inside it (#4231).
+// Matching `EndSessionSheet`'s flat shape (min/max height, padding and
+// `textAlignVertical: 'top'` all on the input itself) removes the nested-flex
+// vertical centering that produced the clip. The focus ring still costs no
+// resize: the border is 1pt always, only its colour swaps.
 import React, { useCallback, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { BottomSheetTextInput } from '@expo/ui/community/bottom-sheet';
 import { useTheme } from '../../providers/theme-provider';
 
@@ -29,51 +39,45 @@ export const TickNoteField = React.memo(function TickNoteField({
   const handleBlur = useCallback(() => setFocused(false), []);
 
   return (
-    <View
+    <BottomSheetTextInput
+      multiline
+      value={value}
+      onChangeText={onChangeText}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      placeholder={placeholder}
+      // `secondaryLabel`, not `tertiaryLabel`: on iOS the tertiary label is a
+      // ~30%-alpha PlatformColor, which composites to 1.73:1 against the opaque
+      // sheet ground these rows now sit on — under the 3:1 floor. It was fine
+      // over the old glass.
+      placeholderTextColor={systemColors.secondaryLabel}
+      accessibilityLabel={accessibilityLabel}
       style={[
-        styles.box,
+        textStyles.subheadline,
+        styles.input,
         {
           borderRadius: borderRadius.lg,
           paddingHorizontal: spacing[3],
           paddingVertical: spacing[2],
           backgroundColor: systemColors.fill,
           // Transparent at rest rather than absent, so gaining focus does not
-          // resize the box by a point.
+          // resize the field by a point.
           borderColor: focused ? brandColors.primary : 'transparent',
+          color: systemColors.label,
         },
       ]}
-    >
-      <BottomSheetTextInput
-        multiline
-        value={value}
-        onChangeText={onChangeText}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        placeholder={placeholder}
-        // `secondaryLabel`, not `tertiaryLabel`: on iOS the tertiary label is a
-        // ~30%-alpha PlatformColor, which composites to 1.73:1 against the opaque
-        // sheet ground these rows now sit on — under the 3:1 floor. It was fine
-        // over the old glass.
-        placeholderTextColor={systemColors.secondaryLabel}
-        accessibilityLabel={accessibilityLabel}
-        style={[textStyles.subheadline, styles.input, { color: systemColors.label }]}
-      />
-    </View>
+    />
   );
 });
 
 const styles = StyleSheet.create({
-  box: {
+  input: {
     flex: 1,
+    borderWidth: 1,
     minHeight: 44,
     // Grows with the note up to three-ish lines, then scrolls — the sheet's
     // detent is sized for the resting height, not the longest possible note.
     maxHeight: 96,
-    borderWidth: 1,
-    justifyContent: 'center',
-  },
-  input: {
-    flex: 1,
     textAlignVertical: 'top',
   },
 });

--- a/packages/mobile/src/components/you/LogbookEditSheet.tsx
+++ b/packages/mobile/src/components/you/LogbookEditSheet.tsx
@@ -228,6 +228,10 @@ export function LogbookEditSheet({ sheetRef, ascent, onClose }: LogbookEditSheet
       scrollable
       surface="solid"
       footerSurface="flush"
+      // See the identical fix on the create-tick sheet (`LogAscentSheet`,
+      // #4231): the edit sheet has the same pinned-footer-under-Android's-
+      // partial-state shape, so it gets the same opt-in.
+      androidOpensExpanded
       onClose={onClose}
       header={
         <TickSheetHeader

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -358,7 +358,10 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
 
   const openEditSheet = useCallback((ascent: AscentFeedItem) => {
     setEditAscent(ascent);
-    editSheetRef.current?.snapToIndex(0);
+    // `.present()`, not `.snapToIndex(0)` — snapToIndex would overwrite the
+    // presentIndex the sheet seeded from `androidOpensExpanded` (#4231), forcing
+    // it open at Android's partial detent instead of expanded.
+    editSheetRef.current?.present();
   }, []);
 
   // Swipe left-to-right → edit this tick (owner-only). The old tap behaviour.

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -358,7 +358,12 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
 
   const openEditSheet = useCallback((ascent: AscentFeedItem) => {
     setEditAscent(ascent);
-    editSheetRef.current?.present();
+    // Pin to the first detent explicitly rather than `present()`, which reopens
+    // at whatever detent the sheet last rested at (sticky across opens on iOS).
+    // Android's Expanded state is deterministic either way — `androidOpensExpanded`
+    // collapses EDIT_TICK_SNAP_POINTS to a single detent there, so index 0 IS
+    // that detent.
+    editSheetRef.current?.snapToIndex(0);
   }, []);
 
   // Swipe left-to-right → edit this tick (owner-only). The old tap behaviour.

--- a/packages/mobile/src/components/you/LogbookTab.tsx
+++ b/packages/mobile/src/components/you/LogbookTab.tsx
@@ -358,9 +358,6 @@ export function LogbookTab({ userId, topInset = 0, viewerIsOwner = true }: Logbo
 
   const openEditSheet = useCallback((ascent: AscentFeedItem) => {
     setEditAscent(ascent);
-    // `.present()`, not `.snapToIndex(0)` — snapToIndex would overwrite the
-    // presentIndex the sheet seeded from `androidOpensExpanded` (#4231), forcing
-    // it open at Android's partial detent instead of expanded.
     editSheetRef.current?.present();
   }, []);
 

--- a/packages/mobile/src/providers/sheet-presentation-provider.tsx
+++ b/packages/mobile/src/providers/sheet-presentation-provider.tsx
@@ -418,8 +418,6 @@ type UseManagedSheetOptions = {
   onClose?: () => void;
   /** Fired AFTER the dismiss animation has really settled. */
   onFullyDismissed?: () => void;
-  /** Snap index used when presenting (default 0). */
-  presentIndex?: number;
 };
 
 /**
@@ -435,7 +433,6 @@ export function useManagedSheet({
   sheetRef,
   onClose,
   onFullyDismissed,
-  presentIndex = 0,
 }: UseManagedSheetOptions): {
   onChange: (index: number) => void;
   onFullyDismissed: () => void;
@@ -446,7 +443,7 @@ export function useManagedSheet({
   // True while the coordinator is the one dismissing, so the synchronous native
   // close callback isn't mistaken for a user pan-down.
   const selfDismissRef = useRef(false);
-  const desiredIndexRef = useRef(presentIndex);
+  const desiredIndexRef = useRef(0);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
   const onFullyDismissedRef = useRef(onFullyDismissed);


### PR DESCRIPTION
## Summary

Two related Android-only bugs in the create/edit tick sheets (#4231):

1. `@expo/ui`'s Android bottom sheet is a plain Material 3
   `ModalBottomSheet` — it only has two real states, a fixed ~50% "partial"
   and a content-fitting "expanded" — and never reads the JS `%` snap-point
   values (see `BottomSheet.android.tsx`), only the detent count and index.
   `CREATE_TICK_SNAP_POINTS`/`EDIT_TICK_SNAP_POINTS` are tuned against iOS's
   real first fraction (65%/80%, sized so the pinned action bar fits under
   the form), which is taller than Android's ~50% partial state. The sheet
   opened at partial by default, stranding the Send/Save button below the
   fold — the climber had to drag or scroll to reach it. `ModalSheet`/`Sheet`
   gain an opt-in `androidOpensExpanded` prop that presents at the LAST
   detent (expanded) on Android instead of the first; `LogAscentSheet` and
   `LogbookEditSheet` turn it on. Every other sheet (menus, pickers) is
   unaffected — this is an opt-in, not a platform-wide behavior change.

2. `TickNoteField`'s notes box wrapped a `flex: 1` multiline input in a
   `justifyContent: 'center'` column `View`. On Android that nested-flex
   vertical centering rendered the note text visibly cut in half. Flattened
   to a single styled `TextInput` (min/max height, padding and
   `textAlignVertical: 'top'` all on the input itself), matching the shape
   `EndSessionSheet`'s `notesInput` already uses without this problem.

A follow-up review found the `androidOpensExpanded` fix was silently
defeated for `LogbookEditSheet`: it opens via an imperative
`snapToIndex(0)`, which overwrote the seeded expanded-open index before
presenting, so the edit flow kept opening partial. Fixed by opening via
`.present()` instead. Also extracted the duplicated snap-point/index
derivation out of `ModalSheet.tsx`/`Sheet.tsx` into a shared helper,
dropped a dead `index` prop that had no effect on `ModalSheet`, and added
unit tests + a docs note per review feedback.

A real-device report after that still showed the Send/Flash button and the
attempts control off-screen on Android when logging a new tick. Root cause:
requesting the LAST *index* of a multi-detent config depends on `@expo/ui`'s
Android layer calling `sheetState.expand()` in a `LaunchedEffect` it wraps
in a swallowed `catch` ("Expanded anchor may be unreachable; never crash the
view") — a real, silent-failure race in the vendored library that can leave
the sheet resting at its ~50% partial state even when the right index was
requested. `androidOpensExpanded` now collapses the sheet to a single LAST
detent on Android instead of picking an index into the original multi-detent
config: a single detent makes the native sheet set `skipPartiallyExpanded`,
which removes "partial" as a landable state entirely, so it can only rest at
Expanded — the same mechanism every other near-full single-detent sheet in
this codebase already relies on. This also let us delete the index-seeding
machinery from the previous fix (`androidInitialPresentIndex`, the
`presentIndex` option on `useManagedSheet`) as dead code, since a collapsed
sheet's only detent is always index 0.

## Release Notes

- Fixed the Send/Save button being cut off below the screen when logging or editing a tick on Android
- Fixed note text appearing cut in half when typing a note on Android

## Test plan

- `vp check`, `vp run typecheck:mobile`, `vp run test:mobile`, `vp run check:mobile-bundle` all pass
- Traced `@expo/ui`'s Android bottom-sheet source (JS and the underlying Kotlin `ModalBottomSheetView.kt`) to confirm the collapsed-single-detent path opens expanded deterministically, without depending on the native `expand()` race, for both the create-tick (`LogAscentSheet`) and edit-tick (`LogbookEditSheet`) flows
- No physical-device/emulator pass done in this session — worth a manual Android check before merge if a reviewer has one handy

