### PR TITLE
fix(db): mount the dev database on the PostgreSQL 18 volume contract

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,14 @@ services:
     image: ghcr.io/boardsesh/boardsesh-dev-db@sha256:d4574a27a639919b70d89c457e88f17bf672b358dd38dbdc3c2ba5f65ecc44e5
     shm_size: '256mb'
     command: postgres -c listen_addresses='*' -c max_connections=300 -c log_min_messages=warning
+    # PostgreSQL 18 changed the storage contract: PGDATA is
+    # /var/lib/postgresql/18/docker and the persistent volume mounts at the
+    # parent, /var/lib/postgresql. Never mount at /var/lib/postgresql/data or
+    # reuse a pre-PG18 volume — the image's entrypoint fails closed on both.
+    # The volume name is versioned so an old PG16/17 db_data volume is retained
+    # rather than rejected. See docs/postgres-18-migration.md.
     volumes:
-      - db_data:/var/lib/postgresql/pgdata
+      - db_data_pg18:/var/lib/postgresql
     ports:
       - '5432:5432'
     environment:
@@ -28,4 +34,4 @@ services:
       retries: 5
 
 volumes:
-  db_data:
+  db_data_pg18:

--- a/scripts/dev-db-up.sh
+++ b/scripts/dev-db-up.sh
@@ -14,7 +14,13 @@
 
 set -e
 
-HBA_FILE="/var/lib/postgresql/pgdata/pg_hba.conf"
+# PGDATA is owned by the image, not by this script: PostgreSQL 18 puts it at
+# /var/lib/postgresql/18/docker, and a future major moves it again. Read it back
+# out of the running container so a version bump does not silently point these
+# edits at a path with no cluster in it.
+postgres_data_dir() {
+  docker exec "$PG_CONTAINER" sh -c 'printf %s "$PGDATA"' 2>/dev/null
+}
 # CDPATH is intentionally cleared only for cd.
 # shellcheck disable=SC1007
 REPO_ROOT=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
@@ -77,6 +83,13 @@ ensure_postgres_network_access() {
   echo "Ensuring pg_hba.conf allows Docker network and Tailscale connections..."
   hba_updated=false
 
+  pgdata=$(postgres_data_dir)
+  if [ -z "$pgdata" ]; then
+    echo "ERROR: could not read PGDATA from the postgres container." >&2
+    exit 1
+  fi
+  HBA_FILE="$pgdata/pg_hba.conf"
+
   if docker exec "$PG_CONTAINER" grep -F -q "host all all 0.0.0.0/0 md5" "$HBA_FILE" 2>/dev/null; then
     echo "  IPv4 md5 rule already present."
   else
@@ -96,7 +109,7 @@ ensure_postgres_network_access() {
   fi
 
   if [ "$hba_updated" = true ]; then
-    docker exec -u postgres "$PG_CONTAINER" pg_ctl reload -D /var/lib/postgresql/pgdata
+    docker exec -u postgres "$PG_CONTAINER" pg_ctl reload -D "$pgdata"
     echo "  pg_hba.conf updated and reloaded."
   fi
 }


### PR DESCRIPTION
## Summary

`vp run db:up` has been broken on `main` since #4695 for anyone on the local Docker path. That PR pinned `docker-compose.yml` to the attested PG18 seeded digest but left the PG16 storage layout behind it, and no CI job noticed because none of them use `docker-compose.yml` or `scripts/dev-db-up.sh` — the workflows attach the image through `services:` blocks instead.

PostgreSQL 18 moved `PGDATA` to `/var/lib/postgresql/18/docker` and declares the parent `/var/lib/postgresql` as the volume. Mounting at the old `/var/lib/postgresql/pgdata` produced two failures:

- The named volume landed on a path the image never writes, so the ~11 GB seed was copied into the container's writable layer on every fresh start and discarded with the container.
- `scripts/dev-db-up.sh:17` looked for `pg_hba.conf` under that same dead path, so `ensure_postgres_network_access` appended into a root-owned empty mountpoint and `set -e` killed the script before migrations ran.

The dead path is directly observable in the pinned image:

```
$ docker exec boardsesh-postgres-1 ls /var/lib/postgresql/pgdata
ls: cannot access '/var/lib/postgresql/pgdata': No such file or directory
```

### What changed

- `docker-compose.yml` mounts the volume at `/var/lib/postgresql`.
- The volume is renamed `db_data` → `db_data_pg18`. A pre-PG18 `db_data` remounted at the parent would trip the image's own "cluster outside PGDATA" guard (`dev-db-entrypoint.sh:34`); a versioned name retains the old volume instead of rejecting it, which is what `docs/postgres-18-migration.md` asks for.
- `scripts/dev-db-up.sh` reads `PGDATA` back out of the running container instead of hardcoding it, so the next major bump moves the path rather than silently pointing these edits at an empty directory.

`PGDATA` is deliberately **not** set in Compose — the image owns it, and pinning it there would break the entrypoint's own major-version check on a future bump.

## Release Notes

none

## Test plan

Verified against the pinned digest `sha256:d4574a27a…` on a real Docker engine (29.7.2, arm64, seeded image emulated):

- `bash scripts/dev-db-up.sh` on the local Docker path (tailnet discovery off `PATH`) completes: both `pg_hba.conf` rules written, `pg_ctl reload` succeeds ("server signaled"), 205 migration records, no pending migrations.
- Second run reports both rules "already present" — proving the first run's writes landed on the real file rather than a dead mountpoint.
- Container inspection: `boardsesh_db_data_pg18 -> /var/lib/postgresql`, `PGDATA=/var/lib/postgresql/18/docker`, `PG_VERSION` 18, `PostgreSQL 18.4`.
- **Persistence:** `docker compose down` then back up retains the database — `migrations=205 tables=104 users=53`, same named volume. This is the case that silently lost data before.

Developers with an existing `db_data` volume keep it; the new stack builds `db_data_pg18` on first start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xcc4mqyw89utHZbLhCea2e