### PR TITLE
docs(db): hand over the PostgreSQL 18 rollout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,13 @@ jobs:
       # Defaults false off PRs (the OTA bot legitimately rewrites it on push).
       changelogData: ${{ github.event_name == 'pull_request' && steps.filter.outputs.changelogData || 'false' }}
       dbMigrations: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.dbMigrations }}
+      # docs/postgres-image-digests.json and docs/*.patch are checked-in PG18
+      # rollout artifacts that nothing reads at run time, so nothing notices
+      # when the tree drifts under them. Their guard reads every input with
+      # readFileSync/readdirSync, which `--changed` can never relate to a diff
+      # of a workflow pin or of a file the patch's context depends on. No other
+      # filter matches docs/** at all. Gates the `pg18-artifacts` job below.
+      pg18Artifacts: ${{ github.event_name != 'pull_request' && 'true' || steps.filter.outputs.pg18Artifacts }}
       # True if any downstream job's gate would fire. This used to gate the
       # `setup` job (bun install + build:db + a `built-packages` artifact every
       # heavy job downloaded); that job was deleted because @boardsesh/db and
@@ -76,10 +83,10 @@ jobs:
       # ci-location-sync-workflow.test.ts asserts on its terms; keep it in sync
       # with the job `if:`s below so a future job can gate on it again.
       runAny: ${{ github.event_name != 'pull_request' || steps.filter.outputs.anyJs == 'true' || steps.filter.outputs.web == 'true' || steps.filter.outputs.i18nCatalogs == 'true' || steps.filter.outputs.sharedSchema == 'true' || steps.filter.outputs.sharedDeps == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.mobile == 'true' || steps.filter.outputs.ocr == 'true' || steps.filter.outputs.locationSync == 'true' || steps.filter.outputs.rootCi == 'true' }}
-      # NOTE: deployConfig, storeMetadata, mobileLocales, and restSurface are
-      # deliberately NOT part of runAny — the deploy-config, listing-guards and
-      # rest-surface jobs below gate on their own filters, so a PR touching only
-      # their files runs nothing else.
+      # NOTE: deployConfig, storeMetadata, mobileLocales, restSurface and
+      # pg18Artifacts are deliberately NOT part of runAny — the deploy-config,
+      # listing-guards, rest-surface and pg18-artifacts jobs below gate on their
+      # own filters, so a PR touching only their files runs nothing else.
     steps:
       # No actions/checkout here on purpose: on `pull_request` dorny/paths-filter
       # reads the changed-file list from the REST API (no working tree needed),
@@ -204,6 +211,27 @@ jobs:
             changelogData:
               - 'packages/mobile/src/data/changelog.generated.json'
               - 'CHANGELOG.md'
+            # Two PG18 rollout artifacts are checked into the repo and read by
+            # nothing at run time, so they drift silently: the handoff copy of
+            # the publisher digest manifest, and a prepared rename deferred
+            # until after the cutover. The guard reads all of these from disk,
+            # so this filter has to name every input it reads -- the manifest,
+            # the patch, every file the patch touches, and every consumer that
+            # pins a published digest.
+            pg18Artifacts:
+              - 'docs/postgres-image-digests.json'
+              - 'docs/*.patch'
+              - 'docs/neon-migration.md'
+              - 'docs/postgres-18-migration.md'
+              - 'scripts/neon-to-railway-replication.sh'
+              - 'scripts/neon-to-railway-replication.test.sh'
+              - 'scripts/postgres18-image-smoke.sh'
+              - 'docker-compose.yml'
+              - '.github/workflows/dev-db-docker.yml'
+              - '.github/workflows/e2e-tests.yml'
+              - '.github/workflows/db-migration-renumber.yml'
+              - 'scripts/__tests__/ci-location-sync-workflow.test.ts'
+              - 'scripts/__tests__/pg18-artifact-drift.test.ts'
             dbMigrations:
               - 'packages/db/drizzle/**'
               - 'packages/db/src/schema/**'
@@ -557,6 +585,30 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Validate store listing copy and mobile locale parity
         run: vp test run --project scripts scripts/store-metadata-limits.test.ts scripts/mobile-locales-parity.test.ts
+
+  pg18-artifacts:
+    needs: [changes]
+    # Deliberately not `--changed`-filtered, same rationale as deploy-config and
+    # listing-guards: the spec reads docs/postgres-image-digests.json, every
+    # docs/*.patch, and each pinned consumer with readFileSync/readdirSync at run
+    # time, so Vitest's module-graph analysis never relates it to a diff that only
+    # edits a workflow pin or a file the patch's context depends on. That is
+    # exactly the diff it guards. Note `.github/workflows/ci.yml` reaches it via
+    # rootCi rather than the pg18Artifacts list.
+    if: needs.changes.outputs.pg18Artifacts == 'true' || needs.changes.outputs.rootCi == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version: 'lts'
+          cache: true
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Validate published image digest pins and committed patches
+        run: vp test run --project scripts scripts/__tests__/pg18-artifact-drift.test.ts
 
   rest-surface:
     needs: [changes]
@@ -1145,6 +1197,7 @@ jobs:
       - deploy-config
       - listing-guards
       - rest-surface
