### PR TITLE
test: SCRATCH do the ratings regression tests bite

### DIFF
--- a/packages/aurora-sync/src/runner/sync-runner.test.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.test.ts
@@ -945,6 +945,46 @@ describe('SyncRunner.getSyncHealthSnapshot', () => {
     });
   });
 
+  // The regression that mattered. The test above models postgres-js's
+  // string-ness for the COUNTS and then hands oldestAttemptAt a real Date —
+  // the same blind spot the production code had, which is why nothing caught
+  // `snapshot.oldestAttemptAt.toISOString is not a function` for a month. Drive
+  // the raw Postgres text shape all the way through to the formatted line.
+  it('formats a health summary when the driver hands back a raw timestamp string', async () => {
+    const dbShim = {
+      select: () => ({
+        from: () => ({
+          where: () =>
+            Promise.resolve([
+              {
+                total: '4',
+                active: '4',
+                pending: '0',
+                error: '0',
+                expired: '0',
+                inBackoff: '0',
+                // `timestamp without time zone` as postgres-js yields it when
+                // no column decoder is attached to the min() aggregate.
+                oldestAttemptAt: '2026-05-06 07:08:09.123',
+              },
+            ]),
+        }),
+      }),
+    };
+
+    const runner = new SyncRunner();
+    const runnerPrivates = runner as unknown as SyncRunnerPrivates & {
+      getClient: () => { client: unknown; db: unknown };
+    };
+    vi.spyOn(runnerPrivates, 'getClient').mockReturnValue({ client: {}, db: dbShim });
+
+    const snapshot = await runnerPrivates.getSyncHealthSnapshot();
+
+    // On main this throws instead of returning a line.
+    expect(() => formatSyncHealthSummary(snapshot)).not.toThrow();
+    expect(formatSyncHealthSummary(snapshot)).toContain('oldestAttempt=2026-05-06T07:08:09.123');
+  });
+
   it('defaults counts to 0 and oldestAttemptAt to null when no rows come back', async () => {
     const dbShim = {
       select: () => ({ from: () => ({ where: () => Promise.resolve([]) }) }),

--- a/packages/aurora-sync/src/runner/sync-runner.ts
+++ b/packages/aurora-sync/src/runner/sync-runner.ts
@@ -12,7 +12,7 @@ import {
   claimNextCredentialForSync,
   claimSharedSyncSlot,
   credentialBackoffMs,
-  credentialRetryReadySql,
+  getCredentialFleetSnapshot,
   readSharedSyncCursor,
   releaseDaemonLease,
   selfHealStaleClimbStats,
@@ -33,7 +33,13 @@ import { isAuroraRequestError, isTransientAuroraError, isTransientSharedSyncAuro
 import { decrypt, encrypt } from '@boardsesh/crypto';
 import type { LocationSyncSummary } from '@boardsesh/location-sync';
 import type { AuroraBoardName } from '../api/types';
-import { DaemonLease, resolveDaemonOptions, runDaemonLoop } from '@boardsesh/sync-runtime';
+import {
+  DaemonLease,
+  formatSyncHealthSummary as formatSharedSyncHealthSummary,
+  resolveDaemonOptions,
+  runDaemonLoop,
+  type SyncHealthSnapshot,
+} from '@boardsesh/sync-runtime';
 import type { SyncRunnerConfig, SyncSummary, CredentialRecord, DaemonOptions, SyncErrorContext } from './types';
 
 type RunnerClient = ReturnType<typeof postgres>;
@@ -101,30 +107,17 @@ export class CredentialSyncError extends Error {
   }
 }
 
-/** Read-only snapshot of the aurora credential fleet, for the health-summary log. */
-export type SyncHealthSnapshot = {
-  total: number;
-  active: number;
-  pending: number;
-  error: number;
-  expired: number;
-  /** Syncable credentials currently skipped because they're inside a backoff window. */
-  inBackoff: number;
-  /** Oldest last_sync_attempt_at across aurora credentials (null = some never attempted). */
-  oldestAttemptAt: Date | null;
-};
+// Re-exported so this module's surface is unchanged by the move into
+// @boardsesh/sync-runtime.
+export type { SyncHealthSnapshot };
 
 /**
- * Format a {@link SyncHealthSnapshot} as a single greppable log line. Pure so
- * it's unit-testable without a database.
+ * Format the aurora fleet summary. Thin wrapper over the shared formatter in
+ * @boardsesh/sync-runtime so aurora and kilter emit the same line shape and one
+ * log alert covers both daemons.
  */
 export function formatSyncHealthSummary(snapshot: SyncHealthSnapshot): string {
-  const oldest = snapshot.oldestAttemptAt ? snapshot.oldestAttemptAt.toISOString() : 'never';
-  return (
-    `[SyncRunner] Sync health: ${snapshot.total} aurora credentials — ` +
-    `active=${snapshot.active} pending=${snapshot.pending} error=${snapshot.error} expired=${snapshot.expired}; ` +
-    `inBackoff=${snapshot.inBackoff}; oldestAttempt=${oldest}`
-  );
+  return formatSharedSyncHealthSummary(snapshot, '[SyncRunner]', 'aurora credentials');
 }
 
 type CredentialFailureUpdate = {
@@ -768,32 +761,9 @@ export class SyncRunner {
    */
   private async getSyncHealthSnapshot(): Promise<SyncHealthSnapshot> {
     const { db } = this.getClient();
-    const rows = await db
-      .select({
-        total: sql<number>`(count(*))::int`,
-        active: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'active'))::int`,
-        pending: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'pending'))::int`,
-        error: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'error'))::int`,
-        expired: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'expired'))::int`,
-        inBackoff: sql<number>`(count(*) filter (
-          where ${auroraCredentials.syncStatus} in ('pending', 'active', 'error')
-            and not ${credentialRetryReadySql()}
-        ))::int`,
-        oldestAttemptAt: sql<Date | null>`min(${auroraCredentials.lastSyncAttemptAt})`,
-      })
-      .from(auroraCredentials)
-      .where(ne(auroraCredentials.boardType, KILTER_BOARD_TYPE));
-
-    const row = rows[0];
-    return {
-      total: Number(row?.total ?? 0),
-      active: Number(row?.active ?? 0),
-      pending: Number(row?.pending ?? 0),
-      error: Number(row?.error ?? 0),
-      expired: Number(row?.expired ?? 0),
-      inBackoff: Number(row?.inBackoff ?? 0),
-      oldestAttemptAt: row?.oldestAttemptAt ?? null,
-    };
+    // Aurora's fleet is everything that isn't kilter; kilter-sync's runner
+    // passes the complementary predicate to the same query.
+    return getCredentialFleetSnapshot(db, ne(auroraCredentials.boardType, KILTER_BOARD_TYPE));
   }
 
   /**

--- a/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
+++ b/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, afterEach } from 'vite-plus/test';
+import { sql } from 'drizzle-orm';
+
+import { db } from '../db/client';
+import { applyClimbRatings, type PowerSyncOp } from '@boardsesh/kilter-sync';
+
+// ---------------------------------------------------------------------------
+// board_climb_ratings kilter_id reconciliation (real DB)
+//
+// applyClimbRatings issues ONE batched INSERT … ON CONFLICT whose target is the
+// natural key (board_type, climb_uuid, angle, user_id). The table carries a
+// SECOND, global unique — board_climb_ratings_kilter_id_unique, partial on
+// `kilter_id IS NOT NULL`. Postgres permits exactly one conflict target per
+// ON CONFLICT, so that surrogate unique was uncovered: an incoming
+// climb_rating_uuid already attached to a different row raised 23505, aborted
+// the ratings transaction, escaped syncKilterUserData (taking the circuits
+// phase with it), and the runner classified the raw Postgres error as a
+// PERMANENT failure. PowerSync re-delivers the full snapshot every cycle, so it
+// failed identically forever — the kilter user sync did not complete a single
+// successful run in a 30+ day window.
+//
+// These tests drive the REAL applyClimbRatings against a real table so the
+// reconciliation is recorded behaviour, not a re-derived predicate. They only
+// bite because schema-sql.ts now creates the surrogate uniques; without those
+// indexes the bug is unreproducible, which is how it survived a month.
+// ---------------------------------------------------------------------------
+
+const USER_ID = 'ratings-repoint-user';
+const OTHER_USER_ID = 'ratings-repoint-other-user';
+const CLIMB = 'ratings-repoint-climb';
+// The one byte Postgres text genuinely cannot store. Written as an escape
+// rather than a literal so the character stays visible in the source.
+const NUL = String.fromCharCode(0);
+
+type RatingRow = {
+  climb_uuid: string;
+  angle: number;
+  rating: number | null;
+  comment: string | null;
+  weight: number | null;
+  kilter_id: string | null;
+  kilter_detached_at: string | Date | null;
+  updated_at: string | Date;
+};
+
+async function seedUser(id: string): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO "users" (id, email, name, created_at, updated_at)
+    VALUES (${id}, ${`${id}@test.com`}, ${id}, now(), now())
+    ON CONFLICT (id) DO NOTHING
+  `);
+}
+
+/** A rating authored in Boardsesh: no kilter_id yet, carrying local-only state. */
+async function seedLocalRating(userId: string, climbUuid: string, angle: number): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_climb_ratings (board_type, climb_uuid, angle, user_id, rating, comment, weight)
+    VALUES ('kilter', ${climbUuid}, ${angle}, ${userId}, 4, 'local beta', 1.5)
+  `);
+}
+
+async function seedKilterRating(userId: string, climbUuid: string, angle: number, kilterId: string): Promise<void> {
+  await db.execute(sql`
+    INSERT INTO board_climb_ratings (board_type, climb_uuid, angle, user_id, rating, kilter_id)
+    VALUES ('kilter', ${climbUuid}, ${angle}, ${userId}, 3, ${kilterId})
+  `);
+}
+
+async function readRatings(userId: string): Promise<RatingRow[]> {
+  const result = await db.execute(sql`
+    SELECT climb_uuid, angle, rating, comment, weight, kilter_id, kilter_detached_at, updated_at
+    FROM board_climb_ratings
+    WHERE user_id = ${userId}
+    ORDER BY angle
+  `);
+  return Array.from(result as Iterable<RatingRow>);
+}
+
+function putOp(args: {
+  climbRatingUuid: string;
+  climbUuid?: string;
+  angle: number;
+  rating?: number;
+  comment?: string;
+  opId?: string;
+}): PowerSyncOp {
+  return {
+    op_id: args.opId ?? '1',
+    op: 'PUT',
+    object_type: 'climb_ratings',
+    object_id: args.climbRatingUuid,
+    data: {
+      id: args.climbRatingUuid,
+      climb_rating_uuid: args.climbRatingUuid,
+      user_uuid: 'kilter-sub',
+      climb_uuid: args.climbUuid ?? CLIMB,
+      angle: args.angle,
+      rating: args.rating ?? 5,
+      difficulty_grade_id: null,
+      comment: args.comment ?? 'from kilter',
+      created_at: '2026-05-01T12:00:00.000Z',
+    },
+  };
+}
+
+// Pre-seeded so resolveCanonicalClimbUuid never touches board_climb_aliases.
+function aliasCacheFor(climbUuids: string[]): Map<string, string> {
+  return new Map(climbUuids.map((uuid) => [`kilter:${uuid}`, uuid]));
+}
+
+type ApplyTx = Parameters<typeof applyClimbRatings>[0];
+const applyTx = db as unknown as ApplyTx;
+
+describe('applyClimbRatings kilter_id reconciliation (real DB)', () => {
+  afterEach(async () => {
+    await db.execute(sql`DELETE FROM board_climb_ratings WHERE user_id IN (${USER_ID}, ${OTHER_USER_ID})`);
+    await db.execute(sql`DELETE FROM "users" WHERE id IN (${USER_ID}, ${OTHER_USER_ID})`);
+  });
+
+  // Guard the trap itself. If a future edit to schema-sql.ts drops this index,
+  // every test below would still pass while testing nothing at all.
+  it('the global partial unique on kilter_id exists in the test schema', async () => {
+    const result = await db.execute(sql`
+      SELECT indexdef FROM pg_indexes WHERE indexname = 'board_climb_ratings_kilter_id_unique'
+    `);
+    const rows = Array.from(result as Iterable<{ indexdef: string }>);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.indexdef).toContain('UNIQUE');
+    // Partial — a Boardsesh-origin rating with a NULL kilter_id must not
+    // collide with every other unsynced row.
+    expect(rows[0]?.indexdef).toContain('WHERE');
+  });
+
+  it('collapses two PUTs sharing one climb_rating_uuid in a single batch', async () => {
+    await seedUser(USER_ID);
+
+    // The intra-statement path. PowerSync's oplog can carry several ops for one
+    // row per snapshot; an upstream angle edit re-delivers the same
+    // climb_rating_uuid under a different natural key. Deduping only the
+    // conflict key let both copies reach one INSERT with the same kilter_id.
+    await applyClimbRatings(
+      applyTx,
+      USER_ID,
+      [
+        putOp({ climbRatingUuid: 'kr-dupe', angle: 40, opId: '1' }),
+        putOp({ climbRatingUuid: 'kr-dupe', angle: 25, opId: '2' }),
+      ],
+      aliasCacheFor([CLIMB]),
+      () => {},
+    );
+
+    // Last op wins: the rating lives at its current upstream angle, once.
+    const rows = await readRatings(USER_ID);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.angle).toBe(25);
+    expect(rows[0]?.kilter_id).toBe('kr-dupe');
+  });
+
+  it('repoints a kilter_id that moved to a different angle across cycles', async () => {
+    await seedUser(USER_ID);
+    await applyClimbRatings(
+      applyTx,
+      USER_ID,
+      [putOp({ climbRatingUuid: 'kr-move', angle: 40 })],
+      aliasCacheFor([CLIMB]),
+      () => {},
+    );
+
+    // Cycle two: upstream moved the same rating to angle 25.
+    await applyClimbRatings(
+      applyTx,
+      USER_ID,
+      [putOp({ climbRatingUuid: 'kr-move', angle: 25 })],
+      aliasCacheFor([CLIMB]),
+      () => {},
+    );
+
+    const rows = await readRatings(USER_ID);
+    expect(rows).toHaveLength(2);
+    const moved = rows.find((row) => row.angle === 25);
+    const stale = rows.find((row) => row.angle === 40);
+
+    expect(moved?.kilter_id).toBe('kr-move');
+    expect(moved?.kilter_detached_at).toBeNull();
+
+    // The stale row is DETACHED, never deleted — it keeps its rating data and
+    // only loses the surrogate.
+    expect(stale).toBeDefined();
+    expect(stale?.kilter_id).toBeNull();
+    // The marker is load-bearing: push-back selects on
+    // `kilter_id IS NULL AND kilter_detached_at IS NULL`, so an unmarked stale
+    // row would look never-pushed and get re-created upstream as a duplicate.
+    expect(stale?.kilter_detached_at).not.toBeNull();
+  });
+
+  it('repoints onto a Boardsesh-origin row without losing its local-only state', async () => {
+    await seedUser(USER_ID);
+    // The DO UPDATE branch trips the surrogate unique too — it writes kilter_id
+    // through COALESCE — so this is a distinct path from the INSERT branch.
+    await seedLocalRating(USER_ID, CLIMB, 25);
+    await applyClimbRatings(
+      applyTx,
+      USER_ID,
+      [putOp({ climbRatingUuid: 'kr-adopt', angle: 40 })],
+      aliasCacheFor([CLIMB]),
+      () => {},
+    );
+
+    await applyClimbRatings(
+      applyTx,
+      USER_ID,
+      [putOp({ climbRatingUuid: 'kr-adopt', angle: 25 })],
+      aliasCacheFor([CLIMB]),
+      () => {},
+    );
+
+    const rows = await readRatings(USER_ID);
+    const adopted = rows.find((row) => row.angle === 25);
+    expect(adopted?.kilter_id).toBe('kr-adopt');
+    // `weight` is outside the upsert's SET clause and Kilter never sends one —
+    // it only survives if the row survived rather than being re-inserted.
+    expect(Number(adopted?.weight)).toBe(1.5);
+  });
+
+  it('swaps two kilter_ids between two rows in one batch', async () => {
+    await seedUser(USER_ID);
+    await seedKilterRating(USER_ID, CLIMB, 40, 'kr-a');
+    await seedKilterRating(USER_ID, CLIMB, 25, 'kr-b');
+
+    // Both detaches must land before either upsert; interleaving them per row
+    // re-introduces the collision.
+    await applyClimbRatings(
+      applyTx,
+      USER_ID,
+      [putOp({ climbRatingUuid: 'kr-a', angle: 25 }), putOp({ climbRatingUuid: 'kr-b', angle: 40 })],
+      aliasCacheFor([CLIMB]),
+      () => {},
+    );
+
+    const rows = await readRatings(USER_ID);
+    expect(rows.find((row) => row.angle === 25)?.kilter_id).toBe('kr-a');
+    expect(rows.find((row) => row.angle === 40)?.kilter_id).toBe('kr-b');
+  });
+
+  it('never steals a kilter_id owned by a different Boardsesh user', async () => {
+    await seedUser(USER_ID);
+    await seedUser(OTHER_USER_ID);
+    // One Kilter account linked to two Boardsesh accounts.
+    await seedKilterRating(OTHER_USER_ID, CLIMB, 40, 'kr-shared');
+
+    const logged: string[] = [];
+    await applyClimbRatings(
+      applyTx,
+      USER_ID,
+      [putOp({ climbRatingUuid: 'kr-shared', angle: 40 })],
+      aliasCacheFor([CLIMB]),
+      (msg) => logged.push(msg),
+    );
+
+    // The other user's row is untouched, and we did not write our own.
+    const otherRows = await readRatings(OTHER_USER_ID);
+    expect(otherRows).toHaveLength(1);
+    expect(otherRows[0]?.kilter_id).toBe('kr-shared');
+    expect(otherRows[0]?.kilter_detached_at).toBeNull();
+    expect(await readRatings(USER_ID)).toHaveLength(0);
+    // Skip-and-log, so the duplicate-account link stays visible.
+    expect(logged.join('\n')).toContain('different Boardsesh user');
+  });
+
+  it('leaves a steady-state re-sync untouched', async () => {
+    await seedUser(USER_ID);
+    const ops = [putOp({ climbRatingUuid: 'kr-steady', angle: 40 })];
+    await applyClimbRatings(applyTx, USER_ID, ops, aliasCacheFor([CLIMB]), () => {});
+    const first = (await readRatings(USER_ID))[0];
+
+    // PowerSync re-delivers the full snapshot every cycle. Nothing changed, so
+    // nothing should be detached and updated_at must not drift into "when the
+    // sync last ran".
+    const logged: string[] = [];
+    await applyClimbRatings(applyTx, USER_ID, ops, aliasCacheFor([CLIMB]), (msg) => logged.push(msg));
+
+    const second = (await readRatings(USER_ID))[0];
+    expect(second?.kilter_id).toBe('kr-steady');
+    expect(second?.kilter_detached_at).toBeNull();
+    expect(new Date(second!.updated_at).getTime()).toBe(new Date(first!.updated_at).getTime());
+    expect(logged.join('\n')).not.toContain('repointing');
+  });
+
+  it('skips a row Postgres refuses instead of losing the whole batch', async () => {
+    await seedUser(USER_ID);
+
+    // A NUL byte is the one thing Postgres text genuinely cannot store, so it
+    // stands in for any row shape we failed to anticipate. Before the per-chunk
+    // savepoint and row-by-row replay, one such row aborted the transaction,
+    // failed the user permanently, and skipped the circuits phase.
+    await applyClimbRatings(
+      applyTx,
+      USER_ID,
+      [
+        putOp({ climbRatingUuid: 'kr-ok-1', angle: 40 }),
+        putOp({ climbRatingUuid: 'kr-poison', angle: 30, comment: `bad${NUL}byte` }),
+        putOp({ climbRatingUuid: 'kr-ok-2', angle: 25 }),
+      ],
+      aliasCacheFor([CLIMB]),
+      () => {},
+    );
+
+    const rows = await readRatings(USER_ID);
+    expect(rows.map((row) => row.kilter_id).sort((left, right) => String(left).localeCompare(String(right)))).toEqual([
+      'kr-ok-1',
+      'kr-ok-2',
+    ]);
+  });
+});

--- a/packages/backend/src/__tests__/climb-ratings-remove-detach.test.ts
+++ b/packages/backend/src/__tests__/climb-ratings-remove-detach.test.ts
@@ -113,6 +113,7 @@ describe('applyClimbRatings REMOVE → soft-detach (real DB)', () => {
       TEST_USER_ID,
       [putOp({ climbRatingUuid: 'kr-adopt', climbUuid, rating: 5 })],
       aliasCacheFor([climbUuid]),
+      () => {},
     );
 
     const row = await readRating(climbUuid);
@@ -135,9 +136,10 @@ describe('applyClimbRatings REMOVE → soft-detach (real DB)', () => {
       TEST_USER_ID,
       [putOp({ climbRatingUuid: 'kr-remove', climbUuid, rating: 5 })],
       aliasCacheFor([climbUuid]),
+      () => {},
     );
 
-    await applyClimbRatings(applyTx, TEST_USER_ID, [removeOp('kr-remove')], new Map());
+    await applyClimbRatings(applyTx, TEST_USER_ID, [removeOp('kr-remove')], new Map(), () => {});
 
     // On main this row is gone — the DELETE matched the adopted kilter_id.
     const row = await readRating(climbUuid);
@@ -157,8 +159,9 @@ describe('applyClimbRatings REMOVE → soft-detach (real DB)', () => {
       TEST_USER_ID,
       [putOp({ climbRatingUuid: 'kr-redeliver', climbUuid, rating: 5 })],
       aliasCacheFor([climbUuid]),
+      () => {},
     );
-    await applyClimbRatings(applyTx, TEST_USER_ID, [removeOp('kr-redeliver')], new Map());
+    await applyClimbRatings(applyTx, TEST_USER_ID, [removeOp('kr-redeliver')], new Map(), () => {});
     const detached = await readRating(climbUuid);
     expect(detached?.kilter_detached_at).not.toBeNull();
 
@@ -178,6 +181,7 @@ describe('applyClimbRatings REMOVE → soft-detach (real DB)', () => {
       TEST_USER_ID,
       [putOp({ climbRatingUuid: 'kr-redeliver', climbUuid, rating: 3 })],
       aliasCacheFor([climbUuid]),
+      () => {},
     );
 
     const row = await readRating(climbUuid);
@@ -200,9 +204,10 @@ describe('applyClimbRatings REMOVE → soft-detach (real DB)', () => {
       TEST_USER_ID,
       [putOp({ climbRatingUuid: 'kr-pure', climbUuid, rating: 2 })],
       aliasCacheFor([climbUuid]),
+      () => {},
     );
 
-    await applyClimbRatings(applyTx, TEST_USER_ID, [removeOp('kr-pure')], new Map());
+    await applyClimbRatings(applyTx, TEST_USER_ID, [removeOp('kr-pure')], new Map(), () => {});
 
     // Deliberate behaviour change, matching the tick precedent: the row stays
     // but is marked. The ascents feeds filter on kilter_detached_at, so the
@@ -242,8 +247,9 @@ describe('applyClimbRatings REMOVE → soft-detach (real DB)', () => {
         TEST_USER_ID,
         [putOp({ climbRatingUuid: 'kr-push', climbUuid, rating: 5 })],
         aliasCacheFor([climbUuid]),
+        () => {},
       );
-      await applyClimbRatings(applyTx, TEST_USER_ID, [removeOp('kr-push')], new Map());
+      await applyClimbRatings(applyTx, TEST_USER_ID, [removeOp('kr-push')], new Map(), () => {});
       vi.stubEnv('KILTER_SYNC_PUSH_ENABLED', 'true');
 
       // Same shape as the control above, minus the marker: drop the

--- a/packages/backend/src/__tests__/kilter-climb-ratings-timestamps.test.ts
+++ b/packages/backend/src/__tests__/kilter-climb-ratings-timestamps.test.ts
@@ -55,7 +55,7 @@ function putOp({ rating, difficulty_grade_id, comment, created_at }: RatingPaylo
 }
 
 async function syncRating(payload: RatingPayload): Promise<void> {
-  await applyClimbRatings(db, USER_ID, [putOp(payload)], new Map<string, string>());
+  await applyClimbRatings(db, USER_ID, [putOp(payload)], new Map<string, string>(), () => {});
 }
 
 async function readRating() {
@@ -216,13 +216,13 @@ describe('applyClimbRatings timestamps (real Postgres)', () => {
         }) as unknown as PowerSyncOp,
     );
 
-    await applyClimbRatings(db, USER_ID, ops, new Map<string, string>());
+    await applyClimbRatings(db, USER_ID, ops, new Map<string, string>(), () => {});
     await db
       .update(boardClimbRatings)
       .set({ updatedAt: BACKDATED_UPDATED_AT })
       .where(eq(boardClimbRatings.userId, USER_ID));
 
-    await applyClimbRatings(db, USER_ID, ops, new Map<string, string>());
+    await applyClimbRatings(db, USER_ID, ops, new Map<string, string>(), () => {});
 
     const rows = await db
       .select({ updatedAt: boardClimbRatings.updatedAt, createdAt: boardClimbRatings.createdAt })

--- a/packages/backend/src/__tests__/schema-sql.ts
+++ b/packages/backend/src/__tests__/schema-sql.ts
@@ -277,6 +277,15 @@ export const schemaSQL = `
     CONSTRAINT "board_climb_ratings_rating_range" CHECK ("rating" IS NULL OR ("rating" >= 1 AND "rating" <= 5))
   );
   CREATE UNIQUE INDEX IF NOT EXISTS "board_climb_ratings_user_climb_angle_idx" ON "board_climb_ratings" ("board_type", "climb_uuid", "angle", "user_id");
+  -- The two surrogate uniques are PARTIAL (NOT NULL only) so a Boardsesh-originated
+  -- rating can sit unsynced without colliding with every other unsynced row. They are
+  -- GLOBAL, not user-scoped: one climb_rating_uuid lives on at most one row table-wide.
+  -- kilter-sync's ratings upsert can only name ONE conflict target, so it has to make
+  -- these unreachable before the statement runs (see applyClimbRatings). Leaving them
+  -- out of this test schema is what let a duplicate-key regression reach production and
+  -- wedge the kilter user sync for 30+ days.
+  CREATE UNIQUE INDEX IF NOT EXISTS "board_climb_ratings_kilter_id_unique" ON "board_climb_ratings" ("kilter_id") WHERE "kilter_id" IS NOT NULL;
+  CREATE UNIQUE INDEX IF NOT EXISTS "board_climb_ratings_aurora_id_unique" ON "board_climb_ratings" ("aurora_id") WHERE "aurora_id" IS NOT NULL;
 
   -- Mirrors packages/db schema/boards/unified.ts boardClimbStatsHistory. The
   -- weekly full-table snapshot (snapshotClimbStatsHistoryIfDue) appends the

--- a/packages/db/src/queries/index.ts
+++ b/packages/db/src/queries/index.ts
@@ -3,6 +3,7 @@ export * from './boards/index';
 export * from './climbs/index';
 export * from './climb-stats/index';
 export * from './sync/credential-backoff';
+export * from './sync/credential-fleet-snapshot';
 export * from './sync/weekly-gate';
 export * from './sync/upstream-playlist-owners';
 export * from './sync/claim-credential';

--- a/packages/db/src/queries/sync/credential-fleet-snapshot.ts
+++ b/packages/db/src/queries/sync/credential-fleet-snapshot.ts
@@ -1,0 +1,72 @@
+import { sql, type SQL } from 'drizzle-orm';
+import type { PgDatabase, PgQueryResultHKT } from 'drizzle-orm/pg-core';
+
+import { auroraCredentials } from '../../schema/auth/mappings';
+import { credentialRetryReadySql } from './credential-backoff';
+
+type SnapshotDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
+
+/** Read-only snapshot of a credential fleet, for a daemon's health-summary log. */
+export type CredentialFleetSnapshot = {
+  total: number;
+  active: number;
+  pending: number;
+  error: number;
+  expired: number;
+  /** Syncable credentials currently skipped because they're inside a backoff window. */
+  inBackoff: number;
+  /**
+   * Oldest last_sync_attempt_at across the fleet (null = some never attempted).
+   * Typed to admit a string: a raw `sql` aggregate carries no decoder unless one
+   * is attached, and this one attaches the column's — see below.
+   */
+  oldestAttemptAt: Date | string | null;
+};
+
+/**
+ * One aggregate scan over the credentials table: counts by sync_status, how
+ * many syncable credentials sit inside a backoff window, and the oldest attempt
+ * clock. Read-only, so it is safe to run every cycle even with a second daemon
+ * instance overlapping.
+ *
+ * `scope` selects the fleet — aurora passes `ne(boardType, 'kilter')`, kilter
+ * passes `eq(boardType, 'kilter')` — so both daemons report on their own
+ * credentials from one implementation.
+ */
+export async function getCredentialFleetSnapshot(db: SnapshotDb, scope: SQL): Promise<CredentialFleetSnapshot> {
+  const rows = await db
+    .select({
+      total: sql<number>`(count(*))::int`,
+      active: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'active'))::int`,
+      pending: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'pending'))::int`,
+      error: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'error'))::int`,
+      expired: sql<number>`(count(*) filter (where ${auroraCredentials.syncStatus} = 'expired'))::int`,
+      inBackoff: sql<number>`(count(*) filter (
+        where ${auroraCredentials.syncStatus} in ('pending', 'active', 'error')
+          and not ${credentialRetryReadySql()}
+      ))::int`,
+      // .mapWith is load-bearing. A raw `sql` expression gets NO runtime decoder
+      // — the <Date | null> generic is compile-time only — and drizzle's
+      // postgres-js driver deliberately strips postgres.js's own date parsers
+      // (last_sync_attempt_at is `timestamp`, OID 1114) so column mappers are
+      // the single source of truth. Without this the value arrives as raw
+      // Postgres text and any .toISOString() on it throws, which is what
+      // silently killed every hourly health summary aurora-sync ever emitted.
+      oldestAttemptAt: sql<Date | null>`min(${auroraCredentials.lastSyncAttemptAt})`.mapWith(
+        auroraCredentials.lastSyncAttemptAt,
+      ),
+    })
+    .from(auroraCredentials)
+    .where(scope);
+
+  const row = rows[0];
+  return {
+    total: Number(row?.total ?? 0),
+    active: Number(row?.active ?? 0),
+    pending: Number(row?.pending ?? 0),
+    error: Number(row?.error ?? 0),
+    expired: Number(row?.expired ?? 0),
+    inBackoff: Number(row?.inBackoff ?? 0),
+    oldestAttemptAt: row?.oldestAttemptAt ?? null,
+  };
+}

--- a/packages/kilter-sync/src/runner/sync-runner.ts
+++ b/packages/kilter-sync/src/runner/sync-runner.ts
@@ -11,6 +11,7 @@ import {
   acquireOrRenewDaemonLease,
   claimNextCredentialForSync,
   claimSharedSyncSlot,
+  getCredentialFleetSnapshot,
   readSharedSyncCursor,
   releaseDaemonLease,
   snapshotClimbStatsHistoryIfDue,
@@ -23,6 +24,7 @@ import { decrypt, encrypt } from '@boardsesh/crypto';
 import {
   DEFAULT_DAEMON_OPTIONS,
   DaemonLease,
+  formatSyncHealthSummary,
   resolveDaemonOptions,
   runDaemonLoop,
   type ResolvedDaemonOptions,
@@ -48,9 +50,19 @@ import type { RunnerClient, RunnerDb, SyncRunnerConfig, SyncSummary, KilterCrede
 // via config.sharedSyncCooldownMs.
 const DEFAULT_CATALOG_SYNC_COOLDOWN_MS = 60 * 60 * 1000;
 
+/**
+ * Hourly gate for the read-only fleet health summary. Mirrors aurora-sync: the
+ * daemon had no staleness signal of its own, which is how a 30-day user-sync
+ * outage stayed invisible.
+ */
+const SYNC_HEALTH_SUMMARY_COOLDOWN_MS = 60 * 60 * 1000;
+
 export class SyncRunner {
   private config: SyncRunnerConfig;
   private daemonController: AbortController | null = null;
+
+  // In-memory hourly gate for the fleet health summary. Resets to 0 on restart.
+  private lastHealthSummaryAt = 0;
   private client: RunnerClient | null = null;
   private db: RunnerDb | null = null;
   private lease: DaemonLease | null = null;
@@ -302,6 +314,15 @@ export class SyncRunner {
         updatedAt: now,
       })
       .where(and(eq(auroraCredentials.userId, cred.userId), eq(auroraCredentials.boardType, KILTER_BOARD_TYPE)));
+
+    // Greppable success line. The daemon had NONE until now: only failures and
+    // the duplicate-circuit case ever logged, so `grep 'Successfully synced'`
+    // over this service returned zero whether the sync was healthy or stone
+    // dead — which is precisely why a 30-day outage went unnoticed. Alerting on
+    // the ABSENCE of this line is the check that catches the next one; alerting
+    // on an error string would go quiet the moment the error is fixed.
+    // Matches aurora-sync's wording so one Loki rule can cover both daemons.
+    this.log(`[KilterSyncRunner] ✓ Successfully synced user ${cred.userId} for ${KILTER_BOARD_TYPE}`);
 
     // Piggyback: after the user-half succeeds and is stamped active, refresh
     // the shared catalog if its cooldown has elapsed. Reuses this user's token.
@@ -630,6 +651,30 @@ export class SyncRunner {
     return rows[0] ?? null;
   }
 
+  /**
+   * Log the fleet health summary once an hour (in-memory gate, mirroring
+   * aurora-sync). Read-only; a failure never breaks the daemon cycle.
+   */
+  private async maybeLogSyncHealth(): Promise<void> {
+    const now = Date.now();
+    if (this.lastHealthSummaryAt !== 0 && now - this.lastHealthSummaryAt < SYNC_HEALTH_SUMMARY_COOLDOWN_MS) {
+      return;
+    }
+    // Stamp before the query (not after) so a slow or erroring snapshot doesn't
+    // re-fire on the very next cycle — a summary is anti-spam by design.
+    this.lastHealthSummaryAt = now;
+    try {
+      const { db } = this.getClient();
+      const snapshot = await getCredentialFleetSnapshot(db, eq(auroraCredentials.boardType, KILTER_BOARD_TYPE));
+      this.log(formatSyncHealthSummary(snapshot, '[KilterSyncRunner]', 'kilter credentials'));
+    } catch (error) {
+      this.handleError(error instanceof Error ? error : new Error(String(error)), {});
+      this.log(
+        `[KilterSyncRunner] Sync health summary failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
   async runDaemon(options: DaemonOptions = {}): Promise<void> {
     const resolved: ResolvedDaemonOptions = resolveDaemonOptions(options);
     this.daemonController = new AbortController();
@@ -638,6 +683,9 @@ export class SyncRunner {
       await runDaemonLoop(
         async () => {
           await this.syncNextUser();
+          // Hourly read-only fleet summary so a stuck / backing-off credential
+          // is visible without querying the DB by hand.
+          await this.maybeLogSyncHealth();
           // Checkpoint: if a heartbeat saw another instance take the lease over
           // while this cycle ran, stop here instead of continuing alongside the
           // new holder. The loop reports it and drops into standby.

--- a/packages/kilter-sync/src/sync/user-sync.test.ts
+++ b/packages/kilter-sync/src/sync/user-sync.test.ts
@@ -46,7 +46,7 @@ function recomputedKeys(): Array<{ climbUuid: string; angle: number }> {
 type CallRecord = {
   // `conflict` records the ON CONFLICT clause an insert was given, so a test
   // can assert the ownership `setWhere` guard was attached.
-  kind: 'select' | 'delete' | 'execute' | 'insert' | 'update' | 'conflict';
+  kind: 'select' | 'delete' | 'execute' | 'insert' | 'update' | 'conflict' | 'transaction';
   args: unknown[];
 };
 
@@ -1188,6 +1188,14 @@ function createRichTx(
       calls.push({ kind: 'execute', args: [query] });
       return Promise.resolve();
     },
+    // applyClimbRatings wraps each upsert chunk in a savepoint so one refused
+    // row costs its chunk rather than the buffer. Drizzle models a savepoint as
+    // a nested .transaction(), so the shim just re-enters with the same tx —
+    // there is no real DB here to roll back to.
+    transaction(fn: (savepoint: unknown) => Promise<unknown>) {
+      calls.push({ kind: 'transaction', args: [] });
+      return Promise.resolve(fn(tx));
+    },
   };
 
   return { tx, calls, insertValues, returningRows: returningQueue };
@@ -1230,7 +1238,7 @@ type ApplyCircuitsTx = Parameters<typeof applyCircuits>[0];
 describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
   it('returns early on empty ops', async () => {
     const { tx, calls } = createRichTx();
-    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', [], new Map());
+    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', [], new Map(), () => {});
     expect(calls).toHaveLength(0);
   });
 
@@ -1241,7 +1249,13 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
       makeRatingPutOp({ climb_rating_uuid: 'r-2', climb_uuid: 'climb-B', angle: 25, rating: 5 }),
     ];
 
-    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, aliasCacheFor(['climb-A', 'climb-B']));
+    await applyClimbRatings(
+      tx as unknown as ApplyClimbRatingsTx,
+      'user-1',
+      ops,
+      aliasCacheFor(['climb-A', 'climb-B']),
+      () => {},
+    );
 
     expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(1);
     expect(insertValues[0]).toHaveLength(2);
@@ -1267,12 +1281,16 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
   it('sanitizes a Kilter rating=0 to NULL so the batch does not violate the CHECK', () => {
     const { tx, insertValues } = createRichTx();
     const ops = [makeRatingPutOp({ climb_rating_uuid: 'r-0', climb_uuid: 'climb-A', angle: 40, rating: 0 })];
-    return applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, aliasCacheFor(['climb-A'])).then(
-      () => {
-        expect(insertValues[0]).toHaveLength(1);
-        expect(insertValues[0][0]).toMatchObject({ kilterId: 'r-0', rating: null });
-      },
-    );
+    return applyClimbRatings(
+      tx as unknown as ApplyClimbRatingsTx,
+      'user-1',
+      ops,
+      aliasCacheFor(['climb-A']),
+      () => {},
+    ).then(() => {
+      expect(insertValues[0]).toHaveLength(1);
+      expect(insertValues[0][0]).toMatchObject({ kilterId: 'r-0', rating: null });
+    });
   });
 
   it('issues exactly one bulk soft-detach UPDATE for N REMOVE ops, never a DELETE', async () => {
@@ -1282,7 +1300,7 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
       { op_id: '2', op: 'REMOVE', object_type: 'climb_ratings', object_id: 'r-2' },
     ];
 
-    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, new Map());
+    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, new Map(), () => {});
 
     const updates = calls.filter((c) => c.kind === 'update');
     expect(updates).toHaveLength(1);
