### PR TITLE
ci(db): pin every consumer to the attested PG18 image digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,7 +695,7 @@ jobs:
         include: ${{ fromJSON(github.event_name != 'pull_request' && '[{"shard":1,"total":2},{"shard":2,"total":2}]' || '[{"shard":1,"total":1}]') }}
     services:
       postgres:
-        image: ghcr.io/boardsesh/boardsesh-postgres-postgis:latest
+        image: ghcr.io/boardsesh/boardsesh-postgres-postgis@sha256:01c2671dbccd2104ec15534de1552d1e092301a5a77cad010795318d47f76796
         credentials:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -845,7 +845,7 @@ jobs:
     timeout-minutes: 20
     services:
       postgres:
-        image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:ce32f2a70405112178f3b8b3e4b373175878539d8532f46dd313e04bbcb14cb4
+        image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5
         credentials:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/db-migration-renumber.yml
+++ b/.github/workflows/db-migration-renumber.yml
@@ -126,7 +126,7 @@ jobs:
       # dev-db already has main's migrations applied, so this exercises exactly the
       # real case — apply the pending set on top of main. Same recipe as e2e-tests.yml.
       postgres:
-        image: ghcr.io/boardsesh/boardsesh-dev-db:latest
+        image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -219,7 +219,7 @@ jobs:
 
     services:
       postgres:
-        image: ghcr.io/boardsesh/boardsesh-dev-db:latest
+        image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password
@@ -474,7 +474,7 @@ jobs:
 
     services:
       postgres:
-        image: ghcr.io/boardsesh/boardsesh-dev-db:latest
+        image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: ghcr.io/boardsesh/boardsesh-dev-db:latest
+    image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5
     shm_size: '256mb'
     command: postgres -c listen_addresses='*' -c max_connections=300 -c log_min_messages=warning
     volumes:

--- a/scripts/__tests__/ci-location-sync-workflow.test.ts
+++ b/scripts/__tests__/ci-location-sync-workflow.test.ts
@@ -73,7 +73,7 @@ describe('location-sync CI integration contract', () => {
 
   it('runs the full project against the pinned migrated dev database', () => {
     expect(integrationJob).toContain(
-      'image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:ce32f2a70405112178f3b8b3e4b373175878539d8532f46dd313e04bbcb14cb4',
+      'image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5',
     );
     expect(integrationJob).toContain("VERIFY_MIGRATION_JOURNAL: '1'");
     expect(integrationJob).toContain('run: bun run --filter=@boardsesh/db db:migrate');


### PR DESCRIPTION
## Summary

Consumer B of the PG18 rollout. The trusted publisher ([run 32616607289](https://github.com/boardsesh/boardsesh/actions/runs/32616607289)) published both images from `main` at `ca308bd225519bd1062dfdbab288e7b063e253c9` with verified provenance. This points every consumer at those exact digests.

| Image | Digest | Platforms | Attestation |
|---|---|---|---|
| `boardsesh-postgres-postgis` (portable) | `sha256:01c2671dbccd2104ec15534de1552d1e092301a5a77cad010795318d47f76796` | amd64 + arm64 | [42389745](https://github.com/boardsesh/boardsesh/attestations/42389745) ✅ |
| `boardsesh-dev-db` (seeded) | `sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5` | amd64 | [42389746](https://github.com/boardsesh/boardsesh/attestations/42389746) ✅ |

## What changed

| File | Was | Now |
|---|---|---|
| `.github/workflows/ci.yml:698` | `postgres-postgis:latest` | portable digest |
| `.github/workflows/ci.yml:848` | `dev-db@sha256:ce32f2a7…` (pre-PG18) | seeded digest |
| `.github/workflows/e2e-tests.yml:222,477` | `dev-db:latest` | seeded digest |
| `.github/workflows/db-migration-renumber.yml:129` | `dev-db:latest` | seeded digest |
| `docker-compose.yml:3` | `dev-db:latest` | seeded digest |
| `scripts/__tests__/ci-location-sync-workflow.test.ts:76` | asserts the old digest | asserts the new one |

## Why

`ci.yml:698` is the reference that keeps the location-sync integration job on PostgreSQL 17, which is why #4475's `test-location-sync-integration` currently fails — migration `0201` refuses to run on pre-PG18 by design. This unblocks it.

The publisher's handoff artifact records `deployment_identity: "digest-only"` and `tags_are_mutable: true`, so a `sha-<commit>` tag is a lookup aid and never a deployment pin.

## Validation

- `vp test run --project scripts ci-location-sync-workflow` — 4/4 pass
- All four changed workflow/compose files parse as YAML
- Zero remaining mutable-tag references to either image; zero remaining references to the stale `ce32f2a7` digest
- `bun install --frozen-lockfile` left `bun.lock` unchanged

CI is the real gate here: these jobs actually pull the pinned digests, so a wrong digest fails loudly.

## Follow-ups, not in this PR

- #4694 — split the seeded dev image into its own workflow so a production publish never waits ~17 min on a developer artifact
- #4508 — seed the dev image from offline snapshots instead of scraping six APKs from a third-party mirror
- The three compose files still run three different Postgres majors (`postgres:15`, `postgres:16-alpine`, `postgres:17`), and `CLAUDE.md` / `AGENTS.md` still cite `docker run postgres:17` as the portability target. Left alone here to keep this PR purely mechanical.

## Release Notes

none