### PR TITLE
fix(sync): make the ratings natural-key winner deterministic

### DIFF
--- a/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
+++ b/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
@@ -311,6 +311,50 @@ describe('applyClimbRatings kilter_id reconciliation (real DB)', () => {
     expect(divergence).toContain('incoming=kr-new');
   });
 
+  it('picks the same winner regardless of the order two upstream ratings arrive in', async () => {
+    // Two upstream ratings collapsing onto one natural key is a real upstream
+    // condition, not a corner case: one production account had 254 of them.
+    // PowerSync gives no stable op order between snapshots, so a last-op-wins
+    // dedupe flips the winner every cycle — kilter_id genuinely changes, the
+    // setWhere guard fires, updated_at churns, and the pair ping-pongs forever.
+    // The winner must be a function of the DATA, not of arrival order.
+    await seedUser(USER_ID);
+    const older = putOp({ climbRatingUuid: 'kr-older', angle: 40, opId: '1' });
+    const newer = putOp({ climbRatingUuid: 'kr-newer', angle: 40, opId: '2' });
+    (newer.data as Record<string, unknown>).created_at = '2026-06-01T12:00:00.000Z';
+
+    await applyClimbRatings(applyTx, USER_ID, [older, newer], aliasCacheFor([CLIMB]), () => {});
+    const forward = (await readRatings(USER_ID))[0]?.kilter_id;
+
+    await db.execute(sql`DELETE FROM board_climb_ratings WHERE user_id = ${USER_ID}`);
+
+    // Same batch, reversed. A last-op-wins implementation returns 'kr-older' here.
+    await applyClimbRatings(applyTx, USER_ID, [newer, older], aliasCacheFor([CLIMB]), () => {});
+    const reversed = (await readRatings(USER_ID))[0]?.kilter_id;
+
+    expect(forward).toBe('kr-newer');
+    expect(reversed).toBe('kr-newer');
+  });
+
+  it('does not churn updated_at when a duplicate pair re-arrives in the other order', async () => {
+    await seedUser(USER_ID);
+    const older = putOp({ climbRatingUuid: 'kr-older', angle: 40, opId: '1' });
+    const newer = putOp({ climbRatingUuid: 'kr-newer', angle: 40, opId: '2' });
+    (newer.data as Record<string, unknown>).created_at = '2026-06-01T12:00:00.000Z';
+
+    await applyClimbRatings(applyTx, USER_ID, [older, newer], aliasCacheFor([CLIMB]), () => {});
+    const first = (await readRatings(USER_ID))[0];
+
+    // The next snapshot delivers the same two rows in the opposite order. With
+    // a stable winner nothing changes, so the setWhere guard suppresses the
+    // UPDATE entirely and the row is not re-shipped to offline clients.
+    await applyClimbRatings(applyTx, USER_ID, [newer, older], aliasCacheFor([CLIMB]), () => {});
+    const second = (await readRatings(USER_ID))[0];
+
+    expect(second?.kilter_id).toBe(first?.kilter_id);
+    expect(new Date(second!.updated_at).getTime()).toBe(new Date(first!.updated_at).getTime());
+  });
+
   it('skips a row Postgres refuses instead of losing the whole batch', async () => {
     await seedUser(USER_ID);
 

--- a/packages/kilter-sync/src/sync/user-sync.test.ts
+++ b/packages/kilter-sync/src/sync/user-sync.test.ts
@@ -1337,7 +1337,14 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
     // Without dedup the VALUES list carries two rows with the same conflict
     // key and Postgres aborts the whole flush ("ON CONFLICT DO UPDATE
     // command cannot affect row a second time"). The dedup must hand the
-    // upsert exactly one row, last-write-wins.
+    // upsert exactly one row.
+    //
+    // The winner is the NEWEST upstream rating, not the last op to arrive.
+    // PowerSync gives no stable op order between snapshots, so arrival-order
+    // dedupe flips the winner every cycle and the pair ping-pongs forever
+    // (observed on a production account: 254 keys alternating each pass).
+    // Here both carry the same created_at, so the surrogate breaks the tie
+    // and 'r-a' wins on every run regardless of order.
     const { tx, calls, insertValues } = createRichTx();
     // Both source uuids resolve to the same canonical via the alias cache.
     const aliasCache = new Map<string, string>();
@@ -1351,16 +1358,28 @@ describe('applyClimbRatings — bulk upsert with COALESCE comment', () => {
 
     await applyClimbRatings(tx as unknown as ApplyClimbRatingsTx, 'user-1', ops, aliasCache, () => {});
 
+    // The same batch reversed must produce the same survivor — that is the
+    // whole point, and it is what a last-op-wins implementation fails.
+    const reversed = createRichTx();
+    await applyClimbRatings(
+      reversed.tx as unknown as ApplyClimbRatingsTx,
+      'user-1',
+      [...ops].reverse(),
+      new Map(aliasCache),
+      () => {},
+    );
+    expect(reversed.insertValues[0][0]).toMatchObject({ kilterId: 'r-a', rating: 3 });
+
     // Exactly one bulk insert carrying ONE deduped values row.
     expect(calls.filter((c) => c.kind === 'insert')).toHaveLength(1);
     expect(insertValues[0]).toHaveLength(1);
-    // Last write wins: the second PUT (r-b, rating 5) is the survivor.
+    // Deterministic tie-break on the surrogate: 'r-a' < 'r-b'.
     expect(insertValues[0][0]).toMatchObject({
       climbUuid: 'climb-canonical',
       angle: 40,
       userId: 'user-1',
-      rating: 5,
-      kilterId: 'r-b',
+      rating: 3,
+      kilterId: 'r-a',
     });
   });
 

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -1325,11 +1325,47 @@ export async function applyClimbRatings(
   //
   // Ordered BEFORE the repoint below so a row dropped here never triggers a
   // pointless detach.
-  const writableByConflictKey = new Map<string, NormalisedRating>();
+  //
+  // The winner is chosen DETERMINISTICALLY, not by arrival order. Plain
+  // last-op-wins looks equivalent and is not: PowerSync does not guarantee a
+  // stable op order between snapshots, so when two upstream ratings collapse to
+  // one natural key the winner flips every cycle. Each flip genuinely changes
+  // kilter_id, so the setWhere guard fires, updated_at churns, the row is
+  // re-shipped to offline clients, and the pair ping-pongs forever without ever
+  // converging. Observed in production on one account: 254 natural keys
+  // alternating between the same two rating UUIDs on every pass.
+  //
+  // Newest upstream rating wins, with the surrogate as a stable tie-break so
+  // the outcome is total and identical on every run.
+  const byConflictKey = new Map<string, NormalisedRating[]>();
   for (const entry of writable) {
-    writableByConflictKey.set(`${KILTER_BOARD_TYPE}:${entry.canonical}:${entry.angle}:${userId}`, entry);
+    const key = `${KILTER_BOARD_TYPE}:${entry.canonical}:${entry.angle}:${userId}`;
+    const bucket = byConflictKey.get(key);
+    if (bucket) bucket.push(entry);
+    else byConflictKey.set(key, [entry]);
   }
-  const survivors = Array.from(writableByConflictKey.values());
+  const survivors: NormalisedRating[] = [];
+  let collapsedDuplicates = 0;
+  for (const bucket of byConflictKey.values()) {
+    if (bucket.length > 1) {
+      collapsedDuplicates += bucket.length - 1;
+      bucket.sort((left, right) => {
+        const leftCreated = left.values.createdAt?.getTime() ?? 0;
+        const rightCreated = right.values.createdAt?.getTime() ?? 0;
+        if (leftCreated !== rightCreated) return rightCreated - leftCreated;
+        return left.kilterId < right.kilterId ? -1 : left.kilterId > right.kilterId ? 1 : 0;
+      });
+    }
+    survivors.push(bucket[0]!);
+  }
+  if (collapsedDuplicates > 0) {
+    // Summarised, not per row: this is an upstream data condition that persists
+    // across every sync, so one line per occurrence would mean hundreds of
+    // identical lines every cycle for the affected account.
+    log(
+      `[kilter-sync] ${collapsedDuplicates} upstream rating(s) collapse onto an already-claimed climb/angle for user ${userId} — keeping the newest per climb/angle`,
+    );
+  }
   if (survivors.length === 0) return;
 
   // The upsert's `kilterId: COALESCE(EXCLUDED.kilter_id, …)` overwrites whatever
@@ -1343,12 +1379,21 @@ export async function applyClimbRatings(
   // warning is the only reason this class of identity drift was ever visible;
   // ratings discarding the same information without a word is how the drift
   // stayed invisible here for a month. Report it, then proceed.
+  const divergent: string[] = [];
   for (const entry of survivors) {
     const naturalKeyRow = ownRowsByNaturalKey.get(`${KILTER_BOARD_TYPE}:${entry.canonical}:${entry.angle}:${userId}`);
     if (!naturalKeyRow?.kilterId) continue;
     if (naturalKeyRow.kilterId === entry.kilterId) continue;
+    divergent.push(`${entry.canonical}@${entry.angle} ${naturalKeyRow.kilterId}->${entry.kilterId}`);
+  }
+  if (divergent.length > 0) {
+    // Count plus a bounded sample rather than one line per row. The first
+    // version logged every occurrence and produced ~700 lines per sync for a
+    // single account, which buries the signal it exists to provide.
+    const sample = divergent.slice(0, 5).join(', ');
+    const more = divergent.length > 5 ? ` (+${divergent.length - 5} more)` : '';
     log(
-      `[kilter-sync] divergent kilter_id on rating ${entry.canonical}@${entry.angle} for user ${userId}: existing=${naturalKeyRow.kilterId} incoming=${entry.kilterId} — replacing (natural key is the identity)`,
+      `[kilter-sync] replacing kilter_id on ${divergent.length} rating(s) for user ${userId} — natural key is the identity: ${sample}${more}`,
     );
   }
 


### PR DESCRIPTION
## Summary

Found by watching #4686 actually run in production, not by reading code. It fixes a defect that
predates that PR but was invisible until its logging exposed it.

Two upstream ratings collapsing onto one natural key is not a corner case — one account has **254
of them**, and they were swapping owner on every single pass:

```
existing=ba1124a6…  incoming=5b1cc743…
existing=5b1cc743…  incoming=ba1124a6…   ← next run, reversed
existing=ba1124a6…  incoming=5b1cc743…   ← and back again
```

### Cause

The natural-key dedupe was a plain `Map.set` — last-op-wins. PowerSync gives **no stable op order
between snapshots**, so the winner flipped every cycle. Each flip genuinely changes `kilter_id`, so
the `setWhere` change-guard sees a real difference and fires, `updated_at` is rewritten, and the row
is re-shipped to every offline client. It never converges: roughly 700 log lines and 254 pointless
`UPDATE`s per sync for that one account, indefinitely.

This is why "last write wins" was the wrong contract. It reads as a tie-break but is really a
dependency on arrival order, and arrival order is not stable here.

### Fix

Pick the winner from the **data**, not the arrival order: newest upstream `created_at` wins, with
the surrogate as a stable tie-break so the ordering is total and the outcome identical on every run.

Both log lines added in #4686 are also summarised. The per-row divergence log produced ~700 lines
per sync for that account, which buries the signal it exists to provide — it's now a count plus a
bounded sample.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- `vp run typecheck` clean; `vp check` no new findings (2 pre-existing errors in
  `scripts/expo-web-e2e.ts`, untouched).
- 512 unit tests pass across kilter-sync / aurora-sync / sync-runtime.
- The existing alias-collapse unit test **encoded last-op-wins**, which is precisely the property
  being removed — so it failed, correctly, and is rewritten to assert the batch and its reverse
  produce the same survivor.
- Two new real-DB tests: same batch in both orders yields the same winner, and a duplicate pair
  re-arriving in the opposite order leaves `updated_at` untouched (proving the churn is gone).

## Production context

`#4686` is deployed. One of the two stuck accounts (`0df1d963…`) has gone `error → active` and
synced successfully for the first time ever. The other (`51e2b642…`) no longer hits the duplicate-key
bug — 0 occurrences in 1277 log lines — but now times out on `REQUEST_TIMEOUT_MS` (120s) partway
through a large snapshot. That is a **separate** pre-existing limit that the earlier crash was
masking; it is not addressed here, and is tracked separately. This PR reduces the per-cycle work for
that account, which may or may not be enough on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiTqFRMv7ALs9jEd8cJjrB