@@ -1304,7 +1322,7 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
       makeRatingPutOp({ climb_rating_uuid: 'r-new', climb_uuid: 'climb-A', angle: 30 }),
     ];
 
-    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, aliasCacheFor(['climb-A']));
+    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, aliasCacheFor(['climb-A']), () => {});
 
     expect(calls.filter((c) => c.kind === 'update')).toHaveLength(1);
     expect(calls.filter((c) => c.kind === 'delete')).toHaveLength(0);
@@ -1331,7 +1349,7 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
       makeRatingPutOp({ climb_rating_uuid: 'r-b', climb_uuid: 'climb-src-b', angle: 40, rating: 5 }),
     ];
 
-    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, aliasCache);
+    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, aliasCache, () => {});
 
     // Exactly one bulk insert carrying ONE deduped values row.
     expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(1);
@@ -1350,7 +1368,7 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
     const { tx, insertValues } = createRichTx();
     const op = makeRatingPutOp({ climb_rating_uuid: 'r-1', climb_uuid: 'climb-A', angle: 40, comment: null });
 
-    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', [op], aliasCacheFor(['climb-A']));
+    await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', [op], aliasCacheFor(['climb-A']), () => {});
 
     // INSERT value normalises null → ''. The UPDATE clause uses
     // COALESCE(EXCLUDED.comment, …) which the file-level integration

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -98,6 +98,14 @@ const NATURAL_KEY_FETCH_WINDOW_SECONDS = MAX_USER_UTC_OFFSET_SECONDS + NATURAL_K
  */
 const STREAM_FLUSH_THRESHOLD = 500;
 
