### PR TITLE
fix(sync): assert the summarised ratings divergence log, not the old per-row one

### DIFF
--- a/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
+++ b/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
@@ -305,10 +305,15 @@ describe('applyClimbRatings kilter_id reconciliation (real DB)', () => {
     const rows = await readRatings(USER_ID);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.kilter_id).toBe('kr-new');
-    const divergence = logged.find((line) => line.includes('divergent kilter_id on rating'));
+    // The log is summarised (a count plus a bounded sample) rather than one
+    // line per row: the per-row form produced ~700 lines per sync for a single
+    // production account, which buries the signal it exists to provide.
+    const divergence = logged.find((line) => line.includes('replacing kilter_id on'));
     expect(divergence).toBeDefined();
-    expect(divergence).toContain('existing=kr-old');
-    expect(divergence).toContain('incoming=kr-new');
+    expect(divergence).toContain('1 rating(s)');
+    // The sample must still name both surrogates, or the line reports that
+    // drift happened without saying what changed.
+    expect(divergence).toContain('kr-old->kr-new');
   });
 
   it('picks the same winner regardless of the order two upstream ratings arrive in', async () => {


### PR DESCRIPTION
**main is red** — this fixes it.

#4688 changed the ratings divergence log from one line per row to a summarised count-plus-sample, and left the assertion from #4686 matching the old string. CI caught it on #4688; I did not check the result before it was merged. That's on me — I opened it as a draft and went straight to production verification instead of watching the run.

The assertion now matches the current format and still pins the part that matters: the line must name **both** surrogates, or it reports that drift happened without saying what changed.

The two remaining `divergent kilter_id` assertions in `user-sync.test.ts` are the **tick** path, whose log line is unchanged — checked, not assumed.

Not a draft, since main is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiTqFRMv7ALs9jEd8cJjrB