### PR TITLE
fix(sync): detect a stalled PowerSync stream instead of capping its duration

### DIFF
--- a/packages/kilter-sync/src/api/powersync-client.test.ts
+++ b/packages/kilter-sync/src/api/powersync-client.test.ts
@@ -28,6 +28,41 @@ function mockFetch(response: Response): void {
   );
 }
 
+/**
+ * A fetch mock that wires `init.signal` through to the body, the way real
+ * fetch does. Without this an abort is invisible to the reader: the loop just
+ * drains the already-buffered chunks and finishes, so a timeout test passes
+ * whether or not the timeout works. Lines are left un-closed because the reader
+ * returns on checkpoint_complete.
+ */
+function mockFetchHonouringSignal(lines: string[]): void {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: unknown, init?: RequestInit) => {
+      const encoder = new TextEncoder();
+      let controller!: ReadableStreamDefaultController<Uint8Array>;
+      const stream = new ReadableStream<Uint8Array>({
+        start(streamController) {
+          controller = streamController;
+          for (const line of lines) streamController.enqueue(encoder.encode(line));
+        },
+      });
+      init?.signal?.addEventListener('abort', () => {
+        const abortError = new Error('aborted');
+        abortError.name = 'AbortError';
+        // error() drops anything still queued, so an abort genuinely
+        // interrupts the read rather than being swallowed.
+        try {
+          controller.error(abortError);
+        } catch {
+          // already closed
+        }
+      });
+      return new Response(stream, { status: 200, headers: { 'Content-Type': 'application/x-ndjson' } });
+    }),
+  );
+}
+
 describe('streamKilterPowerSync', () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
@@ -163,6 +198,75 @@ describe('streamKilterPowerSync', () => {
       code: 'powersync',
       httpStatus: 503,
     });
+  });
+
+  // ---------------------------------------------------------------------
+  // Stall detection. This replaced a flat 120s cap on the whole request,
+  // which permanently blocked one production account whose snapshot simply
+  // took longer than that to apply — a size problem reported as a timeout.
+  // ---------------------------------------------------------------------
+
+  it('does not abort a slow stream that keeps making progress', async () => {
+    vi.useFakeTimers();
+    try {
+      // Each op takes longer than the idle window on its own. Under the old
+      // fixed cap the whole run was doomed; under stall detection, applying an
+      // op is progress, so this must complete.
+      const lines = Array.from(
+        { length: 4 },
+        (_, index) =>
+          `${JSON.stringify({ data: { data: [{ op_id: String(index), op: 'PUT', object_type: 'logs', object_id: `l-${index}`, data: {} }] } })}\n`,
+      );
+      lines.push(`${JSON.stringify({ checkpoint_complete: {} })}\n`);
+      mockFetchHonouringSignal(lines);
+
+      const seen: PowerSyncOp[] = [];
+      const pending = streamKilterPowerSync({
+        accessToken: 'token',
+        streams: ['user_buckets'],
+        onOp: async (op) => {
+          seen.push(op);
+          // 90s per op — well past the 60s idle window, and 4 of them is past
+          // the old 120s total cap.
+          await vi.advanceTimersByTimeAsync(90_000);
+        },
+      });
+
+      await expect(pending).resolves.toBeUndefined();
+      expect(seen).toHaveLength(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('aborts with a named reason when the stream goes idle', async () => {
+    vi.useFakeTimers();
+    try {
+      // A body that opens and then never delivers anything: the shape of a
+      // genuinely hung upstream, which is what a timeout SHOULD catch.
+      //
+      // The mock has to honour init.signal the way real fetch does — wiring the
+      // abort through to the body — or the reader never rejects and the test
+      // hangs instead of asserting.
+      mockFetchHonouringSignal([]);
+
+      const pending = streamKilterPowerSync({
+        accessToken: 'token',
+        streams: ['user_buckets'],
+        onOp: () => {},
+      });
+      const assertion = expect(pending).rejects.toMatchObject({
+        name: 'KilterApiError',
+        code: 'timeout',
+        // The message must say WHY — "stalled" and "too big" call for
+        // different responses, and the old single message conflated them.
+        message: expect.stringContaining('no progress for'),
+      });
+      await vi.advanceTimersByTimeAsync(70_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('throws KilterApiError("powersync", "cancelled by caller") when called with a pre-aborted signal', async () => {

--- a/packages/kilter-sync/src/api/powersync-client.ts
+++ b/packages/kilter-sync/src/api/powersync-client.ts
@@ -36,7 +36,36 @@ export type PowerSyncOp = {
   data?: Record<string, unknown>;
 };
 
-const REQUEST_TIMEOUT_MS = 120_000;
+/**
+ * Abort only when the stream STOPS MAKING PROGRESS, not after a fixed wall
+ * clock. This used to be a flat 120s cap on the whole request, which is the
+ * wrong shape twice over:
+ *
+ *   - The duration of a snapshot scales with the size of the account. A cap
+ *     that a small account never reaches is one a large account can never
+ *     satisfy, so it reads as "upstream is broken" when the real meaning is
+ *     "this climber has a lot of ticks". One production account sat permanently
+ *     at ~127s against the 120s cap and could never complete a sync.
+ *   - `onOp` is awaited inline in the read loop, so time spent writing to
+ *     Postgres counted against what is nominally a network timeout. A slow
+ *     database made the upstream look unresponsive.
+ *
+ * Progress means a line arrived OR an op finished applying, so a long flush is
+ * not mistaken for a stall. A genuinely hung upstream still trips this in one
+ * idle window.
+ */
+const STREAM_IDLE_TIMEOUT_MS = 60_000;
+
+/**
+ * Absolute backstop so a pathological stream cannot occupy the daemon forever
+ * — it syncs one user per cycle, so an unbounded read would starve everyone
+ * else. Deliberately far above any healthy snapshot: this is a runaway guard,
+ * not a latency budget.
+ */
+const STREAM_MAX_DURATION_MS = 10 * 60_000;
+
+/** How often the stall detector checks. Cheap; granularity is not critical. */
+const STALL_CHECK_INTERVAL_MS = 5_000;
 
 function buildRequestBody(streams: KilterStream[]): string {
   return JSON.stringify({
@@ -165,9 +194,42 @@ export async function streamKilterPowerSync(args: {
   // separately so the catch block below can distinguish caller-shutdown
   // (intentional) from timeout (transient) from snapshot-complete (success).
   const completionController = new AbortController();
-  const timeoutSignal: AbortSignal | null = signal ? null : AbortSignal.timeout(REQUEST_TIMEOUT_MS);
-  const upstreamSignal = signal ?? timeoutSignal!;
-  upstreamSignal.addEventListener('abort', () => completionController.abort(upstreamSignal.reason), { once: true });
+
+  // The stall detector runs even when the caller supplies a signal. Previously
+  // a caller signal REPLACED the timeout, so anyone passing a shutdown signal
+  // silently gave up every timeout protection — a latent footgun that happened
+  // not to bite only because the one caller that passes a signal is short-lived.
+  const stallController = new AbortController();
+  let timeoutReason: 'idle' | 'max-duration' | null = null;
+  const startedAt = Date.now();
+  let lastProgressAt = startedAt;
+  // True while an op is being applied. The idle check is suspended for that
+  // window: this timeout exists to detect an UNRESPONSIVE UPSTREAM, and a slow
+  // local write is not that. Counting write time as idleness is the same
+  // category error the old fixed cap made, just at a smaller scale — a big
+  // flush against a busy database would abort a perfectly healthy stream.
+  let applying = false;
+  const markProgress = () => {
+    lastProgressAt = Date.now();
+  };
+  const stallTimer = setInterval(() => {
+    const now = Date.now();
+    // The absolute ceiling still applies while applying: it is a runaway guard,
+    // so it deliberately covers local work too.
+    if (now - startedAt > STREAM_MAX_DURATION_MS) {
+      timeoutReason = 'max-duration';
+      stallController.abort();
+      return;
+    }
+    if (!applying && now - lastProgressAt > STREAM_IDLE_TIMEOUT_MS) {
+      timeoutReason = 'idle';
+      stallController.abort();
+    }
+  }, STALL_CHECK_INTERVAL_MS);
+
+  for (const upstream of [signal, stallController.signal]) {
+    upstream?.addEventListener('abort', () => completionController.abort(upstream.reason), { once: true });
+  }
 
   let response: Response;
   try {
@@ -208,6 +270,7 @@ export async function streamKilterPowerSync(args: {
     // HTTP stream on every other exit. The catch block below still owns
     // error classification; the `finally` only frees the socket.
     for await (const line of readNdjsonLines(response)) {
+      markProgress();
       let parsed: StreamLine;
       try {
         parsed = JSON.parse(line) as StreamLine;
@@ -248,7 +311,14 @@ export async function streamKilterPowerSync(args: {
           // the cycle next tick, so a transient writer failure
           // self-heals. A persistent one becomes a Sentry-visible
           // failure for the user, which is what we want.
-          await onOp(op);
+          applying = true;
+          try {
+            await onOp(op);
+          } finally {
+            applying = false;
+            // Restart the idle window from the end of the write, not its start.
+            markProgress();
+          }
         }
       }
     }
@@ -272,7 +342,7 @@ export async function streamKilterPowerSync(args: {
     // cast keeps the runtime check honest without weakening the type at
     // the top.
     const callerAborted = (signal as AbortSignal | undefined)?.aborted === true;
-    const timedOut = timeoutSignal?.aborted === true;
+    const timedOut = timeoutReason !== null;
     if (completionController.signal.aborted && !callerAborted && !timedOut) {
       return;
     }
@@ -280,10 +350,21 @@ export async function streamKilterPowerSync(args: {
       throw new KilterApiError('powersync', 'PowerSync stream cancelled by caller');
     }
     if (timedOut || (err instanceof Error && err.name === 'AbortError')) {
-      throw new KilterApiError('timeout', 'PowerSync stream aborted');
+      const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
+      // Name the reason: "stalled" and "ran too long" call for different
+      // responses, and the old single message made a size problem look like an
+      // upstream outage.
+      const detail =
+        timeoutReason === 'max-duration'
+          ? `exceeded the ${Math.round(STREAM_MAX_DURATION_MS / 1000)}s ceiling`
+          : timeoutReason === 'idle'
+            ? `no progress for ${Math.round(STREAM_IDLE_TIMEOUT_MS / 1000)}s`
+            : 'aborted';
+      throw new KilterApiError('timeout', `PowerSync stream ${detail} after ${elapsedSeconds}s`);
     }
     throw err;
   } finally {
+    clearInterval(stallTimer);
     // Release the underlying fetch/HTTP stream on every exit path. The
     // catch above runs first (JS evaluates catch before finally), so its
     // error classification still observes the pre-abort


### PR DESCRIPTION
## Summary

The last thing keeping account `51e2b642…` from ever syncing. It is not a tuning problem — the
timeout is the wrong *shape*.

`REQUEST_TIMEOUT_MS` was a flat **120s cap on the entire request**, and that is wrong twice over:

1. **A snapshot's duration scales with the size of the account.** A cap a small account never
   reaches is one a large account can never satisfy. It reports "upstream is broken" when the truth
   is "this climber has a lot of ticks". That account sat permanently at ~127s against the 120s cap
   and could not complete a single sync, on any attempt, ever.
2. **`onOp` is awaited inline in the read loop**, so time spent writing to Postgres counted against
   what is nominally a *network* timeout. A slow database made the upstream look unresponsive.

Simply raising the number would have papered over both: the next large account hits it again, and
genuine hangs take proportionally longer to notice.

### Fix

Abort when the stream stops **making progress**, not after a fixed wall clock. Progress = a line
arrived, or an op finished applying.

- **Idle window** — catches a genuinely hung upstream in one window.
- **Suspended while applying an op.** This timeout exists to detect an unresponsive upstream; a slow
  local write is not that. Counting write time as idleness is the same category error as the old
  cap, just smaller. *A test caught this — my first version aborted a healthy stream whose flush
  outlived the idle window.*
- **Absolute ceiling** as a runaway guard, since the daemon syncs one user per cycle and an
  unbounded read would starve everyone else. That one deliberately covers local work too.

Also fixes a latent footgun: the timeout was `signal ? null : AbortSignal.timeout(…)`, so **any
caller passing a shutdown signal silently gave up all timeout protection**. Stall detection now runs
regardless. It happens not to bite today only because the one caller that passes a signal is
short-lived.

Errors now name the reason and elapsed time — "stalled" and "ran too long" call for different
responses, and the old single message conflated them.

## Release Notes

- Climbers with very large Kilter histories now sync completely instead of giving up partway.

## Test plan

- Direct `tsc -p` clean; 514 unit tests pass; `vp check` no new findings (2 pre-existing errors in
  `scripts/expo-web-e2e.ts`, untouched).
- Two new tests, **both checked to fail without the fix**: under a simulated 120s total cap the
  slow-but-progressing case aborts, and the idle case asserts on the named reason.
- Getting there required making the fetch mock honour `init.signal` the way real fetch does. Without
  it an abort is invisible to the reader, the loop just drains the buffered body, and the test passes
  whether or not the timeout works — which is exactly how my first version of it silently proved
  nothing. Worth knowing for anyone writing timeout tests against this client.

## Not verified

The affected account needs an end-to-end run after deploy to confirm it now completes. I can't
predict how long its snapshot actually takes — only that it was being cut off at 120s while still
making progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiTqFRMv7ALs9jEd8cJjrB