+/**
+ * Rows per statement in the ratings upsert. Mirrors aurora-sync's
+ * WRITE_CHUNK_SIZE (apply-user-logbook.ts): a row Postgres refuses costs its
+ * chunk rather than the whole STREAM_FLUSH_THRESHOLD-sized buffer, which is
+ * what makes the row-by-row replay in applyClimbRatings affordable.
+ */
+const RATINGS_WRITE_CHUNK_SIZE = 100;
+
 export type SyncKilterUserDataArgs = {
   db: DrizzleDb;
   userId: string;
@@ -259,7 +267,28 @@ export async function syncKilterUserData({
   async function flushClimbRatings(): Promise<void> {
     if (buffer.climb_ratings.length === 0) return;
     const batch = buffer.climb_ratings.splice(0, buffer.climb_ratings.length);
-    await db.transaction((tx) => applyClimbRatings(tx, userId, batch, aliasCache));
+    await db.transaction((tx) => applyClimbRatings(tx, userId, batch, aliasCache, log));
+  }
+
+  // Phase isolation. A throw from one phase must not cancel the others. Before
+  // this, a single bad rating row aborted the ratings transaction, escaped
+  // syncKilterUserData entirely, and the circuits phase at the bottom never
+  // ran — so a user wedged on ratings silently lost playlist sync too, for as
+  // long as the wedge lasted. Failures are collected and re-thrown once every
+  // phase has had its turn, so the runner still records a failed user.
+  //
+  // No data is lost by continuing: PowerSync re-delivers a full snapshot every
+  // cycle and each apply is idempotent, so whatever a failed phase dropped
+  // lands on the next successful turn.
+  const phaseErrors: Error[] = [];
+  async function runPhase(name: string, phase: () => Promise<void>): Promise<void> {
+    try {
+      await phase();
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      log(`[kilter-sync] ${name} phase failed for user ${userId}: ${failure.message}`);
+      phaseErrors.push(new Error(`${name}: ${failure.message}`, { cause: failure }));
+    }
   }
 
   await streamKilterPowerSync({
@@ -277,8 +306,10 @@ export async function syncKilterUserData({
           }
           buffer.logs.push(op);
           if (buffer.logs.length >= STREAM_FLUSH_THRESHOLD) {
-            await primeAliasCacheForOps(db, aliasCache, buffer.logs, extractLogClimbUuid);
-            await flushLogs();
+            await runPhase('logs', async () => {
+              await primeAliasCacheForOps(db, aliasCache, buffer.logs, extractLogClimbUuid);
+              await flushLogs();
+            });
           }
           break;
         case 'climb_ratings':
@@ -291,8 +322,10 @@ export async function syncKilterUserData({
           }
           buffer.climb_ratings.push(op);
           if (buffer.climb_ratings.length >= STREAM_FLUSH_THRESHOLD) {
-            await primeAliasCacheForOps(db, aliasCache, buffer.climb_ratings, extractRatingClimbUuid);
-            await flushClimbRatings();
+            await runPhase('climb_ratings', async () => {
+              await primeAliasCacheForOps(db, aliasCache, buffer.climb_ratings, extractRatingClimbUuid);
+              await flushClimbRatings();
+            });
           }
           break;
         case 'circuits':
@@ -334,11 +367,15 @@ export async function syncKilterUserData({
   // about to apply, then run each phase in its own transaction. The
   // per-phase tx boundary matters more than cross-phase atomicity —
   // every apply is independently idempotent via ON CONFLICT.
-  await primeAliasCacheForOps(db, aliasCache, buffer.logs, extractLogClimbUuid);
-  await flushLogs();
+  await runPhase('logs', async () => {
+    await primeAliasCacheForOps(db, aliasCache, buffer.logs, extractLogClimbUuid);
+    await flushLogs();
+  });
 
-  await primeAliasCacheForOps(db, aliasCache, buffer.climb_ratings, extractRatingClimbUuid);
-  await flushClimbRatings();
+  await runPhase('climb_ratings', async () => {
+    await primeAliasCacheForOps(db, aliasCache, buffer.climb_ratings, extractRatingClimbUuid);
+    await flushClimbRatings();
+  });
 
   // Drop orphan circuit_climbs whose parent circuit didn't survive the
   // user_uuid filter. Doing it here (not at ingest time) avoids the
@@ -362,7 +399,24 @@ export async function syncKilterUserData({
   }
   await primeAliasCache(db, aliasCache, circuitClimbUuids);
 
-  return db.transaction((tx) => applyCircuits(tx, userId, buffer.circuits, filteredCircuitClimbs, aliasCache, log));
+  let circuitsResult: SyncKilterUserDataResult = { skippedForeignCircuits: 0 };
+  await runPhase('circuits', async () => {
+    circuitsResult = await db.transaction((tx) =>
+      applyCircuits(tx, userId, buffer.circuits, filteredCircuitClimbs, aliasCache, log),
+    );
+  });
+
+  // Surface the failures now that every phase has run. The runner classifies a
+  // non-KilterApiError as permanent, which is correct here: a phase that threw
+  // despite the per-row replay below applyClimbRatings is an unanticipated
+  // shape, not a retryable blip.
+  if (phaseErrors.length > 0) {
+    throw new Error(
+      `kilter user sync failed in ${phaseErrors.length} phase(s): ${phaseErrors.map((failure) => failure.message).join('; ')}`,
+    );
+  }
+
+  return circuitsResult;
 }
 
 function extractLogClimbUuid(op: PowerSyncOp): string | undefined {
@@ -605,8 +659,10 @@ export async function applyLogs(
   // id; our hand-rolled stream (api/powersync-client.ts) forwards every op
   // verbatim, so we dedupe here. Keyed by log_uuid, last-op-wins (later
   // op_id = freshest state, and logs ride a single bucket so buffer order
-  // is op_id order), mirroring the conflict-key dedupe in
-  // applyClimbRatings. Without this, two PUTs for the same log_uuid both
+  // is op_id order). applyClimbRatings now does the same on
+  // climb_rating_uuid — it used to dedupe only the CONFLICT key, which is
+  // exactly how a duplicate kilter_id reached its INSERT and wedged the user
+  // sync. Without this, two PUTs for the same log_uuid both
   // reach the INSERT below carrying the same kilter_id and violate the
   // GLOBAL boardsesh_ticks_kilter_id_unique index, aborting the flush.
   const dedupedPutsByLogUuid = new Map<string, PowerSyncOp>();
@@ -1048,8 +1104,19 @@ export async function applyClimbRatings(
   userId: string,
   ops: PowerSyncOp[],
   aliasCache: Map<string, string>,
+  log: (msg: string) => void,
 ): Promise<void> {
   if (ops.length === 0) return;
+
+  // Serialize concurrent same-user ratings applies. The repoint below reads
+  // who owns each kilter_id and then writes based on that read, so without a
+  // lock a racing writer between the two turns the detach into a no-op and the
+  // upsert back into a duplicate-key abort. Reuses the per-user tick lock key
+  // rather than minting a ratings-specific one: a second key would create a
+  // lock-ordering hazard the day one writer touches both tables. This phase
+  // runs in its own transaction and takes the lock as its first statement, so
+  // it can't invert order against applyLogs.
+  await acquireUserTickMutationLock(tx, userId);
 
   const removeIds: string[] = [];
   const puts: PowerSyncOp[] = [];
@@ -1098,51 +1165,247 @@ export async function applyClimbRatings(
 
   if (puts.length === 0) return;
 
-  // Dedupe by the conflict key (board_type, climb_uuid, angle, user_id)
-  // BEFORE the upsert. Distinct source UUIDs can alias to one canonical
-  // climb_uuid (resolveCanonicalClimbUuid), so two PUTs at the same
-  // angle+user can collapse to the same conflict key. Postgres rejects
-  // an ON CONFLICT DO UPDATE that touches the same target row twice in
-  // one statement ("command cannot affect row a second time"), which
-  // would abort the whole ratings flush. Last write wins — PowerSync
-  // delivers a full snapshot per cycle, so within one batch the final
-  // PUT carries the freshest state.
-  const valuesByConflictKey = new Map<string, typeof boardClimbRatings.$inferInsert>();
+  // (a) Dedupe by climb_rating_uuid — the SURROGATE, not the conflict key.
+  // PowerSync's oplog can carry several ops for one rating inside a single
+  // snapshot, and an upstream angle/climb edit re-delivers the same
+  // climb_rating_uuid under a DIFFERENT natural key. The conflict-key dedupe
+  // in (d) cannot see that: both copies survive it, reach one INSERT carrying
+  // the same kilter_id, and violate the GLOBAL partial-unique index
+  // board_climb_ratings_kilter_id_unique — aborting the whole flush. That is
+  // half of what wedged the kilter user sync for 30+ days. applyLogs has done
+  // this on log_uuid all along; ratings never had it.
+  //
+  // Last-op-wins: a later op_id is the freshest state, and ratings ride a
+  // single bucket so buffer order is op_id order.
+  const dedupedPutsByRatingUuid = new Map<string, PowerSyncOp>();
   for (const op of puts) {
+    dedupedPutsByRatingUuid.set((op.data as RawClimbRating).climb_rating_uuid, op);
+  }
+
+  type NormalisedRating = {
+    kilterId: string;
+    canonical: string;
+    angle: number;
+    values: typeof boardClimbRatings.$inferInsert;
+  };
+
+  const normalised: NormalisedRating[] = [];
+  for (const op of dedupedPutsByRatingUuid.values()) {
     const raw = op.data as RawClimbRating;
     const canonical = await resolveCanonicalClimbUuid(tx, KILTER_BOARD_TYPE, raw.climb_uuid, aliasCache);
-    valuesByConflictKey.set(`${KILTER_BOARD_TYPE}:${canonical}:${raw.angle}:${userId}`, {
-      boardType: KILTER_BOARD_TYPE,
-      climbUuid: canonical,
-      angle: raw.angle,
-      userId,
-      // Kilter sends 0 for "cleared"; the DB CHECK only allows NULL or 1-5, so
-      // a raw 0 would abort the whole batch. sanitizeKilterRating maps it (and
-      // any other out-of-range value) to NULL.
-      rating: sanitizeKilterRating(raw.rating),
-      difficultyGradeId: raw.difficulty_grade_id,
-      comment: raw.comment ?? '',
-      // Kilter's per-rating payload doesn't carry a `weight`; the field
-      // lives on the aggregated /api/logs response, not the rating row
-      // itself. Leave null for kilter-origin rows.
-      weight: null,
+    normalised.push({
       kilterId: raw.climb_rating_uuid,
-      // When the user actually rated the climb upstream. Without this the
-      // insert falls through to the column's defaultNow(), so created_at
-      // recorded when OUR sync first saw the row — every historical rating
-      // collapsed onto the day the Kilter sync started. Kilter sends an ISO
-      // string with an offset; Date.parse normalises it to UTC, matching the
-      // ::timestamptz-on-both-sides treatment applyLogs gives created_at.
-      // Unparseable input falls back to the column default rather than
-      // writing an Invalid Date (which Postgres rejects and which would abort
-      // the whole ratings batch).
-      createdAt: parseKilterTimestamp(raw.created_at),
+      canonical,
+      angle: raw.angle,
+      values: {
+        boardType: KILTER_BOARD_TYPE,
+        climbUuid: canonical,
+        angle: raw.angle,
+        userId,
+        // Kilter sends 0 for "cleared"; the DB CHECK only allows NULL or 1-5, so
+        // a raw 0 would abort the whole batch. sanitizeKilterRating maps it (and
+        // any other out-of-range value) to NULL.
+        rating: sanitizeKilterRating(raw.rating),
+        difficultyGradeId: raw.difficulty_grade_id,
+        comment: raw.comment ?? '',
+        // Kilter's per-rating payload doesn't carry a `weight`; the field
+        // lives on the aggregated /api/logs response, not the rating row
+        // itself. Leave null for kilter-origin rows.
+        weight: null,
+        kilterId: raw.climb_rating_uuid,
+        // When the user actually rated the climb upstream. Without this the
+        // insert falls through to the column's defaultNow(), so created_at
+        // recorded when OUR sync first saw the row — every historical rating
+        // collapsed onto the day the Kilter sync started. Kilter sends an ISO
+        // string with an offset; Date.parse normalises it to UTC, matching the
+        // ::timestamptz-on-both-sides treatment applyLogs gives created_at.
+        // Unparseable input falls back to the column default rather than
+        // writing an Invalid Date (which Postgres rejects and which would abort
+        // the whole ratings batch).
+        createdAt: parseKilterTimestamp(raw.created_at),
+      },
     });
   }
-  const values = Array.from(valuesByConflictKey.values());
 
-  if (values.length === 0) return;
+  const incomingKilterIds = normalised.map((entry) => entry.kilterId);
+  // Explicit empty-guard: drizzle's inArray([]) emits invalid `IN ()` SQL that
+  // throws at the DB. Non-empty here (puts.length === 0 returned above), so
+  // this is belt-and-braces against a future refactor thinning `normalised`.
+  if (incomingKilterIds.length === 0) return;
 
+  // (b) One GLOBAL SELECT, deliberately NOT user-scoped, to find who already
+  // holds each incoming climb_rating_uuid. board_climb_ratings_kilter_id_unique
+  // is global (partial only on NOT NULL), so a given kilter_id lives on at most
+  // one row table-wide and this IN-list probe is index-served. Partition by
+  // owner, exactly as applyLogs partitions ticks:
+  //   - same user  → a candidate for the repoint in (c).
+  //   - other user → foreign. The same Kilter account is linked to two
+  //     Boardsesh accounts. Writing those rows would collide on the global
+  //     index; adopting them would stamp a globally-taken id onto this user.
+  //     Skip-and-log so the situation stays visible instead of crashing.
+  const byKilterIdRows = await tx
+    .select({
+      kilterId: boardClimbRatings.kilterId,
+      ownerUserId: boardClimbRatings.userId,
+      boardType: boardClimbRatings.boardType,
+      climbUuid: boardClimbRatings.climbUuid,
+      angle: boardClimbRatings.angle,
+    })
+    .from(boardClimbRatings)
+    .where(inArray(boardClimbRatings.kilterId, incomingKilterIds));
+
+  const ownRowsByKilterId = new Map<string, (typeof byKilterIdRows)[number]>();
+  const foreignKilterIds = new Set<string>();
+  for (const row of byKilterIdRows) {
+    if (!row.kilterId) continue;
+    if (row.ownerUserId === userId) {
+      ownRowsByKilterId.set(row.kilterId, row);
+    } else {
+      foreignKilterIds.add(row.kilterId);
+    }
+  }
+
+  const writable: NormalisedRating[] = [];
+  for (const entry of normalised) {
+    if (foreignKilterIds.has(entry.kilterId)) {
+      log(
+        `[kilter-sync] climb_rating_uuid ${entry.kilterId} already linked to a different Boardsesh user — skipping for user ${userId} (duplicate Kilter account link)`,
+      );
+      continue;
+    }
+    writable.push(entry);
+  }
+  if (writable.length === 0) return;
+
+  // (c) Dedupe by the conflict key (board_type, climb_uuid, angle, user_id).
+  // Distinct source UUIDs can alias to one canonical climb_uuid
+  // (resolveCanonicalClimbUuid), so two PUTs at the same angle+user can
+  // collapse to the same conflict key. Postgres rejects an ON CONFLICT DO
+  // UPDATE that touches the same target row twice in one statement ("command
+  // cannot affect row a second time"). Last write wins — PowerSync delivers a
+  // full snapshot per cycle, so the final PUT carries the freshest state.
+  //
+  // Ordered BEFORE the repoint below so a row dropped here never triggers a
+  // pointless detach.
+  const writableByConflictKey = new Map<string, NormalisedRating>();
+  for (const entry of writable) {
+    writableByConflictKey.set(`${KILTER_BOARD_TYPE}:${entry.canonical}:${entry.angle}:${userId}`, entry);
+  }
+  const survivors = Array.from(writableByConflictKey.values());
+  if (survivors.length === 0) return;
+
+  // (d) Repoint. The incoming rating carries a kilter_id this user already has
+  // parked on a DIFFERENT natural key — an angle edited upstream, or a
+  // climb_uuid that re-canonicalises through board_climb_aliases. The upsert
+  // below conflict-targets the natural key, so both its INSERT branch and its
+  // DO UPDATE branch (which sets kilter_id through COALESCE) would try to
+  // stamp a globally-taken id onto another row and trip the partial unique.
+  // Postgres allows exactly ONE conflict target per ON CONFLICT, so the second
+  // unique cannot be covered by the statement — it has to be made unreachable
+  // first. Freeing the id in this same transaction leaves no window where it
+  // is unowned.
+  //
+  // kilter_detached_at IS stamped, and that is load-bearing rather than
+  // cosmetic. push-back selects Boardsesh-origin ratings to POST upstream with
+  // `kilter_id IS NULL AND kilter_detached_at IS NULL` (push-back.ts,
+  // pushPendingRatings). Nulling the surrogate without the marker would make
+  // the stale row look never-pushed, and the day the POST is wired push-back
+  // would re-create it upstream as a duplicate rating. The ascents feed reads
+  // the same marker to drop the row from the effectiveQuality fallback, which
+  // is also right: upstream no longer asserts a rating at the old
+  // (climb, angle) and will never PUT there again.
+  //
+  // The marker's contract is "not backed by a live upstream rating", which
+  // covers both an upstream delete and a moved link — the cause differs, the
+  // required behaviour doesn't. The log line below carries the distinction.
+  // It self-heals: if upstream ever rates that key again the DO UPDATE clears
+  // the marker on re-adoption.
+  const staleKilterIds: string[] = [];
+  for (const entry of survivors) {
+    const existing = ownRowsByKilterId.get(entry.kilterId);
+    if (!existing) continue;
+    // The common case — the id is already on the row we're about to write.
+    // Skipping it here is what keeps a steady-state cycle from churning
+    // updated_at on every rating it re-delivers.
+    if (
+      existing.boardType === KILTER_BOARD_TYPE &&
+      existing.climbUuid === entry.canonical &&
+      existing.angle === entry.angle
+    ) {
+      continue;
+    }
+    log(
+      `[kilter-sync] repointing kilter_id ${entry.kilterId} for user ${userId}: ${existing.climbUuid}@${existing.angle} -> ${entry.canonical}@${entry.angle}`,
+    );
+    staleKilterIds.push(entry.kilterId);
+  }
+  if (staleKilterIds.length > 0) {
+    const detachedAt = new Date();
+    // Keyed on (user_id, kilter_id) rather than the row's primary key: the
+    // predicate is self-verifying — it can only null a row that STILL carries
+    // that exact surrogate — and it lands on board_climb_ratings_user_kilter_idx.
+    // The user_id term is redundant (the partition already dropped foreign-owned
+    // ids) but is kept so the never-cross-users invariant is enforced at the
+    // write, not only by the partition above.
+    await tx
+      .update(boardClimbRatings)
+      .set({ kilterId: null, kilterDetachedAt: detachedAt, updatedAt: detachedAt })
+      .where(and(eq(boardClimbRatings.userId, userId), inArray(boardClimbRatings.kilterId, staleKilterIds)));
+  }
+
+  // (e) Upsert, chunked. One refused row costs its chunk, not the buffer.
+  const values = survivors.map((entry) => entry.values);
+  for (let offset = 0; offset < values.length; offset += RATINGS_WRITE_CHUNK_SIZE) {
+    await upsertClimbRatingChunk(tx, values.slice(offset, offset + RATINGS_WRITE_CHUNK_SIZE), userId, log);
+  }
+}
+
+/**
+ * One chunk of the ratings upsert, wrapped in a savepoint with a row-by-row
+ * replay on failure. Ported from aurora-sync's apply-user-logbook: a row
+ * Postgres still refuses — a shape we haven't anticipated — is skipped and
+ * logged instead of aborting the buffer, failing the user, and (because the
+ * throw escapes syncKilterUserData) taking the circuits phase down with it.
+ * PowerSync re-delivers a full snapshot every cycle, so a deterministic bad
+ * row would otherwise fail identically forever.
+ */
+async function upsertClimbRatingChunk(
+  tx: DrizzleDb,
+  chunk: Array<typeof boardClimbRatings.$inferInsert>,
+  userId: string,
+  log: (msg: string) => void,
+): Promise<void> {
+  if (chunk.length === 0) return;
+  try {
+    await tx.transaction(async (savepoint) => {
+      await writeClimbRatings(savepoint as unknown as DrizzleDb, chunk);
+    });
+    return;
+  } catch (batchError) {
+    log(
+      `[kilter-sync] batched climb-rating write failed for user ${userId} (${chunk.length} row(s)) — retrying row by row: ${
+        batchError instanceof Error ? batchError.message : String(batchError)
+      }`,
+    );
+  }
+
+  for (const row of chunk) {
+    try {
+      await tx.transaction(async (savepoint) => {
+        await writeClimbRatings(savepoint as unknown as DrizzleDb, [row]);
+      });
+    } catch (rowError) {
+      log(
+        `[kilter-sync] skipping climb rating ${row.kilterId ?? '(no kilter_id)'} for user ${userId} on ${row.climbUuid}@${row.angle}: ${
+          rowError instanceof Error ? rowError.message : String(rowError)
+        }`,
+      );
+    }
+  }
+}
+
+/** The ratings upsert statement itself. Conflict target is the natural key. */
+async function writeClimbRatings(tx: DrizzleDb, values: Array<typeof boardClimbRatings.$inferInsert>): Promise<void> {
   await tx
     .insert(boardClimbRatings)
     .values(values)

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -1190,7 +1190,9 @@ export async function applyClimbRatings(
   };
 
   const normalised: NormalisedRating[] = [];
-  for (const op of dedupedPutsByRatingUuid.values()) {
+  for (const op of puts) {
+    // SCRATCH: surrogate dedupe bypassed to reproduce violation path (a).
+    void dedupedPutsByRatingUuid;
     const raw = op.data as RawClimbRating;
     const canonical = await resolveCanonicalClimbUuid(tx, KILTER_BOARD_TYPE, raw.climb_uuid, aliasCache);
     normalised.push({
@@ -1337,7 +1339,8 @@ export async function applyClimbRatings(
     log(
       `[kilter-sync] repointing kilter_id ${entry.kilterId} for user ${userId}: ${existing.climbUuid}@${existing.angle} -> ${entry.canonical}@${entry.angle}`,
     );
-    staleKilterIds.push(entry.kilterId);
+    // SCRATCH: repoint bypassed to reproduce violation path (b).
+    void entry;
   }
   if (staleKilterIds.length > 0) {
     const detachedAt = new Date();

--- a/packages/sync-runtime/src/health-summary.ts
+++ b/packages/sync-runtime/src/health-summary.ts
@@ -1,0 +1,54 @@
+/**
+ * Fleet health summary shared by the aurora and kilter sync daemons.
+ *
+ * Pure string formatting, no drizzle — the snapshot itself is produced by
+ * `getCredentialFleetSnapshot` in `@boardsesh/db/queries`. Keeping the format
+ * here means both daemons emit the same line shape, so one log-based alert rule
+ * covers both.
+ */
+
+/** The shape the formatter needs. Mirrors `CredentialFleetSnapshot`. */
+export type SyncHealthSnapshot = {
+  total: number;
+  active: number;
+  pending: number;
+  error: number;
+  expired: number;
+  inBackoff: number;
+  oldestAttemptAt: Date | string | null;
+};
+
+/**
+ * Read a `timestamp` value that may arrive as a Date or as raw Postgres text.
+ *
+ * The bare `new Date(value)` this looks like would be WRONG: a zone-less wall
+ * clock ("2026-05-06 07:08:09.123") is parsed in the host process's timezone, so
+ * the reported instant would shift by the container's UTC offset. The column is
+ * `timestamp without time zone` and this codebase reads those as UTC — which is
+ * what drizzle's own decoder does (it appends "+0000"), so matching it here
+ * keeps the mapped and the defensive path in agreement.
+ */
+function readTimestamp(value: Date | string): Date {
+  if (value instanceof Date) return value;
+  const trimmed = value.trim();
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/.test(trimmed);
+  return new Date(hasZone ? trimmed : `${trimmed.replace(' ', 'T')}Z`);
+}
+
+/**
+ * Format a {@link SyncHealthSnapshot} as a single greppable log line.
+ *
+ * `tag` is the runner prefix (e.g. `[SyncRunner]`) and `label` names the fleet
+ * (e.g. `aurora credentials`). Pure, so it's unit-testable without a database —
+ * which matters: this function is the one that threw
+ * `oldestAttemptAt.toISOString is not a function` on every cycle for a month,
+ * and a health REPORTER that can throw is worse than no reporter at all.
+ */
+export function formatSyncHealthSummary(snapshot: SyncHealthSnapshot, tag: string, label: string): string {
+  const oldest = snapshot.oldestAttemptAt ? readTimestamp(snapshot.oldestAttemptAt).toISOString() : 'never';
+  return (
+    `${tag} Sync health: ${snapshot.total} ${label} — ` +
+    `active=${snapshot.active} pending=${snapshot.pending} error=${snapshot.error} expired=${snapshot.expired}; ` +
+    `inBackoff=${snapshot.inBackoff}; oldestAttempt=${oldest}`
+  );
+}

--- a/packages/sync-runtime/src/index.ts
+++ b/packages/sync-runtime/src/index.ts
@@ -17,3 +17,5 @@ export { DaemonLease, DaemonLeaseLostError } from './lease';
 export type { DaemonLeaseIo, DaemonLeaseRuntime } from './lease';
 export { sanitizeFirstAscent, FIRST_ASCENT_EARLIEST_MS } from './sanitize-first-ascent';
 export type { FirstAscentFields } from './sanitize-first-ascent';
+export { formatSyncHealthSummary } from './health-summary';
+export type { SyncHealthSnapshot } from './health-summary';


### PR DESCRIPTION
Throwaway. Neuters the surrogate dedupe and the repoint in `applyClimbRatings` while keeping the armed test schema and the new tests, to confirm they actually fail without the fix. Closing as soon as `test-backend` reports.

Expected to fail: the two intra-statement / cross-row paths, the DO UPDATE adoption, and the swap.

Related: #4686