### PR TITLE
fix(sync): do not write a rating older than the one already stored

### DIFF
--- a/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
+++ b/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
@@ -457,6 +457,50 @@ describe('applyClimbRatings kilter_id reconciliation (real DB)', () => {
     expect(claimed.size).toBe(1);
   });
 
+  it('leaves a stored newer rating alone when an older one arrives', async () => {
+    // The residual churn after the cross-flush fix. A duplicate pair split
+    // across flushes leaves the EARLIER flush holding only the older candidate.
+    // Without comparing against what is stored it writes anyway, and the later
+    // flush corrects it — one wasted UPDATE and one updated_at bump per key per
+    // sync, forever. Measured at 369 per run on a production account.
+    await seedUser(USER_ID);
+
+    // Establish the newer rating as the stored one.
+    const newer = putOp({ climbRatingUuid: 'kr-newer', angle: 40 });
+    (newer.data as Record<string, unknown>).created_at = '2026-06-01T12:00:00.000Z';
+    await applyFlush([newer], new Map());
+    const before = (await readRatings(USER_ID))[0];
+    expect(before?.kilter_id).toBe('kr-newer');
+
+    // A later sync whose first flush carries only the older duplicate.
+    const older = putOp({ climbRatingUuid: 'kr-older', angle: 40 });
+    const logged: string[] = [];
+    await applyFlush([older], new Map(), (msg) => logged.push(msg));
+
+    const after = (await readRatings(USER_ID))[0];
+    expect(after?.kilter_id).toBe('kr-newer');
+    // No write at all, so no updated_at bump and nothing re-shipped to clients.
+    expect(new Date(after!.updated_at).getTime()).toBe(new Date(before!.updated_at).getTime());
+    expect(logged.join('\n')).toContain('older than the stored rating');
+  });
+
+  it('still replaces the stored rating when the incoming one is genuinely newer', async () => {
+    // The guard must not become "never update". An upstream rating that really
+    // is newer has to win, or a re-rated climb would freeze at its first value.
+    await seedUser(USER_ID);
+    const older = putOp({ climbRatingUuid: 'kr-older', angle: 40 });
+    await applyFlush([older], new Map());
+
+    const newer = putOp({ climbRatingUuid: 'kr-newer', angle: 40, rating: 2 });
+    (newer.data as Record<string, unknown>).created_at = '2026-06-01T12:00:00.000Z';
+    await applyFlush([newer], new Map());
+
+    const rows = await readRatings(USER_ID);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.kilter_id).toBe('kr-newer');
+    expect(rows[0]?.rating).toBe(2);
+  });
+
   it('skips a row Postgres refuses instead of losing the whole batch', async () => {
     await seedUser(USER_ID);
 

--- a/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
+++ b/packages/backend/src/__tests__/climb-ratings-kilter-id-repoint.test.ts
@@ -59,10 +59,19 @@ async function seedLocalRating(userId: string, climbUuid: string, angle: number)
   `);
 }
 
-async function seedKilterRating(userId: string, climbUuid: string, angle: number, kilterId: string): Promise<void> {
+async function seedKilterRating(
+  userId: string,
+  climbUuid: string,
+  angle: number,
+  kilterId: string,
+  // A kilter-origin row carries the UPSTREAM rating date, not the insert time.
+  // Defaulting this to now() made every fixture look newer than any realistic
+  // incoming rating, which is not a shape production ever produces.
+  createdAt = '2020-01-01T00:00:00.000Z',
+): Promise<void> {
   await db.execute(sql`
-    INSERT INTO board_climb_ratings (board_type, climb_uuid, angle, user_id, rating, kilter_id)
-    VALUES ('kilter', ${climbUuid}, ${angle}, ${userId}, 3, ${kilterId})
+    INSERT INTO board_climb_ratings (board_type, climb_uuid, angle, user_id, rating, kilter_id, created_at)
+    VALUES ('kilter', ${climbUuid}, ${angle}, ${userId}, 3, ${kilterId}, ${createdAt})
   `);
 }
 
@@ -499,6 +508,28 @@ describe('applyClimbRatings kilter_id reconciliation (real DB)', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]?.kilter_id).toBe('kr-newer');
     expect(rows[0]?.rating).toBe(2);
+  });
+
+  it('still swaps when the incumbent rating is itself being relocated', async () => {
+    // The stale-candidate guard must not block an upstream swap. Both ratings
+    // trade climb/angle in one batch, so each incumbent is vacating its key —
+    // deferring to it would apply half the swap and wedge the pair. An earlier
+    // version of the guard did exactly that, and only the real-DB swap test
+    // caught it.
+    await seedUser(USER_ID);
+    await seedKilterRating(USER_ID, CLIMB, 40, 'kr-a', '2021-01-01T00:00:00.000Z');
+    // Deliberately NEWER than the incoming ops, so the guard would skip it if it
+    // did not notice kr-b is moving too.
+    await seedKilterRating(USER_ID, CLIMB, 25, 'kr-b', '2030-01-01T00:00:00.000Z');
+
+    await applyFlush(
+      [putOp({ climbRatingUuid: 'kr-a', angle: 25 }), putOp({ climbRatingUuid: 'kr-b', angle: 40 })],
+      new Map(),
+    );
+
+    const rows = await readRatings(USER_ID);
+    expect(rows.find((row) => row.angle === 25)?.kilter_id).toBe('kr-a');
+    expect(rows.find((row) => row.angle === 40)?.kilter_id).toBe('kr-b');
   });
 
   it('skips a row Postgres refuses instead of losing the whole batch', async () => {

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -1295,6 +1295,7 @@ export async function applyClimbRatings(
   }
 
   const incomingKilterIds = normalised.map((entry) => entry.kilterId);
+  const incomingKilterIdSet = new Set(incomingKilterIds);
   // Explicit empty-guard: drizzle's inArray([]) emits invalid `IN ()` SQL that
   // throws at the DB. Non-empty here (puts.length === 0 returned above), so
   // this is belt-and-braces against a future refactor thinning `normalised`.
@@ -1445,7 +1446,14 @@ export async function applyClimbRatings(
       // production account after the cross-flush claim fix.
       const stored = ownRowsByNaturalKey.get(key);
       const storedCreatedAt = stored?.createdAt ? new Date(stored.createdAt).getTime() : null;
-      if (stored?.kilterId && stored.kilterId !== winner.kilterId && storedCreatedAt !== null) {
+      // Only when the incumbent is STAYING PUT. If its surrogate is also in this
+      // batch it is being relocated — an upstream swap, where two ratings trade
+      // climb/angle — and deferring to it would block half the swap and leave
+      // the pair permanently half-applied. The earlier-flush case this guard
+      // exists for is precisely the opposite: the incumbent's surrogate arrives
+      // in a LATER flush, so it is absent here.
+      const incumbentIsMoving = stored?.kilterId ? incomingKilterIdSet.has(stored.kilterId) : false;
+      if (stored?.kilterId && stored.kilterId !== winner.kilterId && storedCreatedAt !== null && !incumbentIsMoving) {
         if (!ratingBeats(winnerKey, { createdAtMs: storedCreatedAt, kilterId: stored.kilterId })) {
           staleSkips += 1;
           continue;

--- a/packages/kilter-sync/src/sync/user-sync.ts
+++ b/packages/kilter-sync/src/sync/user-sync.ts
@@ -46,6 +46,24 @@ type DrizzleDb = PgDatabase<PgQueryResultHKT, Record<string, unknown>>;
 type RatingClaims = Map<string, { kilterId: string; createdAtMs: number }>;
 
 /**
+ * Total order over rating candidates for one climb/angle: the newest upstream
+ * rating wins, with the surrogate breaking ties so the result is stable across
+ * runs regardless of the order PowerSync delivers ops in.
+ *
+ * Deliberately one function rather than three inline copies — the bucket sort,
+ * the cross-flush claim check and the stored-row check must agree exactly, and
+ * an order that disagrees with itself reintroduces the ping-pong it exists to
+ * prevent.
+ */
+function ratingBeats(
+  candidate: { createdAtMs: number; kilterId: string },
+  incumbent: { createdAtMs: number; kilterId: string },
+): boolean {
+  if (candidate.createdAtMs !== incumbent.createdAtMs) return candidate.createdAtMs > incumbent.createdAtMs;
+  return candidate.kilterId < incumbent.kilterId;
+}
+
+/**
  * Per-user pull (design Flow B): drain Kilter's PowerSync stream for this
  * user's buckets and translate ops into boardsesh rows.
  *
@@ -1304,6 +1322,12 @@ export async function applyClimbRatings(
       boardType: boardClimbRatings.boardType,
       climbUuid: boardClimbRatings.climbUuid,
       angle: boardClimbRatings.angle,
+      // Needed to tell whether an incoming candidate is actually NEWER than what
+      // is already stored. Without it an earlier flush cannot distinguish "this
+      // key is unwritten" from "this key already holds a newer rating", so it
+      // writes regardless and a later flush has to correct it — a wasted UPDATE
+      // on every sync, forever.
+      createdAt: boardClimbRatings.createdAt,
     })
     .from(boardClimbRatings)
     .where(
@@ -1386,32 +1410,46 @@ export async function applyClimbRatings(
   const survivors: NormalisedRating[] = [];
   let collapsedDuplicates = 0;
   let crossFlushSkips = 0;
+  let staleSkips = 0;
   const stagedClaims = new Map<string, { kilterId: string; createdAtMs: number }>();
   for (const bucket of byConflictKey.values()) {
     if (bucket.length > 1) {
       collapsedDuplicates += bucket.length - 1;
       bucket.sort((left, right) => {
-        const leftCreated = left.values.createdAt?.getTime() ?? 0;
-        const rightCreated = right.values.createdAt?.getTime() ?? 0;
-        if (leftCreated !== rightCreated) return rightCreated - leftCreated;
-        return left.kilterId < right.kilterId ? -1 : left.kilterId > right.kilterId ? 1 : 0;
+        const leftKey = { createdAtMs: left.values.createdAt?.getTime() ?? 0, kilterId: left.kilterId };
+        const rightKey = { createdAtMs: right.values.createdAt?.getTime() ?? 0, kilterId: right.kilterId };
+        if (ratingBeats(leftKey, rightKey)) return -1;
+        if (ratingBeats(rightKey, leftKey)) return 1;
+        return 0;
       });
     }
     const winner = bucket[0]!;
     const key = `${KILTER_BOARD_TYPE}:${winner.canonical}:${winner.angle}:${userId}`;
     const claimed = claimedNaturalKeys.get(key);
     const winnerCreatedMs = winner.values.createdAt?.getTime() ?? 0;
+    const winnerKey = { createdAtMs: winnerCreatedMs, kilterId: winner.kilterId };
     if (claimed) {
       // An earlier flush already wrote this climb/angle. Only displace it if
-      // this candidate really is newer (the same total order used within a
-      // bucket); otherwise skip, because writing it would undo the better
-      // choice and restart the churn.
-      const isNewer =
-        winnerCreatedMs > claimed.createdAtMs ||
-        (winnerCreatedMs === claimed.createdAtMs && winner.kilterId < claimed.kilterId);
-      if (!isNewer) {
+      // this candidate really is newer; otherwise skip, because writing it
+      // would undo the better choice and restart the churn.
+      if (!ratingBeats(winnerKey, claimed)) {
         crossFlushSkips += 1;
         continue;
+      }
+    } else {
+      // Nothing claimed this key yet in this sync, so compare against what is
+      // already STORED. A duplicate pair split across flushes leaves the earlier
+      // flush holding only the older candidate; without this it writes anyway
+      // and the later flush corrects it, costing a redundant UPDATE and an
+      // updated_at bump on every single sync. Measured at 369 per run on one
+      // production account after the cross-flush claim fix.
+      const stored = ownRowsByNaturalKey.get(key);
+      const storedCreatedAt = stored?.createdAt ? new Date(stored.createdAt).getTime() : null;
+      if (stored?.kilterId && stored.kilterId !== winner.kilterId && storedCreatedAt !== null) {
+        if (!ratingBeats(winnerKey, { createdAtMs: storedCreatedAt, kilterId: stored.kilterId })) {
+          staleSkips += 1;
+          continue;
+        }
       }
     }
     // Staged, NOT written into the shared map yet. applyClimbRatings runs
@@ -1421,6 +1459,11 @@ export async function applyClimbRatings(
     // row at all. The caller merges these only after the transaction commits.
     stagedClaims.set(key, { kilterId: winner.kilterId, createdAtMs: winnerCreatedMs });
     survivors.push(winner);
+  }
+  if (staleSkips > 0) {
+    log(
+      `[kilter-sync] ${staleSkips} rating(s) older than the stored rating for their climb/angle for user ${userId} — leaving the newer one in place`,
+    );
   }
   if (crossFlushSkips > 0) {
     log(


### PR DESCRIPTION
## Summary

The residual churn after #4689. That change took one production account from **745** redundant
`UPDATE`s per sync to **369**, where it plateaued across four consecutive runs — same keys, same
direction every time:

```
210384F2…@30   5f1a887c… -> fd7458b3…     (identical on runs 1, 2, 3 and 4)
```

A *stable* direction rules out a ping-pong, so this is a third distinct cause rather than the one
#4689 fixed.

### Cause

When a duplicate pair is split across flushes, the **earlier** flush holds only the older
candidate. The pre-SELECT fetched `kilter_id` but **not** `created_at`, so that flush could not
distinguish "this key is unwritten" from "this key already holds a newer rating". It wrote
regardless, and the later flush then corrected it.

The final state was always right — the newest rating wins — but every sync paid one wasted `UPDATE`
and one `updated_at` bump per affected key, re-shipping those rows to every offline client, forever.

### Fix

Select `created_at` too, and skip a candidate the stored rating already beats.

The three places that need this order — the bucket sort, the cross-flush claim check, and the new
stored-row check — now share **one comparator** instead of inlining it three times. An order that
disagrees with itself would reintroduce exactly the ping-pong these fixes exist to prevent, and
three inline copies is how that happens.

## Release Notes

- [x] No release note needed (internal / technical change)

## Test plan

- Direct `tsc` clean on both packages; 514 unit tests pass; `vp check` no new findings (2
  pre-existing errors in `scripts/expo-web-e2e.ts`, untouched).
- Two real-DB tests: an older arrival leaves the stored row untouched **with `updated_at`
  unchanged**, and a genuinely newer one still wins.
- The second test is the important one. The obvious failure mode of a guard like this is quietly
  becoming "never update", which would freeze a re-rated climb at its first value — a worse bug than
  the churn it replaces.

## Measured, not assumed

Every number here comes from running the real account against production after each deploy:

| | replacements / sync |
|---|---|
| before #4688 | 745 → 753 (alternating, never converging) |
| after #4689 | 463 → 369 → 369 → 369 (plateau) |
| target | 0 |

I'll confirm the 0 after this deploys rather than claiming it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiTqFRMv7ALs9jEd8cJjrB
