### PR TITLE
fix(sync): carry the ratings tie-break across flush boundaries

### DIFF
--- a/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
+++ b/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
@@ -360,6 +360,50 @@ describe('applyClimbRatings kilter_id reconciliation (real DB)', () => {
     expect(new Date(second!.updated_at).getTime()).toBe(new Date(first!.updated_at).getTime());
   });
 
+  it("does not let a later flush undo an earlier flush's newer pick", async () => {
+    // The bug a single-batch test cannot see. Duplicates for one climb/angle
+    // that land in DIFFERENT flushes were both written, and the later flush
+    // won regardless of which rating was newer — so the choice never
+    // converged and updated_at churned on every sync forever.
+    await seedUser(USER_ID);
+    const newer = putOp({ climbRatingUuid: 'kr-newer', angle: 40 });
+    (newer.data as Record<string, unknown>).created_at = '2026-06-01T12:00:00.000Z';
+    const older = putOp({ climbRatingUuid: 'kr-older', angle: 40 });
+
+    // One shared map = one sync; two calls = two flushes.
+    const claimed = new Map<string, { kilterId: string; createdAtMs: number }>();
+    await applyClimbRatings(applyTx, USER_ID, [newer], aliasCacheFor([CLIMB]), () => {}, claimed);
+    await applyClimbRatings(applyTx, USER_ID, [older], aliasCacheFor([CLIMB]), () => {}, claimed);
+
+    const rows = await readRatings(USER_ID);
+    expect(rows).toHaveLength(1);
+    // The newer rating from flush 1 survives; the older one in flush 2 is
+    // skipped rather than overwriting it.
+    expect(rows[0]?.kilter_id).toBe('kr-newer');
+  });
+
+  it('carries the flush claim across a whole sync without churning updated_at', async () => {
+    await seedUser(USER_ID);
+    const newer = putOp({ climbRatingUuid: 'kr-newer', angle: 40 });
+    (newer.data as Record<string, unknown>).created_at = '2026-06-01T12:00:00.000Z';
+    const older = putOp({ climbRatingUuid: 'kr-older', angle: 40 });
+
+    const syncOne = new Map<string, { kilterId: string; createdAtMs: number }>();
+    await applyClimbRatings(applyTx, USER_ID, [newer], aliasCacheFor([CLIMB]), () => {}, syncOne);
+    await applyClimbRatings(applyTx, USER_ID, [older], aliasCacheFor([CLIMB]), () => {}, syncOne);
+    const first = (await readRatings(USER_ID))[0];
+
+    // A second sync sees the same snapshot again. Nothing should move, which
+    // is what "converged" means: no UPDATE, no re-ship to offline clients.
+    const syncTwo = new Map<string, { kilterId: string; createdAtMs: number }>();
+    await applyClimbRatings(applyTx, USER_ID, [newer], aliasCacheFor([CLIMB]), () => {}, syncTwo);
+    await applyClimbRatings(applyTx, USER_ID, [older], aliasCacheFor([CLIMB]), () => {}, syncTwo);
+    const second = (await readRatings(USER_ID))[0];
+
+    expect(second?.kilter_id).toBe('kr-newer');
+    expect(new Date(second!.updated_at).getTime()).toBe(new Date(first!.updated_at).getTime());
+  });
+
   it('skips a row Postgres refuses instead of losing the whole batch', async () => {
     await seedUser(USER_ID);
 

--- a/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
+++ b/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
@@ -111,6 +111,20 @@ function aliasCacheFor(climbUuids: string[]): Map<string, string> {
 type ApplyTx = Parameters<typeof applyClimbRatings>[0];
 const applyTx = db as unknown as ApplyTx;
 
+type RatingClaims = Map<string, { kilterId: string; createdAtMs: number }>;
+
+/**
+ * One flush, exactly as flushClimbRatings does it: the claims returned by a
+ * call are merged into the shared map only after it resolves. Tests that merge
+ * eagerly (or not at all) would not exercise the cross-flush protection they
+ * are named for.
+ */
+async function applyFlush(batch: PowerSyncOp[], claims: RatingClaims, log: (msg: string) => void = () => {}) {
+  const committed = await applyClimbRatings(applyTx, USER_ID, batch, aliasCacheFor([CLIMB]), log, claims);
+  for (const [key, claim] of committed) claims.set(key, claim);
+  return committed;
+}
+
 describe('applyClimbRatings kilter_id reconciliation (real DB)', () => {
   afterEach(async () => {
     await db.execute(sql`DELETE FROM board_climb_ratings WHERE user_id IN (${USER_ID}, ${OTHER_USER_ID})`);
@@ -371,9 +385,9 @@ describe('applyClimbRatings kilter_id reconciliation (real DB)', () => {
     const older = putOp({ climbRatingUuid: 'kr-older', angle: 40 });
 
     // One shared map = one sync; two calls = two flushes.
-    const claimed = new Map<string, { kilterId: string; createdAtMs: number }>();
-    await applyClimbRatings(applyTx, USER_ID, [newer], aliasCacheFor([CLIMB]), () => {}, claimed);
-    await applyClimbRatings(applyTx, USER_ID, [older], aliasCacheFor([CLIMB]), () => {}, claimed);
+    const claimed: RatingClaims = new Map();
+    await applyFlush([newer], claimed);
+    await applyFlush([older], claimed);
 
     const rows = await readRatings(USER_ID);
     expect(rows).toHaveLength(1);
@@ -388,20 +402,59 @@ describe('applyClimbRatings kilter_id reconciliation (real DB)', () => {
     (newer.data as Record<string, unknown>).created_at = '2026-06-01T12:00:00.000Z';
     const older = putOp({ climbRatingUuid: 'kr-older', angle: 40 });
 
-    const syncOne = new Map<string, { kilterId: string; createdAtMs: number }>();
-    await applyClimbRatings(applyTx, USER_ID, [newer], aliasCacheFor([CLIMB]), () => {}, syncOne);
-    await applyClimbRatings(applyTx, USER_ID, [older], aliasCacheFor([CLIMB]), () => {}, syncOne);
+    const syncOne: RatingClaims = new Map();
+    await applyFlush([newer], syncOne);
+    await applyFlush([older], syncOne);
     const first = (await readRatings(USER_ID))[0];
 
     // A second sync sees the same snapshot again. Nothing should move, which
     // is what "converged" means: no UPDATE, no re-ship to offline clients.
-    const syncTwo = new Map<string, { kilterId: string; createdAtMs: number }>();
-    await applyClimbRatings(applyTx, USER_ID, [newer], aliasCacheFor([CLIMB]), () => {}, syncTwo);
-    await applyClimbRatings(applyTx, USER_ID, [older], aliasCacheFor([CLIMB]), () => {}, syncTwo);
+    const syncTwo: RatingClaims = new Map();
+    await applyFlush([newer], syncTwo);
+    await applyFlush([older], syncTwo);
     const second = (await readRatings(USER_ID))[0];
 
     expect(second?.kilter_id).toBe('kr-newer');
     expect(new Date(second!.updated_at).getTime()).toBe(new Date(first!.updated_at).getTime());
+  });
+
+  it('does not keep a flush claim when the transaction rolls back', async () => {
+    // The claim map is consulted by later flushes in the same sync to avoid
+    // undoing an earlier, newer pick. applyClimbRatings runs INSIDE
+    // db.transaction, so a claim recorded during the call would outlive a
+    // rollback that discarded the write it describes — and the next flush would
+    // then skip that climb/angle as "already claimed", leaving no row at all.
+    //
+    // This is reachable, not theoretical: a failing flush is caught by runPhase
+    // and the sync continues to the next one.
+    await seedUser(USER_ID);
+    const claimed: RatingClaims = new Map();
+
+    const newer = putOp({ climbRatingUuid: 'kr-rolledback', angle: 40 });
+    (newer.data as Record<string, unknown>).created_at = '2026-06-01T12:00:00.000Z';
+
+    // Flush 1 applies cleanly and is then rolled back by an unrelated failure.
+    await expect(
+      db.transaction(async (tx) => {
+        await applyClimbRatings(tx as unknown as ApplyTx, USER_ID, [newer], aliasCacheFor([CLIMB]), () => {}, claimed);
+        throw new Error('simulated failure after the write');
+      }),
+    ).rejects.toThrow('simulated failure');
+
+    // Nothing was written, so nothing may be claimed.
+    expect(await readRatings(USER_ID)).toHaveLength(0);
+    expect(claimed.size).toBe(0);
+
+    // Flush 2 carries an OLDER rating for the same climb/angle. If the rolled
+    // back claim had survived, this would be skipped as already-claimed and the
+    // user would end up with no rating for this climb at all.
+    const older = putOp({ climbRatingUuid: 'kr-after-rollback', angle: 40 });
+    await applyFlush([older], claimed);
+
+    const rows = await readRatings(USER_ID);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.kilter_id).toBe('kr-after-rollback');
+    expect(claimed.size).toBe(1);
   });
 
   it('skips a row Postgres refuses instead of losing the whole batch', async () => {

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -241,6 +241,11 @@ export async function syncKilterUserData({
   // UUID once per sync. Pre-primed below before each phase runs.
   const aliasCache = new Map<string, string>();
 
+  // Shared across every ratings flush in this sync so the newest-wins
+  // tie-break spans flush boundaries — see the claimedNaturalKeys parameter on
+  // applyClimbRatings for why per-flush alone does not converge.
+  const claimedRatingKeys = new Map<string, { kilterId: string; createdAtMs: number }>();
+
   // Defensive scoping: the `circuit_buckets` stream is parameterised on
   // the Kilter server by circuit_uuid. Subscribing with empty
   // `parameters: {}` works against the production sync rules today (the
@@ -267,7 +272,7 @@ export async function syncKilterUserData({
   async function flushClimbRatings(): Promise<void> {
     if (buffer.climb_ratings.length === 0) return;
     const batch = buffer.climb_ratings.splice(0, buffer.climb_ratings.length);
-    await db.transaction((tx) => applyClimbRatings(tx, userId, batch, aliasCache, log));
+    await db.transaction((tx) => applyClimbRatings(tx, userId, batch, aliasCache, log, claimedRatingKeys));
   }
 
   // Phase isolation. A throw from one phase must not cancel the others. Before
@@ -1115,6 +1120,23 @@ export async function applyClimbRatings(
   ops: PowerSyncOp[],
   aliasCache: Map<string, string>,
   log: (msg: string) => void,
+  /**
+   * Natural key -> the rating already claimed for it EARLIER IN THIS SYNC.
+   *
+   * The dedupe below is per flush, and a flush is only STREAM_FLUSH_THRESHOLD
+   * ops wide. Two upstream ratings for one climb/angle landing in different
+   * flushes therefore both got written, and the later flush won — overriding
+   * the newest-wins tie-break and undoing the earlier write. The result is
+   * stable but never converges: every later sync re-writes the same rows in
+   * the same direction, churning updated_at and re-shipping them to offline
+   * clients. Observed on a production account as 714 pointless UPDATEs on
+   * every single run, indefinitely.
+   *
+   * One map for the whole sync makes the tie-break global rather than per
+   * flush. Omit it (tests, one-shot CLI calls) and a single call keeps exactly
+   * its old single-flush semantics.
+   */
+  claimedNaturalKeys: Map<string, { kilterId: string; createdAtMs: number }> = new Map(),
 ): Promise<void> {
   if (ops.length === 0) return;
 
@@ -1346,6 +1368,7 @@ export async function applyClimbRatings(
   }
   const survivors: NormalisedRating[] = [];
   let collapsedDuplicates = 0;
+  let crossFlushSkips = 0;
   for (const bucket of byConflictKey.values()) {
     if (bucket.length > 1) {
       collapsedDuplicates += bucket.length - 1;
@@ -1356,7 +1379,30 @@ export async function applyClimbRatings(
         return left.kilterId < right.kilterId ? -1 : left.kilterId > right.kilterId ? 1 : 0;
       });
     }
-    survivors.push(bucket[0]!);
+    const winner = bucket[0]!;
+    const key = `${KILTER_BOARD_TYPE}:${winner.canonical}:${winner.angle}:${userId}`;
+    const claimed = claimedNaturalKeys.get(key);
+    const winnerCreatedMs = winner.values.createdAt?.getTime() ?? 0;
+    if (claimed) {
+      // An earlier flush already wrote this climb/angle. Only displace it if
+      // this candidate really is newer (the same total order used within a
+      // bucket); otherwise skip, because writing it would undo the better
+      // choice and restart the churn.
+      const isNewer =
+        winnerCreatedMs > claimed.createdAtMs ||
+        (winnerCreatedMs === claimed.createdAtMs && winner.kilterId < claimed.kilterId);
+      if (!isNewer) {
+        crossFlushSkips += 1;
+        continue;
+      }
+    }
+    claimedNaturalKeys.set(key, { kilterId: winner.kilterId, createdAtMs: winnerCreatedMs });
+    survivors.push(winner);
+  }
+  if (crossFlushSkips > 0) {
+    log(
+      `[kilter-sync] ${crossFlushSkips} rating(s) already claimed by an earlier flush this sync for user ${userId} — keeping the earlier, newer pick`,
+    );
   }
   if (collapsedDuplicates > 0) {
     // Summarised, not per row: this is an upstream data condition that persists

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -40,6 +40,12 @@ import { streamKilterPowerSync, type PowerSyncOp } from '../api/powersync-client
 type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
 
 /**
+ * Natural key -> the rating chosen for it, used to keep the newest-wins
+ * tie-break consistent across the flushes of one sync.
+ */
+type RatingClaims = Map<string, { kilterId: string; createdAtMs: number }>;
+
+/**
  * Per-user pull (design Flow B): drain Kilter's PowerSync stream for this
  * user's buckets and translate ops into boardsesh rows.
  *
@@ -244,7 +250,7 @@ export async function syncKilterUserData({
   // Shared across every ratings flush in this sync so the newest-wins
   // tie-break spans flush boundaries — see the claimedNaturalKeys parameter on
   // applyClimbRatings for why per-flush alone does not converge.
-  const claimedRatingKeys = new Map<string, { kilterId: string; createdAtMs: number }>();
+  const claimedRatingKeys: RatingClaims = new Map();
 
   // Defensive scoping: the `circuit_buckets` stream is parameterised on
   // the Kilter server by circuit_uuid. Subscribing with empty
@@ -272,7 +278,18 @@ export async function syncKilterUserData({
   async function flushClimbRatings(): Promise<void> {
     if (buffer.climb_ratings.length === 0) return;
     const batch = buffer.climb_ratings.splice(0, buffer.climb_ratings.length);
-    await db.transaction((tx) => applyClimbRatings(tx, userId, batch, aliasCache, log, claimedRatingKeys));
+    // Merge the claims only AFTER the transaction commits. applyClimbRatings
+    // stages them rather than mutating the shared map, because a rollback would
+    // otherwise leave claims describing writes that never happened — and the
+    // next flush would skip those climb/angle keys as already claimed, silently
+    // leaving no rating at all. That is reachable today: a failing flush is
+    // caught by runPhase and the sync continues to the next one.
+    const committedClaims = await db.transaction((tx) =>
+      applyClimbRatings(tx, userId, batch, aliasCache, log, claimedRatingKeys),
+    );
+    for (const [naturalKey, claim] of committedClaims) {
+      claimedRatingKeys.set(naturalKey, claim);
+    }
   }
 
   // Phase isolation. A throw from one phase must not cancel the others. Before
@@ -1136,9 +1153,9 @@ export async function applyClimbRatings(
    * flush. Omit it (tests, one-shot CLI calls) and a single call keeps exactly
    * its old single-flush semantics.
    */
-  claimedNaturalKeys: Map<string, { kilterId: string; createdAtMs: number }> = new Map(),
-): Promise<void> {
-  if (ops.length === 0) return;
+  claimedNaturalKeys: RatingClaims = new Map(),
+): Promise<RatingClaims> {
+  if (ops.length === 0) return new Map();
 
   // Serialize concurrent same-user ratings applies. The repoint below reads
   // who owns each kilter_id and then writes based on that read, so without a
@@ -1195,7 +1212,7 @@ export async function applyClimbRatings(
       .where(and(eq(boardClimbRatings.userId, userId), inArray(boardClimbRatings.kilterId, removeIds)));
   }
 
-  if (puts.length === 0) return;
+  if (puts.length === 0) return new Map();
 
   // (a) Dedupe by climb_rating_uuid — the SURROGATE, not the conflict key.
   // PowerSync's oplog can carry several ops for one rating inside a single
@@ -1263,7 +1280,7 @@ export async function applyClimbRatings(
   // Explicit empty-guard: drizzle's inArray([]) emits invalid `IN ()` SQL that
   // throws at the DB. Non-empty here (puts.length === 0 returned above), so
   // this is belt-and-braces against a future refactor thinning `normalised`.
-  if (incomingKilterIds.length === 0) return;
+  if (incomingKilterIds.length === 0) return new Map();
 
   // (b) One GLOBAL SELECT, deliberately NOT user-scoped, to find who already
   // holds each incoming climb_rating_uuid. board_climb_ratings_kilter_id_unique
@@ -1335,7 +1352,7 @@ export async function applyClimbRatings(
     }
     writable.push(entry);
   }
-  if (writable.length === 0) return;
+  if (writable.length === 0) return new Map();
 
   // (c) Dedupe by the conflict key (board_type, climb_uuid, angle, user_id).
   // Distinct source UUIDs can alias to one canonical climb_uuid
@@ -1369,6 +1386,7 @@ export async function applyClimbRatings(
   const survivors: NormalisedRating[] = [];
   let collapsedDuplicates = 0;
   let crossFlushSkips = 0;
+  const stagedClaims = new Map<string, { kilterId: string; createdAtMs: number }>();
   for (const bucket of byConflictKey.values()) {
     if (bucket.length > 1) {
       collapsedDuplicates += bucket.length - 1;
@@ -1396,7 +1414,12 @@ export async function applyClimbRatings(
         continue;
       }
     }
-    claimedNaturalKeys.set(key, { kilterId: winner.kilterId, createdAtMs: winnerCreatedMs });
+    // Staged, NOT written into the shared map yet. applyClimbRatings runs
+    // INSIDE db.transaction, so a claim recorded here would survive a rollback
+    // that discarded the write it describes — and the next flush in the same
+    // sync would then skip that climb/angle as "already claimed", leaving no
+    // row at all. The caller merges these only after the transaction commits.
+    stagedClaims.set(key, { kilterId: winner.kilterId, createdAtMs: winnerCreatedMs });
     survivors.push(winner);
   }
   if (crossFlushSkips > 0) {
@@ -1412,7 +1435,7 @@ export async function applyClimbRatings(
       `[kilter-sync] ${collapsedDuplicates} upstream rating(s) collapse onto an already-claimed climb/angle for user ${userId} — keeping the newest per climb/angle`,
     );
   }
-  if (survivors.length === 0) return;
+  if (survivors.length === 0) return new Map();
 
   // The upsert's `kilterId: COALESCE(EXCLUDED.kilter_id, …)` overwrites whatever
   // surrogate the natural-key row already carries, orphaning the old one. That
@@ -1504,9 +1527,28 @@ export async function applyClimbRatings(
 
   // (e) Upsert, chunked. One refused row costs its chunk, not the buffer.
   const values = survivors.map((entry) => entry.values);
+  const skippedKilterIds = new Set<string>();
   for (let offset = 0; offset < values.length; offset += RATINGS_WRITE_CHUNK_SIZE) {
-    await upsertClimbRatingChunk(tx, values.slice(offset, offset + RATINGS_WRITE_CHUNK_SIZE), userId, log);
+    await upsertClimbRatingChunk(
+      tx,
+      values.slice(offset, offset + RATINGS_WRITE_CHUNK_SIZE),
+      userId,
+      log,
+      skippedKilterIds,
+    );
   }
+
+  // A row Postgres refused was never written, so it must not hold a claim —
+  // otherwise a later flush with a different candidate for the same climb/angle
+  // would defer to a write that does not exist.
+  if (skippedKilterIds.size > 0) {
+    for (const entry of survivors) {
+      if (!skippedKilterIds.has(entry.kilterId)) continue;
+      stagedClaims.delete(`${KILTER_BOARD_TYPE}:${entry.canonical}:${entry.angle}:${userId}`);
+    }
+  }
+
+  return stagedClaims;
 }
 
 /**
@@ -1523,6 +1565,7 @@ async function upsertClimbRatingChunk(
   chunk: Array<typeof boardClimbRatings.$inferInsert>,
   userId: string,
   log: (msg: string) => void,
+  skippedKilterIds: Set<string>,
 ): Promise<void> {
   if (chunk.length === 0) return;
   try {
@@ -1544,6 +1587,7 @@ async function upsertClimbRatingChunk(
         await writeClimbRatings(savepoint as unknown as DrizzleDb, [row]);
       });
     } catch (rowError) {
+      if (row.kilterId) skippedKilterIds.add(row.kilterId);
       log(
         `[kilter-sync] skipping climb rating ${row.kilterId ?? '(no kilter_id)'} for user ${userId} on ${row.climbUuid}@${row.angle}: ${
           rowError instanceof Error ? rowError.message : String(rowError)


### PR DESCRIPTION
## Summary

Follow-up to #4688, found by running that fix against the production account it was meant to help.
The tie-break worked — and the account still didn't converge: **714 identical replacements on every
run**, same rows, same direction each time.

Same direction rather than alternating is the tell. #4688 assumed a ping-pong *between* runs. It's
actually a ping-pong *within* a run:

```
run 3:  B044DFB7…@50  6aeb9e71… -> 000e6e3e…
run 4:  B044DFB7…@50  6aeb9e71… -> 000e6e3e…   ← identical, not reversed
```

If the write had stuck, run 4 would see `000e6e3e` and report nothing.

### Cause

The dedupe is **per flush**, and a flush is only `STREAM_FLUSH_THRESHOLD` (500) ops wide. Two
upstream ratings for one climb/angle landing in *different* flushes both get written, and the later
flush wins — regardless of which rating is actually newer. So flush 1 writes the correct winner,
flush 4 overwrites it with the loser, the run ends in a stable-but-wrong state, and the next sync
re-applies the same correction. Forever.

This is exactly the hazard aurora-sync's `dedupeByAuroraId` comment already documents:

> Deduping at PAYLOAD level rather than per chunk matters: a chunk boundary between the two copies
> would hide the collision from a per-chunk guard and let it reach the index.

That warning was about the unique index; the same boundary also defeats a per-chunk *tie-break*.

### Fix

Thread one claim map through the whole sync so the newest-wins order is global rather than per
flush. A later flush skips a candidate an earlier flush already claimed unless it's genuinely newer
under the same total order. The parameter defaults to an empty map, so a one-shot call keeps its old
single-flush semantics.

Cost: one `Map` entry per distinct climb/angle for the duration of a sync.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Direct `tsc` clean on both changed packages; 512 unit tests pass; `vp check` no new findings.
- Two new real-DB tests that a single-batch test **cannot** express, since the bug only exists
  across flush boundaries: a later flush must not undo an earlier flush's newer pick, and a second
  sync over the same snapshot must leave `updated_at` untouched.

⚠️ Note on tooling: `vp run typecheck` returned a false clean here from a cached result while the
file genuinely had two `TS2304` errors. Direct `tsc -p` caught it. Worth knowing when a change
touches a package the cache thinks is unchanged.

## Production context

- `0df1d963…` — fully converged on #4688: run 1 did a one-time reconciliation (45 replacements,
  1 repoint), run 2 was **0 and 0**. Steady state is now 3 log lines per sync, down from ~700.
  That account's ratings fit in a single flush, which is why it converged and this one didn't.
- `51e2b642…` — no duplicate-key errors, but still fails on the 120s `REQUEST_TIMEOUT_MS` partway
  through a large snapshot. **Separate pre-existing issue, not addressed here.** This PR removes its
  714 redundant UPDATEs per run, which reduces the work but is unlikely to close a ~7s gap on its
  own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiTqFRMv7ALs9jEd8cJjrB
