### PR TITLE
fix(web): raise the climb-view CDN window to a day so crawls stop re-rendering the catalogue

### DIFF
--- a/packages/web/app/__tests__/middleware.test.ts
+++ b/packages/web/app/__tests__/middleware.test.ts
@@ -13,7 +13,6 @@ function sp(params: Record<string, string> = {}): URLSearchParams {
 }
 
 const TTL_24H = 86400;
-const TTL_1H = 3600;
 const LEGACY_LIST = '/kilter/original/12x12-square/screw_bolt/40/list';
 const SLUG_LIST = '/b/kilter-original-12x12/40/list';
 // View pages, all three URL shapes that resolve to the same climb.
@@ -180,19 +179,21 @@ describe('getListPageCacheTTL', () => {
 describe('getClimbViewPageCacheTTL', () => {
   describe('route matching', () => {
     it('matches the slug view format', () => {
-      expect(getClimbViewPageCacheTTL(SLUG_VIEW, sp())).toBe(TTL_1H);
+      expect(getClimbViewPageCacheTTL(SLUG_VIEW, sp())).toBe(TTL_24H);
     });
 
     it('matches the named-segment (legacy) view format', () => {
-      expect(getClimbViewPageCacheTTL(NAMED_VIEW, sp())).toBe(TTL_1H);
+      expect(getClimbViewPageCacheTTL(NAMED_VIEW, sp())).toBe(TTL_24H);
     });
 
     it('matches the numeric view format (so its redirect is cacheable)', () => {
-      expect(getClimbViewPageCacheTTL(NUMERIC_VIEW, sp())).toBe(TTL_1H);
+      expect(getClimbViewPageCacheTTL(NUMERIC_VIEW, sp())).toBe(TTL_24H);
     });
 
     it('matches the tension board view', () => {
-      expect(getClimbViewPageCacheTTL('/tension/original/12x12/screw_bolt/30/view/some-climb-uuid', sp())).toBe(TTL_1H);
+      expect(getClimbViewPageCacheTTL('/tension/original/12x12/screw_bolt/30/view/some-climb-uuid', sp())).toBe(
+        TTL_24H,
+      );
     });
 
     it('rejects an unsupported board (legacy view shape)', () => {
@@ -226,7 +227,7 @@ describe('getClimbViewPageCacheTTL', () => {
 
   describe('search params', () => {
     it('caches with non-user-specific params (tracking/query noise)', () => {
-      expect(getClimbViewPageCacheTTL(SLUG_VIEW, sp({ utm_source: 'twitter' }))).toBe(TTL_1H);
+      expect(getClimbViewPageCacheTTL(SLUG_VIEW, sp({ utm_source: 'twitter' }))).toBe(TTL_24H);
     });
 
     it.each([
@@ -599,7 +600,7 @@ describe('middleware cache headers on list pages', () => {
 });
 
 describe('middleware cache headers on climb view pages', () => {
-  const expected1h = `s-maxage=${TTL_1H}, stale-while-revalidate=${TTL_1H * 7}`;
+  const expectedClimbViewCacheHeader = `s-maxage=${TTL_24H}, stale-while-revalidate=${TTL_24H * 7}`;
 
   it.each([
     ['slug view', SLUG_VIEW],
@@ -607,10 +608,10 @@ describe('middleware cache headers on climb view pages', () => {
     // The numeric view URL 308-redirects to its slug form; caching the request
     // lets the CDN serve that deterministic redirect without re-rendering.
     ['numeric view (redirect)', NUMERIC_VIEW],
-  ])('sets 1h CDN cache headers on the %s URL', (_shape, url) => {
+  ])('sets 24h CDN cache headers on the %s URL', (_shape, url) => {
     const response = middleware(makeRequest(url));
-    expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe(expected1h);
-    expect(response.headers.get('CDN-Cache-Control')).toBe(expected1h);
+    expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe(expectedClimbViewCacheHeader);
+    expect(response.headers.get('CDN-Cache-Control')).toBe(expectedClimbViewCacheHeader);
   });
 
   it('does not cache a play page', () => {
@@ -629,8 +630,8 @@ describe('middleware cache headers on climb view pages', () => {
       const enResponse = middleware(makeRequest(SLUG_VIEW));
       const localizedResponse = middleware(makeRequest(`/${locale}${SLUG_VIEW}`));
       // Both are cacheable, but the CDN keys them by their distinct request URLs.
-      expect(enResponse.headers.get('Vercel-CDN-Cache-Control')).toBe(expected1h);
-      expect(localizedResponse.headers.get('Vercel-CDN-Cache-Control')).toBe(expected1h);
+      expect(enResponse.headers.get('Vercel-CDN-Cache-Control')).toBe(expectedClimbViewCacheHeader);
+      expect(localizedResponse.headers.get('Vercel-CDN-Cache-Control')).toBe(expectedClimbViewCacheHeader);
     },
   );
 

--- a/packages/web/app/api/internal/revalidate-climb/route.ts
+++ b/packages/web/app/api/internal/revalidate-climb/route.ts
@@ -11,6 +11,13 @@ const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET;
  * /[board]/.../view/[climb_uuid] render rebuilds with fresh data instead of
  * waiting for the 1h `unstable_cache` TTL to expire.
  *
+ * This only reaches Next's data cache — it does not purge the CDN entry set
+ * via Vercel-CDN-Cache-Control (see `getClimbViewPageCacheTTL` in
+ * `list-page-cache.ts`). So after a backend climb mutation, the CDN can keep
+ * serving the pre-mutation HTML for up to 24h (plus stale-while-revalidate)
+ * even though the next origin render would already reflect the change.
+ * Purging the CDN entry by tag on this same path is tracked in #4665.
+ *
  * Auth: bearer token equal to REVALIDATE_SECRET — kept distinct from
  * CRON_SECRET so a leaked backend env doesn't grant access to other
  * cron-triggered routes that might do more than cache busting.

--- a/packages/web/app/lib/list-page-cache.ts
+++ b/packages/web/app/lib/list-page-cache.ts
@@ -7,11 +7,17 @@ import type { SearchRequestPagination } from '@/app/lib/types';
 const LIST_PAGE_CACHE_TTL_SECONDS = 86400;
 
 // A climb view page is fully determined by its URL and reads no server-side
-// personalization (queue/session/auth all live in client components). Its only
-// data source, `getClimb`, is `unstable_cache`d at 3600s — so the page HTML is
-// already up to an hour stale today. Matching that keeps the CDN from adding a
-// new staleness class beyond what the data cache already allows.
-const CLIMB_VIEW_PAGE_CACHE_TTL_SECONDS = 3600;
+// personalization (queue/session/auth all live in client components), so it's
+// as cacheable as a list page. The crawl surface is 4 locale twins × ~53k
+// climbs (~212k distinct URLs, #4650); at a 1h CDN window nearly every
+// crawler fetch missed and re-rendered at origin (~40k/day). The data caches
+// underneath (`getClimb`/stats in `app/lib/data/queries.ts`, and the
+// front-door similar-climbs/beta-links cache) stay at 3600s, so a re-render
+// is still ≤1h stale even though the CDN copy may now be ≤24h stale (plus a
+// 7d stale-while-revalidate window from the ×7 in middleware). The #4592 fix
+// for the CDN-cacheable self-redirect loop on non-Latin climb names must stay
+// in place — a cacheable redirect loop at this TTL would pin for a full day.
+const CLIMB_VIEW_PAGE_CACHE_TTL_SECONDS = 86400;
 
 /**
  * Checks whether search params contain any user-specific filters.


### PR DESCRIPTION
## Summary

- CDN cache window for climb-view pages (`/[board]/.../view/[uuid]` and `/b/[slug]/[angle]/view/[uuid]`) was 1h (`s-maxage=3600`). Crawlers walk ~212k distinct climb-view URLs (4 locale twins × ~53k climbs), so a 1h window meant nearly every crawler fetch missed the CDN and re-rendered at origin (~40k/day). List pages already cache for 24h — this brings climb-view pages in line, since they're just as URL-determined and personalization-free (#4650).
- Confirmed the gate for this change, #4592 (the CDN-cacheable self-redirect loop fix for non-Latin climb names), is merged into `main` — this branch is based on `origin/main` and necessarily includes it. That fix has to stay in place: a cacheable redirect loop at a 24h TTL would now pin for a full day instead of an hour.
- The data caches underneath (`getClimb`/stats in `app/lib/data/queries.ts`, front-door similar-climbs/beta-links) stay at 3600s, so an origin re-render is still ≤1h stale even though the CDN copy may now be ≤24h stale (plus a 7d stale-while-revalidate window from the ×7 in middleware).
- Extended the header comment on `revalidate-climb/route.ts`: tag revalidation only reaches Next's data cache, not the CDN entry, so after a backend climb mutation the CDN can keep serving pre-mutation HTML for up to 24h (+SWR). Purge-by-tag for the CDN entry is tracked in #4665.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- [x] `vp test run --project web app/__tests__/middleware.test.ts --reporter=agent` — 160 tests pass
- [x] `vp run typecheck` — clean
- [x] `vp check` — 0 errors (pre-existing warnings in untouched `packages/db` test files only)