+      - pg18-artifacts
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/docs/pg18-replication-rename.patch
+++ b/docs/pg18-replication-rename.patch
@@ -1,0 +1,311 @@
+diff --git c/.github/workflows/dev-db-docker.yml w/.github/workflows/dev-db-docker.yml
+index 1ed8daa3f..b07d3e6d9 100644
+--- c/.github/workflows/dev-db-docker.yml
++++ w/.github/workflows/dev-db-docker.yml
+@@ -16,8 +16,8 @@ on:
+       - 'scripts/dev-db-image-smoke.sh'
+       - 'scripts/dev-db-up.sh'
+       - 'scripts/lib/postgres-credentials.sh'
+-      - 'scripts/neon-to-railway-replication.sh'
+-      - 'scripts/neon-to-railway-replication.test.sh'
++      - 'scripts/postgres-logical-replication.sh'
++      - 'scripts/postgres-logical-replication.test.sh'
+       - 'scripts/postgres-credentials.test.sh'
+       - 'scripts/postgres18-architecture-smoke.sh'
+       - 'scripts/postgres16-role-transition-smoke.sh'
+diff --git c/docs/neon-migration.md w/docs/neon-migration.md
+index 807c975b7..904ba21d6 100644
+--- c/docs/neon-migration.md
++++ w/docs/neon-migration.md
+@@ -163,8 +163,8 @@ export SUBSCRIPTION_NAME='boardsesh_pg18_sub'
+ export SLOT_NAME='boardsesh_pg18_migration'
+ export INCLUDE_SCHEMAS='public drizzle'
+ 
+-scripts/neon-to-railway-replication.sh setup
+-scripts/neon-to-railway-replication.sh status
++scripts/postgres-logical-replication.sh setup
++scripts/postgres-logical-replication.sh status
+ ```
+ 
+ The `setup` command verifies `wal_level = logical`, creates the required Railway
+@@ -233,12 +233,12 @@ has reached a source flush LSN:
+ ```bash
+ WRITES_FENCED=true \
+ FENCED_WRITER_ROLES='boardsesh_runtime boardsesh_sync boardsesh_migrator' \
+-  scripts/neon-to-railway-replication.sh sync-sequences
++  scripts/postgres-logical-replication.sh sync-sequences
+ ```
+ 
+ ## 5. Cutover Steps
+ 
+-1. Run `scripts/neon-to-railway-replication.sh status` and confirm:
++1. Run `scripts/postgres-logical-replication.sh status` and confirm:
+    - `Railway table sync states` shows `srsubstate = 'r'` (ready) for **all** rows. Anything else (`i` initialize, `d` data copy, `s` synchronizing) means initial sync is still running — do not proceed.
+    - `replication_lag` on Railway is well under 1 second.
+    - `Row count comparison` shows matching counts on the listed `CHECK_TABLES` (`boardsesh_ticks`, `board_user_syncs`, `comments`, `votes`, `feed_items`, `users`).
+@@ -276,7 +276,7 @@ FENCED_WRITER_ROLES='boardsesh_runtime boardsesh_sync boardsesh_migrator' \
+    PUBLICATION_NAME=boardsesh_pg18_migration \
+    SUBSCRIPTION_NAME=boardsesh_pg18_sub \
+    SLOT_NAME=boardsesh_pg18_migration \
+-     scripts/neon-to-railway-replication.sh teardown
++     scripts/postgres-logical-replication.sh teardown
+    ```
+ 
+    The two role names are repeated here because the normal path still has a live
+@@ -330,7 +330,7 @@ TEARDOWN_CONFIRMED=true \
+ PUBLICATION_NAME=boardsesh_pg18_migration \
+ SUBSCRIPTION_NAME=boardsesh_pg18_sub \
+ SLOT_NAME=boardsesh_pg18_migration \
+-  scripts/neon-to-railway-replication.sh teardown
++  scripts/postgres-logical-replication.sh teardown
+ ```
+ 
+ **If the subscription was already gone**, that command drops the WAL retention.
+@@ -373,7 +373,7 @@ TARGET_SUBSCRIBER_ROLE=boardsesh_pg18_subscriber \
+ PUBLICATION_NAME=boardsesh_pg18_migration \
+ SUBSCRIPTION_NAME=boardsesh_pg18_sub \
+ SLOT_NAME=boardsesh_pg18_migration \
+-  scripts/neon-to-railway-replication.sh teardown
++  scripts/postgres-logical-replication.sh teardown
+ ```
+ 
+ If the names went with the shell that ran `setup`, Railway still holds both. The
+diff --git c/docs/postgres-18-migration.md w/docs/postgres-18-migration.md
+index 287a27989..907845d8b 100644
+--- c/docs/postgres-18-migration.md
++++ w/docs/postgres-18-migration.md
+@@ -541,7 +541,7 @@ instead of silently copying a filtered subset.
+      --dbname "$TARGET_PASSWORD_FREE_URI" "$SCHEMA_DUMP"
+    ```
+ 
+-   `scripts/neon-to-railway-replication.sh setup` implements this filtering and
++   `scripts/postgres-logical-replication.sh setup` implements this filtering and
+    ownership sequence. A restore that reports ignored errors is a failed gate;
+    do not record or continue past partially restored DDL.
+ 
+@@ -608,7 +608,7 @@ SUBSCRIPTION_NAME=boardsesh_pg18_sub \
+ SLOT_NAME=boardsesh_pg18_migration \
+ INCLUDE_SCHEMAS='public drizzle' \
+ EXCLUDE_SCHEMAS='neon_auth neon_control_plane' \
+-  scripts/neon-to-railway-replication.sh setup
++  scripts/postgres-logical-replication.sh setup
+ ```
+ 
+ The subscription must be owned by `boardsesh_pg18_subscriber` and use
+@@ -707,7 +707,7 @@ SUBSCRIPTION_NAME=boardsesh_pg18_sub \
+ SLOT_NAME=boardsesh_pg18_migration \
+ INCLUDE_SCHEMAS='public drizzle' \
+ EXCLUDE_SCHEMAS='neon_auth neon_control_plane' \
+-  scripts/neon-to-railway-replication.sh sync-sequences
++  scripts/postgres-logical-replication.sh sync-sequences
+ ```
+ 
+ With the fence still held, compare every covered table's exact row count and
+@@ -773,7 +773,7 @@ SUBSCRIPTION_NAME=boardsesh_pg18_sub \
+ SLOT_NAME=boardsesh_pg18_migration \
+ INCLUDE_SCHEMAS='public drizzle' \
+ EXCLUDE_SCHEMAS='neon_auth neon_control_plane' \
+-  scripts/neon-to-railway-replication.sh teardown
++  scripts/postgres-logical-replication.sh teardown
+ ```
+ 
+ ## Availability follow-ups after PG18 is stable
+diff --git c/scripts/neon-to-railway-replication.sh w/scripts/postgres-logical-replication.sh
+similarity index 99%
+rename from scripts/neon-to-railway-replication.sh
+rename to scripts/postgres-logical-replication.sh
+index 74521f76f..969f362b5 100755
+--- c/scripts/neon-to-railway-replication.sh
++++ w/scripts/postgres-logical-replication.sh
+@@ -42,10 +42,10 @@ trap cleanup EXIT
+ usage() {
+   cat <<'USAGE'
+ Usage:
+-  scripts/neon-to-railway-replication.sh setup
+-  scripts/neon-to-railway-replication.sh status
+-  scripts/neon-to-railway-replication.sh sync-sequences
+-  scripts/neon-to-railway-replication.sh teardown
++  scripts/postgres-logical-replication.sh setup
++  scripts/postgres-logical-replication.sh status
++  scripts/postgres-logical-replication.sh sync-sequences
++  scripts/postgres-logical-replication.sh teardown
+ 
+ Environment:
+   NEON_DATABASE_URL                 Neon admin/source connection string.
+diff --git c/scripts/neon-to-railway-replication.test.sh w/scripts/postgres-logical-replication.test.sh
+similarity index 96%
+rename from scripts/neon-to-railway-replication.test.sh
+rename to scripts/postgres-logical-replication.test.sh
+index 45e7c2911..e99eea8e1 100755
+--- c/scripts/neon-to-railway-replication.test.sh
++++ w/scripts/postgres-logical-replication.test.sh
+@@ -271,7 +271,7 @@ TARGET_RUNTIME_SCHEMAS=public \
+ SOURCE_DATABASE_NAME=main \
+ TARGET_DATABASE_NAME=main \
+ CHECK_TABLES=example \
+-  bash -x "$PWD/scripts/neon-to-railway-replication.sh" setup >/dev/null 2>"$TRACE_LOG"
++  bash -x "$PWD/scripts/postgres-logical-replication.sh" setup >/dev/null 2>"$TRACE_LOG"
+ 
+ [[ -f "$SUBSCRIPTION_FILE_CHECK" ]]
+ [[ ! -e "$HYPOPG_CREATE_MARKER" ]]
+@@ -304,7 +304,7 @@ TARGET_RUNTIME_SCHEMAS=public \
+ SOURCE_DATABASE_NAME=main \
+ TARGET_DATABASE_NAME=main \
+ LOAD_SCHEMA=false \
+-  bash "$PWD/scripts/neon-to-railway-replication.sh" setup >/dev/null 2>"$ERROR_LOG"
++  bash "$PWD/scripts/postgres-logical-replication.sh" setup >/dev/null 2>"$ERROR_LOG"
+ [[ -f "$HYPOPG_CREATE_MARKER" ]]
+ 
+ : >"$ARGUMENT_LOG"
+@@ -320,7 +320,7 @@ if PATH="$FAKE_BIN:$PATH" \
+   TARGET_RUNTIME_SCHEMAS=public \
+   SOURCE_DATABASE_NAME=main \
+   TARGET_DATABASE_NAME=main \
+-    bash "$PWD/scripts/neon-to-railway-replication.sh" setup >/dev/null 2>"$ERROR_LOG"; then
++    bash "$PWD/scripts/postgres-logical-replication.sh" setup >/dev/null 2>"$ERROR_LOG"; then
+   printf 'Expected a source column ACL to fail before target setup.\n' >&2
+   exit 1
+ fi
+@@ -343,7 +343,7 @@ if PATH="$FAKE_BIN:$PATH" \
+   TARGET_RUNTIME_SCHEMAS=public \
+   SOURCE_DATABASE_NAME=main \
+   TARGET_DATABASE_NAME=main \
+-    bash "$PWD/scripts/neon-to-railway-replication.sh" setup >/dev/null 2>"$ERROR_LOG"; then
++    bash "$PWD/scripts/postgres-logical-replication.sh" setup >/dev/null 2>"$ERROR_LOG"; then
+   printf 'Expected publisher DDL/DML boundary drift to fail before target setup.\n' >&2
+   exit 1
+ fi
+@@ -370,7 +370,7 @@ if PATH="$FAKE_BIN:$PATH" \
+   EXCLUDE_SCHEMAS='public neon_auth' \
+   SOURCE_DATABASE_NAME=main \
+   TARGET_DATABASE_NAME=main \
+-    bash "$PWD/scripts/neon-to-railway-replication.sh" setup >/dev/null 2>"$ERROR_LOG"; then
++    bash "$PWD/scripts/postgres-logical-replication.sh" setup >/dev/null 2>"$ERROR_LOG"; then
+   printf 'Expected overlapping/duplicate helper schema policy to fail.\n' >&2
+   exit 1
+ fi
+@@ -396,7 +396,7 @@ if PATH="$FAKE_BIN:$PATH" \
+   TARGET_RUNTIME_SCHEMAS=public \
+   SOURCE_DATABASE_NAME=main \
+   TARGET_DATABASE_NAME=main \
+-    bash "$PWD/scripts/neon-to-railway-replication.sh" setup >/dev/null 2>"$ERROR_LOG"; then
++    bash "$PWD/scripts/postgres-logical-replication.sh" setup >/dev/null 2>"$ERROR_LOG"; then
+   printf 'Expected startup SET ROLE publisher URL to fail before target setup.\n' >&2
+   exit 1
+ fi
+@@ -420,7 +420,7 @@ if PATH="$FAKE_BIN:$PATH" \
+   TARGET_RUNTIME_SCHEMAS=public \
+   SOURCE_DATABASE_NAME=main \
+   TARGET_DATABASE_NAME=main \
+-  bash -x "$PWD/scripts/neon-to-railway-replication.sh" status \
++  bash -x "$PWD/scripts/postgres-logical-replication.sh" status \
+   >/dev/null 2>"$ERROR_LOG"; then
+   printf 'Expected an invalid percent escape to fail.\n' >&2
+   exit 1
+@@ -439,7 +439,7 @@ if PATH="$FAKE_BIN:$PATH" \
+   TARGET_RUNTIME_SCHEMAS=public \
+   SOURCE_DATABASE_NAME=main \
+   TARGET_DATABASE_NAME=main \
+-  bash -x "$PWD/scripts/neon-to-railway-replication.sh" status \
++  bash -x "$PWD/scripts/postgres-logical-replication.sh" status \
+   >/dev/null 2>"$ERROR_LOG"; then
+   printf 'Expected an encoded password query parameter to fail.\n' >&2
+   exit 1
+@@ -458,7 +458,7 @@ for rejected_option in host hostaddr service passfile sslpassword; do
+     TARGET_RUNTIME_ROLE=boardsesh_runtime \
+     SOURCE_DATABASE_NAME=main \
+     TARGET_DATABASE_NAME=main \
+-    bash -x "$PWD/scripts/neon-to-railway-replication.sh" status \
++    bash -x "$PWD/scripts/postgres-logical-replication.sh" status \
+     >/dev/null 2>"$ERROR_LOG"; then
+     printf 'Expected query override %s to fail.\n' "$rejected_option" >&2
+     exit 1
+@@ -480,7 +480,7 @@ if PATH="$FAKE_BIN:$PATH" \
+   TARGET_RUNTIME_SCHEMAS=public \
+   SOURCE_DATABASE_NAME=main \
+   TARGET_DATABASE_NAME=main \
+-  bash -x "$PWD/scripts/neon-to-railway-replication.sh" setup \
++  bash -x "$PWD/scripts/postgres-logical-replication.sh" setup \
+   >/dev/null 2>"$ERROR_LOG"; then
+   printf 'Expected a noncanonical publisher application_name to fail.\n' >&2
+   exit 1
+@@ -510,7 +510,7 @@ run_teardown() {
+     SOURCE_DATABASE_NAME=main \
+     TARGET_DATABASE_NAME=main \
+     TEARDOWN_CONFIRMED=true \
+-    bash "$PWD/scripts/neon-to-railway-replication.sh" teardown
++    bash "$PWD/scripts/postgres-logical-replication.sh" teardown
+ }
+ 
+ rm -f "$SUBSCRIBER_DROPPED_MARKER"
+@@ -592,7 +592,7 @@ run_teardown_without_role_variables() {
+     SOURCE_DATABASE_NAME=main \
+     TARGET_DATABASE_NAME=main \
+     TEARDOWN_CONFIRMED=true \
+-    bash "$PWD/scripts/neon-to-railway-replication.sh" teardown
++    bash "$PWD/scripts/postgres-logical-replication.sh" teardown
+ }
+ 
+ rm -f "$SUBSCRIBER_DROPPED_MARKER" "$PUBLICATION_DROPPED_MARKER" "$SLOT_DROPPED_MARKER"
+diff --git c/scripts/postgres18-image-smoke.sh w/scripts/postgres18-image-smoke.sh
+index f13cc25f4..14bbe30e9 100755
+--- c/scripts/postgres18-image-smoke.sh
++++ w/scripts/postgres18-image-smoke.sh
+@@ -944,7 +944,7 @@ run_sequence_sync() {
+     --env 'INCLUDE_SCHEMAS=public drizzle pg18_extension_mixed pg18_empty_app' \
+     --env WRITES_FENCED=true \
+     --env 'FENCED_WRITER_ROLES=pg18_smoke_runtime pg18_smoke_migrator' \
+-    "$IMAGE_TAG" /workspace/scripts/neon-to-railway-replication.sh sync-sequences
++    "$IMAGE_TAG" /workspace/scripts/postgres-logical-replication.sh sync-sequences
+ }
+ 
+ run_data_verification() {
+@@ -983,7 +983,7 @@ run_replication_setup_validation() {
+     --env SLOT_NAME=pg18_smoke_subscription \
+     --env 'INCLUDE_SCHEMAS=public drizzle pg18_extension_mixed pg18_empty_app' \
+     --env LOAD_SCHEMA=false \
+-    "$IMAGE_TAG" /workspace/scripts/neon-to-railway-replication.sh setup
++    "$IMAGE_TAG" /workspace/scripts/postgres-logical-replication.sh setup
+ }
+ 
+ expect_setup_publisher_blocker() {
+@@ -1113,7 +1113,7 @@ docker run --rm \
+   --env SUBSCRIPTION_NAME=pg18_smoke_subscription \
+   --env SLOT_NAME=pg18_smoke_subscription \
+   --env 'INCLUDE_SCHEMAS=public drizzle pg18_extension_mixed pg18_empty_app' \
+-  "$IMAGE_TAG" /workspace/scripts/neon-to-railway-replication.sh setup
++  "$IMAGE_TAG" /workspace/scripts/postgres-logical-replication.sh setup
+ 
+ excluded_target_state="$(docker exec "$TARGET_CONTAINER_NAME" psql -X -Atq -F '|' -U postgres -d main -c "
+ SELECT (to_regnamespace('neon_control_plane') IS NULL)::text || '|' ||
+@@ -1844,7 +1844,7 @@ if docker run --rm \
+   --entrypoint bash \
+   --env NEON_DATABASE_URL="$source_admin_url" \
+   --env RAILWAY_DATABASE_URL="$target_admin_url" \
+-  "$IMAGE_TAG" /workspace/scripts/neon-to-railway-replication.sh teardown \
++  "$IMAGE_TAG" /workspace/scripts/postgres-logical-replication.sh teardown \
+   >"$AUDIT_REPORT_FILE" 2>&1; then
+   printf 'Expected teardown without TEARDOWN_CONFIRMED=true to be rejected\n' >&2
+   exit 1
+@@ -1918,7 +1918,7 @@ run_confirmed_teardown() {
+     --env SLOT_NAME=pg18_smoke_subscription \
+     --env 'INCLUDE_SCHEMAS=public drizzle pg18_extension_mixed pg18_empty_app' \
+     --env TEARDOWN_CONFIRMED=true \
+-    "$IMAGE_TAG" /workspace/scripts/neon-to-railway-replication.sh teardown
++    "$IMAGE_TAG" /workspace/scripts/postgres-logical-replication.sh teardown
+ }
+ 
+ # Teardown also removes the temporary subscriber credential, because the
+diff --git c/vite.config.ts w/vite.config.ts
+index ffea0f828..7ce38d468 100644
+--- c/vite.config.ts
++++ w/vite.config.ts
+@@ -240,7 +240,7 @@ export default defineConfig({
+       },
+       'test:postgres18-contract': {
+         command:
+-          'node --import tsx --test packages/db/scripts/migration-owner-role.test.ts && bash packages/db/docker/dev-db-entrypoint.test.sh && bash packages/db/docker/apply-drizzle-migrations.test.sh && bash scripts/postgres-credentials.test.sh && bash scripts/neon-to-railway-replication.test.sh && bash scripts/postgres18-workflow-contract.test.sh && bash -n packages/db/docker/dev-db-entrypoint.sh packages/db/docker/apply-drizzle-migrations.sh scripts/dev-db-up.sh scripts/dev-db-image-smoke.sh scripts/lib/postgres-credentials.sh scripts/postgres16-role-transition-smoke.sh scripts/postgres18-image-smoke.sh scripts/postgres18-architecture-smoke.sh scripts/postgres18-production-role-transition.sh scripts/postgres18-workflow-contract.test.sh scripts/postgres-migration-audit.sh scripts/postgres-migration-verify-data.sh scripts/neon-to-railway-replication.sh scripts/neon-to-railway-replication.test.sh scripts/postgres-credentials.test.sh packages/db/docker/setup-development-db.sh packages/web/db/setup-development-db.sh',
++          'node --import tsx --test packages/db/scripts/migration-owner-role.test.ts && bash packages/db/docker/dev-db-entrypoint.test.sh && bash packages/db/docker/apply-drizzle-migrations.test.sh && bash scripts/postgres-credentials.test.sh && bash scripts/postgres-logical-replication.test.sh && bash scripts/postgres18-workflow-contract.test.sh && bash -n packages/db/docker/dev-db-entrypoint.sh packages/db/docker/apply-drizzle-migrations.sh scripts/dev-db-up.sh scripts/dev-db-image-smoke.sh scripts/lib/postgres-credentials.sh scripts/postgres16-role-transition-smoke.sh scripts/postgres18-image-smoke.sh scripts/postgres18-architecture-smoke.sh scripts/postgres18-production-role-transition.sh scripts/postgres18-workflow-contract.test.sh scripts/postgres-migration-audit.sh scripts/postgres-migration-verify-data.sh scripts/postgres-logical-replication.sh scripts/postgres-logical-replication.test.sh scripts/postgres-credentials.test.sh packages/db/docker/setup-development-db.sh packages/web/db/setup-development-db.sh',
+         cache: false,
+       },
+       'test:postgres16-role-transition': {

--- a/docs/postgres-18-migration.md
+++ b/docs/postgres-18-migration.md
@@ -148,9 +148,31 @@ choose a supported path:
 - change the target artifact to a supported equal/newer PostGIS release and
   repeat every image/rehearsal gate.
 
-There is no override flag. A full rehearsal must restore the schema, copy every
-geography/geometry value, exercise spatial indexes and queries, and compare
-representative `ST_AsEWKB` values.
+The rule is enforced in four places, and only two of them have a knob:
+
+| Where                                         | What it compares                                               | Knob                       |
+| --------------------------------------------- | -------------------------------------------------------------- | -------------------------- |
+| `scripts/postgres-migration-audit.sh:1771`    | source `pg_extension.extversion` vs `EXPECTED_POSTGIS_VERSION` | `EXPECTED_POSTGIS_VERSION` |
+| `scripts/postgres-migration-audit.sh:2024`    | target, same comparison                                        | `EXPECTED_POSTGIS_VERSION` |
+| `scripts/postgres-migration-audit.sh:1943`    | whole-extension manifest, source vs target, version included   | none                       |
+| `scripts/neon-to-railway-replication.sh:1412` | the same manifest, as a hard `fail` before any restore         | none                       |
+
+`EXPECTED_POSTGIS_VERSION` (`postgres-migration-audit.sh:16`, documented at `:87`)
+relaxes the first two rows only. It is a build-time knob for wiring the expected
+version through from the image label, not an escape hatch: setting it does not
+move the two manifest comparisons, so a mismatched source still fails closed
+before any restore. Do not reach for it to get past this gate.
+
+A full rehearsal must restore the schema, copy every geography/geometry value,
+exercise spatial indexes and queries, and compare representative `ST_AsEWKB`
+values.
+
+Note also that `postgis_tiger_geocoder` and `postgis_topology` cannot simply be
+left off the target. The extension manifest at `:1943` is cluster-wide and has no
+allowlist, so a source extension with no target counterpart blocks regardless of
+how few objects it owns. Dropping them on the source is the only path that
+satisfies `unclassified_schemas()`, the manifest, and
+`assert_superuser_catalog_precreated` unchanged.
 
 ### 2. Publish and pin the PG18 image
 

--- a/docs/postgres-18-postgis-audit.md
+++ b/docs/postgres-18-postgis-audit.md
@@ -5,12 +5,13 @@ Target artifact: PostgreSQL 18.4, PostGIS 3.6.4 (newest PGDG offers for PG18)
 
 ## Actual spatial usage: two columns
 
-| Column | Type | Rows | Populated |
-|---|---|---|---|
-| `public.gyms.location` | `geography(Point,4326)` | 4875 | 3114 |
-| `public.user_boards.location` | `geography(Point,4326)` | 6375 | 3318 |
+| Column                        | Type                    | Rows | Populated |
+| ----------------------------- | ----------------------- | ---- | --------- |
+| `public.gyms.location`        | `geography(Point,4326)` | 4875 | 3114      |
+| `public.user_boards.location` | `geography(Point,4326)` | 6375 | 3318      |
 
 Two partial GiST indexes:
+
 - `gyms_location_idx` — `USING gist (location) WHERE deleted_at IS NULL AND is_public = true`
 - `user_boards_location_gist_idx` — `USING gist (location) WHERE is_public = true AND deleted_at IS NULL`
 

--- a/docs/postgres-18-postgis-audit.md
+++ b/docs/postgres-18-postgis-audit.md
@@ -1,0 +1,38 @@
+# PostGIS usage audit — Railway production (read-only), 2026-08-23
+
+Source: PostgreSQL 16.9, PostGIS 3.7.0dev (3.6.0rc2-339-g6d7299047), GEOS 3.15.0dev
+Target artifact: PostgreSQL 18.4, PostGIS 3.6.4 (newest PGDG offers for PG18)
+
+## Actual spatial usage: two columns
+
+| Column | Type | Rows | Populated |
+|---|---|---|---|
+| `public.gyms.location` | `geography(Point,4326)` | 4875 | 3114 |
+| `public.user_boards.location` | `geography(Point,4326)` | 6375 | 3318 |
+
+Two partial GiST indexes:
+- `gyms_location_idx` — `USING gist (location) WHERE deleted_at IS NULL AND is_public = true`
+- `user_boards_location_gist_idx` — `USING gist (location) WHERE is_public = true AND deleted_at IS NULL`
+
+No geometry, raster, or topogeometry columns anywhere in the app schemas.
+
+## tiger / topology are empty scaffolding
+
+- `tiger.geocode_settings`: 0 rows
+- live tuples across `tiger`, `tiger_data`, `topology`: 0
+
+`postgis_tiger_geocoder` (120 objects) and `postgis_topology` (10 objects) are installed but never used. Not installing them on the target removes 130 objects from the migration surface.
+
+## Assessment
+
+`geography(Point,4326)` and GiST indexing are among the oldest, most stable parts of PostGIS — unchanged in API and on-disk representation across 3.x. Nothing here uses a 3.7-only feature, because nothing here uses anything beyond point storage and proximity indexing.
+
+Production is on a development build only because the Railway service tracks `postgis/postgis:16-master` with auto-updates enabled. That drift bought nothing and is what makes the version comparison look alarming.
+
+## Available PostGIS for PG18 (PGDG bookworm-pgdg, amd64)
+
+    3.6.2+dfsg-1.pgdg12+1
+    3.6.3+dfsg-1.pgdg12+1
+    3.6.4+dfsg-2.pgdg12+1   <- newest, what the attested image ships
+
+There is no stable 3.7 release to target.

--- a/docs/postgres-18-rollout-handover.md
+++ b/docs/postgres-18-rollout-handover.md
@@ -8,21 +8,21 @@ Everything up to and including image publication and consumer pinning is **done 
 
 ## 1. What is merged
 
-| PR | What | Merge commit |
-|---|---|---|
-| #4497 | Trusted PostgreSQL image publisher | `577c5c021` |
-| #4474 | PG18 producer A — migration and cutover tooling | `a5795a08eee7514986339e3278e791248a40b222` |
-| #4695 | Consumer B — pin every consumer to the attested digests | `6a699e564` |
-| marcodejongh/blackheathdc-ansible#344 | Homelab PostgreSQL standby and DR | merged |
+| PR                                    | What                                                    | Merge commit                               |
+| ------------------------------------- | ------------------------------------------------------- | ------------------------------------------ |
+| #4497                                 | Trusted PostgreSQL image publisher                      | `577c5c021`                                |
+| #4474                                 | PG18 producer A — migration and cutover tooling         | `a5795a08eee7514986339e3278e791248a40b222` |
+| #4695                                 | Consumer B — pin every consumer to the attested digests | `6a699e564`                                |
+| marcodejongh/blackheathdc-ansible#344 | Homelab PostgreSQL standby and DR                       | merged                                     |
 
 ### Published images — these are the accepted artifacts
 
 Publisher run [32616607289](https://github.com/boardsesh/boardsesh/actions/runs/32616607289), source `ca308bd225519bd1062dfdbab288e7b063e253c9`.
 
-| Image | Digest | Platforms | Attestation |
-|---|---|---|---|
+| Image                                                                 | Digest                                                                    | Platforms     | Attestation                                                                       |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------- | ------------- | --------------------------------------------------------------------------------- |
 | `ghcr.io/boardsesh/boardsesh-postgres-postgis` (portable, production) | `sha256:01c2671dbccd2104ec15534de1552d1e092301a5a77cad010795318d47f76796` | amd64 + arm64 | [42389745](https://github.com/boardsesh/boardsesh/attestations/42389745) verified |
-| `ghcr.io/boardsesh/boardsesh-dev-db` (seeded, dev/CI) | `sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5` | amd64 | [42389746](https://github.com/boardsesh/boardsesh/attestations/42389746) verified |
+| `ghcr.io/boardsesh/boardsesh-dev-db` (seeded, dev/CI)                 | `sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5` | amd64         | [42389746](https://github.com/boardsesh/boardsesh/attestations/42389746) verified |
 
 Handoff artifact copied to `docs/postgres-image-digests.json`. It records `deployment_identity: "digest-only"` and `tags_are_mutable: true` — a `sha-<commit>` tag is a lookup aid, never a deployment pin.
 
@@ -38,12 +38,16 @@ Handoff artifact copied to `docs/postgres-image-digests.json`. It records `deplo
 
 ### PR #4475 — snapshot fencing (green, ready for review)
 
-**28 passing, 0 failing** at `c9579a444`. Migration renumbered to **0205** after main took 0200-0204.
+**28 passing, 0 failing** at `c9579a444`. Migration renumbered to **0205** after main took 0200-0204, and main has not moved past it. No unresolved review threads; `mergeStateStatus` is `BLOCKED` only on `REVIEW_REQUIRED`, so a human approval is the last thing it needs.
 
 Two things worth knowing before touching it:
 
-- The journal entry kept its original `when`, older than main's newest. Both appliers order by `when`, so it would have been **silently skipped** — not a loud failure. `check:db-migrations` caught it; restamped by hand following `db-renumber`'s own `nextWhen` convention. See issue #4696: `check:db-migrations` tells you to run `vp run db:renumber`, but that tool only inspects the migration *number* and no-ops on a stale `when`.
+- The journal entry kept its original `when`, older than main's newest. Both appliers order by `when`, so it would have been **silently skipped** — not a loud failure. `check:db-migrations` caught it; restamped by hand following `db-renumber`'s own `nextWhen` convention. See issue #4696: `check:db-migrations` tells you to run `vp run db:renumber`, but that tool only inspects the migration _number_ and no-ops on a stale `when`.
 - `test-location-sync-integration` was red for the whole rollout because it ran on PG17. Consumer B fixed it — it now passes.
+
+### Consumer B left `vp run db:up` broken — fixed separately
+
+#4695 pinned `docker-compose.yml` to the seeded digest but not the PG18 storage contract: the volume stayed mounted at the PG16 `/var/lib/postgresql/pgdata`, and `scripts/dev-db-up.sh` kept looking for `pg_hba.conf` under that dead path, so the script died before migrations ran and the seeded cluster was thrown away with the container. No CI job noticed because none of them use either file. Fixed in #4698 — worth knowing about because it is the first thing anyone picking this up will run.
 
 ### Branch `agent/split-seeded-image-publisher` — reviewed, three P2s open
 
@@ -57,40 +61,42 @@ Three P2s remain before merge:
 
 1. Both publishers validate both Dockerfiles, deliberately, to keep two privileged run bodies byte-identical and hash-shared. Fail-closed, but it means removing or relocating either Dockerfile breaks **both** publishers — document it in the `validate-main` bullet.
 2. Both publishers declare `environment: postgres-image-publisher`, so the seeded developer publisher holds the same environment-scoped OIDC identity as the production one. Nothing currently trusts it beyond GitHub's attestation API, but any future external trust policy must key on `job_workflow_ref`, never on the environment name.
-3. `vp check` is red on the branch with two `TS2339` errors in `scripts/expo-web-e2e.ts` (`Property 'unref' does not exist on type 'number'`). The file is untouched by the change and this looks like DOM-vs-Node `setTimeout` typing, but it was not confirmed against a pristine `main` — verify, and fix separately.
+3. `vp check` is red on the branch with two `TS2339` errors in `scripts/expo-web-e2e.ts` (`Property 'unref' does not exist on type 'number'`). **Confirmed pre-existing** — both reproduce at `scripts/expo-web-e2e.ts:40` and `:84` on a docs-only branch off `main`, so the split does not introduce them. It is DOM-vs-Node `setTimeout` typing and belongs in its own fix. Note CI's `lint` job does not report them, so whatever selects the `scripts/` project differs between a local run and CI — worth understanding before trusting a local `vp check` as the gate.
 
 ### Filed issues
 
-| Issue | What |
-|---|---|
+| Issue                                                       | What                                                                                       |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | [#4508](https://github.com/boardsesh/boardsesh/issues/4508) | Build dev-db from offline snapshots instead of scraping six APKs from a third-party mirror |
-| [#4513](https://github.com/boardsesh/boardsesh/issues/4513) | Teardown wedges on a disabled subscription — bites during the WAL emergency itself |
-| [#4514](https://github.com/boardsesh/boardsesh/issues/4514) | Rename the Neon-era replication script (patch saved, see below) |
-| [#4694](https://github.com/boardsesh/boardsesh/issues/4694) | Split the seeded image out of the production publish path |
-| [#4696](https://github.com/boardsesh/boardsesh/issues/4696) | `db:renumber` no-ops on a stale `when` that `check:db-migrations` rejects |
+| [#4513](https://github.com/boardsesh/boardsesh/issues/4513) | Teardown wedges on a disabled subscription — bites during the WAL emergency itself         |
+| [#4514](https://github.com/boardsesh/boardsesh/issues/4514) | Rename the Neon-era replication script (patch saved, see below)                            |
+| [#4694](https://github.com/boardsesh/boardsesh/issues/4694) | Split the seeded image out of the production publish path                                  |
+| [#4696](https://github.com/boardsesh/boardsesh/issues/4696) | `db:renumber` no-ops on a stale `when` that `check:db-migrations` rejects                  |
 
-`docs/pg18-replication-rename.patch` (committed here) holds a verified rename of `neon-to-railway-replication.sh` → `postgres-logical-replication.sh` across all 7 referencing files, applying cleanly against `661e8c488`. Deferred so commit A did not need another review cycle. The workflow path filter and the `test:postgres18-contract` file list must move together — `scripts/postgres18-workflow-contract.test.sh` fails closed on a half-done rename.
+`docs/pg18-replication-rename.patch` (committed here) holds a verified rename of `neon-to-railway-replication.sh` → `postgres-logical-replication.sh` across all 7 referencing files. It still applies against current `main`, but it has already started to drift: the `vite.config.ts` hunk now lands at an offset of +15 lines, absorbed silently by `git apply`'s context matching. The next edit inside that one-line command string turns it into a hard reject with no warning, so a `git apply --check` gate over `docs/*.patch` goes in alongside this handover. Deferred so commit A did not need another review cycle. The workflow path filter and the `test:postgres18-contract` file list must move together — `scripts/postgres18-workflow-contract.test.sh` fails closed on a half-done rename.
 
 ---
 
 ## 3. Production audit — read-only, 2026-08-23
 
-Credentials came from 1Password `Boardsesh` vault, item **`RAILWAY Postgres PROD (readonly)`**, used via a mode-0600 passfile and deleted afterwards. Nothing was mutated.
+No credential appears anywhere in this file. Everything below is read-only configuration output: a system identifier is minted by `initdb`, authenticates nothing, and is the only cheap way for the next operator to prove the cluster being cut over is the one audited here — a Railway service recreate mints a new one and silently invalidates every number in this section.
 
-| | |
-|---|---|
-| Version | **PostgreSQL 16.9** (Debian, x86_64) |
-| System identifier | `7635874554056458274` |
-| Database | `railway` (canonical, matches the runbook) |
-| Size | 11 GB |
-| Encoding / collate / ctype | UTF8 / en_US.utf8 / en_US.utf8 |
-| `data_checksums` | **off** |
-| `wal_level` | **replica** |
-| `max_replication_slots` / `max_wal_senders` | 10 / 10 |
-| PostGIS | **3.7.0dev** (`3.6.0rc2-339-g6d7299047`), GEOS `3.15.0dev` |
-| Publications / replication slots | none — clean slate |
-| Roles (non-system) | `postgres` (superuser), `boardsesh_readonly` |
-| Schemas | `public` 464, `tiger` 120, `neon_auth` 30, `topology` 10, `drizzle` 3 |
+Credentials came from 1Password `Boardsesh` vault, item **`RAILWAY Postgres PROD (readonly)`**, used via a mode-0600 passfile and deleted afterwards. Naming the item is deliberate: it stops the next operator minting a second, untracked readonly credential. The same convention is already published in `docs/aurora-sync.md` and `packages/aurora-sync/.env.1password`. Nothing was mutated.
+
+|                                             |                                                                       |
+| ------------------------------------------- | --------------------------------------------------------------------- |
+| Version                                     | **PostgreSQL 16.9** (Debian, x86_64)                                  |
+| System identifier                           | `7635874554056458274`                                                 |
+| Database                                    | `railway` (canonical, matches the runbook)                            |
+| Size                                        | 11 GB                                                                 |
+| Encoding / collate / ctype                  | UTF8 / en_US.utf8 / en_US.utf8                                        |
+| `data_checksums`                            | **off**                                                               |
+| `wal_level`                                 | **replica**                                                           |
+| `max_replication_slots` / `max_wal_senders` | 10 / 10                                                               |
+| PostGIS                                     | **3.7.0dev** (`3.6.0rc2-339-g6d7299047`), GEOS `3.15.0dev`            |
+| Publications / replication slots            | none — clean slate                                                    |
+| Roles (non-system)                          | `postgres` (superuser), `boardsesh_readonly`                          |
+| Schemas                                     | `public` 464, `tiger` 120, `neon_auth` 30, `topology` 10, `drizzle` 3 |
 
 Railway runs the database from image `postgis/postgis:16-master` **with auto-updates enabled** — a mutable dev tag on production.
 
@@ -106,6 +112,19 @@ Logical replication needs `wal_level = logical`. Changing it requires a **restar
 
 Production is on `3.7.0dev`; the attested image ships stable **3.6.4**. `docs/postgres-18-migration.md` §1 blocks the catalog audit unless both sides match, on the basis that a downgrade is not assumed wire-compatible.
 
+**The gate is four enforcement points, not one.** Budget the work accordingly:
+
+| Where                                         | What it compares                                               | Knob                       |
+| --------------------------------------------- | -------------------------------------------------------------- | -------------------------- |
+| `scripts/postgres-migration-audit.sh:1771`    | source `pg_extension.extversion` vs `EXPECTED_POSTGIS_VERSION` | `EXPECTED_POSTGIS_VERSION` |
+| `scripts/postgres-migration-audit.sh:2024`    | target, same comparison                                        | `EXPECTED_POSTGIS_VERSION` |
+| `scripts/postgres-migration-audit.sh:1943`    | whole-extension manifest, source vs target, version included   | none                       |
+| `scripts/neon-to-railway-replication.sh:1412` | same manifest, as a hard `fail` before any restore             | none                       |
+
+Note that `docs/postgres-18-migration.md` §1 says "There is no override flag", but `postgres-migration-audit.sh:16` is `EXPECTED_POSTGIS_VERSION="${EXPECTED_POSTGIS_VERSION:-3.6.4}"` and documents it at `:87` as an optional control. It relaxes the first two rows only; the manifest comparisons have no knob at all. That contradiction is corrected in the runbook alongside this handover.
+
+`tiger` / `topology` are not simply ignorable either. Leaving them off the target trips three independent gates — `unclassified_schemas()` at `:1263`, the cluster-wide extension manifest at `:1943` (which has no allowlist mechanism), and `assert_superuser_catalog_precreated` before the dump even starts. Dropping them on the **source**, where they hold 0 live tuples, is the only path that satisfies all three unchanged.
+
 **PGDG has no stable 3.7 for PG18.** Available for `postgresql-18-postgis-3` on `bookworm-pgdg/amd64`:
 
     3.6.2+dfsg-1.pgdg12+1
@@ -116,10 +135,10 @@ So "upgrade the target to match" is not possible from packages. Production is on
 
 **But the actual exposure is tiny.** Full spatial usage in the app schemas:
 
-| Column | Type | Rows | Populated |
-|---|---|---|---|
-| `public.gyms.location` | `geography(Point,4326)` | 4875 | 3114 |
-| `public.user_boards.location` | `geography(Point,4326)` | 6375 | 3318 |
+| Column                        | Type                    | Rows | Populated |
+| ----------------------------- | ----------------------- | ---- | --------- |
+| `public.gyms.location`        | `geography(Point,4326)` | 4875 | 3114      |
+| `public.user_boards.location` | `geography(Point,4326)` | 6375 | 3318      |
 
 Two partial GiST indexes:
 
@@ -140,11 +159,12 @@ No geometry, raster or topogeometry columns anywhere. And `tiger` / `topology` a
 
 ## 5. What to do next
 
-1. **Rehearse the restore** (§4). Dump Railway, restore into `ghcr.io/boardsesh/boardsesh-postgres-postgis@sha256:01c2671d…`, verify the two geography columns, their row counts, and both partial GiST indexes. That settles Blocker 2 with evidence and produces the rehearsal the checkpoint requires.
-2. **Decide Blocker 2** on that evidence.
-3. **Schedule the `wal_level` restart** with the write interruption it implies.
-4. **Run the PG16 role transition** (`docs/postgres-18-migration.md` §"Ordered PG16 production-role transition"). None of `boardsesh_owner`, `boardsesh_runtime` or `boardsesh_migrator` exist yet; the app appears to connect as `postgres`. `scripts/postgres18-production-role-transition.sh` has bounded `lock_timeout`, a wall-clock hold ceiling, and a long-running-transaction pre-flight — validated against a real PG16 in CI.
-5. **Then** the Phase 4 checkpoint, then replication.
+1. **Fix [#4513](https://github.com/boardsesh/boardsesh/issues/4513) before any replication run.** `teardown` disables the subscription and then drops it as two autocommitted statements; if the drop fails because the publisher is unreachable — the same incident that made you run teardown — the subscription is left disabled, and `assert_subscription_contract` requires `subenabled`, so a re-run refuses to drop anything while the source keeps retaining WAL. This is the one filed issue that bites _during_ an emergency rather than during development, and the fix is one contract predicate.
+2. **Pin the Railway Postgres image with auto-updates off, before anything restarts it.** The service tracks the mutable `postgis/postgis:16-master` tag, so a restart can silently pull a newer `3.7.x-dev` and invalidate every number in §3 and in `docs/postgres-18-postgis-audit.md`. This has to precede step 4.
+3. **Rehearse the restore** (§4) and **decide Blocker 2** on that evidence. Verify the two geography columns, their row counts, and both partial GiST indexes survive into `ghcr.io/boardsesh/boardsesh-postgres-postgis@sha256:01c2671d…`.
+4. **Schedule the `wal_level` restart** with the write interruption it implies. Confirm no `production-deploy` run is queued or executing first: a restart during its `migrate` job fails that job, and the `production-deploy` concurrency group then holds main until someone re-dispatches. `/health` is Redis-governed and will not flap; `/health/db` is the alertable endpoint.
+5. **Run the PG16 role transition** (`docs/postgres-18-migration.md` §"Ordered PG16 production-role transition"). **This is the blocking security item, not a housekeeping step:** none of `boardsesh_owner`, `boardsesh_runtime` or `boardsesh_migrator` exist yet, so until it runs, any leaked connection string is full cluster control rather than a scoped role. Confirm the current identity first with a read-only `SELECT current_user, usesuper FROM pg_user WHERE usename = current_user;` — that the app connects as `postgres` is inferred from the role list, never observed. `scripts/postgres18-production-role-transition.sh` has bounded `lock_timeout`, a wall-clock hold ceiling, and a long-running-transaction pre-flight — validated against a real PG16 in CI.
+6. **Then** the Phase 4 checkpoint, then replication.
 
 ### Publishing again — read this first
 
@@ -154,11 +174,11 @@ Measured: portable **1 m 39 s**, seeded **16 m 52 s**, ~19 min dispatch to reche
 
 Two attempts were lost to this before the third succeeded behind a deliberate merge freeze:
 
-| Run | SHA | Outcome |
-|---|---|---|
+| Run         | SHA         | Outcome                                                                                                           |
+| ----------- | ----------- | ----------------------------------------------------------------------------------------------------------------- |
 | 31924828661 | `a5795a08…` | aborted at the pre-auth recheck; main moved during the ~2 h approval wait. Never authenticated, nothing published |
-| 31929880126 | `b61480a1…` | main moved before approval could be given; cancelled |
-| 32616607289 | `ca308bd2…` | **success** |
+| 31929880126 | `b61480a1…` | main moved before approval could be given; cancelled                                                              |
+| 32616607289 | `ca308bd2…` | **success**                                                                                                       |
 
 So: announce a freeze, dispatch, approve within a few minutes, and expect a second approval prompt for the attestation job. Do not weaken the exact-main guard — re-dispatch for the new head instead. #4694 exists to shrink this window.
 
@@ -168,8 +188,8 @@ So: announce a freeze, dispatch, approve within a few minutes, and expect a seco
 
 Things that cost time here and may not apply on the new machine:
 
-- **Docker was entirely unusable.** The VM stopped booting — every command returned `Bad response from Docker engine`; `dockerd.log` showed `healthcheck failed fatally` and containerd `setns` errors. A full Docker Desktop restart did not recover it. `Docker.raw` was 119 GB against 34 GB free host disk. Reclaiming 48.8 GB of build cache did not help. This blocked the dev-db image build, the `postgres18-image` smoke, and the ansible offline suite at ansible-core 2.16.3 — all of which CI ran instead.
-- **`grep` here is `ugrep`, not GNU grep**, and `/usr/bin/grep` is BSD. Two real portability bugs came from this class: `stat -f` is BSD-only (on GNU, `-f` means `--file-system`), and the runners have no `ripgrep` at all. That second one was worse than a broken test — the credential test's argv guard was *fail-open* in CI, because an empty result from a missing binary is indistinguishable from "no forbidden match".
+- **Docker was entirely unusable.** The VM stopped booting — every command returned `Bad response from Docker engine`; `dockerd.log` showed `healthcheck failed fatally` and containerd `setns` errors. A full Docker Desktop restart did not recover it. `Docker.raw` was 119 GB against 34 GB free host disk. Reclaiming 48.8 GB of build cache did not help. This blocked the dev-db image build, the `postgres18-image` smoke, and the ansible offline suite at ansible-core 2.16.3 — all of which CI ran instead. **Resolved** — Docker Desktop has since been reset and the engine is healthy. What remains is that `psql`/`pg_dump` are not installed at all; run the catalog tooling from inside the portable image instead, the way `scripts/postgres18-image-smoke.sh:846-871` already does.
+- **`grep` here is `ugrep`, not GNU grep**, and `/usr/bin/grep` is BSD. Two real portability bugs came from this class: `stat -f` is BSD-only (on GNU, `-f` means `--file-system`), and the runners have no `ripgrep` at all. That second one was worse than a broken test — the credential test's argv guard was _fail-open_ in CI, because an empty result from a missing binary is indistinguishable from "no forbidden match".
 - **Local `psql` is 14.22**, connecting to a PG16 server. Fine for the audit queries used, but worth upgrading before the cutover.
 - A fresh git worktree needs `bun install --frozen-lockfile` before `vp` will run.
 

--- a/docs/postgres-18-rollout-handover.md
+++ b/docs/postgres-18-rollout-handover.md
@@ -36,9 +36,9 @@ Handoff artifact copied to `docs/postgres-image-digests.json`. It records `deplo
 
 ## 2. Open work
 
-### PR #4475 — snapshot fencing (effectively green)
+### PR #4475 — snapshot fencing (green, ready for review)
 
-27 passing, 0 failing. Migration renumbered to **0205** after main took 0200-0204.
+**28 passing, 0 failing** at `c9579a444`. Migration renumbered to **0205** after main took 0200-0204.
 
 Two things worth knowing before touching it:
 

--- a/docs/postgres-18-rollout-handover.md
+++ b/docs/postgres-18-rollout-handover.md
@@ -1,0 +1,168 @@
+# PostgreSQL 18 rollout — handover
+
+State as of 2026-08-23, `main` at `6a699e564`. Written to move this to a machine that can run Docker.
+
+Everything up to and including image publication and consumer pinning is **done and merged**. Nothing has touched the Railway production database except one read-only audit. The remaining work is the production cutover, and it is blocked on two things this machine could not resolve.
+
+---
+
+## 1. What is merged
+
+| PR | What | Merge commit |
+|---|---|---|
+| #4497 | Trusted PostgreSQL image publisher | `577c5c021` |
+| #4474 | PG18 producer A — migration and cutover tooling | `a5795a08eee7514986339e3278e791248a40b222` |
+| #4695 | Consumer B — pin every consumer to the attested digests | `6a699e564` |
+| marcodejongh/blackheathdc-ansible#344 | Homelab PostgreSQL standby and DR | merged |
+
+### Published images — these are the accepted artifacts
+
+Publisher run [32616607289](https://github.com/boardsesh/boardsesh/actions/runs/32616607289), source `ca308bd225519bd1062dfdbab288e7b063e253c9`.
+
+| Image | Digest | Platforms | Attestation |
+|---|---|---|---|
+| `ghcr.io/boardsesh/boardsesh-postgres-postgis` (portable, production) | `sha256:01c2671dbccd2104ec15534de1552d1e092301a5a77cad010795318d47f76796` | amd64 + arm64 | [42389745](https://github.com/boardsesh/boardsesh/attestations/42389745) verified |
+| `ghcr.io/boardsesh/boardsesh-dev-db` (seeded, dev/CI) | `sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5` | amd64 | [42389746](https://github.com/boardsesh/boardsesh/attestations/42389746) verified |
+
+Handoff artifact copied to `docs/postgres-image-digests.json`. It records `deployment_identity: "digest-only"` and `tags_are_mutable: true` — a `sha-<commit>` tag is a lookup aid, never a deployment pin.
+
+### Repo configuration applied
+
+- Environment `postgres-image-publisher`: required reviewer `marcodejongh`, `can_admins_bypass=false`, custom branch policy of exactly `main`.
+- **`prevent_self_review = false`** — a deliberate, accepted risk. Single maintainer, and a GitHub App cannot be an environment reviewer. The three audits now require the field to be present and boolean rather than `true`, so a missing or reshaped API field still fails closed, and the mutation test was retargeted rather than deleted. Rationale in `docs/postgres-image-publishing.md`. Flip it back to `true` the moment a second reviewer exists — no code change needed.
+- Repo variable `RETIRED_DB_IMAGE_DIGESTS = none`.
+
+---
+
+## 2. Open work
+
+### PR #4475 — snapshot fencing (effectively green)
+
+27 passing, 0 failing. Migration renumbered to **0205** after main took 0200-0204.
+
+Two things worth knowing before touching it:
+
+- The journal entry kept its original `when`, older than main's newest. Both appliers order by `when`, so it would have been **silently skipped** — not a loud failure. `check:db-migrations` caught it; restamped by hand following `db-renumber`'s own `nextWhen` convention. See issue #4696: `check:db-migrations` tells you to run `vp run db:renumber`, but that tool only inspects the migration *number* and no-ops on a stale `when`.
+- `test-location-sync-integration` was red for the whole rollout because it ran on PG17. Consumer B fixed it — it now passes.
+
+### Branch `agent/split-seeded-image-publisher` — WIP, do not merge
+
+Commit `9f0a602c1`. Splits the seeded dev image into its own publisher workflow (issue #4694). **Unreviewed and unvalidated** — the security review phase had not run. Before merging: recompute every `PRIVILEGED_RUN_SHA256` and `PRIVILEGED_JOB_SHA256`, confirm every mutation test still fails for the weakenings it catches, add equivalent coverage for the new workflow, and get an independent review of the trust boundary in both.
+
+### Filed issues
+
+| Issue | What |
+|---|---|
+| [#4508](https://github.com/boardsesh/boardsesh/issues/4508) | Build dev-db from offline snapshots instead of scraping six APKs from a third-party mirror |
+| [#4513](https://github.com/boardsesh/boardsesh/issues/4513) | Teardown wedges on a disabled subscription — bites during the WAL emergency itself |
+| [#4514](https://github.com/boardsesh/boardsesh/issues/4514) | Rename the Neon-era replication script (patch saved, see below) |
+| [#4694](https://github.com/boardsesh/boardsesh/issues/4694) | Split the seeded image out of the production publish path |
+| [#4696](https://github.com/boardsesh/boardsesh/issues/4696) | `db:renumber` no-ops on a stale `when` that `check:db-migrations` rejects |
+
+`docs/pg18-replication-rename.patch` (committed here) holds a verified rename of `neon-to-railway-replication.sh` → `postgres-logical-replication.sh` across all 7 referencing files, applying cleanly against `661e8c488`. Deferred so commit A did not need another review cycle. The workflow path filter and the `test:postgres18-contract` file list must move together — `scripts/postgres18-workflow-contract.test.sh` fails closed on a half-done rename.
+
+---
+
+## 3. Production audit — read-only, 2026-08-23
+
+Credentials came from 1Password `Boardsesh` vault, item **`RAILWAY Postgres PROD (readonly)`**, used via a mode-0600 passfile and deleted afterwards. Nothing was mutated.
+
+| | |
+|---|---|
+| Version | **PostgreSQL 16.9** (Debian, x86_64) |
+| System identifier | `7635874554056458274` |
+| Database | `railway` (canonical, matches the runbook) |
+| Size | 11 GB |
+| Encoding / collate / ctype | UTF8 / en_US.utf8 / en_US.utf8 |
+| `data_checksums` | **off** |
+| `wal_level` | **replica** |
+| `max_replication_slots` / `max_wal_senders` | 10 / 10 |
+| PostGIS | **3.7.0dev** (`3.6.0rc2-339-g6d7299047`), GEOS `3.15.0dev` |
+| Publications / replication slots | none — clean slate |
+| Roles (non-system) | `postgres` (superuser), `boardsesh_readonly` |
+| Schemas | `public` 464, `tiger` 120, `neon_auth` 30, `topology` 10, `drizzle` 3 |
+
+Railway runs the database from image `postgis/postgis:16-master` **with auto-updates enabled** — a mutable dev tag on production.
+
+---
+
+## 4. The two blockers
+
+### Blocker 1 — `wal_level = replica`
+
+Logical replication needs `wal_level = logical`. Changing it requires a **restart of the Railway Postgres service**, i.e. a short production outage before any migration work starts. `max_replication_slots` and `max_wal_senders` are already 10, so nothing else needs changing.
+
+### Blocker 2 — PostGIS version
+
+Production is on `3.7.0dev`; the attested image ships stable **3.6.4**. `docs/postgres-18-migration.md` §1 blocks the catalog audit unless both sides match, on the basis that a downgrade is not assumed wire-compatible.
+
+**PGDG has no stable 3.7 for PG18.** Available for `postgresql-18-postgis-3` on `bookworm-pgdg/amd64`:
+
+    3.6.2+dfsg-1.pgdg12+1
+    3.6.3+dfsg-1.pgdg12+1
+    3.6.4+dfsg-2.pgdg12+1   <- newest, what the image ships
+
+So "upgrade the target to match" is not possible from packages. Production is only on a dev build because the service tracks the `master` tag.
+
+**But the actual exposure is tiny.** Full spatial usage in the app schemas:
+
+| Column | Type | Rows | Populated |
+|---|---|---|---|
+| `public.gyms.location` | `geography(Point,4326)` | 4875 | 3114 |
+| `public.user_boards.location` | `geography(Point,4326)` | 6375 | 3318 |
+
+Two partial GiST indexes:
+
+    gyms_location_idx              USING gist (location) WHERE deleted_at IS NULL AND is_public = true
+    user_boards_location_gist_idx  USING gist (location) WHERE is_public = true AND deleted_at IS NULL
+
+No geometry, raster or topogeometry columns anywhere. And `tiger` / `topology` are **empty scaffolding** — `tiger.geocode_settings` has 0 rows, 0 live tuples across `tiger`, `tiger_data`, `topology`. Not installing those two extensions on the target removes 130 objects from the migration surface.
+
+`geography(Point,4326)` plus GiST is among the oldest and most stable parts of PostGIS, unchanged in API and storage across 3.x. Nothing here uses a 3.7-only feature.
+
+**Open decision, not taken.** Three candidate paths, no consensus reached:
+
+1. Keep the target at 3.6.4 and narrow the audit from "versions equal" to "target supports every spatial type and function actually in use", failing loudly if new spatial usage appears.
+2. Prove it by restoring a real Railway dump into the attested PG18/3.6.4 image and confirming both geography columns, their data, and both partial GiST indexes survive. This doubles as the §4 rehearsal the checkpoint needs. **This is the natural first task on a machine with working Docker.**
+3. Treat the dev-build drift as the actual bug: pin the Railway service to a stable PostGIS 16 image with auto-updates off, then revisit.
+
+---
+
+## 5. What to do next
+
+1. **Rehearse the restore** (§4). Dump Railway, restore into `ghcr.io/boardsesh/boardsesh-postgres-postgis@sha256:01c2671d…`, verify the two geography columns, their row counts, and both partial GiST indexes. That settles Blocker 2 with evidence and produces the rehearsal the checkpoint requires.
+2. **Decide Blocker 2** on that evidence.
+3. **Schedule the `wal_level` restart** with the write interruption it implies.
+4. **Run the PG16 role transition** (`docs/postgres-18-migration.md` §"Ordered PG16 production-role transition"). None of `boardsesh_owner`, `boardsesh_runtime` or `boardsesh_migrator` exist yet; the app appears to connect as `postgres`. `scripts/postgres18-production-role-transition.sh` has bounded `lock_timeout`, a wall-clock hold ceiling, and a long-running-transaction pre-flight — validated against a real PG16 in CI.
+5. **Then** the Phase 4 checkpoint, then replication.
+
+### Publishing again — read this first
+
+The publisher binds to the exact live `main` head and rechecks before registry login, before OIDC attestation, and before the digest artifact upload. The recheck happens **after both image builds**.
+
+Measured: portable **1 m 39 s**, seeded **16 m 52 s**, ~19 min dispatch to recheck. Observed cadence on `main` is ~1 commit per 24 minutes, and every merge also fires an automated `chore(changelog)` commit.
+
+Two attempts were lost to this before the third succeeded behind a deliberate merge freeze:
+
+| Run | SHA | Outcome |
+|---|---|---|
+| 31924828661 | `a5795a08…` | aborted at the pre-auth recheck; main moved during the ~2 h approval wait. Never authenticated, nothing published |
+| 31929880126 | `b61480a1…` | main moved before approval could be given; cancelled |
+| 32616607289 | `ca308bd2…` | **success** |
+
+So: announce a freeze, dispatch, approve within a few minutes, and expect a second approval prompt for the attestation job. Do not weaken the exact-main guard — re-dispatch for the new head instead. #4694 exists to shrink this window.
+
+---
+
+## 6. Environment notes from this machine
+
+Things that cost time here and may not apply on the new machine:
+
+- **Docker was entirely unusable.** The VM stopped booting — every command returned `Bad response from Docker engine`; `dockerd.log` showed `healthcheck failed fatally` and containerd `setns` errors. A full Docker Desktop restart did not recover it. `Docker.raw` was 119 GB against 34 GB free host disk. Reclaiming 48.8 GB of build cache did not help. This blocked the dev-db image build, the `postgres18-image` smoke, and the ansible offline suite at ansible-core 2.16.3 — all of which CI ran instead.
+- **`grep` here is `ugrep`, not GNU grep**, and `/usr/bin/grep` is BSD. Two real portability bugs came from this class: `stat -f` is BSD-only (on GNU, `-f` means `--file-system`), and the runners have no `ripgrep` at all. That second one was worse than a broken test — the credential test's argv guard was *fail-open* in CI, because an empty result from a missing binary is indistinguishable from "no forbidden match".
+- **Local `psql` is 14.22**, connecting to a PG16 server. Fine for the audit queries used, but worth upgrading before the cutover.
+- A fresh git worktree needs `bun install --frozen-lockfile` before `vp` will run.
+
+## Release Notes
+
+none

--- a/docs/postgres-18-rollout-handover.md
+++ b/docs/postgres-18-rollout-handover.md
@@ -45,9 +45,19 @@ Two things worth knowing before touching it:
 - The journal entry kept its original `when`, older than main's newest. Both appliers order by `when`, so it would have been **silently skipped** — not a loud failure. `check:db-migrations` caught it; restamped by hand following `db-renumber`'s own `nextWhen` convention. See issue #4696: `check:db-migrations` tells you to run `vp run db:renumber`, but that tool only inspects the migration *number* and no-ops on a stale `when`.
 - `test-location-sync-integration` was red for the whole rollout because it ran on PG17. Consumer B fixed it — it now passes.
 
-### Branch `agent/split-seeded-image-publisher` — WIP, do not merge
+### Branch `agent/split-seeded-image-publisher` — reviewed, three P2s open
 
-Commit `9f0a602c1`. Splits the seeded dev image into its own publisher workflow (issue #4694). **Unreviewed and unvalidated** — the security review phase had not run. Before merging: recompute every `PRIVILEGED_RUN_SHA256` and `PRIVILEGED_JOB_SHA256`, confirm every mutation test still fails for the weakenings it catches, add equivalent coverage for the new workflow, and get an independent review of the trust boundary in both.
+Tip `5c1ccfdd7`. Splits the seeded dev image into its own publisher workflow (issue #4694). Contract suite **157/157**.
+
+An independent security review ran and returned **CHANGES_REQUIRED**, but the trust boundary itself came back intact in both workflows. It re-derived every hash with the file's own algorithm and found exactly 12 changed — 6 run bodies, 5 job hashes, and `CONTRACT_WORKFLOW_METADATA_SHA256` for the added trigger path. `validate-main`, `smoke-portable` and `smoke-seeded` hash identically to their pre-split values, which is good evidence the reviewed text was moved rather than retyped.
+
+Its P1 was about the commit, not the code: an earlier commit here snapshotted the worktree while the agent was still writing, so the tip was missing the eight lines that stop the two publishers re-coupling — the `forbiddenIdentifiers` loop and the `setup-qemu-action` ban for the amd64-only seeded image. Fixed in `5c1ccfdd7`; suite re-run green. Worth knowing as a general hazard: committing an agent worktree mid-run can capture a partial state that still looks coherent.
+
+Three P2s remain before merge:
+
+1. Both publishers validate both Dockerfiles, deliberately, to keep two privileged run bodies byte-identical and hash-shared. Fail-closed, but it means removing or relocating either Dockerfile breaks **both** publishers — document it in the `validate-main` bullet.
+2. Both publishers declare `environment: postgres-image-publisher`, so the seeded developer publisher holds the same environment-scoped OIDC identity as the production one. Nothing currently trusts it beyond GitHub's attestation API, but any future external trust policy must key on `job_workflow_ref`, never on the environment name.
+3. `vp check` is red on the branch with two `TS2339` errors in `scripts/expo-web-e2e.ts` (`Property 'unref' does not exist on type 'number'`). The file is untouched by the change and this looks like DOM-vs-Node `setTimeout` typing, but it was not confirmed against a pristine `main` — verify, and fix separately.
 
 ### Filed issues
 

--- a/docs/postgres-image-digests.json
+++ b/docs/postgres-image-digests.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 2,
+  "source": {
+    "repository": "boardsesh/boardsesh",
+    "url": "https://github.com/boardsesh/boardsesh",
+    "ref": "refs/heads/main",
+    "sha": "ca308bd225519bd1062dfdbab288e7b063e253c9"
+  },
+  "tag_policy": {
+    "lookup_tag": "sha-ca308bd225519bd1062dfdbab288e7b063e253c9",
+    "deployment_identity": "digest-only",
+    "tags_are_mutable": true
+  },
+  "oci_labels": {
+    "org.opencontainers.image.revision": "ca308bd225519bd1062dfdbab288e7b063e253c9",
+    "org.opencontainers.image.source": "https://github.com/boardsesh/boardsesh",
+    "org.opencontainers.image.ref.name": "refs/heads/main"
+  },
+  "images": {
+    "portable": {
+      "name": "ghcr.io/boardsesh/boardsesh-postgres-postgis",
+      "digest": "sha256:01c2671dbccd2104ec15534de1552d1e092301a5a77cad010795318d47f76796",
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64"
+      ],
+      "attestation_url": "https://github.com/boardsesh/boardsesh/attestations/42389745",
+      "attestation_verified": true
+    },
+    "seeded": {
+      "name": "ghcr.io/boardsesh/boardsesh-dev-db",
+      "digest": "sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5",
+      "platforms": [
+        "linux/amd64"
+      ],
+      "attestation_url": "https://github.com/boardsesh/boardsesh/attestations/42389746",
+      "attestation_verified": true
+    }
+  }
+}

--- a/docs/postgres-image-digests.json
+++ b/docs/postgres-image-digests.json
@@ -20,19 +20,14 @@
     "portable": {
       "name": "ghcr.io/boardsesh/boardsesh-postgres-postgis",
       "digest": "sha256:01c2671dbccd2104ec15534de1552d1e092301a5a77cad010795318d47f76796",
-      "platforms": [
-        "linux/amd64",
-        "linux/arm64"
-      ],
+      "platforms": ["linux/amd64", "linux/arm64"],
       "attestation_url": "https://github.com/boardsesh/boardsesh/attestations/42389745",
       "attestation_verified": true
     },
     "seeded": {
       "name": "ghcr.io/boardsesh/boardsesh-dev-db",
       "digest": "sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5",
-      "platforms": [
-        "linux/amd64"
-      ],
+      "platforms": ["linux/amd64"],
       "attestation_url": "https://github.com/boardsesh/boardsesh/attestations/42389746",
       "attestation_verified": true
     }

--- a/scripts/__tests__/pg18-artifact-drift.test.ts
+++ b/scripts/__tests__/pg18-artifact-drift.test.ts
@@ -1,0 +1,135 @@
+/// <reference types="node" />
+
+import { spawnSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Two artifacts of the PostgreSQL 18 rollout are checked into the repo and are
+ * read by nothing at run time, so nothing notices when the tree drifts out from
+ * under them:
+ *
+ *   - `docs/postgres-image-digests.json`, the handoff copy of the publisher's
+ *     digest manifest, which is supposed to name the exact images every
+ *     consumer is pinned to; and
+ *   - `docs/pg18-replication-rename.patch`, a prepared rename deliberately
+ *     deferred until after the cutover.
+ *
+ * Both fail silently. A consumer pin can be edited to a digest the manifest
+ * does not record, and the patch's context can be invalidated by an ordinary
+ * edit to any of the seven files it touches — `git apply` absorbs line offsets
+ * without complaint right up until it rejects outright.
+ *
+ * These read their inputs from disk at run time rather than importing them, so
+ * Vitest's `--changed` module-graph analysis cannot relate them to a diff that
+ * only touches a workflow, `docker-compose.yml`, or the patch itself. They run
+ * from their own gated job in `ci.yml`; see the `pg18Artifacts` paths filter.
+ */
+
+const DIGEST_MANIFEST_PATH = 'docs/postgres-image-digests.json';
+const PORTABLE_IMAGE = 'ghcr.io/boardsesh/boardsesh-postgres-postgis';
+const SEEDED_IMAGE = 'ghcr.io/boardsesh/boardsesh-dev-db';
+
+/**
+ * Every file that pins one of the two published images by digest. Each entry is
+ * asserted to still contain a pin, so deleting one is as loud as changing one.
+ */
+const PINNED_CONSUMERS = [
+  'docker-compose.yml',
+  '.github/workflows/ci.yml',
+  '.github/workflows/e2e-tests.yml',
+  '.github/workflows/db-migration-renumber.yml',
+  'scripts/__tests__/ci-location-sync-workflow.test.ts',
+] as const;
+
+type DigestManifest = {
+  images: Record<string, { name: string; digest: string }>;
+};
+
+function readDigestManifest(): DigestManifest {
+  return JSON.parse(readFileSync(DIGEST_MANIFEST_PATH, 'utf8')) as DigestManifest;
+}
+
+/** Every `<image>@sha256:<digest>` reference to either published image, in file order. */
+function pinnedReferences(source: string): { image: string; digest: string }[] {
+  const references: { image: string; digest: string }[] = [];
+  const pattern = new RegExp(`(${PORTABLE_IMAGE}|${SEEDED_IMAGE})@(sha256:[0-9a-f]{64})`, 'g');
+  for (const match of source.matchAll(pattern)) {
+    references.push({ image: match[1], digest: match[2] });
+  }
+  return references;
+}
+
+describe('published PostgreSQL image digests', () => {
+  const manifest = readDigestManifest();
+
+  it('records a digest for both published images', () => {
+    expect(manifest.images.portable.name).toBe(PORTABLE_IMAGE);
+    expect(manifest.images.seeded.name).toBe(SEEDED_IMAGE);
+    expect(manifest.images.portable.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(manifest.images.seeded.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+
+  const expectedDigest: Record<string, string> = {
+    [PORTABLE_IMAGE]: manifest.images.portable.digest,
+    [SEEDED_IMAGE]: manifest.images.seeded.digest,
+  };
+
+  it.each(PINNED_CONSUMERS)('pins %s to the recorded digests', (consumerPath) => {
+    const source = readFileSync(consumerPath, 'utf8');
+    const references = pinnedReferences(source);
+
+    // A consumer that stops pinning at all is the failure this is really for:
+    // an unpinned `:latest` would otherwise pass a digest-equality check
+    // vacuously, because there would be no digest left to compare.
+    expect(references.length, `${consumerPath} no longer pins a published image by digest`).toBeGreaterThan(0);
+
+    for (const reference of references) {
+      expect(reference.digest, `${consumerPath} pins ${reference.image} to a digest the manifest does not record`).toBe(
+        expectedDigest[reference.image],
+      );
+    }
+  });
+
+  it('leaves no mutable tag reference behind in a pinned consumer', () => {
+    for (const consumerPath of PINNED_CONSUMERS) {
+      const source = readFileSync(consumerPath, 'utf8');
+      const taggedReferences = [
+        ...source.matchAll(new RegExp(`(?:${PORTABLE_IMAGE}|${SEEDED_IMAGE}):([\\w.-]+)`, 'g')),
+      ];
+      expect(
+        taggedReferences.map((match) => match[0]),
+        `${consumerPath} refers to a published image by tag; tags are mutable and are a lookup aid, never a deployment pin`,
+      ).toEqual([]);
+    }
+  });
+});
+
+describe('committed patches still apply', () => {
+  const patchPaths = readdirSync('docs')
+    .filter((entry) => entry.endsWith('.patch'))
+    .sort()
+    .map((entry) => `docs/${entry}`);
+
+  // Asserted positively so an empty glob fails loudly instead of turning the
+  // loop below into a no-op that reports success.
+  it('finds at least one committed patch to check', () => {
+    expect(patchPaths.length).toBeGreaterThan(0);
+  });
+
+  it.each(patchPaths)('%s applies cleanly to the current tree', (patchPath) => {
+    const result = spawnSync('git', ['apply', '--check', '--verbose', patchPath], { encoding: 'utf8' });
+
+    expect(result.error).toBeUndefined();
+    expect(
+      result.status,
+      [
+        `${patchPath} no longer applies. It is a prepared change that has not landed yet,`,
+        'so a file it touches has moved out from under it. Regenerate the patch against',
+        'the current tree, or land the change and delete the patch.',
+        '',
+        result.stderr,
+      ].join('\n'),
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Handover for continuing the PG18 rollout on a machine that can run Docker. Adds `docs/postgres-18-rollout-handover.md`, the PostGIS audit findings, the accepted image digests, and the deferred replication-script rename patch.

**Everything through image publication and consumer pinning is merged.** The production cutover has not started. One read-only audit is the only thing that has touched Railway.

## The two blockers

**`wal_level = replica`** — logical replication needs `logical`, which costs a Railway Postgres restart.

**PostGIS version.** Production runs `3.7.0dev` (from the `postgis/postgis:16-master` tag); the attested image ships stable `3.6.4`. PGDG has no stable 3.7 for PG18, so the target cannot be moved up to match:

```
3.6.2+dfsg-1.pgdg12+1
3.6.3+dfsg-1.pgdg12+1
3.6.4+dfsg-2.pgdg12+1   <- newest
```

But the actual exposure is two `geography(Point,4326)` columns and two partial GiST indexes, with `tiger`/`topology` empty scaffolding (0 live tuples). Nothing uses a 3.7-only feature. Full evidence in `docs/postgres-18-postgis-audit.md`.

**The decision was not taken** — narrow the audit rule, prove it with a restore rehearsal, or move production off the `master` tag. The rehearsal is the natural first task once Docker works, since it settles the question with evidence *and* produces the §4 rehearsal the Phase 4 checkpoint requires.

## Also captured

- Accepted digests and attestation URLs (`docs/postgres-image-digests.json`)
- Why two publish attempts died: the exact-main recheck runs *after* both builds, and the seeded image takes ~17 min of that ~19 min window
- The `prevent_self_review = false` accepted risk and the condition for reverting it
- `docs/pg18-replication-rename.patch`, deferred from commit A
- Environment traps that produced three real bugs: `ugrep` vs GNU grep, no `ripgrep` on runners (which made a credential guard *fail-open*), and BSD-only `stat -f`

## Not included

`agent/split-seeded-image-publisher` (`9f0a602c1`) is pushed separately and is **WIP, unreviewed, do not merge** — the security review had not run and the contract hashes are unconfirmed.

## Release Notes

none